### PR TITLE
Fix retired GitHub Actions runner label macos-13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,11 @@ jobs:
         include:
           - os: macos-latest
             target: aarch64-apple-darwin
-          - os: macos-13
+          # macos-15-intel: GitHub's replacement for the retired macos-13 label
+          # (GitHub retired macos-13 on 2025-12-04; see
+          # https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).
+          # x86_64 macOS support ends when macos-15 retires in Fall 2027.
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary

- Replaced deprecated `macos-13` runner (retired 2025-12-04) with `macos-15-intel` per GitHub's official migration guidance
- Added comment documenting that x86_64 macOS support expires Fall 2027 when macos-15 image retires
- Verified all workflows; found only one instance of macos-13; no macos-14 found; ubuntu-latest and macos-latest are current

## What was broken

GitHub retired the `macos-13` runner on 2025-12-04. The release workflow's x86_64-apple-darwin build job used `macos-13`, causing the job to queue indefinitely (not fail — just sit pending forever). The v0.2.0 release sat queued for 74 minutes while all other platform builds completed successfully.

Indefinite queueing is worse than explicit failure because:
- The release appears to be in progress when it's actually stuck
- CI never reports a problem, so nothing alerts the user
- The only signal is checking the Actions page and noticing "still queued after X minutes"

## Verification

CI will now schedule on `macos-15-intel`. Before merging, I will verify:
1. Release workflow schedules successfully on all matrix labels (macos-latest, macos-15-intel, ubuntu-latest, ubuntu-24.04-arm)
2. Each job actually runs (not queued)
3. All jobs complete and produce build artifacts

## References

- GitHub announcement: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
- GitHub runners docs: https://docs.github.com/en/actions/reference/runners/github-hosted-runners