### PR TITLE
Verify install.sh on clean debian/alpine containers, wire into CI (#99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,3 +296,269 @@ jobs:
             rm -f "$symlink_path"
             echo "::error::expected the symlinked commitlore.bin to be refused"; exit 1;
           } || { status=$?; rm -f "$symlink_path"; test $status -eq 1; }
+
+  # #99: install.sh (the README's second, non-canonical install path — curl the
+  # script, pipe it to sh) had never run on a machine that was not the
+  # author's. `check`'s fresh-clone step and `binary` above both prove
+  # something real, but neither touches install.sh at all — they build
+  # dist/commitlore.mjs or dist/commitlore directly from this checkout and run
+  # it there. install.sh's own job is different: download a release asset,
+  # verify its checksum *before* installing anything, and detect which of six
+  # coding agents are on the machine — none of that is exercised anywhere
+  # else.
+  #
+  # This runs it inside containers that start with **nothing preinstalled** —
+  # no curl/jq/tar/git added ahead of time to make it pass — on two images
+  # chosen for what each one actually is, not for convenience:
+  #   - debian:stable-slim: glibc, bash present, but neither curl nor wget
+  #     ships by default. Whatever install.sh does about that is what a real
+  #     "minimal tooling" machine hits.
+  #   - alpine:latest: busybox sh, not bash. install.sh's shebang is
+  #     `#!/bin/sh`; this is the actual portability test, and #99 found a real
+  #     failure here (see the "musl" step below) — that failure is the point
+  #     of running this image, not a flake to work around.
+  #
+  # ubuntu-latest is not in this matrix on purpose: `binary` above already
+  # proves the compiled binary itself works on a real (non-containerized)
+  # Linux and macOS host with no Node on PATH. Adding it here would test the
+  # same binary a second time through a thicker layer, not a new claim.
+  install-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run build:binary
+
+      # Stage a release the exact shape release.yml publishes — same
+      # asset-naming convention (`commitlore-<version>-<target>.tar.gz`), same
+      # `sha256sum *.tar.gz > SHA256SUMS` invocation (compare
+      # .github/workflows/release.yml's `build`/`publish` jobs) — just not
+      # fetched from github.com. A second, corrupted copy exists only to
+      # prove the checksum check rejects a bad download: flipped bytes in the
+      # archive, SHA256SUMS left pointing at the original (now wrong) hash.
+      - name: Stage a release layout for install.sh to fetch
+        id: stage
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          target="x86_64-unknown-linux-gnu"  # ubuntu-latest's own arch -- matches the build:binary output above
+          asset="commitlore-${version}-${target}.tar.gz"
+
+          good="$RUNNER_TEMP/staged-good"
+          bin_stage="$RUNNER_TEMP/staged-bin"
+          mkdir -p "$good" "$bin_stage"
+          cp dist/commitlore "$bin_stage/commitlore"
+          chmod +x "$bin_stage/commitlore"
+          tar -czf "$good/$asset" -C "$bin_stage" commitlore
+          ( cd "$good" && sha256sum "$asset" > SHA256SUMS )
+
+          corrupt="$RUNNER_TEMP/staged-corrupt"
+          mkdir -p "$corrupt"
+          cp "$good/$asset" "$good/SHA256SUMS" "$corrupt/"
+          # Overwrite 16 bytes well inside the archive with fixed, non-matching
+          # content. SHA256SUMS in $corrupt is untouched -- still the hash of
+          # the *original* bytes -- so this is deliberately a mismatch, not a
+          # coincidence.
+          dd if=/dev/zero of="$corrupt/$asset" bs=1 seek=1000 count=16 conv=notrunc status=none
+
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+          echo "good_dir=$good" >> "$GITHUB_OUTPUT"
+          echo "corrupt_dir=$corrupt" >> "$GITHUB_OUTPUT"
+
+      - name: Serve the staged releases over HTTP
+        run: |
+          set -euo pipefail
+          python3 -m http.server 8199 --directory "${{ steps.stage.outputs.good_dir }}" --bind 127.0.0.1 &
+          python3 -m http.server 8198 --directory "${{ steps.stage.outputs.corrupt_dir }}" --bind 127.0.0.1 &
+          for port in 8199 8198; do
+            up=""
+            for _ in $(seq 1 20); do
+              if curl -sf "http://127.0.0.1:$port/SHA256SUMS" >/dev/null 2>&1; then up=1; break; fi
+              sleep 0.5
+            done
+            [ -n "$up" ] || { echo "::error::staging HTTP server on :$port never came up"; exit 1; }
+          done
+
+      # install.sh's documented, default command has no override -- it hits
+      # github.com directly. "Download from a release if one exists" means
+      # checking first and using it when so, rather than assuming either way.
+      # As of #99 it does not: v0.1.0 was published with zero attached
+      # assets (`gh release view v0.1.0` -- `assets: []`), which is exactly
+      # what this check finds on its own (SHA256SUMS 404s). Every assertion
+      # below therefore runs against the staged layout above; this step also
+      # means that changes the day a real release actually carries assets,
+      # with no edit to this workflow required.
+      - name: Does the latest real release publish this target's asset?
+        id: real
+        run: |
+          set -euo pipefail
+          url="https://github.com/${{ github.repository }}/releases/latest/download/SHA256SUMS"
+          code="$(curl -s -o /dev/null -w '%{http_code}' -L "$url")"
+          if [ "$code" = "200" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::latest release publishes SHA256SUMS -- the real-path step below will run against github.com"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::latest release has no SHA256SUMS asset (HTTP $code) -- install.sh's documented one-liner cannot be exercised against a real release right now; every assertion in this job uses the staged release from the previous step instead"
+          fi
+
+      # === debian:stable-slim ==================================================
+
+      # Nothing preinstalled. Neither curl nor wget ships on this image by
+      # default -- confirmed by removing both from consideration entirely,
+      # not by reading the Dockerfile. fetch()'s own command -v checks should
+      # catch this and die with a named, actionable message instead of a raw
+      # "curl: not found" from the shell.
+      - name: "debian: nothing preinstalled -- the dependency check fires cleanly"
+        run: |
+          set -euo pipefail
+          out="$(docker run --rm --network host \
+            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8199" \
+            -e HOME=/root \
+            -v "$PWD/install.sh:/install.sh:ro" \
+            debian:stable-slim sh /install.sh 2>&1)" && rc=0 || rc=$?
+          echo "$out"
+          test "$rc" -eq 2 || { echo "::error::expected exit 2 (download failed), got $rc"; exit 1; }
+          echo "$out" | grep -qF "neither curl nor wget is available to download the release" || {
+            echo "::error::expected the curl/wget-missing message, got something else"; exit 1;
+          }
+
+      # curl is the one thing this image is missing that install.sh hard
+      # requires (sha256sum and tar both ship by default on Debian). Adding
+      # it here is not "pre-installing dependencies to make the test pass" --
+      # it is the second half of the same test: the step above already
+      # proved the bare-machine failure is clean and named; this step proves
+      # the success path actually works once that one gap is filled, which
+      # #99's item 4 (binary runs, --version, agent detection with none
+      # installed) needs a working download to even reach.
+      - name: "debian: add curl, then the full install + agent-detection path succeeds"
+        run: |
+          set -euo pipefail
+          expected_version="$(node -p "require('./package.json').version")"
+          docker run --rm --network host \
+            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8199" \
+            -e HOME=/root \
+            -e EXPECTED_VERSION="$expected_version" \
+            -v "$PWD/install.sh:/install.sh:ro" \
+            debian:stable-slim sh -c '
+              set -eu
+              apt-get update -qq
+              apt-get install -y -qq curl
+              echo "=== install.sh ==="
+              sh /install.sh
+              echo "=== post-install assertions ==="
+              [ -x /root/.local/bin/commitlore ] || { echo "binary was not installed"; exit 1; }
+              v="$(/root/.local/bin/commitlore --version)"
+              [ "$v" = "$EXPECTED_VERSION" ] || { echo "unexpected --version output: $v (expected $EXPECTED_VERSION)"; exit 1; }
+              # None of the six clients this script knows about exist in this
+              # container. All six must be reported absent, none "wired", and
+              # -- the part a clean summary line alone does not prove -- no
+              # config file may exist at any path install.sh would have
+              # written to.
+              for p in /root/.claude /root/.codex/config.toml /root/.gemini/settings.json \
+                       /root/.cursor/mcp.json /root/.codeium/windsurf/mcp_config.json \
+                       /root/.config/opencode/opencode.json; do
+                [ ! -e "$p" ] || { echo "a config was written for an agent that is not installed: $p"; exit 1; }
+              done
+            ' 2>&1 | tee "$RUNNER_TEMP/debian-success.log"
+          grep -qF "Not detected on this machine: Claude Code, Codex, Gemini CLI, Cursor, Windsurf, opencode" \
+            "$RUNNER_TEMP/debian-success.log" || {
+            echo "::error::the six-agent-absent summary line is missing or changed"; exit 1;
+          }
+
+      # === alpine:latest -- busybox sh, not bash. The real portability test. ==
+
+      # Nothing preinstalled here either, and nothing needs to be: busybox
+      # ships wget, sha256sum, and tar by default, so the download and
+      # checksum-verify steps run with no setup at all. What actually breaks
+      # is the binary itself -- the published target is
+      # `<arch>-unknown-linux-gnu` (glibc), and Alpine is musl. Before #99's
+      # fix, install.sh copied the unusable binary into place, printed
+      # "installed to ...", and then crashed on its own "$dest" --version
+      # sanity check with a bare `not found` (busybox's rendering of "no
+      # dynamic interpreter") and exit 127 -- not one of the four exit codes
+      # this script documents for itself. The fix executes the freshly
+      # extracted binary *before* installing it anywhere and `die`s with a
+      # named, attributed message if it cannot run.
+      - name: "alpine: nothing preinstalled -- the musl/glibc mismatch is refused cleanly"
+        run: |
+          set -euo pipefail
+          out="$(docker run --rm --network host \
+            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8199" \
+            -e HOME=/root \
+            -v "$PWD/install.sh:/install.sh:ro" \
+            alpine:latest sh /install.sh 2>&1)" && rc=0 || rc=$?
+          echo "$out"
+          test "$rc" -eq 1 || { echo "::error::expected exit 1 (unsupported platform), got $rc"; exit 1; }
+          echo "$out" | grep -qF "does not run on this machine" || {
+            echo "::error::expected the musl/glibc diagnostic, got something else"; exit 1;
+          }
+          echo "$out" | grep -qF "nothing was installed" || {
+            echo "::error::expected the nothing-was-installed reassurance"; exit 1;
+          }
+          docker run --rm --network host -e HOME=/root debian:stable-slim \
+            test ! -e /root/.local/bin/commitlore
+
+      # Checksum verification is the one guarantee this script exists to make
+      # (see install.sh's own header comment) -- a check that has never been
+      # seen to reject anything is not a checksum check. Run against both
+      # images: debian with curl added (glibc, the common case) and bare
+      # alpine (busybox's own sha256sum applet, reached before the musl
+      # binary-execution guard above ever runs -- checksum verification
+      # happens first). Both must refuse the corrupted asset the same way.
+      - name: "checksum corruption is rejected on both images -- nothing is installed"
+        run: |
+          set -euo pipefail
+
+          out_debian="$(docker run --rm --network host \
+            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8198" \
+            -e HOME=/root \
+            -v "$PWD/install.sh:/install.sh:ro" \
+            debian:stable-slim sh -c '
+              set -eu
+              apt-get update -qq
+              apt-get install -y -qq curl
+              sh /install.sh
+            ' 2>&1)" && rc_debian=0 || rc_debian=$?
+          echo "$out_debian"
+          test "$rc_debian" -eq 3 || { echo "::error::debian: expected exit 3 (checksum mismatch), got $rc_debian"; exit 1; }
+          echo "$out_debian" | grep -qF "checksum mismatch for" || { echo "::error::debian: expected the checksum-mismatch message"; exit 1; }
+          echo "$out_debian" | grep -qF "Nothing was installed" || { echo "::error::debian: expected the nothing-was-installed reassurance"; exit 1; }
+
+          out_alpine="$(docker run --rm --network host \
+            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8198" \
+            -e HOME=/root \
+            -v "$PWD/install.sh:/install.sh:ro" \
+            alpine:latest sh /install.sh 2>&1)" && rc_alpine=0 || rc_alpine=$?
+          echo "$out_alpine"
+          test "$rc_alpine" -eq 3 || { echo "::error::alpine: expected exit 3 (checksum mismatch), got $rc_alpine"; exit 1; }
+          echo "$out_alpine" | grep -qF "checksum mismatch for" || { echo "::error::alpine: expected the checksum-mismatch message"; exit 1; }
+
+      # === the real path, once it exists ======================================
+
+      # Skipped entirely today (see the "Does the latest real release
+      # publish..." step -- v0.1.0 has no assets). The day a real release
+      # does carry an asset for this target, this step starts running
+      # automatically and must pass: the actual documented one-liner,
+      # against the actual GitHub release, with no override at all.
+      - name: "real release path (only runs once a release actually publishes assets)"
+        if: steps.real.outputs.available == 'true'
+        run: |
+          set -euo pipefail
+          out="$(docker run --rm --network host \
+            -e HOME=/root \
+            -v "$PWD/install.sh:/install.sh:ro" \
+            debian:stable-slim sh -c '
+              set -eu
+              apt-get update -qq
+              apt-get install -y -qq curl
+              sh /install.sh
+              /root/.local/bin/commitlore --version
+            ' 2>&1)" && rc=0 || rc=$?
+          echo "$out"
+          test "$rc" -eq 0 || { echo "::error::the real, documented install command failed against the actual GitHub release"; exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## Unreleased
 
+### install.sh runs in CI now, on clean containers with nothing preinstalled — feat-issue-99
+
+install.sh had never run on a machine that was not the author's: it was only
+ever tested against a simulated release in a sandboxed `$HOME` on macOS. A
+new CI job (`install-script` in `.github/workflows/ci.yml`) runs it inside
+`debian:stable-slim` and `alpine:latest` containers with nothing
+preinstalled — no curl/jq/tar/git added ahead of time to hide what the
+script actually requires.
+
+Debian ships neither curl nor wget by default; install.sh's own
+`command -v` check already handles that cleanly (exit 2, a named message),
+verified rather than assumed. A second step adds curl — the one missing
+piece — and verifies the full path: binary installed, `--version` matches,
+and all six coding-agent detections report absent with no config file
+written for any of them.
+
+Alpine surfaced a real bug: busybox ships wget/sha256sum/tar by default, so
+the download and checksum-verify steps ran with nothing added, but the
+published binaries are `-unknown-linux-gnu` (glibc) and Alpine is musl.
+install.sh copied the unusable binary into place, printed "installed to
+...", and then crashed on its own `"$dest" --version` sanity check with a
+bare `not found` and exit 127 — not one of the four exit codes this script
+documents for itself. Fixed by executing the freshly extracted binary
+before installing it anywhere and `die`-ing with a named, attributed
+message (exit 1, the existing "unsupported platform" bucket) if it cannot
+run.
+
+The checksum path is exercised deliberately: a corrupted copy of the staged
+release asset (SHA256SUMS left pointing at the original, now-wrong hash) is
+served to both images, and both must refuse it (exit 3, nothing written to
+the install directory).
+
+The real GitHub release (`v0.1.0`) currently has zero attached assets — the
+job checks that first and runs every assertion above against a locally
+staged, `release.yml`-shaped artifact via `COMMITLORE_INSTALL_BASE_URL`
+(install.sh's own documented escape hatch for exactly this). The one step
+that exercises the true `github.com` download path is conditional on a real
+asset existing, so it starts running with no workflow edit the day a
+release actually publishes one.
+
+Not touched: `release.yml`'s build matrix (the SEA binary still has to
+build on its real target OS, not a container standing in for one), and no
+part of local development or the test suite was containerized — this is one
+CI job for one script.
+
 ### `package.json` no longer describes a package this project can publish — bug-issue-93
 
 `npm publish` would have succeeded: nothing in `package.json` enforced

--- a/install.sh
+++ b/install.sh
@@ -145,6 +145,21 @@ log "checksum verified ($actual)"
 tar -xzf "$asset_file" -C "$work" commitlore
 chmod +x "$work/commitlore"
 
+# The checksum proves the bytes are the ones the release published — it says
+# nothing about whether this machine can *run* them. The published target is
+# `<arch>-unknown-linux-gnu`: built against glibc, dynamically linked against
+# glibc's loader. A musl-libc host (Alpine and its `#!/bin/sh` -> busybox ash
+# are the common case; there is no `-musl` asset for this target) has no
+# `/lib/ld-linux-*.so.*` for that binary to run against, and the kernel's
+# refusal to exec it surfaces as a bare "not found" from the shell — which
+# reads exactly like a typo in this script, not a platform gap. Executing the
+# freshly extracted binary here, before it is copied anywhere, turns that
+# into the same clear, attributed failure every other unsupported-platform
+# case in this script already gives.
+if ! "$work/commitlore" --version >/dev/null 2>&1; then
+  die "the downloaded binary for $target does not run on this machine (nothing was installed). This usually means a musl-libc host such as Alpine — only glibc (\"-gnu\") Linux binaries are published, and Alpine's dynamic linker cannot load them. Install from source instead: https://github.com/$REPO#install-from-the-clone" 1
+fi
+
 if [ -n "${COMMITLORE_INSTALL_DIR:-}" ]; then
   dest_dir="$COMMITLORE_INSTALL_DIR"
 elif [ -n "${PREFIX:-}" ]; then


### PR DESCRIPTION
Closes #99.

## What this does

`install.sh` — the README's second, non-canonical install path (`curl -fsSL .../install.sh | sh`) — had never run on a machine that was not the author's. #96's own commit says so directly: "ran end-to-end against a fake local release ... inside a sandboxed HOME on this machine (Darwin/arm64)." Nothing in CI touches install.sh's own download → checksum-verify → install → agent-detect pipeline; `check`'s fresh-clone step and `binary` both build and run `dist/commitlore(.mjs)` directly from the checkout.

Added an `install-script` job to `.github/workflows/ci.yml` that runs `install.sh` inside `debian:stable-slim` and `alpine:latest` containers with **nothing preinstalled** — no curl/jq/tar/git added ahead of time to hide what the script actually needs — and fixed one real bug the alpine run surfaced.

## What the script actually requires

Verified directly, not read off the images' docs:

- **Hard requirement, already checked cleanly**: `curl` or `wget`, and `sha256sum` or `shasum`. `install.sh`'s own `command -v` checks already `die` with a named message (exit 2 / exit 3) instead of a raw shell error if both are missing — this PR didn't need to add that, only verify it.
- **`tar`**: used unconditionally, with no existence check — but ships by default on both target images (Debian's `coreutils`-adjacent base, Alpine's busybox), so this never actually fired. Documenting it here since the task asked what the script requires, not just what broke.
- **`jq`**: genuinely optional — the script already only uses it if present, and reports exactly what to add by hand otherwise.
- **`git`**: not used by `install.sh` at all (that's `commitlore init`'s job, a separate command).
- **`curl`/`wget` are not bundled by either base image.** `debian:stable-slim` ships neither. `alpine:latest` ships `wget` (busybox) but not `curl`.

## What failed on alpine, and what I did about it

Alpine's `/bin/sh` is busybox ash, not bash — the real portability test, since the shebang is `#!/bin/sh`. Busybox ships `wget`, `sha256sum`, and `tar` by default, so with **nothing added**, the download and checksum-verify steps ran cleanly. What broke: the published release target is `<arch>-unknown-linux-gnu` — built against glibc — and Alpine is musl. `install.sh` copied the (unusable) binary into place, printed `installed to ...`, and then crashed on its own `"$dest" --version` sanity check:

```
commitlore-install: installed to /root/.local/bin/commitlore
/install.sh: line 180: /root/.local/bin/commitlore: not found
```

Exit 127 — not one of the four exit codes this script documents for itself (`1`/`2`/`3`/`4`), and a message that reads like a bug in the script (a typo'd path) rather than what it actually is (a platform this binary cannot run on).

**Fix**: execute the freshly extracted binary (`"$work/commitlore" --version`) before installing it anywhere, and `die` with a named, attributed message if it does not run — reusing exit code 1 (the existing "unsupported platform" bucket), consistent with the OS/arch checks earlier in the same script. After the fix:

```
commitlore-install: checksum verified (c965b7f1...)
commitlore-install: error: the downloaded binary for aarch64-unknown-linux-gnu does not run on this
machine (nothing was installed). This usually means a musl-libc host such as Alpine — only glibc
("-gnu") Linux binaries are published, and Alpine's dynamic linker cannot load them. Install from
source instead: https://github.com/MongLong0214/commitlore#install-from-the-clone
```

Exit 1, and confirmed nothing was written to the install directory. This doesn't make Alpine installable (no `-musl` release target exists, and publishing one is out of scope here — a `release.yml` change, not this ticket) — it makes the failure legible instead of a raw crash. The CI job asserts on this exact message and exit code, so it stays a red, intentional signal rather than something someone "fixes" later by quietly pre-installing something.

## The corrupted-checksum test

A second, corrupted copy of the staged artifact (16 bytes overwritten inside the archive; `SHA256SUMS` left pointing at the *original*, now-wrong hash) is served to both images. Both must refuse it:

```
commitlore-install: downloading commitlore-0.1.0-aarch64-unknown-linux-gnu.tar.gz
commitlore-install: error: checksum mismatch for commitlore-0.1.0-aarch64-unknown-linux-gnu.tar.gz
  expected: c965b7f1e8d0c70a7f7ace9a95105ab2d0627027154bfad91903a8b6bb1b4ceb
  got:      45ed6f958990523256778c77f1b773d19acc7eb365bbc6b3312f4fad10faf9f1
  Nothing was installed. Do not re-run against the same cache; re-download fresh, and if it
  mismatches again, report it — the release may be corrupted.
```

Exit 3 on both images, confirmed nothing landed in the install directory either time. This is the first time this check has been deliberately exercised — before this PR it had never been seen to reject anything.

## Real vs. staged — the honest split

The task this closes was explicit that this project has been burned by tests that exercise something other than what users receive, so here's exactly what's real and what isn't:

- **Real, right now**: the release `v0.1.0` **exists but publishes zero assets** — `gh release view v0.1.0` reports `assets: []`, and `curl -fsSL https://github.com/MongLong0214/commitlore/releases/latest/download/SHA256SUMS` returns `404`. The documented one-liner cannot succeed against the actual GitHub release today, independent of anything in this PR.
- **Staged, and said so in the workflow's own comments**: every assertion above runs against a release built and packaged in the same job (`npm run build:binary`, then packaged exactly the way `release.yml`'s `build`/`publish` jobs do — same asset-naming convention, same `sha256sum *.tar.gz > SHA256SUMS`), served over real HTTP on `127.0.0.1` and fetched via `COMMITLORE_INSTALL_BASE_URL` — `install.sh`'s own documented escape hatch for "testing this script against a locally built binary and a hand-made SHA256SUMS." Real HTTP download, real checksum comparison, real extracted-and-executed binary; only the URL is not `github.com`.
- **Automatic promotion to real**: a step checks `releases/latest/download/SHA256SUMS` first. If that ever returns 200 (a real release publishing assets), a final step runs the true, undecorated `curl -fsSL .../install.sh | sh` command against the actual GitHub release and must pass — no workflow edit required the day that happens. Today it's skipped, logged with a `::warning::` explaining why.

## Verification

- Every step above was run for real against Docker on this machine (`debian:stable-slim`, `alpine:latest`, `--network host`) before being written into the workflow — not composed from documentation.
- `dist/` rebuilds with zero drift against this change (`git diff --exit-code -- dist/`).
- `bash spec/verify.sh` passes (25 fixtures + README example sync + vocab table).
- Full suite: **1373 passed | 1 skipped (1374), 38 files** — matches dev's count at #98 exactly.
- The new `ci.yml` parses as valid YAML.
- Each commit passes `node dist/commitlore.mjs validate --commit HEAD`.

**Not yet verified**: this exact workflow hasn't run on GitHub's own `ubuntu-latest` hosted runner (this PR's own CI run will be the first time); the conditional real-release-path step, since no release currently publishes an asset for it to find.

## Scope

- One new CI job for one script — not a Docker migration for development or the test suite.
- No Docker in `release.yml`'s build matrix; the SEA binary still builds on its real target OS (`postject` injects into the *running* `node` binary, per ADR-0015 — there's no cross-target flag to give it).
- No dependency pre-installed to make a test pass; every dependency check above is either the script's own existing `command -v` guard (verified working) or an explicit, commented, single addition (`curl` on Debian) needed to reach the success path the task also asked to verify.

