### PR TITLE
Register the measurement protocol and correct M4's analysis

### DIFF
--- a/bench/PREREGISTRATION.md
+++ b/bench/PREREGISTRATION.md
@@ -879,3 +879,180 @@ Briefs get shorter and less comfortable to write. The operator loses the ability
 steer the agent toward the known-good design, which is precisely the ability whose
 absence is being measured. Work will be redone that a leaking brief would have got
 right the first time, and the cost of that redo is the measurement.
+
+---
+
+## 18. M4 outcome correction and the protocol registered before any re-run
+
+Appended after M4's result was visible. Sections 1–17 remain the rules that were
+actually registered; nothing above is rewritten to make the executed run match a
+later design. This section records the divergence and registers
+[`docs/MEASUREMENT-PROTOCOL.md`](../docs/MEASUREMENT-PROTOCOL.md) for every
+measurement whose collection starts after this entry. No benchmark was re-run for
+this correction.
+
+### M4's data and original result
+
+The final artifact has 112 usable rows: eight tasks × seven seeds × two arms. All
+rows carry one harness commit and one dist digest, with no exclusions. The raw rates
+are `commitlore-on` 35/56 and `commitlore-guard` 41/56.
+
+Section 16 registered three arms, but this artifact contains only the two arms in
+the primary `guard`-against-`on` comparison; no `commitlore-off` result is
+fabricated. It records zero constraint violations in each present arm (0/56,
+Wilson 95% CI 0%–6.4%) but no separate cited-compliance outcome, so that
+registered secondary outcome cannot be reported. One `commitlore-on`
+`grading-fail-fast` row finished on its own past the unenforced turn budget and
+is labelled `over-turns`; all other rows finished within budget. The row was not
+stopped or truncated, re-proposed, and remains in every analysis.
+
+This supersedes §16's historical phrase "stopped by `over-turns`." Section 11
+defines the label as an observation after natural completion, not an enforced
+stop, so §16's wording was wrong even though its inclusion decision was right.
+
+The registered independent-groups analysis reported:
+
+- two-tailed Fisher exact `p = 0.3117`;
+- `on − guard = −10.7pp`; and
+- independent Newcombe 95% CI `[−27.1pp, +6.5pp]`.
+
+That test is not valid for the executed design. Each `(task, seed)` appears in both
+arms, so the 112 rows form 56 pairs rather than two independent samples.
+
+### Corrected paired and clustered result
+
+The paired table has 46 concordant pairs, `b = 2` where guard prevented a
+re-proposal, and `c = 8` where guard re-proposed and `on` did not.
+
+- McNemar mid-p: `p = 0.0654`.
+- Exact conditional McNemar sensitivity: `p = 0.1094`.
+- Equal-weight analysis of all eight task-cluster differences:
+  `on − guard = −10.7pp`, 95% CI `[−23.1pp, +1.6pp]`,
+  `t(7) = −2.049`, `p = 0.0796`.
+
+The task analysis is the transparent cluster correction available without
+choosing a new GEE or GLMM after the outcome was visible. It does not alter the
+prospective protocol: future paired clustered benchmarks use the permutation
+test registered below. GEE, GLMM and the unweighted task analysis are
+sensitivity analyses only.
+
+The test was changed after the result was seen. This is a correction of an error,
+not a re-cut in search of significance. The honest reason it is safe here is that
+**both analyses are null, so nothing about the conclusion turns on the change**. If
+they had disagreed, the corrected analysis could not simply replace the original;
+an independently registered run would be required.
+
+The pooled binary outcome has ANOVA `ICC = 0.581`, equal task-cluster size 14,
+`DEFF = 8.56`, and effective `n = 112 / 8.56 = 13.09` (13 rounded). Nominal n,
+pair count, cluster count, ICC, design effect and effective n are now reported
+together.
+
+### The executed qualification diverged from the usable-instrument rule
+
+Section 16 registered a floor only: at least 4/6 comparator re-proposals. Four of
+the eight selected tasks then ran 7/7 in both measured arms and contributed no
+discordance. Five candidates had qualified at 6/6; four of them became those four
+saturated tasks.
+
+The 4/6–5/6 rule registered in the first version of the prospective protocol is
+withdrawn before any future collection. It treated the binary symptom rather
+than the measurement defect. A count outcome preserves the difference between
+one and several re-proposals; a 5/6 ceiling would then discard the tasks with
+the most observable events, while a 4/6 floor would dichotomize the new count
+during selection. Dichotomizing counts loses granularity and power
+([Geroldinger et al.,
+2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10729462/)), and ceiling/floor
+compression makes a measure insensitive to real differences
+([Šimkovic and Träuble,
+2019](https://pmc.ncbi.nlm.nih.gov/articles/PMC6699673/)).
+
+Future calibration therefore evaluates the prespecified task pool as a whole.
+It estimates the count distribution and task ICC for the power simulation but
+does not drop individual tasks. The pool proceeds intact or collection stops
+before a treatment run. The completed M4 is not subset: §4 still holds, and all
+eight tasks remain in the corrected analysis.
+
+Implementation is tracked in
+[#109](https://github.com/MongLong0214/commitlore/issues/109).
+
+### Protocol registered for future measurements
+
+The full registration is
+[`docs/MEASUREMENT-PROTOCOL.md`](../docs/MEASUREMENT-PROTOCOL.md). Its
+confirmatory choices are fixed here:
+
+1. **Outcome:** `RunRecord.violations`, the non-negative count of distinct,
+   mechanically detected re-proposal clauses matched in one run, with one
+   labelled `violation_if` clause per prohibited re-proposal fixed before
+   collection. The current row type already records that integer count and
+   `matched` evidence, but not a first-event time or calibrated ordinal
+   severity. Count is chosen over
+   binary because dichotomization reduced power in small cross-over studies
+   ([Geroldinger et al.,
+   2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10729462/)). Time-to-event is
+   rejected because `RunRecord` has no first-event timestamp and would discard
+   later events; ordinal severity is rejected because no registered scale or
+   thresholds exist, although ordinal models can preserve information under
+   ceiling/floor effects
+   ([Hedeker, 2015](https://pmc.ncbi.nlm.nih.gov/articles/PMC4270960/)).
+2. **Test:** for each `(task, seed)` pair, swap the arm label within the pair.
+   The two-sided `α = 0.05` statistic is the equal-weight mean of the task-level
+   mean paired count differences. Fully enumerate `2^P` assignments for
+   `P ≤ 20`; otherwise use 99,999 random assignments plus the observed one and
+   the plus-one p-value. The 95% interval is obtained by inverting that same
+   permutation test. Permutation is chosen over GEE/GLMM because model-based
+   inference can inflate type I error with few clusters, whereas permutation
+   procedures preserve nominal error without that approximation
+   ([Leyrat et al.,
+   2018](https://academic.oup.com/ije/article/47/1/321/4091562);
+   [Maleyeff et al.,
+   2025](https://pmc.ncbi.nlm.nih.gov/articles/PMC12365356/)).
+3. **Size:** M4's eight tasks × seven seeds are only
+   `56 / (1 + 6 × 0.581) = 12.48` effective pairs and detect approximately
+   `d = 0.87`, not the registered one-third binary-rate reduction. The shipping
+   threshold is 0.5 fewer re-proposal violations per run, planned as `d = 0.5`;
+   one prevented revival every two runs is worth the avoided rework. At 80%
+   power, two-sided 5%, seven seeds and ICC 0.581, the planning minimum is **22
+   tasks × 7 seeds = 154 pairs and 154 runs per arm**. At least 10,000 design
+   simulations using the exact registered permutation analysis must confirm 80%
+   power before collection; otherwise add tasks. The alternatives rejected are
+   56/arm and adding seeds to the same eight clusters, whose effective
+   information asymptotes at `8 / 0.581 = 13.77`
+   ([Leyrat et al.,
+   2018](https://academic.oup.com/ije/article/47/1/321/4091562);
+   [Watson, Akinyemi and Hemming,
+   2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10962558/)).
+4. **Multiplicity:** the pooled test is the single primary test. If all eight
+   current task effects are tested, they are one secondary family controlled by
+   the Romano–Wolf stepdown procedure using the same joint permutations, with
+   adjusted p-values and simultaneous 95% intervals. A larger future pool keeps
+   all task effects in one family. No correction, Bonferroni and Holm are
+   rejected: the first inflates family-wise error, Bonferroni was conservative
+   under correlation, and Romano–Wolf was more efficient than Holm while
+   retaining nominal error and coverage
+   ([Watson, Akinyemi and Hemming,
+   2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10962558/)).
+
+### Exposure and model were not recorded
+
+In all 112 rows, `matched.length > 0` is identical to `reproposed`. That is outcome
+evidence, not evidence that guard fired. The artifact records assignment but no
+treatment opportunity or exposure, so it cannot distinguish "applied and did
+nothing" from "never applied." Future experiments fail the exposure gate and are
+not analysed when exposure is unverifiable
+([#108](https://github.com/MongLong0214/commitlore/issues/108)).
+
+The original 93-row tranche and the final 112-row artifact also carry no `model`,
+and no M4 manifest supplies one. The observations cannot be attributed to a
+specific model ([#106](https://github.com/MongLong0214/commitlore/issues/106)).
+The prospective protocol therefore applies the same pre-analysis gate to model,
+harness and executable provenance: identities must be present and uniform (or
+registered as strata), otherwise no confirmatory analysis is performed.
+
+Section 16 calls `bench/VERDICT-M4.md` the "full verdict." That remains the
+historical executed report, including the registered Fisher result; it is not
+the canonical corrected analysis. The complete corrected verdict is
+[`docs/VERDICT-M4.md`](../docs/VERDICT-M4.md), and the historical report now
+links to it explicitly. M4's observations remain valid and its result remains
+null. What failed is the measurement design's ability to discriminate.
+Recorded harness/dist provenance is uniform; model provenance is missing.

--- a/bench/README.md
+++ b/bench/README.md
@@ -4,7 +4,9 @@
 harness commit and the `dist/` digest for every row, `bench/report.ts` summarizes
 it, and the README's numbers block is generated from it. M3 was voided for
 lacking that provenance (§15); M4 was designed, registered and run to supply it,
-and its result is null — see `bench/VERDICT-M4.md`. Every earlier dataset
+and its result is null. The historical executed report is
+`bench/VERDICT-M4.md`; the canonical paired-and-clustered correction is
+`docs/VERDICT-M4.md`. Every earlier dataset
 (M1, M1-b, M2) still lacks the fields and is not pooled into the generated block
 for that reason, not because it was withdrawn as a record; each has its own
 verdict document.
@@ -934,8 +936,10 @@ Anyone reading a null result from this harness has to read this table with it.
 
 Fisher exact also treats runs as independent, while the design is paired by
 (task, seed). The output says so. The test is the one ADR-0007 and T-702
-registered, and on paired data it is the conservative choice rather than the
-most powerful one.
+registered, but it does not provide a valid hypothesis test for paired data.
+The original number remains part of the historical report; the registered
+replacement and M4 correction are in `docs/MEASUREMENT-PROTOCOL.md` and
+`docs/VERDICT-M4.md`.
 
 ### What makes the measured effect a floor — one thing, not two
 
@@ -1058,9 +1062,10 @@ Still open:
    runs can and cannot detect*. Raising seeds or tasks is the only fix; no choice
    of test recovers power that the sample size does not contain.
 4. **Fisher exact ignores the pairing.** The design is paired by (task, seed);
-   the registered test treats runs as independent. A paired test (McNemar, or a
-   mixed model over tasks) would use the design, and should be decided in ADR-0007
-   rather than swapped in after seeing a p-value.
+   the registered test treats runs as independent and is invalid here. M4 keeps
+   that original result beside its post-result correction; future measurements
+   use the paired and clustered design registered in
+   `docs/MEASUREMENT-PROTOCOL.md`.
 5. Transcript-level re-proposal detection (negation) — see *Detection surfaces*.
    The saved transcripts from this run are the calibration input.
 6. Whether `records-uninjected` becomes a third arm — see *the control arm*. This

--- a/bench/VERDICT-M4.md
+++ b/bench/VERDICT-M4.md
@@ -1,9 +1,15 @@
 # M4 verdict — the qualified matrix, and it is still null
 
+> **Historical executed report.** This file preserves the analysis M4 originally
+> reported. Fisher exact is not valid for its paired design, and `over-turns`
+> did not stop or truncate the recorded run. The canonical correction is
+> [`docs/VERDICT-M4.md`](../docs/VERDICT-M4.md); the result remains null and no
+> observation is retracted.
+
 **n = 56 per arm, 7 of 7 seeds complete on all 8 qualifying tasks, 112 of 112
-runs.** No truncation-driven shortfall in the matrix itself — one run stopped
-by `over-turns` rather than `completed`, counted, not excluded (see *Limits*
-below).
+runs.** No truncation-driven shortfall in the matrix itself — one run finished
+naturally after the unenforced turn budget and is labelled `over-turns`,
+counted, not excluded (see *Limits* below).
 
 Registered as `PREREGISTRATION.md` §16, after the control-only qualification
 round recorded there. M1 (p = 0.7480), M1-b (p = 0.0522) and M2 (p = 0.2247)
@@ -60,9 +66,9 @@ Recorded here because a null result computed on an invalid test is not a
 settled null; it is an open question with a number attached. Both problems
 below are properties of the design, not of what the numbers came back as —
 they would be exactly as true if p had come back significant. Independently
-computed against `bench/results/t702-m4-final.jsonl`; a parallel branch,
-`feat-measurement-protocol`, is registering the corrected statistical
-protocol formally and will supersede the analysis in this section.
+computed against `bench/results/t702-m4-final.jsonl`; the registered protocol
+and canonical correction in `docs/` supersede the analysis in this section
+without retracting the observations.
 
 ### 1. The 112 runs are not 112 independent observations — they are 56 pairs
 
@@ -232,20 +238,16 @@ folded into this document, because a gap in the harness is not a property of
 the M4 result — it is a property of every dataset this harness produces until
 the two lines `bench/README.md` names are written.
 
-### 2. One run was truncated, and it is recorded, not excluded
+### 2. One run exceeded the turn budget, and it is recorded, not excluded
 
-`qualification-gitseed-grading-fail-fast`, `commitlore-on`, seed 5, stopped by
-`over-turns` at 31 turns rather than `completed`. `PREREGISTRATION.md` §14
-names truncation as something that flatters whichever arm it happens to land
-in — fewer turns is fewer chances to re-propose, so a truncated run is biased
-toward under-counting, not over-counting, the very outcome this experiment
-measures. §4 governs what happens to it: **it is not excluded.** `stopped_by:
-"error"`, `simulated: true` and never-started rows leave the analysis set;
-`over-turns` is not one of those three, and this row carries a real
-measurement (`reproposed: true`) like every other row in the table above. It
-is recorded here because the row exists and the mechanism that could bias it
-is named in the pre-registration, not because inspection turned up a reason to
-doubt this particular result.
+`qualification-gitseed-grading-fail-fast`, `commitlore-on`, seed 5, is labelled
+`over-turns` at 31 turns rather than `completed`. In this harness the label
+means that the process finished on its own after an observed, unenforced turn
+budget; the harness did not stop or truncate it. §4 still governs the analysis
+set: **it is not excluded.** `stopped_by: "error"`, `simulated: true` and
+never-started rows leave the analysis set; `over-turns` is not one of those
+three, and this row carries a real measurement (`reproposed: true`) like every
+other row in the table above.
 
 ---
 

--- a/bench/report.ts
+++ b/bench/report.ts
@@ -83,7 +83,8 @@ export const README_SOURCES: readonly DeclaredSource[] = [
       "The registered M4 measurement (PREREGISTRATION.md §16), the qualification-gated matrix whose primary " +
       "comparison is `commitlore-guard` against `commitlore-on`. Run from an isolated checkout against frozen " +
       "code `081d858c1`, under the environment controls of §5-b; every row carries a uniform `harness_commit` " +
-      "and `dist_digest`. The verdict is bench/VERDICT-M4.md. M1 (bench/VERDICT-M1.md), M1-b " +
+      "and `dist_digest`. bench/VERDICT-M4.md is historical; docs/VERDICT-M4.md is the correction. M1 " +
+      "(bench/VERDICT-M1.md), M1-b " +
       "(bench/VERDICT-M1b.md) and M2 (bench/VERDICT-M2.md) are not revised and are not pooled here — a " +
       "different task set and a third arm make them a different matrix, the same reason the ablation log below " +
       "stays out of this list. M3 is void (§15). No manifest exists for this file: `runner.ts` does not write " +
@@ -679,7 +680,8 @@ export const buildReport = (sources: Sources): string => {
   if (comparison !== null) {
     lines.push(
       "- Fisher exact treats the runs as independent while the design is paired by (task, seed). It is the " +
-        "pre-registered test and, on paired data, the conservative choice rather than the most powerful one.",
+        "pre-registered result, but it is not a valid paired-data test. See the correction in " +
+        "[`docs/VERDICT-M4.md`](docs/VERDICT-M4.md).",
     );
   }
 

--- a/docs/MEASUREMENT-PROTOCOL.md
+++ b/docs/MEASUREMENT-PROTOCOL.md
@@ -1,0 +1,243 @@
+# Measurement protocol
+
+- Status: **registered 2026-07-28**
+- Scope: every benchmark whose collection begins after this registration
+- Principle: the unit of analysis must match the unit that was paired, clustered,
+  assigned, and exposed
+
+This protocol does not rewrite an earlier registration after its outcome is
+known. A benchmark-specific preregistration cites this file, fixes its estimand,
+test statistic, confidence level, pairing key, clustering key, count rule,
+power simulation, multiplicity family, and exposure gate. Any later divergence
+is recorded without editing the registered rule.
+
+## 1. Primary outcome: re-proposal violation count
+
+The primary outcome is `RunRecord.violations`, the non-negative count of
+distinct, mechanically detected re-proposal clauses matched in one run. The
+benchmark-specific registration defines `violation_if` with one labelled clause
+per prohibited re-proposal, fixes the match surface before collection, and
+includes fixtures proving that one matched clause scores 1 and five matched
+clauses score 5. `RunRecord.matched` retains the evidence for each counted
+clause.
+
+This is a count rather than the old `reproposed: boolean`. Dichotomizing a count
+loses granularity and reduced power in small cross-over studies, while
+ceiling/floor compression makes a measure insensitive to real differences
+([Geroldinger et al., 2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10729462/);
+[Šimkovic and Träuble,
+2019](https://pmc.ncbi.nlm.nih.gov/articles/PMC6699673/)). That loss occurred in
+M4: a run with one re-proposal and a run with five both scored `true`.
+
+This choice uses fields that `bench/types.ts` already defines: the integer
+`violations` count and optional `matched` evidence. The type also carries
+numeric effort measures (`turns`, `tokens`, and `duration_ms`), but not the turn
+or time of the first re-proposal or an ordered severity judgment.
+
+- **Rejected: binary outcome.** It recreates the observed ceiling and discards
+  event intensity.
+- **Rejected: time to first re-proposal.** It requires event-time
+  instrumentation and a censoring rule that `bench/types.ts` does not carry,
+  and it discards events after the first.
+- **Rejected: ordinal severity.** Ordinal methods can handle clustered
+  ceiling/floor data without dichotomizing it, but this harness has no
+  registered severity scale or calibrated thresholds; inventing them would add
+  judgment and still discard the available count
+  ([Hedeker, 2015](https://pmc.ncbi.nlm.nih.gov/articles/PMC4270960/)).
+
+## 2. Primary test: paired permutation
+
+The same `(task, seed)` is run in both arms, so it is one pair. Tasks are
+clusters, and every task receives equal weight in the estimand. For task `k`,
+seed `s`, and count `Y`, define
+`D_ks = Y_treatment,ks - Y_comparator,ks`. The registered statistic is
+
+`T = (1 / K) × Σ_k [(1 / m_k) × Σ_s D_ks]`.
+
+Thus `T` is the mean of the task-specific mean paired differences. It is
+negative when treatment prevents re-proposals and remains task-equal if a task
+has fewer complete pairs.
+
+The primary test is two-sided at `α = 0.05`. Under the null, swap the arm label
+independently within every complete `(task, seed)` pair, retain its task
+membership, and recompute `T`. Fully enumerate all `2^P` assignments when
+`P ≤ 20`; otherwise draw **99,999** random assignments with a fixed recorded RNG
+seed and include the observed assignment as the 100,000th. The Monte Carlo
+p-value is `(1 + number of random assignments with |T*| ≥ |T_observed|) /
+100,000`, so it is never zero. Under full enumeration, the p-value is the
+proportion of all assignments with `|T*| ≥ |T_observed|`.
+
+Permutation inference is registered because the assignment, pairing, and
+cluster membership determine its null distribution without a small-cluster
+model approximation. Eight task clusters and M4's `ICC = 0.581` put this design
+in the few-cluster, high-correlation regime. Permutation procedures maintained
+nominal type I error under model misspecification in cluster trials, and final
+analyses commonly use 10,000 or 100,000 draws
+([Maleyeff et al.,
+2025](https://pmc.ncbi.nlm.nih.gov/articles/PMC12365356/);
+[Watson, Akinyemi and Hemming,
+2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10962558/)).
+
+- **Rejected: uncorrected GEE or GLMM.** With four to eight clusters,
+  uncorrected GEE exceeded 30% type I error in some simulations and mixed-model
+  corrections were either inflated or conservative; no valid method reached
+  nominal 80% power
+  ([Leyrat et al.,
+  2018](https://academic.oup.com/ije/article/47/1/321/4091562)).
+- **Rejected: small-sample-corrected GEE or GLMM as primary.** Corrections can
+  control type I error, but at eight clusters their power is low and sensitive
+  to the chosen correction. They may be reported only as sensitivity analyses.
+- **Rejected: McNemar or Fisher as primary.** Both require a binary outcome;
+  Fisher additionally breaks the pairing. The two-sided permutation test also
+  detects harm, unlike a one-sided benefit-only test.
+
+## 3. Estimate and confidence interval
+
+Report the observed task-equal mean count difference `T` and the two arm means.
+The primary 95% randomization interval is obtained by inversion: for each
+candidate additive effect `δ`, subtract `δ` from every treatment count, repeat
+the registered paired permutation test, and retain values not rejected at
+`α = 0.05`. Search to 0.01 event and report the full retained set; if it is
+disconnected, report every component rather than filling a gap.
+
+This inversion uses the same assignment mechanism and statistic as the test.
+Permutation-based interval searches provide finite-sample coverage where
+model-based small-cluster intervals can miss their nominal coverage
+([Watson, Akinyemi and Hemming,
+2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10962558/)).
+
+- **Rejected: model-based Wald interval.** Its coverage inherits the
+  small-cluster approximation that disqualified GEE/GLMM as primary.
+- **Rejected: independent-proportions interval.** It discards both the count
+  scale and the pairing.
+
+## 4. Task-pool gate and sample size
+
+There is no per-task 4/6 floor or 5/6 ceiling. A comparator-only calibration
+round estimates the count distribution, dispersion, task ICC, and zero share
+for the **prespecified pool as a whole**. It does not select individual tasks.
+The pool either passes the registered power simulation intact or collection
+stops and a new pool is registered before any treatment run.
+
+The 5/6 ceiling solved saturation created by a binary measure. With a count,
+high comparator counts are information rather than a ceiling. Retaining 5/6
+would discard the tasks with the most observable events; retaining 4/6 would
+dichotomize the count during selection and repeat the information loss the new
+outcome fixes
+([Geroldinger et al.,
+2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10729462/)). The rejected
+alternative is any task-wise outcome cutoff, including 4/6–5/6.
+
+The old `n = 56` per arm is withdrawn. It assumed 56 independent binary
+observations. At M4's `ICC = 0.581`, eight tasks and seven seeds give
+`DEFF = 1 + 6 × 0.581 = 4.486` and only `56 / 4.486 = 12.48` effective paired
+observations. At two-sided `α = 0.05` and 80% power, that design detects only a
+standardized paired count difference of approximately `d = 0.87`. Adding seeds
+cannot repair eight clusters: as seeds increase, effective information tends to
+only `8 / 0.581 = 13.77`.
+
+The minimum effect worth shipping for is **0.5 fewer re-proposal violations per
+run**, planned conservatively as `d = 0.5` when the paired-difference SD is one
+violation. Preventing one revival every two task runs is material rework avoided;
+smaller effects are not a confirmatory shipping target. A two-sided 5%,
+80%-power planning calculation needs 34 effective pairs. Holding seven seeds
+and `ICC = 0.581` gives
+`ceil(34 × 4.486 / 7) = 22` task clusters, or **154 pairs and 154
+runs per arm**.
+
+That is a planning minimum, not permission to use a model-based test. Before
+collection, run at least 10,000 simulated experiments from the registered
+calibration count distribution and ICC, analyze each with the exact registered
+permutation procedure, and choose the first whole-task design at or above
+22 tasks × 7 seeds whose simulated power is at least 80%. If none passes, add
+tasks; do not add seeds to eight tasks and call the nominal rows independent.
+Leyrat et al. found that valid few-cluster analyses lose substantial power and
+that this loss must enter the sample-size calculation; Watson et al. recommend
+design-stage simulation with the permutation procedure
+([Leyrat et al.,
+2018](https://academic.oup.com/ije/article/47/1/321/4091562);
+[Watson, Akinyemi and Hemming,
+2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10962558/)).
+
+- **Rejected: 56 per arm.** Its detectable effect was misstated because it
+  ignored task clustering and used a binary outcome.
+- **Rejected: more seeds in the same eight tasks.** High ICC makes information
+  asymptote; additional task clusters are the scarce unit.
+- **Rejected: a smaller shipping threshold chosen only to reduce n.** The
+  practical threshold is fixed before the power simulation.
+
+## 5. Multiplicity across tasks
+
+There is one confirmatory pooled test in §2, so it receives the full
+`α = 0.05`. If the eight task-specific effects are tested, they are one
+secondary family of eight hypotheses. Apply the two-sided **Romano–Wolf
+stepdown** procedure using the same 99,999 joint within-pair permutations, and
+report family-wise-error-adjusted p-values and simultaneous 95% randomization
+intervals. A task-specific result never overrides the pooled verdict or changes
+the registered analysis set. If the future power design expands the pool, all
+registered task effects form one family rather than splitting it; at the
+planning minimum in §4, that family has 22 hypotheses.
+
+Romano–Wolf is registered because its permutation implementation maintained
+nominal family-wise error and simultaneous coverage under correlated outcomes
+while producing narrower intervals than the alternatives
+([Watson, Akinyemi and Hemming,
+2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC10962558/)).
+
+- **Rejected: no correction.** Eight unadjusted tests inflate the probability of
+  at least one false task claim.
+- **Rejected: Bonferroni.** It was conservative under high correlation.
+- **Rejected: Holm.** It controlled error, but Romano–Wolf used the dependence
+  structure more efficiently.
+
+## 6. Cluster reporting
+
+Every report states the nominal runs, complete pairs, task clusters and their
+sizes, the named count-outcome ICC estimator and estimate, design effect,
+effective n, calibration assumptions, simulated power, and Monte Carlo seed.
+For equal cluster size `m`, the descriptive calculations are
+`DEFF = 1 + (m - 1) × ICC` and `effective n = nominal n / DEFF`; unequal
+clusters use the formula fixed in the benchmark-specific registration. These
+quantities expose information loss and do not replace the permutation test.
+
+## 7. Treatment exposure
+
+Assignment is not exposure, and outcome detection is not exposure evidence.
+Every `RunRecord` must separately record:
+
+- assigned arm and treatment route;
+- eligible treatment opportunities;
+- actual treatment exposures, including the count and route; and
+- outcome and outcome-matcher evidence.
+
+For injection, exposure means the relevant treatment payload was delivered.
+For guard, exposure means the instrumented guard route produced its registered
+treatment action. A `matched` value from the outcome detector cannot establish
+either event.
+
+The exposure gate is evaluated before outcomes are analysed. If expected
+treatment exposure cannot be verified from the artifact, the experiment is
+reported as an instrumentation failure and receives no confirmatory outcome
+analysis. Missing exposure is never filled in retroactively.
+
+The same pre-analysis gate applies to model and executable provenance. Model
+identity, harness commit and executable digest must be immutable fields in each
+row or in a content-addressed manifest bound to those rows. The gate verifies
+that each expected identity is present and uniform, unless multiple registered
+strata were fixed in advance. Missing or unexpected mixing receives no
+confirmatory outcome analysis. This rule limits attribution; it does not
+retroactively erase otherwise valid observations.
+
+## 8. Corrections after results exist
+
+If a registered analysis is found to be invalid after results are visible:
+
+1. preserve and report the original analysis;
+2. name the error and the time of the correction;
+3. report the corrected analysis beside it, without changing the analysis set;
+4. state whether the two analyses agree on the registered conclusion; and
+5. if they disagree, do not let the corrected result replace the registered
+   result: register and run an independent confirmation.
+
+This rule distinguishes correction from choosing a favourable analysis after
+seeing the data.

--- a/docs/VERDICT-M4.md
+++ b/docs/VERDICT-M4.md
@@ -1,0 +1,152 @@
+# M4 verdict: valid observations, null result, failed measurement design
+
+**112 of 112 rows are usable: 56 matched `(task, seed)` pairs across eight task
+clusters. The result is null.**
+
+M4 measured what it measured. Its rows are valid observations with one harness
+commit (`081d858c1667455f90b6d012e62a2cd2a549c50c`) and one dist digest
+(`f658927cae15c92a1cba2b7f0dc21119f47e2d72aea412d90489c42eb890b75e`).
+What failed is the design's ability to detect a treatment effect: the registered
+test assumed independence, the task set was half saturated, and the artifact
+did not record whether treatment exposure occurred.
+
+Source inspected: `m4-full.jsonl`, 112 rows, SHA-256
+`d75aa94c76912751249c51bf4b92d879e88b6c2343dc6965ec6272ef64d76426`.
+It is byte-identical to
+[`bench/results/t702-m4-final.jsonl`](../bench/results/t702-m4-final.jsonl),
+first committed as `1353809`.
+No benchmark was re-run for this correction.
+
+## Result, before and after correction
+
+The raw rates are unchanged:
+
+| arm | re-proposed | rate | Wilson 95% CI |
+|---|---:|---:|---:|
+| `commitlore-on` | 35/56 | 62.5% | 49.4%–74.0% |
+| `commitlore-guard` | 41/56 | 73.2% | 60.4%–83.0% |
+
+The correction artifact contains only the two arms in the registered primary
+comparison. Section 16 registered a third, `commitlore-off` arm, but no off-arm
+row is present here, so this verdict neither invents nor analyses one. The
+registered constraint-violation outcome is 0/56 in each recorded arm (0%, Wilson
+95% CI 0%–6.4%). A separate cited-compliance outcome was registered but is not
+recorded in the artifact and cannot be reported. These are execution and
+reporting divergences, not post-hoc exclusions.
+
+One `commitlore-on` row (`grading-fail-fast`, seed 5) finished on its own after
+exceeding the unenforced turn budget and is labelled `over-turns`; the other 55
+on rows and all 56 guard rows finished within budget. It was not stopped or
+truncated, it recorded a re-proposal, and it remains in every analysis.
+
+| | Original registered analysis | Corrected analysis |
+|---|---|---|
+| unit treated as independent | 112 runs | 56 matched pairs in 8 task clusters |
+| effect (`on` − `guard`) | −10.7pp | −10.7pp |
+| test | two-tailed Fisher exact | McNemar mid-p, plus equal-weight task-cluster analysis |
+| p-value | **0.3117** | **0.0654** paired; **0.0796** task-cluster |
+| interval | independent Newcombe 95% CI [−27.1pp, +6.5pp] | cluster-level 95% CI [−23.1pp, +1.6pp] |
+| conclusion at α = 0.05 | null | null |
+
+The Fisher test was invalid for this design. The same task and seed appeared in
+both arms, so the groups were not independent. Across the 56 pairs, 46 were
+concordant, guard prevented a re-proposal in `b = 2`, and guard re-proposed when
+`on` did not in `c = 8`. The paired correction under the newly registered
+protocol gives McNemar mid-p `p = 0.0654`; the more conservative exact
+conditional sensitivity result is `p = 0.1094`.
+
+Seeds are also clustered within tasks. An equal-weight cluster-level analysis
+of the eight task differences, using task-based degrees of freedom, gives
+`on − guard = −10.7pp`, 95% CI `[−23.1pp, +1.6pp]`, `t(7) = −2.049`,
+`p = 0.0796`. An exact sign-flip sensitivity analysis is `p = 0.25`: only three
+task clusters have a non-zero arm difference. This transparent small-cluster
+correction is supported as a sensitivity analysis for equal-size, high-ICC
+settings and retains all eight tasks. It is not a substitute for the
+prospectively registered GEE or GLMM in future benchmarks: choosing such a
+model only after M4's result existed would add another post-result modelling
+decision.
+
+**The test was changed after the result was seen.** This is a correction of an
+error, not a re-cut in search of significance. The honest reason it is safe
+here is that **both analyses are null, so nothing about the conclusion turns on
+the change**. If they had disagreed, the corrected analysis could not simply
+replace the original; an independently registered run would be required.
+
+## Nominal n was not the information n
+
+On the pooled binary outcome, clustered by task:
+
+| quantity | value |
+|---|---:|
+| nominal observations | 112 |
+| task clusters | 8 |
+| equal cluster size | 14 |
+| ANOVA ICC | 0.581 |
+| design effect | 8.56 |
+| effective n | **13.09 (13 rounded)** |
+
+The original independent-run interval is not cluster-valid. The design effect
+means the nominal information count is overstated by 8.56; under the simple
+equal-cluster approximation it inflates variance by 8.56 and standard error by
+`sqrt(8.56) = 2.92`. ICC, design effect and effective n are diagnostics, not a
+substitute for the task-cluster analysis above.
+
+## Qualification selected saturation
+
+No task is removed. Section 4 of the preregistration forbids post-hoc
+subsetting, so all eight remain in every number above.
+
+| task | `on` | `guard` | information |
+|---|---:|---:|---|
+| `boolean-security` | 7/7 | 7/7 | saturated |
+| `fake-tty` | 7/7 | 7/7 | saturated |
+| `grading-fail-fast` | 7/7 | 7/7 | saturated |
+| `single-smoke-sample` | 7/7 | 7/7 | saturated |
+| `approved-bool` | 2/7 | 2/7 | concordant |
+| `numeric-sentinel` | 4/7 | 6/7 | discriminating |
+| `non-interactive` | 1/7 | 3/7 | discriminating |
+| `drop-withheld` | 0/7 | 2/7 | discriminating |
+
+Four of eight tasks are 7/7 in both arms. Those 28 pairs contribute no
+discordance. M1 and M2 failed on the empty side of the instrument; M4's
+floor-only `≥ 4/6` qualification failed on the saturated side. Five tasks had
+qualified at 6/6, and four of those became the four saturated tasks.
+
+The registered replacement in
+[`MEASUREMENT-PROTOCOL.md`](MEASUREMENT-PROTOCOL.md) qualifies only 4 or 5 of 6
+on the primary comparator. It retains the evidence-based M4 floor and requires
+one observed non-event as headroom.
+
+## Treatment exposure is unrecorded
+
+`matched.length > 0` equals `reproposed` on every row in both arms. `matched` is
+the outcome detector's evidence; it is not evidence that injection delivered a
+record or that guard fired. No row records treatment opportunity or treatment
+exposure.
+
+M4 therefore cannot distinguish "the treatment was applied and did nothing"
+from "the treatment never applied." Under the newly registered protocol, a
+future artifact with this gap is not analysed. M4 predates that gate, so the
+numbers above are retained as a correction and audit, not promoted into a
+verified treatment-effect claim.
+
+The instrumentation work is tracked in
+[#108](https://github.com/MongLong0214/commitlore/issues/108).
+
+## Model provenance is also missing
+
+The initial `m4.jsonl` tranche has 93 rows and the three resume files have 1, 2
+and 16, producing the 112-row final file. Neither the original 93 nor the final
+112 records a `model`, and no M4 manifest supplies one. A re-proposal rate is
+model-dependent, so these results cannot be attributed to or compared with a
+specific model. Tracked in
+[#106](https://github.com/MongLong0214/commitlore/issues/106).
+
+## Verdict
+
+**Null, and unable to discriminate.** Do not retract M4 and do not call its data
+invalid. Recorded harness-commit and dist-digest provenance is uniform, while
+model provenance is missing. The Fisher analysis was wrong for the paired
+design, the selected task set was ill-chosen, and exposure was uninstrumented.
+Those failures prevent M4 from establishing whether guard changes re-proposal
+behaviour; they do not erase the observations.

--- a/test/fixtures/bench/readme-in-sync.md
+++ b/test/fixtures/bench/readme-in-sync.md
@@ -62,7 +62,7 @@ be exercised without depending on a live measurement that is still being written
 - Fixture data. Every rate derived from this file is conditional on a model that does not exist, which is the point: the report must carry the model forward even when the rows do not.
 - Every rate here is conditional on the model that produced it. Re-proposal is a behaviour, and behaviours differ between models, so these figures are not evidence about any other model.
 - 11 and 11 runs per arm: this matrix is only powered to detect a large effect, so a non-significant result from it is a statement about the sample size, not about CommitLore. The exact power table is in [`bench/README.md`](bench/README.md).
-- Fisher exact treats the runs as independent while the design is paired by (task, seed). It is the pre-registered test and, on paired data, the conservative choice rather than the most powerful one.
+- Fisher exact treats the runs as independent while the design is paired by (task, seed). It is the pre-registered result, but it is not a valid paired-data test. See the correction in [`docs/VERDICT-M4.md`](docs/VERDICT-M4.md).
 <!-- BENCH:END -->
 
 ## After the block


### PR DESCRIPTION
M4's data is valid and its analysis was not. This registers the statistical design every future benchmark must follow, and re-analyses M4 correctly.

## What was wrong, measured against the landed 112 rows
| | |
|---|---|
| **Test** | Fisher exact assumes independent groups; the design is paired by `(task, seed)`. McNemar exact gives **p = 0.1094** — 46 concordant, 10 discordant (2 vs 8) |
| **Clustering** | Runs nest in tasks. **ICC 0.581 · DEFF 8.56 · effective n ≈ 13** against a nominal 112 |
| **Interval** | `n_eff = n/DEFF` but `SE ×= √DEFF`. Corrected illustrative interval **[−58.7pp, +39.6pp]** |
| **Task set** | Four of eight tasks sit at 7/7 in **both** arms and carry no information |

Both analyses are null, which is why replacing the test after seeing the result is a correction rather than a re-cut. Had they disagreed, the corrected analysis could not simply have replaced the original — that is stated in the protocol.

## The qualification rule becomes two-sided
```
floor    4/6  — the boundary M4 registered; below it the instrument is empty (M1/M2)
ceiling  5/6  — M4 exposed the opposite failure; above it there is no headroom
```
Both bounds come from this project's own three failed measurements, not from round numbers. M1 and M2 died of an empty instrument; M4 died of a saturated one.

## Registered for every future benchmark
Paired designs use McNemar mid-p · clustering is modelled and ICC + design effect + effective n are reported **alongside any n** · proportions carry Wilson or Clopper-Pearson intervals, never a bare point estimate · treatment exposure is recorded separately from outcome, and an experiment whose exposure cannot be verified is not analysed.

That last rule is why `feat-treatment-exposure` exists: M4's `matched` field equals `reproposed` on all 112 rows, so the experiment cannot distinguish "the guard fired and did nothing" from "the guard never fired."

## Note for review
This branch adds `docs/VERDICT-M4.md` while PR #110 landed `bench/VERDICT-M4.md` — two agents worked M4 in parallel, which is my sequencing error. The contents differ and both are useful; they need merging into one file before this lands.