### PR TITLE
README: position CommitLore as Git-native decision memory

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore: コミット 4842356 の記録 r-2b58d4 は [claim] と評価され、guard は MATCH を返す">
+  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore: Git は何が変わったかを記憶し、CommitLore はなぜ変わったかを記憶する。新しいエージェントも除外された代案と理由を読む。">
 </p>
 
 <p align="center">
@@ -14,31 +14,122 @@
 
 # CommitLore
 
-CommitLore は、判断の背景を Git のコミット trailer と `refs/notes/commitlore` に保存するプロトコルです。
-主役はプロトコルであり、CLI は記録を検証・ルーティングして shell、hook、MCP クライアントへ渡します。
-コーディングエージェントを改善することは実証されていません。
+## Git は何が変わったかを記憶する。CommitLore はなぜ変わったかを記憶する。
 
-## インストール
+**AI 支援コードベースのための Git-native decision memory。** CommitLore は、コード変更の背後にある制約、除外した代案、警告、検証の空白を Git に直接記録します。開発者やコーディングエージェントは、何を変える前にもなぜこうなっているかを理解できます。
 
-インストールは一度、リポジトリごとにもう一度 — 一つのコマンドに収まらないのは意図的です。以下の hook と index はリポジトリごとの状態であり、まだ見たことのないリポジトリのためにマシン全体のインストールがあらかじめ用意しておけるものではありません（[ADR-0011](docs/adr/ADR-0011-plugin-first-distribution.md)）。
+ホスト型メモリサービスも、ベンダー固有のチャット履歴もありません。リポジトリと共に移動する、レビュー可能な意思決定コンテキストだけです。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
 ```
 
-このマシン向けに checksum を検証済みのリリースバイナリをダウンロードします — Node は不要です（[ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)）。そのうえで `commitlore` コマンドを `PATH` に通します。続けて、このマシンにインストールされているコーディングエージェントを検出します — Claude Code、Codex、Gemini CLI、Cursor、Windsurf、opencode。見つかったエージェントそれぞれに CommitLore の MCP サーバー（Claude Code の場合はプラグイン）を接続します。既存の設定ファイルはその旨を伝えずに上書きすることはなく、インストールされていないエージェント向けの設定を作ることもありません。何を接続し、何をスキップしたかをそのまま出力します。
+検証フックとローカル index を使う各リポジトリで、続けて `commitlore init` を実行します。installer は対応するコーディングエージェントを検出し、安全に可能な場所でローカル MCP server を登録します。
 
-続けて、CommitLore を使いたい各リポジトリの中で:
+この一行は利便性のためです。レビュー済みまたは固定されたインストールが必要なら、まず `install.sh` をダウンロードして確認するか、リポジトリを clone するか、リリース資産を手動でダウンロードして `SHA256SUMS` を検証してください。スクリプトはダウンロードするバイナリのチェックサムを検証しますが、すでに `sh` に渡したスクリプト自体を認証するものではありません。
 
 ```bash
-commitlore init
+# installer を固定してダウンロードし、確認してから実行します。
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.2.0/install.sh
+sh install.sh v0.2.0
+
+# または release binary を自分で検証してから展開します。
+version=0.2.0; target=aarch64-apple-darwin
+curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
+curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
+grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
 ```
 
-そのリポジトリに commit-msg 検証 hook をインストールし、ローカルの記録 index を構築します。何を行ったかを報告し、再実行しても安全です — すでに設定済みのリポジトリはその旨を報告するだけで、何も変更しません。
+## 実際に動かす
 
-プロトコルを読むだけならインストールは不要です。記録はどれも普通の git trailer だからです（[後述](#一つの記録)）。`sh` にスクリプトを流し込む代わりに、Node での clone、ソースからの build、手動で検証したダウンロードを使いたい場合は、[clone からインストール](#clone-からインストール)に三つとも書いてあります。
+**新しいエージェント、チャット履歴はゼロ。それでも明白な修正案がなぜ除外されたかを知っています。** この checkout で、`install.sh` に対する実際の Claude `PreToolUse` payload を同じ hook path に送ります。
 
-## 測定の記録
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+応答には、installer の欠陥の修正として `-musl` target を公開する案を除外した active record とその理由が含まれます。hook はコンテキストを返すものであり、編集を止めるとは主張しません。
+
+```console
+Ruled-out:
+  [claim] r-instci99a ... publishing a `-musl` release target |
+  a release.yml/build-matrix change, not an install.sh or CI-verification fix
+```
+
+## 違い
+
+- **CLAUDE.md はエージェントに作業方法を伝える。CommitLore はこのコードがなぜ存在するかを伝える。**
+- **ADR はアーキテクチャを文書化する。CommitLore は diff の中に隠れた意思決定を文書化する。**
+- **もう一つの memory database ではない。Git に組み込まれた decision protocol です。**
+
+権威ある原本は通常の commit trailer と `refs/notes/commitlore` です。index と report はこれらの Git record から派生し、再構築できます。
+
+## 一つの記録
+
+この例は conformance fixture でもあります。Git trailer parser は、すべての翻訳 README で下の code block を同じように読みます。
+
+```text
+Prevent silent session drops during long-running operations
+
+The auth service returns inconsistent status codes on token
+expiry, so the interceptor catches all 4xx responses and
+triggers an inline refresh.
+
+Limit: Auth service does not support token introspection
+Record-Id: r-4b7e21
+Ruled-out: Extend token TTL to 24h | security policy violation
+Ruled-out: Background refresh on timer | race condition
+Certainty: firm
+Blast: module
+Undo: easy
+Warn: 4xx handling is intentionally broad
+  -- do not narrow without verifying upstream behavior
+Verified: Single expired token refresh (unit)
+Unverified: Auth service cold-start > 500ms behavior
+CommitLore-Version: 2.0.0
+```
+
+### Protocol vocabulary
+
+| Trailer | Meaning |
+|---|---|
+| `Limit:` | External condition that constrained the decision |
+| `Record-Id:` | Stable identity across rewritten commit hashes |
+| `Ruled-out:` | `alternative \| reason` |
+| `Certainty:` | `firm` \| `tentative` \| `guess` |
+| `Blast:` | `local` \| `module` \| `system` |
+| `Undo:` | `easy` \| `costly` \| `permanent` |
+| `Warn:` | Warning for a future modifier; trust-graded before delivery |
+| `Verified:` / `Unverified:` | What was and was not checked |
+| `Follows:` / `Supersedes:` | Decision-chain and lifecycle links |
+| `Expires:` | Date or condition that ends a limit |
+| `Evidence:` | Path, anchor, or URL supporting a claim |
+| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
+| `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
+
+path の履歴は `commitlore context <path>` で読み、Git を直接使うこともできます。
+
+```bash
+git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
+```
+
+text search ではなく Git trailer parser を使います。本文の `Key:` は trailer とは限りません。
+
+## リポジトリが証明すること
+
+- テスト済みの Git workflow では、意思決定の履歴は rebase、squash、remote transfer、path rename を経ても残る。
+- すべての route は同じ trust grading を使い、信頼されない text は instruction ではなく information として渡す。
+- free-form trailer 内の injection に似た text は model-readable route から保留される。
+- 読める repository に record がない状態は、不完全な history や fetch されていない notes mirror と区別される。
+
+これは Git に結び付けられ、人間が検証できる意思決定履歴についての製品上の主張です。CommitLore が agent performance を改善するという主張には依存しません。
+
+## Evidence: 112 回の実験、null の結果
+
+> **AI tool を作り、112 回実験した。結果は null だった。**
+
+これは製品の信頼モデルの一部なので脚注に隠しません。M4 は測定した agent behavior で裏付けられる効果を見つけませんでした。その後、paired・clustered design を反映して分析を修正し、記録された算術エラーも訂正しました。全ての限界は [M4 verdict](bench/VERDICT-M4.md)、その結果から導いた製品上の主張は [roadmap](docs/ROADMAP-TO-DONE.md) で読めます。
 
 <!-- BENCH:BEGIN -->
 <!-- Generated by `node bench/report.ts --section` from the result logs named below. Do not edit by hand:
@@ -64,17 +155,7 @@ commitlore init
 
 **Analysis set — all 112 rows.** Nothing was excluded: no simulated rows, no failed runs, no run that never started.
 
-**Significance:**
-
-| Quantity | Value |
-|---|---|
-| Arms | `commitlore-on` (treatment) vs `commitlore-guard` (baseline) |
-| Re-proposed / did not | `commitlore-on` 35/21, `commitlore-guard` 41/15 |
-| Fisher exact, two-tailed | p = 0.3117 |
-| Rate difference, treatment minus baseline | -10.7pp, 95% CI [-27.1pp, 6.5pp] |
-| Odds ratio | 0.6098 |
-| Paired (task, seed) cells | 56 |
-| Rows excluded from the analysis set | 0 |
+**Significance:** not computed — guard exposure is unknown for 112 analysis rows
 
 **How the runs ended** — failures are reported, not filtered:
 
@@ -87,190 +168,26 @@ commitlore init
 
 - No model is recorded — neither on the rows nor in a manifest. A re-proposal rate whose model is unknown is not a comparable number, and these figures must not be quoted against another model's.
 - Every rate here is conditional on the model that produced it. Re-proposal is a behaviour, and behaviours differ between models, so these figures are not evidence about any other model.
-- 56 and 56 runs per arm: this matrix is only powered to detect a large effect, so a non-significant result from it is a statement about the sample size, not about CommitLore. The exact power table is in [`bench/README.md`](bench/README.md).
-- Fisher exact treats the runs as independent while the design is paired by (task, seed). It is the pre-registered test and, on paired data, the conservative choice rather than the most powerful one.
+- 112 runs in the analysis set: this matrix is only powered to detect a large effect, so a non-significant result from it is a statement about the sample size, not about CommitLore. The exact power table is in [`bench/README.md`](bench/README.md).
 <!-- BENCH:END -->
 
-登録済みの仮説 ── 記録された決定を見られるエージェントは、却下された案の再提案が減る ── は、これまでのどの測定でも裏付けられていません。M1、M1-b、M2 はほぼ沈黙したタスク集合（10 タスク中 7 つで control 群の再提案が一度もなかった）でヌルとなり、その後の実行 M3 は、実行中にテスト対象のバイナリが変わったため無効になりました（[`PREREGISTRATION.md` §15](bench/PREREGISTRATION.md#15-m3-is-void-the-binary-under-test-changed-while-it-ran)）。
+## source からインストール
 
-M4 はその診断に的を絞って設計しました。各タスクの control 群の基準率だけで、treatment 群を走らせるかどうかを決める qualification ラウンドを先に通します。M4 で通過した 8 タスクはすべて両群で再提案が起き、上記の結果は依然としてヌルです。この数値は、すべての行にハーネスのコミットとバンドルバイナリのダイジェストを記録した、このプロジェクト初のデータセットである [`bench/results/t702-m4-final.jsonl`](bench/results/t702-m4-final.jsonl) から生成しています。日付付きの判定文書は各実行が下した結論の記録です: [`VERDICT-M1.md`](bench/VERDICT-M1.md)、[`VERDICT-M1b.md`](bench/VERDICT-M1b.md)、[`VERDICT-M2.md`](bench/VERDICT-M2.md)、[無効実行の記録](bench/PREREGISTRATION.md#15-m3-is-void-the-binary-under-test-changed-while-it-ran)、[`VERDICT-M4.md`](bench/VERDICT-M4.md)。詳細は [`bench/README.md`](bench/README.md) にあります。
-
-## リポジトリが実際に証明していること
-
-- **記録は通常の Git ワークフローを生き残ります。** コミット trailer と notes mirror は、[rebase と squash](test/squash.test.ts)、[履歴の書き換えと remote 間の転送](test/notes.test.ts)、[一段・多段の rename](test/follow.test.ts)でテストされています。
-- **信頼の意味は全ルートで共通です。** query 出力、CLI injection、編集 hook、MCP tool、guard は同じ `directive | claim | blocked` グレードを使います。ルート検証は [`query.test.ts`](test/query.test.ts)、[`inject.test.ts`](test/inject.test.ts)、[`mcp.test.ts`](test/mcp.test.ts)、[`guard.test.ts`](test/guard.test.ts) にあります。
-- **同梱のインジェクションスキャナーに一致した記録は、文章としてモデルへ届きません。** どれか一つの自由記述 trailer が一致すると、その記録全体が `blocked` になり、モデルが読むルートは内容を引用せず保留した事実だけを伝えます。この決定論的な語彙フィルターの結果は、実環境での検出率を示すものではありません。[パターン作成者による corpus、独立作成 corpus、無害 corpus](spec/fixtures/injection/README.md) は別々に報告します。CLI と hook は [`inject.test.ts`](test/inject.test.ts)、MCP の同一回答は [`mcp.test.ts`](test/mcp.test.ts) が検証します。
-- **不明と空は別です。** 読み取り可能で記録がないリポジトリでは guard は `0` で終了します。壊れた Git は `history: unavailable`、未取得の notes mirror は `notes: unfetched` と報告します。どちらの不完全な検査も `3` で終了します。この契約は [`notes-availability.test.ts`](test/notes-availability.test.ts)、[`guard.test.ts`](test/guard.test.ts)、[`RELEASE-GATE`](docs/RELEASE-GATE.md) に固定されています。
-
-## 一つの記録
-
-この例は conformance fixture でもあります。Git の trailer parser は、全言語の README でこのブロックをバイト単位で同じように読む必要があります。
-
-```text
-Prevent silent session drops during long-running operations
-
-The auth service returns inconsistent status codes on token
-expiry, so the interceptor catches all 4xx responses and
-triggers an inline refresh.
-
-Limit: Auth service does not support token introspection
-Record-Id: r-4b7e21
-Ruled-out: Extend token TTL to 24h | security policy violation
-Ruled-out: Background refresh on timer | race condition
-Certainty: firm
-Blast: module
-Undo: easy
-Warn: 4xx handling is intentionally broad
-  -- do not narrow without verifying upstream behavior
-Verified: Single expired token refresh (unit)
-Unverified: Auth service cold-start > 500ms behavior
-CommitLore-Version: 2.0.0
-```
-
-### プロトコル語彙
-
-| Trailer | 意味 |
-|---|---|
-| `Limit:` | 判断を制約した外部条件 |
-| `Record-Id:` | コミット hash が書き換わっても維持される識別子 |
-| `Ruled-out:` | `代案 \| 採用しなかった理由` |
-| `Certainty:` | `firm` \| `tentative` \| `guess` |
-| `Blast:` | `local` \| `module` \| `system` |
-| `Undo:` | `easy` \| `costly` \| `permanent` |
-| `Warn:` | 将来の変更者への警告。配信前に信頼グレードを適用 |
-| `Verified:` / `Unverified:` | 確認したこと・していないこと |
-| `Follows:` / `Supersedes:` | 判断チェーンと lifecycle の link |
-| `Expires:` | 制約が終わる日付または条件 |
-| `Evidence:` | claim を裏付ける path、anchor、URL |
-| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
-| `CommitLore-Version:` / `X-*:` | プロトコル識別子と拡張 |
-
-完全な契約は [`spec/SPEC.md`](spec/SPEC.md) にあります。
-
-## 信頼は badge ではなく routing
-
-コミット `4842356` には次の active record があります。
-
-```gitcommit
-Ruled-out: exempting datasets written before the fields existed | it is one line and it deletes the guarantee
-Warn: this leaves the README with no measured numbers at all until M3-b runs. That is the honest state and it is also a worse first impression. The alternative was publishing numbers produced by a binary nobody recorded
-Record-Id: r-2b58d4
-Provenance: authored
-```
-
-同じ `Warn:` がグレードにより次のようにルーティングされます。
-
-| グレード | 条件 | モデルが読むルートの出力 |
-|---|---|---|
-| `[directive]` | `Provenance: authored`、active record、このリポジトリで明示的に信頼された author | 警告を指示として渡す |
-| `[claim]` | trusted author なし、外部 author、または reconstructed/unknown provenance | 「指示ではない」と明記した情報として渡す |
-| `blocked` | 自由記述 trailer がインジェクションパターンに一致 | 保留通知だけを渡し、一致した内容は描画しない |
-
-既定では誰も trusted author ではありません。暗号学的な author 検証は未実装で、[issue #28](https://github.com/MongLong0214/commitlore/issues/28) で追跡しています。
-
-## clone からインストール
-
-CommitLore の registry package はありません。配布チャネルは Git リポジトリそのものです（[ADR-0011](docs/adr/ADR-0011-plugin-first-distribution.md)）。CLI には Node.js 22 以上が必要です。
+source distribution を確認または実行するには次を使います。
 
 ```bash
 git clone https://github.com/MongLong0214/commitlore ~/.commitlore
-node ~/.commitlore/dist/commitlore.mjs --version
 node ~/.commitlore/dist/commitlore.mjs init
 node ~/.commitlore/dist/commitlore.mjs context src/auth
 ```
 
-`init` は `doctor --fix`・`hooks install`・`index --rebuild` をまとめて実行し、何を行い何ができなかったかを報告し、再実行しても安全です — 自分では解決できない `warn` や `fail` は成功メッセージに紛れ込ませず、そのまま報告します。三つを個別に使いたい場合は `commitlore doctor`・`commitlore hooks install`・`commitlore index --rebuild` もそれぞれ残っています。
+## 既知の制限事項
 
-コミット済み bundle は build なしで、`node_modules` なしで動きます。SQLite index は Node 本体に同梱された `node:sqlite` を使うため（[ADR-0012](docs/adr/ADR-0012-drop-the-native-dependency.md)）、clone だけで index の構築も query もできます — native module も compiler も `npm install` も不要です。`--no-index` は index を使わず Git だけで答えたいときのために残っています。
-
-### Node なしでコンパイル済みバイナリとして実行
-
-`git clone` + Node runtime が引き続き正式なインストール方法です。Node が PATH に全くないマシン向けに、同じ clone から単一のコンパイル済み実行ファイルを build できます（[ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)）:
-
-```bash
-cd ~/.commitlore
-npm ci
-npm run build:binary
-./dist/commitlore --version
-./dist/commitlore doctor
-```
-
-`dist/commitlore` は実行時に Node も interpreter も `node_modules` も不要です — `doctor`、`validate`、`context`、`guard`、`inject`、`index --rebuild` はすべて `PATH=/usr/bin:/bin` で動作します。commit はされません（サイズが大きく、platform・architecture 固有で、diff ではなく CI が push のたびに再 build するため）。`commitlore hooks install` と plugin の `PreToolUse` hook はどちらも build 済みならこれを自動的に解決します。
-
-### 事前ビルド済みリリースバイナリをインストール
-
-Node も clone もないマシン向け: すべての `vX.Y.Z` タグは platform ごとに 1 つずつバイナリを build し（`.github/workflows/release.yml`）、それら全体をカバーする `SHA256SUMS` を添付し、各 asset を [`actions/attest-build-provenance`](https://github.com/MongLong0214/commitlore/attestations) で証明します（Sigstore ベース、公開検証可能、本プロジェクトが管理する鍵はありません）。
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
-```
-
-`install.sh` は OS と architecture を検出し、同じ release から対応する asset と `SHA256SUMS` をダウンロードし、インストール前に checksum を検証します — 他のインストールスクリプトと同様、`sh` にパイプする前に中身を読んでください。バージョンを固定するには: `sh install.sh v0.2.0`。公開されている target: `aarch64-apple-darwin`、`x86_64-apple-darwin`、`x86_64-unknown-linux-gnu`、`aarch64-unknown-linux-gnu`。Windows バイナリはまだありません — SEA build と commit-msg hook shim がそちらで未検証のためです。[ADR-0015](docs/adr/ADR-0015-single-executable-binary.md) 参照。
-
-バイナリが配置されると、同じスクリプトがこのマシンにインストールされているコーディングエージェントを検出し（Claude Code、Codex、Gemini CLI、Cursor、Windsurf、opencode）、見つかったエージェントそれぞれに CommitLore の MCP サーバー（Claude Code の場合はプラグイン）を接続し、何を接続し何をスキップしたかを出力します。既存の設定ファイルはその旨を伝えずに上書きすることはなく、インストールされていないエージェント向けの設定を作ることもありません。
-
-シェルへのパイプが唯一の文書化された方法であってはいけません。同じインストールを手動で行う場合:
-
-```bash
-version=0.2.0   # または: curl -fsSL https://github.com/MongLong0214/commitlore/releases/latest/download/SHA256SUMS | head -1
-target=aarch64-apple-darwin   # または x86_64-apple-darwin | x86_64-unknown-linux-gnu | aarch64-unknown-linux-gnu
-
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
-
-# 展開する前に検証します。「OK」でなければここで止めてください — この検証に失敗したバイナリは実行しないでください。
-grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c -   # Linux: sha256sum -c -
-
-tar -xzf "commitlore-$version-$target.tar.gz"
-./commitlore --version
-```
-
-## GitHub Actions
-
-query、guard、inject を実行する job は全 history を取得する必要があります。
-
-```yaml
-- uses: actions/checkout@v4
-  with:
-    fetch-depth: 0
-```
-
-MCP client には同じ clone の entry point を登録します。
-
-```json
-{
-  "mcpServers": {
-    "commitlore": {
-      "command": "node",
-      "args": ["/absolute/path/to/commitlore/dist/commitlore.mjs", "mcp"]
-    }
-  }
-}
-```
-
-`install.sh` はマシンに既にインストールされている対応クライアント（Codex、Gemini CLI、Cursor、Windsurf、opencode）それぞれに、これと同等のブロックを自動で書き込みます — 検出できなかったクライアントや CI 向けには、これをそのまま使ってください。
-
-プロトコルを読むだけなら CLI は不要です。
-
-```bash
-git log --format='%(trailers:key=Ruled-out,valueonly,separator=%x3B)'
-git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
-```
-
-text search ではなく Git の trailer parser を使ってください。文章中の `Key:` は trailer block とは限りません。
-
-## まだ行わないこと
-
-- author の暗号学的検証: [#28](https://github.com/MongLong0214/commitlore/issues/28)
-- リポジトリ全体の record coverage 集計: [#32](https://github.com/MongLong0214/commitlore/issues/32)
-- path ではなく symbol への anchor: [#33](https://github.com/MongLong0214/commitlore/issues/33)
-- 対話型 commit builder と自動 expiry 通知: [#34](https://github.com/MongLong0214/commitlore/issues/34)
-- 有効な benchmark による guard の行動効果の実証: [#37](https://github.com/MongLong0214/commitlore/issues/37)
+- Windows は未対応です: [#95](https://github.com/MongLong0214/commitlore/issues/95)。
+- Alpine および他の musl Linux host は未対応です: [#99](https://github.com/MongLong0214/commitlore/issues/99)。
+- cryptographic author verification、repository-wide record coverage、symbol anchor、interactive record builder は未実装です: [#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
+- benchmark は agent behavior に対する guard の効果を実証していません: [#37](https://github.com/MongLong0214/commitlore/issues/37)。
 
 ## コントリビュート
 
-[spec](spec/SPEC.md)、[ADR](docs/adr/)、[`CONTRIBUTING.md`](CONTRIBUTING.md) を先に読んでください。このリポジトリは自身の判断を記録しているため、ファイルを変更する前に `commitlore context <path>` を実行します。
-
-## ライセンス
-
-[MIT](LICENSE)
+[spec](spec/SPEC.md)、[ADR](docs/adr/)、[`CONTRIBUTING.md`](CONTRIBUTING.md) を読んでください。CommitLore は [MIT License](LICENSE) の下で永久に無料のオープンソースです。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore: 커밋 4842356의 기록 r-2b58d4는 [claim] 등급이며 guard는 MATCH를 반환한다">
+  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore: Git은 무엇이 바뀌었는지 기억하고, CommitLore는 왜 바뀌었는지 기억한다. 새 에이전트도 제외한 대안과 그 이유를 본다.">
 </p>
 
 <p align="center">
@@ -14,31 +14,122 @@
 
 # CommitLore
 
-CommitLore는 결정 맥락을 Git 커밋 trailer와 `refs/notes/commitlore`에 보관하는 프로토콜이다.
-프로토콜이 먼저이고, CLI는 기록을 검증하고 라우팅해 셸·훅·MCP 클라이언트에 제공한다.
-코딩 에이전트를 더 낫게 만든다는 것은 입증되지 않았다.
+## Git은 무엇이 바뀌었는지 기억합니다. CommitLore는 왜 바뀌었는지 기억합니다.
 
-## 설치
+**AI 보조 코드베이스를 위한 Git-native decision memory.** CommitLore는 코드 변경 뒤의 한계, 제외한 대안, 경고, 검증 공백을 Git에 직접 기록한다. 그래서 개발자와 코딩 에이전트는 무엇을 바꾸기 전에 왜 이렇게 되었는지 이해할 수 있다.
 
-설치는 한 번, 저장소마다 한 번 — 딱 한 명령으로 끝나지 않는 이유가 있다: 아래의 훅과 인덱스는 저장소별 상태이고, 아직 본 적 없는 저장소를 위해 머신 전역 설치가 미리 만들어 둘 수 있는 것이 아니다([ADR-0011](docs/adr/ADR-0011-plugin-first-distribution.md)).
+호스팅 메모리 서비스도, 벤더 전용 채팅 기록도 없다. 저장소와 함께 이동하는, 검토 가능한 결정 맥락만 있다.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
 ```
 
-이 머신에 맞는, checksum까지 검증된 release 바이너리를 내려받는다 — Node가 필요 없다([ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)). 그리고 `commitlore` 명령을 `PATH`에 등록한다. 이어서 이 머신에 설치된 코딩 에이전트를 감지한다 — Claude Code, Codex, Gemini CLI, Cursor, Windsurf, opencode. 감지된 각 에이전트에는 CommitLore의 MCP 서버(Claude Code는 플러그인)를 연결한다. 기존 설정 파일은 알리지 않고 덮어쓰지 않으며, 설치되지 않은 에이전트를 위한 설정은 만들지 않는다. 무엇을 연결했고 무엇을 건너뛰었는지 그대로 출력한다.
+검증 훅과 로컬 인덱스를 쓸 각 저장소에서 이어서 `commitlore init`을 실행한다. 설치기는 지원되는 코딩 에이전트를 감지하고, 안전하게 가능한 곳에 로컬 MCP 서버를 등록한다.
 
-그다음, CommitLore를 쓸 각 저장소 안에서:
+한 줄 명령은 편의를 위한 것이다. 검토하거나 고정한 설치가 필요하면 먼저 `install.sh`를 내려받아 살펴보거나, 저장소를 clone하거나, 릴리스 자산을 직접 내려받아 `SHA256SUMS`를 검증한다. 스크립트는 내려받는 바이너리의 체크섬을 검증하지만, 이미 `sh`로 전달한 스크립트를 인증하지는 않는다.
 
 ```bash
-commitlore init
+# 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.2.0/install.sh
+sh install.sh v0.2.0
+
+# 또는 릴리스 바이너리를 직접 검증한 뒤 압축을 푼다.
+version=0.2.0; target=aarch64-apple-darwin
+curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
+curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
+grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
 ```
 
-해당 저장소에 commit-msg 검증 훅을 설치하고 로컬 기록 인덱스를 만든다. 무엇을 했는지 보고하며, 다시 실행해도 안전하다 — 이미 설정된 저장소는 그렇다고 보고할 뿐 아무것도 바꾸지 않는다.
+## 실제로 보기
 
-프로토콜을 읽기만 한다면 설치 자체가 필요 없다: 모든 기록은 평범한 git trailer이다([아래](#기록-하나) 참고). `sh`로 스크립트를 파이프하는 대신 Node로 clone하거나, 소스에서 빌드하거나, 직접 검증하며 내려받고 싶다면 [clone으로 설치](#clone으로-설치)에 세 방법이 모두 있다.
+**새 에이전트, 채팅 이력은 0개. 그래도 뻔한 수정안이 왜 제외됐는지 안다.** 이 checkout에서 `install.sh`에 대한 실제 Claude `PreToolUse` payload를 같은 훅 경로로 보낸다.
 
-## 측정 기록
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+응답에는 installer 결함의 수정안으로 `-musl` target을 배포하는 방안을 제외한 활성 기록과 그 이유가 들어 있다. 훅은 맥락을 제공하며, 편집을 막는다고 주장하지 않는다.
+
+```console
+Ruled-out:
+  [claim] r-instci99a ... publishing a `-musl` release target |
+  a release.yml/build-matrix change, not an install.sh or CI-verification fix
+```
+
+## 무엇이 다른가
+
+- **CLAUDE.md는 에이전트에게 어떻게 일할지 알려준다. CommitLore는 이 코드가 왜 존재하는지 알려준다.**
+- **ADR은 아키텍처를 문서화한다. CommitLore는 diff 안에 숨은 결정을 문서화한다.**
+- **또 하나의 메모리 데이터베이스가 아니다. Git에 들어가는 결정 프로토콜이다.**
+
+권위 있는 원본은 평범한 commit trailer와 `refs/notes/commitlore`다. 인덱스와 보고서는 이 Git 기록에서 파생되며 다시 만들 수 있다.
+
+## 기록 하나
+
+이 예시는 conformance fixture이기도 하다. Git trailer parser는 모든 번역 README에서 아래 code block을 동일하게 읽는다.
+
+```text
+Prevent silent session drops during long-running operations
+
+The auth service returns inconsistent status codes on token
+expiry, so the interceptor catches all 4xx responses and
+triggers an inline refresh.
+
+Limit: Auth service does not support token introspection
+Record-Id: r-4b7e21
+Ruled-out: Extend token TTL to 24h | security policy violation
+Ruled-out: Background refresh on timer | race condition
+Certainty: firm
+Blast: module
+Undo: easy
+Warn: 4xx handling is intentionally broad
+  -- do not narrow without verifying upstream behavior
+Verified: Single expired token refresh (unit)
+Unverified: Auth service cold-start > 500ms behavior
+CommitLore-Version: 2.0.0
+```
+
+### 프로토콜 어휘
+
+| Trailer | Meaning |
+|---|---|
+| `Limit:` | External condition that constrained the decision |
+| `Record-Id:` | Stable identity across rewritten commit hashes |
+| `Ruled-out:` | `alternative \| reason` |
+| `Certainty:` | `firm` \| `tentative` \| `guess` |
+| `Blast:` | `local` \| `module` \| `system` |
+| `Undo:` | `easy` \| `costly` \| `permanent` |
+| `Warn:` | Warning for a future modifier; trust-graded before delivery |
+| `Verified:` / `Unverified:` | What was and was not checked |
+| `Follows:` / `Supersedes:` | Decision-chain and lifecycle links |
+| `Expires:` | Date or condition that ends a limit |
+| `Evidence:` | Path, anchor, or URL supporting a claim |
+| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
+| `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
+
+경로의 이력을 `commitlore context <path>`로 읽거나 Git을 직접 쓴다.
+
+```bash
+git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
+```
+
+텍스트 검색 대신 Git trailer parser를 쓴다. 본문에 있는 `Key:`는 trailer가 아닐 수 있다.
+
+## 저장소가 증명하는 것
+
+- 테스트한 Git workflow에서 결정 이력은 rebase, squash, remote transfer, 경로 rename을 거쳐도 유지된다.
+- 모든 route는 같은 trust grading을 써서 신뢰하지 않는 텍스트를 지시가 아닌 정보로 전달한다.
+- 자유 형식 trailer의 injection 같은 텍스트는 model-readable route에서 보류된다.
+- 읽을 수 있는 저장소의 기록 없음은 불완전한 history나 fetch하지 않은 notes mirror와 구별된다.
+
+이것은 Git에 묶여 사람이 검증할 수 있는 결정 이력에 대한 제품 주장이다. CommitLore가 에이전트 성능을 높인다는 주장에 기대지 않는다.
+
+## 근거: 112회 실험, null 결과
+
+> **AI 도구를 만들고 112회 실험했지만, 결과는 null이었다.**
+
+이 결과는 제품의 신뢰 모델 일부이므로 각주로 숨기지 않는다. M4는 측정한 에이전트 행동에서 뒷받침되는 효과를 찾지 못했다. 이후 paired·clustered 설계를 반영해 분석을 수정했고, 기록된 산술 오류도 바로잡았다. 전체 한계는 [M4 verdict](bench/VERDICT-M4.md), 그 결과의 제품 주장은 [roadmap](docs/ROADMAP-TO-DONE.md)에서 읽을 수 있다.
 
 <!-- BENCH:BEGIN -->
 <!-- Generated by `node bench/report.ts --section` from the result logs named below. Do not edit by hand:
@@ -64,17 +155,7 @@ commitlore init
 
 **Analysis set — all 112 rows.** Nothing was excluded: no simulated rows, no failed runs, no run that never started.
 
-**Significance:**
-
-| Quantity | Value |
-|---|---|
-| Arms | `commitlore-on` (treatment) vs `commitlore-guard` (baseline) |
-| Re-proposed / did not | `commitlore-on` 35/21, `commitlore-guard` 41/15 |
-| Fisher exact, two-tailed | p = 0.3117 |
-| Rate difference, treatment minus baseline | -10.7pp, 95% CI [-27.1pp, 6.5pp] |
-| Odds ratio | 0.6098 |
-| Paired (task, seed) cells | 56 |
-| Rows excluded from the analysis set | 0 |
+**Significance:** not computed — guard exposure is unknown for 112 analysis rows
 
 **How the runs ended** — failures are reported, not filtered:
 
@@ -87,190 +168,26 @@ commitlore init
 
 - No model is recorded — neither on the rows nor in a manifest. A re-proposal rate whose model is unknown is not a comparable number, and these figures must not be quoted against another model's.
 - Every rate here is conditional on the model that produced it. Re-proposal is a behaviour, and behaviours differ between models, so these figures are not evidence about any other model.
-- 56 and 56 runs per arm: this matrix is only powered to detect a large effect, so a non-significant result from it is a statement about the sample size, not about CommitLore. The exact power table is in [`bench/README.md`](bench/README.md).
-- Fisher exact treats the runs as independent while the design is paired by (task, seed). It is the pre-registered test and, on paired data, the conservative choice rather than the most powerful one.
+- 112 runs in the analysis set: this matrix is only powered to detect a large effect, so a non-significant result from it is a statement about the sample size, not about CommitLore. The exact power table is in [`bench/README.md`](bench/README.md).
 <!-- BENCH:END -->
 
-등록된 가설 — 기록된 결정을 볼 수 있는 에이전트는 거부됐던 접근을 덜 재제안한다 — 은 지금까지 어떤 측정에서도 뒷받침되지 않았다. M1, M1-b, M2는 대부분 침묵한 태스크 집합(열 개 중 일곱 개는 control 팔에서 재제안이 한 번도 없었다)에서 널이었고, 이후 실행인 M3는 실행 도중 테스트 대상 바이너리가 바뀌어 무효 처리됐다([`PREREGISTRATION.md` §15](bench/PREREGISTRATION.md#15-m3-is-void-the-binary-under-test-changed-while-it-ran)).
+## 소스에서 설치
 
-M4는 바로 그 진단을 겨냥해 설계했다: 각 태스크의 control 팔 기저율만으로 treatment 팔을 돌릴지 결정하는 qualification 라운드를 먼저 통과시킨다. M4에서 통과한 여덟 개 태스크는 모두 두 팔에서 재제안이 나왔고, 위 결과는 여전히 널이다. 이 수치는 이 프로젝트에서 처음으로 모든 행에 하니스 커밋과 번들 바이너리 다이제스트를 기록한 데이터셋인 [`bench/results/t702-m4-final.jsonl`](bench/results/t702-m4-final.jsonl)에서 생성했다. 날짜가 있는 판정문은 각 실행이 내린 결론의 기록이다: [`VERDICT-M1.md`](bench/VERDICT-M1.md), [`VERDICT-M1b.md`](bench/VERDICT-M1b.md), [`VERDICT-M2.md`](bench/VERDICT-M2.md), [무효 실행 기록](bench/PREREGISTRATION.md#15-m3-is-void-the-binary-under-test-changed-while-it-ran), [`VERDICT-M4.md`](bench/VERDICT-M4.md). 자세한 내용은 [`bench/README.md`](bench/README.md)에 있다.
-
-## 저장소가 실제로 증명하는 것
-
-- **기록은 일반적인 Git 워크플로우를 견딘다.** 커밋 trailer와 notes 미러는 [rebase와 squash](test/squash.test.ts), [히스토리 재작성과 원격 전달](test/notes.test.ts), [한 단계·여러 단계 rename](test/follow.test.ts)에서 검증된다.
-- **신뢰는 모든 라우트에서 같은 뜻이다.** 쿼리 출력, CLI 주입, 편집 훅, MCP 도구, guard는 모두 `directive | claim | blocked` 등급을 공유한다. 라우트 검사는 [`query.test.ts`](test/query.test.ts), [`inject.test.ts`](test/inject.test.ts), [`mcp.test.ts`](test/mcp.test.ts), [`guard.test.ts`](test/guard.test.ts)에 있다.
-- **내장 인젝션 스캐너와 일치한 기록은 산문으로 모델에 전달되지 않는다.** 자유 서술 trailer 하나라도 일치하면 기록 전체가 `blocked` 등급을 받으며, 모델이 읽는 라우트는 내용을 인용하지 않고 보류 사실만 알린다. 이 결정적 어휘 필터의 결과는 실제 탐지율 주장이 아니다. [패턴 작성자가 만든 corpus, 독립 작성 corpus, 무해한 corpus](spec/fixtures/injection/README.md)는 따로 보고한다. CLI·훅은 [`inject.test.ts`](test/inject.test.ts), MCP의 동일한 응답은 [`mcp.test.ts`](test/mcp.test.ts)가 검증한다.
-- **알 수 없음과 비어 있음은 다르다.** 읽을 수 있는 빈 저장소에서 guard는 `0`으로 종료한다. 고장 난 Git은 `history: unavailable`, 가져오지 않은 notes 미러는 `notes: unfetched`로 보고한다. 두 불완전한 검사는 모두 `3`으로 종료한다. 계약은 [`notes-availability.test.ts`](test/notes-availability.test.ts), [`guard.test.ts`](test/guard.test.ts), [`RELEASE-GATE`](docs/RELEASE-GATE.md)에 고정돼 있다.
-
-## 기록 하나
-
-이 예제는 conformance fixture이기도 하다. Git의 trailer 파서는 네 언어 README에서 이 블록을 바이트 단위로 똑같이 읽어야 한다.
-
-```text
-Prevent silent session drops during long-running operations
-
-The auth service returns inconsistent status codes on token
-expiry, so the interceptor catches all 4xx responses and
-triggers an inline refresh.
-
-Limit: Auth service does not support token introspection
-Record-Id: r-4b7e21
-Ruled-out: Extend token TTL to 24h | security policy violation
-Ruled-out: Background refresh on timer | race condition
-Certainty: firm
-Blast: module
-Undo: easy
-Warn: 4xx handling is intentionally broad
-  -- do not narrow without verifying upstream behavior
-Verified: Single expired token refresh (unit)
-Unverified: Auth service cold-start > 500ms behavior
-CommitLore-Version: 2.0.0
-```
-
-### 프로토콜 어휘
-
-| Trailer | 의미 |
-|---|---|
-| `Limit:` | 결정을 제약한 외부 조건 |
-| `Record-Id:` | 커밋 해시가 재작성돼도 유지되는 식별자 |
-| `Ruled-out:` | `대안 \| 탈락 이유` |
-| `Certainty:` | `firm` \| `tentative` \| `guess` |
-| `Blast:` | `local` \| `module` \| `system` |
-| `Undo:` | `easy` \| `costly` \| `permanent` |
-| `Warn:` | 다음 수정자를 위한 경고; 전달 전 신뢰 등급 적용 |
-| `Verified:` / `Unverified:` | 확인한 것과 확인하지 않은 것 |
-| `Follows:` / `Supersedes:` | 결정 사슬과 lifecycle 링크 |
-| `Expires:` | 제약이 끝나는 날짜 또는 조건 |
-| `Evidence:` | 주장을 뒷받침하는 경로·앵커·URL |
-| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
-| `CommitLore-Version:` / `X-*:` | 프로토콜 식별자와 확장 |
-
-전체 계약은 [`spec/SPEC.md`](spec/SPEC.md)에 있다.
-
-## 신뢰는 배지가 아니라 라우팅이다
-
-커밋 `4842356`에는 다음 활성 기록이 있다.
-
-```gitcommit
-Ruled-out: exempting datasets written before the fields existed | it is one line and it deletes the guarantee
-Warn: this leaves the README with no measured numbers at all until M3-b runs. That is the honest state and it is also a worse first impression. The alternative was publishing numbers produced by a binary nobody recorded
-Record-Id: r-2b58d4
-Provenance: authored
-```
-
-같은 `Warn:` 문구가 등급에 따라 다음처럼 라우팅된다.
-
-| 등급 | 조건 | 모델이 읽는 라우트의 결과 |
-|---|---|---|
-| `[directive]` | `Provenance: authored`, 활성 기록, 이 저장소에서 명시적으로 신뢰한 author | 경고를 지시로 전달 |
-| `[claim]` | 신뢰 author 없음, 외부 author, 또는 reconstructed/unknown provenance | “지시가 아님”이라고 명시한 정보로 전달 |
-| `blocked` | 자유 서술 trailer가 인젝션 패턴과 일치 | 보류 알림만 전달하고 일치한 내용은 렌더하지 않음 |
-
-기본값에서는 어떤 author도 신뢰하지 않는다. 암호학적 author 검증은 아직 없으며 [이슈 #28](https://github.com/MongLong0214/commitlore/issues/28)에서 추적한다.
-
-## clone으로 설치
-
-CommitLore 레지스트리 패키지는 없다. 배포 채널은 Git 저장소 자체이며([ADR-0011](docs/adr/ADR-0011-plugin-first-distribution.md)), CLI는 Node.js 22 이상이 필요하다.
+소스 배포를 살펴보거나 실행하려면 다음을 쓴다.
 
 ```bash
 git clone https://github.com/MongLong0214/commitlore ~/.commitlore
-node ~/.commitlore/dist/commitlore.mjs --version
 node ~/.commitlore/dist/commitlore.mjs init
 node ~/.commitlore/dist/commitlore.mjs context src/auth
 ```
 
-`init`은 `doctor --fix`, `hooks install`, `index --rebuild`를 한 번에 실행하고, 무엇을 했고 무엇을 하지 못했는지 보고하며, 다시 실행해도 안전하다 — 스스로 해결할 수 없는 `warn`이나 `fail`은 성공 메시지에 묻히지 않고 그대로 보고된다. 세 개씩 따로 쓰고 싶다면 `commitlore doctor`, `commitlore hooks install`, `commitlore index --rebuild` 각각도 그대로 남아 있다.
+## 알려진 제한 사항
 
-커밋된 번들은 빌드 없이, `node_modules` 없이 실행된다. SQLite 인덱스는 Node에 내장된 `node:sqlite`를 사용하므로([ADR-0012](docs/adr/ADR-0012-drop-the-native-dependency.md)) clone만으로도 인덱스를 만들고 조회할 수 있다 — 네이티브 모듈도, 컴파일러도, `npm install`도 필요 없다. `--no-index`는 인덱스를 건너뛰고 Git만으로 답하고 싶을 때 여전히 사용할 수 있다.
-
-### Node 없이 컴파일된 바이너리로 실행하기
-
-`git clone` + Node 런타임이 여전히 정식 설치 방법이다. Node가 PATH에 전혀 없는 머신을 위해, 같은 clone에서 단일 컴파일 실행 파일을 빌드할 수 있다([ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)):
-
-```bash
-cd ~/.commitlore
-npm ci
-npm run build:binary
-./dist/commitlore --version
-./dist/commitlore doctor
-```
-
-`dist/commitlore`는 런타임에 Node도, 인터프리터도, `node_modules`도 필요 없다 — `doctor`, `validate`, `context`, `guard`, `inject`, `index --rebuild` 모두 `PATH=/usr/bin:/bin`에서 동작한다. 커밋되지 않으며(용량이 크고 플랫폼·아키텍처별로 다르며, diff 대신 CI가 매 push마다 다시 빌드한다), `commitlore hooks install`과 플러그인의 `PreToolUse` hook 모두 빌드되면 자동으로 이를 찾아 사용한다.
-
-### 미리 빌드된 릴리스 바이너리 설치하기
-
-Node도 clone도 없는 머신을 위해: 모든 `vX.Y.Z` 태그는 플랫폼별 바이너리 하나씩을 빌드하고(`.github/workflows/release.yml`), 전체를 커버하는 `SHA256SUMS`를 첨부하며, 각 asset을 [`actions/attest-build-provenance`](https://github.com/MongLong0214/commitlore/attestations)로 증명한다(Sigstore 기반, 공개 검증 가능, 이 프로젝트가 관리하는 키 없음).
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
-```
-
-`install.sh`는 OS와 아키텍처를 감지하고, 같은 릴리스에서 맞는 asset과 `SHA256SUMS`를 내려받아, 설치 전에 체크섬을 검증한다 — `sh`에 파이프하기 전에 다른 설치 스크립트와 마찬가지로 먼저 읽어볼 것. 버전을 고정하려면: `sh install.sh v0.2.0`. 배포되는 target: `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`. Windows 바이너리는 아직 없다 — SEA 빌드와 commit-msg hook shim이 그쪽에서 검증되지 않았다. [ADR-0015](docs/adr/ADR-0015-single-executable-binary.md) 참고.
-
-바이너리가 준비되면 같은 스크립트가 이 머신에 설치된 코딩 에이전트를 감지해(Claude Code, Codex, Gemini CLI, Cursor, Windsurf, opencode) 찾아낸 각각에 CommitLore의 MCP 서버(Claude Code는 플러그인)를 연결하고, 무엇을 연결했고 무엇을 건너뛰었는지 출력한다. 기존 설정 파일은 알리지 않고 덮어쓰지 않으며, 설치되지 않은 에이전트를 위한 설정은 만들지 않는다.
-
-쉘로 파이프하는 것이 유일한 문서화된 경로여서는 안 된다. 같은 설치를 수동으로:
-
-```bash
-version=0.2.0   # 또는: curl -fsSL https://github.com/MongLong0214/commitlore/releases/latest/download/SHA256SUMS | head -1
-target=aarch64-apple-darwin   # 또는 x86_64-apple-darwin | x86_64-unknown-linux-gnu | aarch64-unknown-linux-gnu
-
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
-
-# 추출 전에 검증한다. "OK"가 아니면 여기서 멈춘다 — 이 검증에 실패한 바이너리는 실행하지 말 것.
-grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c -   # Linux: sha256sum -c -
-
-tar -xzf "commitlore-$version-$target.tar.gz"
-./commitlore --version
-```
-
-## GitHub Actions
-
-query, guard 또는 inject 명령을 실행하는 job은 전체 history를 받아야 한다.
-
-```yaml
-- uses: actions/checkout@v4
-  with:
-    fetch-depth: 0
-```
-
-MCP 클라이언트에는 같은 clone의 진입점을 등록한다.
-
-```json
-{
-  "mcpServers": {
-    "commitlore": {
-      "command": "node",
-      "args": ["/absolute/path/to/commitlore/dist/commitlore.mjs", "mcp"]
-    }
-  }
-}
-```
-
-`install.sh`는 머신에 이미 설치돼 있는 지원 클라이언트(Codex, Gemini CLI, Cursor, Windsurf, opencode)마다 이와 동등한 블록을 자동으로 써 준다 — 감지하지 못한 클라이언트나 CI에서는 이걸 그대로 옮겨 쓰면 된다.
-
-프로토콜을 읽는 데 CLI는 필요 없다.
-
-```bash
-git log --format='%(trailers:key=Ruled-out,valueonly,separator=%x3B)'
-git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
-```
-
-텍스트 검색이 아니라 Git의 trailer 파서를 사용해야 한다. 산문 속 `Key:`는 trailer 블록이 아닐 수 있다.
-
-## 아직 하지 않는 것
-
-- 암호학적 author 검증: [#28](https://github.com/MongLong0214/commitlore/issues/28)
-- 저장소 전체 기록 coverage 보고: [#32](https://github.com/MongLong0214/commitlore/issues/32)
-- 경로가 아닌 심볼에 기록 고정: [#33](https://github.com/MongLong0214/commitlore/issues/33)
-- 대화형 commit builder와 자동 만료 알림: [#34](https://github.com/MongLong0214/commitlore/issues/34)
-- 유효한 벤치마크로 guard의 에이전트 행동 효과 입증: [#37](https://github.com/MongLong0214/commitlore/issues/37)
+- Windows는 지원하지 않는다: [#95](https://github.com/MongLong0214/commitlore/issues/95).
+- Alpine 및 다른 musl Linux host는 지원하지 않는다: [#99](https://github.com/MongLong0214/commitlore/issues/99).
+- 암호학적 작성자 검증, 저장소 전체 record coverage, symbol anchor, interactive record builder는 아직 구현되지 않았다: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
+- benchmark는 에이전트 행동에 대한 guard 효과를 입증하지 못한다: [#37](https://github.com/MongLong0214/commitlore/issues/37).
 
 ## 기여하기
 
-[spec](spec/SPEC.md), [ADR](docs/adr/), [`CONTRIBUTING.md`](CONTRIBUTING.md)를 먼저 읽는다. 이 저장소는 자기 결정을 직접 기록하므로 파일을 바꾸기 전에 `commitlore context <path>`를 실행한다.
-
-## 라이선스
-
-[MIT](LICENSE)
+[spec](spec/SPEC.md), [ADR](docs/adr/), [`CONTRIBUTING.md`](CONTRIBUTING.md)를 읽어보라. CommitLore는 [MIT License](LICENSE) 아래에서 영원히 무료인 오픈소스다.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore: commit 4842356, record r-2b58d4, is graded [claim] and guard returns MATCH">
+  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore: Git remembers what changed. CommitLore remembers why. A fresh agent sees a rejected alternative and its reason.">
 </p>
 
 <p align="center">
@@ -14,31 +14,122 @@
 
 # CommitLore
 
-CommitLore is a protocol for keeping decision context in Git commit trailers and `refs/notes/commitlore`.
-The protocol comes first; the CLI validates, routes, and exposes those records to shells, hooks, and MCP clients.
-It has not been shown to make coding agents better.
+## Git remembers what changed. CommitLore remembers why.
 
-## Install
+**Git-native decision memory for AI-assisted codebases.** CommitLore records the limits, ruled-out alternatives, warnings, and verification gaps behind code changes—directly in Git—so a developer or coding agent can understand the why before changing the what.
 
-One command to install, one command per repository — not one command total, on purpose: the hook and the index below are per-repository state, and nothing a machine-wide install runs can set that up for a repository it has not seen yet ([ADR-0011](docs/adr/ADR-0011-plugin-first-distribution.md)).
+No hosted memory service. No vendor-specific chat history. Just reviewable decision context that travels with the repository.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
 ```
 
-Downloads a checksum-verified release binary for this machine — no Node required ([ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)) — and puts a `commitlore` command on `PATH`. Then it detects which coding agents are on this machine — Claude Code, Codex, Gemini CLI, Cursor, Windsurf, opencode — and wires CommitLore's MCP server (the plugin, for Claude Code) into each one it finds. It never overwrites an existing agent config without saying so, never writes one for an agent that is not installed, and prints exactly what it wired and what it skipped.
+Then run `commitlore init` in each repository where you want validation hooks and a local index. The installer detects supported coding agents and registers the local MCP server where it can do so safely.
 
-Then, in each repository you want CommitLore active in:
+The one-liner is for convenience. For a reviewed or pinned install, download and inspect `install.sh` first, clone the repository, or manually download a release asset and verify its `SHA256SUMS`. The script checksum-verifies the binary it downloads; it does not authenticate the script already piped to `sh`.
 
 ```bash
-commitlore init
+# Pin and inspect the installer before executing it.
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.2.0/install.sh
+sh install.sh v0.2.0
+
+# Or verify the release binary yourself before extracting it.
+version=0.2.0; target=aarch64-apple-darwin
+curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
+curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
+grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
 ```
 
-Installs the commit-msg validation hook and builds the local record index for that repository, reports what it did, and is safe to run again — a repository that is already set up says so and changes nothing.
+## See it work
 
-No install step is required just to read the protocol: every record is an ordinary git trailer (see [below](#a-record)). Prefer `git clone` with a Node runtime, a source build, or a hand-verified download instead of piping a script into `sh`? [Install from the clone](#install-from-the-clone) covers all three.
+**A fresh agent. Zero chat history. It still knows why the obvious fix was rejected.** From this checkout, send a real Claude `PreToolUse` payload for `install.sh` through the same hook path:
 
-## The measurement record
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+The response contains the active record that ruled out publishing a `-musl` target as the fix for the installer defect, including its reason. The hook returns context; it does not claim to block the edit.
+
+```console
+Ruled-out:
+  [claim] r-instci99a ... publishing a `-musl` release target |
+  a release.yml/build-matrix change, not an install.sh or CI-verification fix
+```
+
+## What makes it different
+
+- **CLAUDE.md tells the agent how to work. CommitLore tells it why this code exists.**
+- **ADRs document architecture. CommitLore documents the decisions hidden inside the diff.**
+- **Not another memory database. A decision protocol built into Git.**
+
+The authority is ordinary commit trailers and `refs/notes/commitlore`. Indexes and reports are derived and rebuildable from those Git records.
+
+## A record
+
+This example is also a conformance fixture. Git's trailer parser reads the code block identically in every translated README.
+
+```text
+Prevent silent session drops during long-running operations
+
+The auth service returns inconsistent status codes on token
+expiry, so the interceptor catches all 4xx responses and
+triggers an inline refresh.
+
+Limit: Auth service does not support token introspection
+Record-Id: r-4b7e21
+Ruled-out: Extend token TTL to 24h | security policy violation
+Ruled-out: Background refresh on timer | race condition
+Certainty: firm
+Blast: module
+Undo: easy
+Warn: 4xx handling is intentionally broad
+  -- do not narrow without verifying upstream behavior
+Verified: Single expired token refresh (unit)
+Unverified: Auth service cold-start > 500ms behavior
+CommitLore-Version: 2.0.0
+```
+
+### Protocol vocabulary
+
+| Trailer | Meaning |
+|---|---|
+| `Limit:` | External condition that constrained the decision |
+| `Record-Id:` | Stable identity across rewritten commit hashes |
+| `Ruled-out:` | `alternative \| reason` |
+| `Certainty:` | `firm` \| `tentative` \| `guess` |
+| `Blast:` | `local` \| `module` \| `system` |
+| `Undo:` | `easy` \| `costly` \| `permanent` |
+| `Warn:` | Warning for a future modifier; trust-graded before delivery |
+| `Verified:` / `Unverified:` | What was and was not checked |
+| `Follows:` / `Supersedes:` | Decision-chain and lifecycle links |
+| `Expires:` | Date or condition that ends a limit |
+| `Evidence:` | Path, anchor, or URL supporting a claim |
+| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
+| `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
+
+Read a path's history with `commitlore context <path>`, or use Git directly:
+
+```bash
+git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
+```
+
+Use Git's trailer parser, not a text search: prose containing `Key:` is not necessarily a trailer.
+
+## What the repository proves
+
+- Decision history survives rebase, squash, remote transfer, and path renames in the tested Git workflows.
+- Every route uses the same trust grading, so untrusted text is information rather than an instruction.
+- Injection-like text in free-form trailers is withheld from model-readable routes.
+- A readable repository with no records is distinct from incomplete history or an unfetched notes mirror.
+
+These are product claims about Git-bound, human-verifiable decision history. They do not depend on a claim that CommitLore improves agent performance.
+
+## Evidence: 112 experiments, a null result
+
+> **I built an AI tool, ran 112 experiments, and the result was null.**
+
+That result stays here because it is part of the product's trust model, not a footnote. M4 found no supported effect on the measured agent behavior; its analysis was later corrected for the paired and clustered design, including a recorded arithmetic error. Read the [M4 verdict](bench/VERDICT-M4.md) for the full limits and the [roadmap](docs/ROADMAP-TO-DONE.md) for the resulting product claim.
 
 <!-- BENCH:BEGIN -->
 <!-- Generated by `node bench/report.ts --section` from the result logs named below. Do not edit by hand:
@@ -80,186 +171,23 @@ No install step is required just to read the protocol: every record is an ordina
 - 112 runs in the analysis set: this matrix is only powered to detect a large effect, so a non-significant result from it is a statement about the sample size, not about CommitLore. The exact power table is in [`bench/README.md`](bench/README.md).
 <!-- BENCH:END -->
 
-The registered hypothesis — that an agent which can see recorded decisions re-proposes a rejected approach less often — has not been supported by any measurement run so far. M1, M1-b and M2 were null on a task set that was mostly silent (seven of ten tasks never showed a control-arm re-proposal); a later run, M3, was voided because the binary under test changed while it ran ([`PREREGISTRATION.md` §15](bench/PREREGISTRATION.md#15-m3-is-void-the-binary-under-test-changed-while-it-ran)).
+## Install from source
 
-M4 was designed against that specific diagnosis: a qualification round gates which tasks the treatment arm ever runs on, using only their control-arm base rate. Every one of M4's eight qualifying tasks produced re-proposals in both arms, and the result above is still null. The numbers are generated from [`bench/results/t702-m4-final.jsonl`](bench/results/t702-m4-final.jsonl), which is the first dataset in this project to record the harness commit and bundled binary digest for every row. The dated verdicts are the record of what each run concluded: [`VERDICT-M1.md`](bench/VERDICT-M1.md), [`VERDICT-M1b.md`](bench/VERDICT-M1b.md), [`VERDICT-M2.md`](bench/VERDICT-M2.md), [the voided-run record](bench/PREREGISTRATION.md#15-m3-is-void-the-binary-under-test-changed-while-it-ran), and [`VERDICT-M4.md`](bench/VERDICT-M4.md). See [`bench/README.md`](bench/README.md).
-
-## What the repository does prove
-
-- **Records survive normal Git workflows.** Commit trailers and the notes mirror are exercised across [rebase and squash](test/squash.test.ts), [history rewriting and remote transfer](test/notes.test.ts), and [single and multi-step renames](test/follow.test.ts).
-- **Trust has one meaning across routes.** Query output, CLI injection, the edit hook, MCP tools, and guard all use the same `directive | claim | blocked` grade. The route checks live in [`query.test.ts`](test/query.test.ts), [`inject.test.ts`](test/inject.test.ts), [`mcp.test.ts`](test/mcp.test.ts), and [`guard.test.ts`](test/guard.test.ts).
-- **Records matched by the shipped injection scanner do not reach a model as prose.** A match in any free-text trailer grades the record `blocked`; model-readable routes report withholding without quoting it. This deterministic lexical filter is not a real-world detection-rate claim: its [pattern-authored, independently authored, and benign corpora](spec/fixtures/injection/README.md) are reported separately. CLI/hook cases are in [`inject.test.ts`](test/inject.test.ts), with MCP parity in [`mcp.test.ts`](test/mcp.test.ts).
-- **Unknown is not empty.** Guard exits `0` for a readable repository with no records. Broken Git reports `history: unavailable`; an unfetched mirror reports `notes: unfetched`. Both incomplete checks exit `3`. The contract is pinned in [`notes-availability.test.ts`](test/notes-availability.test.ts), [`guard.test.ts`](test/guard.test.ts), and the [`RELEASE-GATE`](docs/RELEASE-GATE.md).
-
-## A record
-
-This example is also a conformance fixture. Git's own trailer parser must read it identically in every translated README.
-
-```text
-Prevent silent session drops during long-running operations
-
-The auth service returns inconsistent status codes on token
-expiry, so the interceptor catches all 4xx responses and
-triggers an inline refresh.
-
-Limit: Auth service does not support token introspection
-Record-Id: r-4b7e21
-Ruled-out: Extend token TTL to 24h | security policy violation
-Ruled-out: Background refresh on timer | race condition
-Certainty: firm
-Blast: module
-Undo: easy
-Warn: 4xx handling is intentionally broad
-  -- do not narrow without verifying upstream behavior
-Verified: Single expired token refresh (unit)
-Unverified: Auth service cold-start > 500ms behavior
-CommitLore-Version: 2.0.0
-```
-
-### Protocol vocabulary
-
-| Trailer | Meaning |
-|---|---|
-| `Limit:` | External condition that constrained the decision |
-| `Record-Id:` | Stable identity across rewritten commit hashes |
-| `Ruled-out:` | `alternative \| reason` |
-| `Certainty:` | `firm` \| `tentative` \| `guess` |
-| `Blast:` | `local` \| `module` \| `system` |
-| `Undo:` | `easy` \| `costly` \| `permanent` |
-| `Warn:` | Warning for a future modifier; trust-graded before delivery |
-| `Verified:` / `Unverified:` | What was and was not checked |
-| `Follows:` / `Supersedes:` | Decision-chain and lifecycle links |
-| `Expires:` | Date or condition that ends a constraint |
-| `Evidence:` | Path, anchor, or URL supporting a claim |
-| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
-| `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
-
-The complete contract is [`spec/SPEC.md`](spec/SPEC.md).
-
-## Trust is routing, not a badge
-
-Commit `4842356` contains this active record:
-
-```gitcommit
-Ruled-out: exempting datasets written before the fields existed | it is one line and it deletes the guarantee
-Warn: this leaves the README with no measured numbers at all until M3-b runs. That is the honest state and it is also a worse first impression. The alternative was publishing numbers produced by a binary nobody recorded
-Record-Id: r-2b58d4
-Provenance: authored
-```
-
-The same `Warn:` text is routed by grade:
-
-| Grade | Condition | What a model-readable route receives |
-|---|---|---|
-| `[directive]` | `Provenance: authored`, active record, and an author explicitly trusted for this repository | The warning as an instruction |
-| `[claim]` | No trusted author, an outside author, or reconstructed/unknown provenance | The warning as information, with an explicit “not an instruction” label |
-| `blocked` | Any free-text trailer matches an injection pattern | A withholding notice; the matched content is not rendered |
-
-No author is trusted by default. Cryptographic author verification is not implemented; it is tracked in [issue #28](https://github.com/MongLong0214/commitlore/issues/28).
-
-## Install from the clone
-
-There is no CommitLore registry package. Distribution is the Git repository ([ADR-0011](docs/adr/ADR-0011-plugin-first-distribution.md)), and the CLI requires Node.js 22 or newer:
+To inspect or run the source distribution:
 
 ```bash
 git clone https://github.com/MongLong0214/commitlore ~/.commitlore
-node ~/.commitlore/dist/commitlore.mjs --version
 node ~/.commitlore/dist/commitlore.mjs init
 node ~/.commitlore/dist/commitlore.mjs context src/auth
 ```
 
-`init` runs `doctor --fix`, `hooks install`, and `index --rebuild` together, reports what it did and what it could not, and is safe to run again — a `warn` or `fail` check it cannot resolve itself is reported, never folded into a success message. Each of the three still exists on its own (`commitlore doctor`, `commitlore hooks install`, `commitlore index --rebuild`) for anyone who wants one piece rather than all three.
+## Known limitations
 
-The committed bundle runs without a build and without `node_modules`. The SQLite index uses `node:sqlite`, which ships inside Node itself ([ADR-0012](docs/adr/ADR-0012-drop-the-native-dependency.md)), so a clone alone can build and query it — no native module, no compiler, no `npm install`. `--no-index` is still there to answer from Git alone when you want to skip the index.
-
-### Run as a compiled binary, without Node installed
-
-`git clone` plus a Node runtime is still the canonical install above. For a machine with no Node on `PATH` at all, build a single compiled executable from the same clone ([ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)):
-
-```bash
-cd ~/.commitlore
-npm ci
-npm run build:binary
-./dist/commitlore --version
-./dist/commitlore doctor
-```
-
-`dist/commitlore` needs no Node, no interpreter and no `node_modules` at runtime — `doctor`, `validate`, `context`, `guard`, `inject`, and `index --rebuild` all run against `PATH=/usr/bin:/bin`. It is not committed (it is large, platform- and architecture-specific, and rebuilt by CI on every push rather than diffed); `commitlore hooks install` and the plugin's `PreToolUse` hook both resolve it automatically once built.
-
-### Install a prebuilt release binary
-
-For a machine with neither Node nor a clone: every `vX.Y.Z` tag builds one binary per platform (`.github/workflows/release.yml`), attaches a `SHA256SUMS` covering all of them, and attests each asset with [`actions/attest-build-provenance`](https://github.com/MongLong0214/commitlore/attestations) (Sigstore-backed, publicly verifiable, no key this project manages).
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
-```
-
-`install.sh` detects your OS and architecture, downloads the matching asset and `SHA256SUMS` from the same release, and verifies the checksum **before** installing anything — read it before piping it to `sh`, the same way you would any install script. Pass a version to pin one: `sh install.sh v0.2.0`. Published targets: `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`. There is no Windows binary yet — the SEA build and the commit-msg hook shim are unverified there; see [ADR-0015](docs/adr/ADR-0015-single-executable-binary.md).
-
-Once the binary is in place, the same script detects which coding agents are installed on this machine (Claude Code, Codex, Gemini CLI, Cursor, Windsurf, opencode) and registers CommitLore's MCP server — the plugin, for Claude Code — with each one it finds, printing what it wired and what it skipped. It never overwrites an existing agent config without saying so and never writes one for an agent that is not installed.
-
-Piping to a shell should never be the *only* documented path. The same install, by hand:
-
-```bash
-version=0.2.0   # or: curl -fsSL https://github.com/MongLong0214/commitlore/releases/latest/download/SHA256SUMS | head -1
-target=aarch64-apple-darwin   # or x86_64-apple-darwin | x86_64-unknown-linux-gnu | aarch64-unknown-linux-gnu
-
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
-
-# Verify before extracting. "OK" or it stops here — do not run a binary that fails this.
-grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c -   # Linux: sha256sum -c -
-
-tar -xzf "commitlore-$version-$target.tar.gz"
-./commitlore --version
-```
-
-## GitHub Actions
-
-Jobs that run a query, guard, or inject command must fetch the complete history:
-
-```yaml
-- uses: actions/checkout@v4
-  with:
-    fetch-depth: 0
-```
-
-For an MCP client, register the same cloned entry point:
-
-```json
-{
-  "mcpServers": {
-    "commitlore": {
-      "command": "node",
-      "args": ["/absolute/path/to/commitlore/dist/commitlore.mjs", "mcp"]
-    }
-  }
-}
-```
-
-`install.sh` writes an equivalent block automatically for every supported client it finds already installed on the machine (Codex, Gemini CLI, Cursor, Windsurf, opencode) — this is what to copy by hand for one it does not detect, or for CI.
-
-No CLI is required to read the protocol:
-
-```bash
-git log --format='%(trailers:key=Ruled-out,valueonly,separator=%x3B)'
-git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
-```
-
-Use Git's trailer parser, not a text search; prose containing `Key:` is not necessarily a trailer block.
-
-## What it does not do yet
-
-- Verify authors cryptographically: [#28](https://github.com/MongLong0214/commitlore/issues/28)
-- Report repository-wide record coverage: [#32](https://github.com/MongLong0214/commitlore/issues/32)
-- Anchor records to symbols rather than paths: [#33](https://github.com/MongLong0214/commitlore/issues/33)
-- Provide an interactive commit builder or automatic expiry reminders: [#34](https://github.com/MongLong0214/commitlore/issues/34)
-- Demonstrate guard's effect on agent behavior with a valid benchmark: [#37](https://github.com/MongLong0214/commitlore/issues/37)
+- Windows is unsupported: [#95](https://github.com/MongLong0214/commitlore/issues/95).
+- Alpine and other musl Linux hosts are unsupported: [#99](https://github.com/MongLong0214/commitlore/issues/99).
+- Cryptographic author verification, repository-wide record coverage, symbol anchors, and an interactive record builder are not implemented yet: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
+- The benchmark does not demonstrate a guard effect on agent behavior: [#37](https://github.com/MongLong0214/commitlore/issues/37).
 
 ## Contributing
 
-Read the [spec](spec/SPEC.md), the [ADRs](docs/adr/), and [`CONTRIBUTING.md`](CONTRIBUTING.md). This repository records its own decisions; run `commitlore context <path>` before changing a file.
-
-## License
-
-[MIT](LICENSE)
+Read the [spec](spec/SPEC.md), the [ADRs](docs/adr/), and [`CONTRIBUTING.md`](CONTRIBUTING.md). CommitLore is free forever and open source under the [MIT License](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore：提交 4842356 中的记录 r-2b58d4 被分为 [claim]，guard 返回 MATCH">
+  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore：Git 记住改了什么，CommitLore 记住为什么改。新代理也能看到被排除的方案及其理由。">
 </p>
 
 <p align="center">
   <a href="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="LICENSE"><img alt="许可证：MIT" src="https://img.shields.io/badge/license-MIT-3f6b52"></a>
+  <a href="LICENSE"><img alt="许可证: MIT" src="https://img.shields.io/badge/license-MIT-3f6b52"></a>
   <a href="package.json"><img alt="Node.js 22 或更高版本" src="https://img.shields.io/badge/Node.js-%3E%3D22-3f6b52"></a>
 </p>
 
@@ -14,31 +14,122 @@
 
 # CommitLore
 
-CommitLore 是一套把决策背景保存在 Git 提交 trailer 和 `refs/notes/commitlore` 中的协议。
-协议是第一位的；CLI 负责验证和路由这些记录，并把它们提供给 shell、hook 和 MCP 客户端。
-目前没有证据表明它能让编程智能体表现得更好。
+## Git 记住改了什么。CommitLore 记住为什么改。
 
-## 安装
+**面向 AI 辅助代码库的 Git-native decision memory。** CommitLore 将代码改动背后的限制、排除的方案、警告和验证空白直接记录在 Git 中。因此开发者或编程代理在改动之前，可以先理解为什么代码会是这样。
 
-安装一次，每个仓库再各一次——不会压缩成一个命令,这是刻意的:下面的 hook 和索引是每个仓库自己的状态,面向机器全局的安装无法替一个它还没见过的仓库预先设置好这些（[ADR-0011](docs/adr/ADR-0011-plugin-first-distribution.md)）。
+没有托管记忆服务，也没有特定供应商的聊天历史。只有随仓库流转、可供审查的决策上下文。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
 ```
 
-为这台机器下载一个经过 checksum 校验的 release 二进制文件——不需要 Node（[ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)）,并把 `commitlore` 命令放上 `PATH`。接着检测这台机器上装了哪些编程智能体——Claude Code、Codex、Gemini CLI、Cursor、Windsurf、opencode。对检测到的每一个,都会把 CommitLore 的 MCP 服务器(Claude Code 则是插件)接进去。它不会在未告知的情况下覆盖已有配置,也不会为未安装的智能体写配置,并会原样打印出接了什么、跳过了什么。
+然后在每个需要验证 hook 与本地 index 的仓库运行 `commitlore init`。安装程序会检测受支持的编程代理，并在可以安全处理的地方注册本地 MCP server。
 
-然后,在每个想启用 CommitLore 的仓库里:
+这一行命令是为了方便。若需要经过审阅或固定版本的安装，请先下载并检查 `install.sh`，或 clone 仓库，或手动下载发布资产并验证其 `SHA256SUMS`。脚本会校验下载二进制文件的校验和；它不会认证已经通过管道交给 `sh` 的脚本本身。
 
 ```bash
-commitlore init
+# 固定版本并检查 installer 后再执行。
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.2.0/install.sh
+sh install.sh v0.2.0
+
+# 或自行验证 release binary 后再解压。
+version=0.2.0; target=aarch64-apple-darwin
+curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
+curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
+grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
 ```
 
-为该仓库安装 commit-msg 校验 hook,构建本地记录索引。它会报告做了什么,并且可以放心重复运行——已经配置好的仓库只会如实报告,不会做任何改动。
+## 看它实际运行
 
-只是读取协议的话根本不需要安装:每条记录都是普通的 git trailer(见[下文](#一条记录))。不想把脚本 pipe 进 `sh`,而是想用 Node clone、从源码构建,或者手动校验下载?[从 clone 安装](#从-clone-安装)这三种都写了。
+**一个全新的代理，没有聊天历史。它仍知道为什么那个显而易见的修复被排除了。** 在这个 checkout 中，将针对 `install.sh` 的真实 Claude `PreToolUse` payload 送入同一条 hook path。
 
-## 测量记录
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+响应会包含一条 active record：它排除了把发布 `-musl` target 当作 installer 缺陷修复的做法，并说明原因。hook 提供上下文；它并不声称会阻止编辑。
+
+```console
+Ruled-out:
+  [claim] r-instci99a ... publishing a `-musl` release target |
+  a release.yml/build-matrix change, not an install.sh or CI-verification fix
+```
+
+## 有何不同
+
+- **CLAUDE.md 告诉代理如何工作。CommitLore 告诉它这段代码为何存在。**
+- **ADR 记录架构。CommitLore 记录藏在 diff 中的决策。**
+- **不是又一个 memory database，而是构建在 Git 中的 decision protocol。**
+
+权威来源是普通的 commit trailer 与 `refs/notes/commitlore`。index 和 report 都从这些 Git record 派生，且可以重建。
+
+## 一条记录
+
+这个示例也是 conformance fixture。Git trailer parser 会在所有翻译版 README 中以相同方式读取下面的 code block。
+
+```text
+Prevent silent session drops during long-running operations
+
+The auth service returns inconsistent status codes on token
+expiry, so the interceptor catches all 4xx responses and
+triggers an inline refresh.
+
+Limit: Auth service does not support token introspection
+Record-Id: r-4b7e21
+Ruled-out: Extend token TTL to 24h | security policy violation
+Ruled-out: Background refresh on timer | race condition
+Certainty: firm
+Blast: module
+Undo: easy
+Warn: 4xx handling is intentionally broad
+  -- do not narrow without verifying upstream behavior
+Verified: Single expired token refresh (unit)
+Unverified: Auth service cold-start > 500ms behavior
+CommitLore-Version: 2.0.0
+```
+
+### Protocol vocabulary
+
+| Trailer | Meaning |
+|---|---|
+| `Limit:` | External condition that constrained the decision |
+| `Record-Id:` | Stable identity across rewritten commit hashes |
+| `Ruled-out:` | `alternative \| reason` |
+| `Certainty:` | `firm` \| `tentative` \| `guess` |
+| `Blast:` | `local` \| `module` \| `system` |
+| `Undo:` | `easy` \| `costly` \| `permanent` |
+| `Warn:` | Warning for a future modifier; trust-graded before delivery |
+| `Verified:` / `Unverified:` | What was and was not checked |
+| `Follows:` / `Supersedes:` | Decision-chain and lifecycle links |
+| `Expires:` | Date or condition that ends a limit |
+| `Evidence:` | Path, anchor, or URL supporting a claim |
+| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
+| `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
+
+用 `commitlore context <path>` 读取 path 的历史，或直接使用 Git：
+
+```bash
+git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
+```
+
+请使用 Git trailer parser，而不是 text search：正文里的 `Key:` 不一定是 trailer。
+
+## 仓库能够证明什么
+
+- 在经过测试的 Git workflow 中，决策历史会跨越 rebase、squash、remote transfer 与 path rename 保留下来。
+- 所有 route 使用相同的 trust grading，因此不受信任的 text 会作为 information 而不是 instruction 传递。
+- free-form trailer 中类似 injection 的 text 会从 model-readable route 中被保留。
+- 可读取的 repository 没有 record，与不完整的 history 或未 fetch 的 notes mirror 是不同状态。
+
+这是关于绑定到 Git、可由人验证的决策历史的产品主张。它不依赖“CommitLore 提升 agent performance”的主张。
+
+## Evidence：112 次实验，null 结果
+
+> **我构建了一个 AI tool，跑了 112 次实验，结果是 null。**
+
+这是产品信任模型的一部分，而不是应当藏起来的脚注。M4 没有发现对所测 agent behavior 有支持依据的效果。后来分析针对 paired 与 clustered design 作了修正，也更正了一项有记录的算术错误。完整限制见 [M4 verdict](bench/VERDICT-M4.md)，由此得到的产品主张见 [roadmap](docs/ROADMAP-TO-DONE.md)。
 
 <!-- BENCH:BEGIN -->
 <!-- Generated by `node bench/report.ts --section` from the result logs named below. Do not edit by hand:
@@ -64,17 +155,7 @@ commitlore init
 
 **Analysis set — all 112 rows.** Nothing was excluded: no simulated rows, no failed runs, no run that never started.
 
-**Significance:**
-
-| Quantity | Value |
-|---|---|
-| Arms | `commitlore-on` (treatment) vs `commitlore-guard` (baseline) |
-| Re-proposed / did not | `commitlore-on` 35/21, `commitlore-guard` 41/15 |
-| Fisher exact, two-tailed | p = 0.3117 |
-| Rate difference, treatment minus baseline | -10.7pp, 95% CI [-27.1pp, 6.5pp] |
-| Odds ratio | 0.6098 |
-| Paired (task, seed) cells | 56 |
-| Rows excluded from the analysis set | 0 |
+**Significance:** not computed — guard exposure is unknown for 112 analysis rows
 
 **How the runs ended** — failures are reported, not filtered:
 
@@ -87,190 +168,26 @@ commitlore init
 
 - No model is recorded — neither on the rows nor in a manifest. A re-proposal rate whose model is unknown is not a comparable number, and these figures must not be quoted against another model's.
 - Every rate here is conditional on the model that produced it. Re-proposal is a behaviour, and behaviours differ between models, so these figures are not evidence about any other model.
-- 56 and 56 runs per arm: this matrix is only powered to detect a large effect, so a non-significant result from it is a statement about the sample size, not about CommitLore. The exact power table is in [`bench/README.md`](bench/README.md).
-- Fisher exact treats the runs as independent while the design is paired by (task, seed). It is the pre-registered test and, on paired data, the conservative choice rather than the most powerful one.
+- 112 runs in the analysis set: this matrix is only powered to detect a large effect, so a non-significant result from it is a statement about the sample size, not about CommitLore. The exact power table is in [`bench/README.md`](bench/README.md).
 <!-- BENCH:END -->
 
-已注册的假设 —— 能看到已记录决策的智能体,再提出被否决方案的频率会更低 —— 至今没有任何一次测量给出支持。M1、M1-b、M2 在一个大半沉默的任务集上得出零结果(十个任务中有七个 control 组从未出现过再提议);后续的一次运行 M3,因为被测二进制在运行期间发生变化而作废([`PREREGISTRATION.md` §15](bench/PREREGISTRATION.md#15-m3-is-void-the-binary-under-test-changed-while-it-ran))。
+## 从 source 安装
 
-M4 正是针对这一诊断而设计:先跑一轮 qualification,只凭每个任务 control 组的基础再提议率,决定 treatment 组是否会在该任务上运行。M4 通过筛选的八个任务,两组都出现了再提议,上面的结果依然是零效应。这些数字由 [`bench/results/t702-m4-final.jsonl`](bench/results/t702-m4-final.jsonl) 生成——这是本项目第一个每一行都记录了 harness commit 和 bundle 摘要的数据集。带日期的判定文档记录了每次运行得出的结论:[`VERDICT-M1.md`](bench/VERDICT-M1.md)、[`VERDICT-M1b.md`](bench/VERDICT-M1b.md)、[`VERDICT-M2.md`](bench/VERDICT-M2.md)、[作废运行记录](bench/PREREGISTRATION.md#15-m3-is-void-the-binary-under-test-changed-while-it-ran)、[`VERDICT-M4.md`](bench/VERDICT-M4.md)。详见 [`bench/README.md`](bench/README.md)。
-
-## 仓库确实能证明什么
-
-- **记录能经受常见 Git 工作流。** 提交 trailer 和 notes mirror 在 [rebase 与 squash](test/squash.test.ts)、[历史重写与远程传递](test/notes.test.ts)，以及[单步和多步重命名](test/follow.test.ts)中都有测试。
-- **信任在每条路由上的含义一致。** 查询输出、CLI 注入、编辑 hook、MCP 工具和 guard 都使用同一套 `directive | claim | blocked` 分级。路由测试位于 [`query.test.ts`](test/query.test.ts)、[`inject.test.ts`](test/inject.test.ts)、[`mcp.test.ts`](test/mcp.test.ts) 和 [`guard.test.ts`](test/guard.test.ts)。
-- **命中内置注入扫描器的记录不会作为正文送给模型。** 任一自由文本 trailer 命中时，整条记录都会被分为 `blocked`；模型可读路由只说明内容已被隐藏，不会引用其正文。这个确定性词法过滤器的结果不代表真实环境中的检测率；[由模式作者编写、独立编写及正常文本三个语料集](spec/fixtures/injection/README.md)分别报告。CLI 与 hook 由 [`inject.test.ts`](test/inject.test.ts) 验证，MCP 的一致结果由 [`mcp.test.ts`](test/mcp.test.ts) 验证。
-- **未知不等于为空。** 对于可读但没有记录的仓库，guard 以 `0` 退出。Git 损坏时报告 `history: unavailable`；notes mirror 未拉取时报告 `notes: unfetched`。两种不完整检查都以 `3` 退出。该契约固定在 [`notes-availability.test.ts`](test/notes-availability.test.ts)、[`guard.test.ts`](test/guard.test.ts) 和 [`RELEASE-GATE`](docs/RELEASE-GATE.md) 中。
-
-## 一条记录
-
-这个示例也是 conformance fixture。Git 的 trailer parser 必须在四种语言的 README 中逐字节读出相同内容。
-
-```text
-Prevent silent session drops during long-running operations
-
-The auth service returns inconsistent status codes on token
-expiry, so the interceptor catches all 4xx responses and
-triggers an inline refresh.
-
-Limit: Auth service does not support token introspection
-Record-Id: r-4b7e21
-Ruled-out: Extend token TTL to 24h | security policy violation
-Ruled-out: Background refresh on timer | race condition
-Certainty: firm
-Blast: module
-Undo: easy
-Warn: 4xx handling is intentionally broad
-  -- do not narrow without verifying upstream behavior
-Verified: Single expired token refresh (unit)
-Unverified: Auth service cold-start > 500ms behavior
-CommitLore-Version: 2.0.0
-```
-
-### 协议词汇
-
-| Trailer | 含义 |
-|---|---|
-| `Limit:` | 约束决策的外部条件 |
-| `Record-Id:` | 提交 hash 被重写后仍保持稳定的标识 |
-| `Ruled-out:` | `备选方案 \| 未采用原因` |
-| `Certainty:` | `firm` \| `tentative` \| `guess` |
-| `Blast:` | `local` \| `module` \| `system` |
-| `Undo:` | `easy` \| `costly` \| `permanent` |
-| `Warn:` | 给未来修改者的警告；传递前会经过信任分级 |
-| `Verified:` / `Unverified:` | 已验证和未验证的事项 |
-| `Follows:` / `Supersedes:` | 决策链和 lifecycle 链接 |
-| `Expires:` | 约束结束的日期或条件 |
-| `Evidence:` | 支持 claim 的路径、anchor 或 URL |
-| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
-| `CommitLore-Version:` / `X-*:` | 协议标识和扩展 |
-
-完整契约见 [`spec/SPEC.md`](spec/SPEC.md)。
-
-## 信任是路由，不是徽章
-
-提交 `4842356` 包含以下 active record：
-
-```gitcommit
-Ruled-out: exempting datasets written before the fields existed | it is one line and it deletes the guarantee
-Warn: this leaves the README with no measured numbers at all until M3-b runs. That is the honest state and it is also a worse first impression. The alternative was publishing numbers produced by a binary nobody recorded
-Record-Id: r-2b58d4
-Provenance: authored
-```
-
-同一段 `Warn:` 文本会按等级路由：
-
-| 等级 | 条件 | 模型可读路由收到的内容 |
-|---|---|---|
-| `[directive]` | `Provenance: authored`、active record，并且作者在此仓库中被明确设为可信 | 把警告作为指令传递 |
-| `[claim]` | 没有可信作者、作者来自外部，或 provenance 为 reconstructed/unknown | 把警告作为信息传递，并明确标注“不是指令” |
-| `blocked` | 任一自由文本 trailer 命中注入模式 | 只传递隐藏通知，不渲染命中的正文 |
-
-默认不信任任何作者。加密作者验证尚未实现，由 [issue #28](https://github.com/MongLong0214/commitlore/issues/28) 跟踪。
-
-## 从 clone 安装
-
-CommitLore 没有 registry package。发布渠道就是 Git 仓库本身（[ADR-0011](docs/adr/ADR-0011-plugin-first-distribution.md)），CLI 需要 Node.js 22 或更高版本：
+要检查或运行 source distribution，请使用：
 
 ```bash
 git clone https://github.com/MongLong0214/commitlore ~/.commitlore
-node ~/.commitlore/dist/commitlore.mjs --version
 node ~/.commitlore/dist/commitlore.mjs init
 node ~/.commitlore/dist/commitlore.mjs context src/auth
 ```
 
-`init` 会把 `doctor --fix`、`hooks install`、`index --rebuild` 一起跑完,报告做了什么、没能做成什么,并且可以放心重复运行——自己解决不了的 `warn` 或 `fail` 会如实报告,不会被吞进一句"成功"里。这三个命令各自也都还在,想单独用哪个都行:`commitlore doctor`、`commitlore hooks install`、`commitlore index --rebuild`。
+## 已知限制
 
-仓库中提交的 bundle 无需构建、也无需 `node_modules` 即可运行。SQLite 索引使用 Node 自带的 `node:sqlite`（[ADR-0012](docs/adr/ADR-0012-drop-the-native-dependency.md)），因此仅靠 clone 就能构建并查询索引——不需要原生模块，不需要编译器，也不需要 `npm install`。想跳过索引、只用 Git 回答时，仍可以使用 `--no-index`。
+- 不支持 Windows：[#95](https://github.com/MongLong0214/commitlore/issues/95)。
+- 不支持 Alpine 与其他 musl Linux host：[#99](https://github.com/MongLong0214/commitlore/issues/99)。
+- 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
+- benchmark 未能证明 guard 对 agent behavior 有效果：[#37](https://github.com/MongLong0214/commitlore/issues/37)。
 
-### 无需 Node，作为编译好的二进制运行
+## 贡献
 
-`git clone` + Node 运行时仍是正式的安装方式。对于 PATH 中完全没有 Node 的机器，可以从同一个 clone 构建单个编译后的可执行文件（[ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)）：
-
-```bash
-cd ~/.commitlore
-npm ci
-npm run build:binary
-./dist/commitlore --version
-./dist/commitlore doctor
-```
-
-`dist/commitlore` 在运行时不需要 Node、不需要解释器，也不需要 `node_modules`——`doctor`、`validate`、`context`、`guard`、`inject`、`index --rebuild` 都能在 `PATH=/usr/bin:/bin` 下运行。它不会被提交（体积大、与平台/架构相关，且由 CI 在每次 push 时重新构建而不是 diff）；`commitlore hooks install` 和插件的 `PreToolUse` hook 一旦构建完成都会自动解析到它。
-
-### 安装预构建的发布二进制文件
-
-对于既没有 Node 也没有 clone 的机器：每个 `vX.Y.Z` 标签都会为每个平台构建一个二进制文件（`.github/workflows/release.yml`），附带覆盖全部文件的 `SHA256SUMS`，并通过 [`actions/attest-build-provenance`](https://github.com/MongLong0214/commitlore/attestations) 为每个资产生成证明（基于 Sigstore，可公开验证，本项目无需管理任何密钥）。
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
-```
-
-`install.sh` 会检测你的 OS 和架构，从同一个 release 下载匹配的资产和 `SHA256SUMS`，并在安装前验证校验和——像对待任何安装脚本一样，在把它传给 `sh` 之前先读一读。要固定版本：`sh install.sh v0.2.0`。已发布的 target：`aarch64-apple-darwin`、`x86_64-apple-darwin`、`x86_64-unknown-linux-gnu`、`aarch64-unknown-linux-gnu`。目前还没有 Windows 二进制文件——SEA 构建和 commit-msg hook shim 在该平台上尚未验证，见 [ADR-0015](docs/adr/ADR-0015-single-executable-binary.md)。
-
-二进制文件装好之后，同一个脚本会检测这台机器上装了哪些编程智能体（Claude Code、Codex、Gemini CLI、Cursor、Windsurf、opencode），给检测到的每一个接上 CommitLore 的 MCP 服务器（Claude Code 则是插件），并打印出接了什么、跳过了什么。它不会在未告知的情况下覆盖已有配置，也不会为未安装的智能体写配置。
-
-传给 shell 执行不应是唯一有文档记录的方式。手动完成同样的安装：
-
-```bash
-version=0.2.0   # 或者: curl -fsSL https://github.com/MongLong0214/commitlore/releases/latest/download/SHA256SUMS | head -1
-target=aarch64-apple-darwin   # 或 x86_64-apple-darwin | x86_64-unknown-linux-gnu | aarch64-unknown-linux-gnu
-
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
-
-# 解压前先验证。结果必须是 "OK"，否则到此为止——不要运行未通过校验的二进制文件。
-grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c -   # Linux: sha256sum -c -
-
-tar -xzf "commitlore-$version-$target.tar.gz"
-./commitlore --version
-```
-
-## GitHub Actions
-
-运行 query、guard 或 inject 命令的 job 必须获取完整 history。
-
-```yaml
-- uses: actions/checkout@v4
-  with:
-    fetch-depth: 0
-```
-
-在 MCP 客户端中注册同一 clone 的入口：
-
-```json
-{
-  "mcpServers": {
-    "commitlore": {
-      "command": "node",
-      "args": ["/absolute/path/to/commitlore/dist/commitlore.mjs", "mcp"]
-    }
-  }
-}
-```
-
-`install.sh` 会为这台机器上已经装好的每个受支持客户端（Codex、Gemini CLI、Cursor、Windsurf、opencode）自动写入等价的这段配置——它没检测到的客户端，或者 CI 环境，就照抄这段。
-
-读取协议并不需要 CLI：
-
-```bash
-git log --format='%(trailers:key=Ruled-out,valueonly,separator=%x3B)'
-git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
-```
-
-应使用 Git 的 trailer parser，而不是文本搜索；正文中的 `Key:` 不一定属于 trailer block。
-
-## 尚未实现
-
-- 加密验证作者身份：[#28](https://github.com/MongLong0214/commitlore/issues/28)
-- 报告整个仓库的 record coverage：[#32](https://github.com/MongLong0214/commitlore/issues/32)
-- 把记录 anchor 到 symbol 而不是 path：[#33](https://github.com/MongLong0214/commitlore/issues/33)
-- 交互式 commit builder 和自动 expiry 提醒：[#34](https://github.com/MongLong0214/commitlore/issues/34)
-- 用有效 benchmark 证明 guard 对智能体行为的影响：[#37](https://github.com/MongLong0214/commitlore/issues/37)
-
-## 参与贡献
-
-请先阅读 [spec](spec/SPEC.md)、[ADR](docs/adr/) 和 [`CONTRIBUTING.md`](CONTRIBUTING.md)。本仓库会记录自身决策；修改文件前请运行 `commitlore context <path>`。
-
-## 许可证
-
-[MIT](LICENSE)
+请阅读 [spec](spec/SPEC.md)、[ADR](docs/adr/) 和 [`CONTRIBUTING.md`](CONTRIBUTING.md)。CommitLore 是采用 [MIT License](LICENSE) 的永久免费开源软件。

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,62 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg"
-     width="1200" height="400" viewBox="0 0 1200 400"
-     role="img" aria-labelledby="title desc">
-  <title id="title">CommitLore — decisions carried by Git</title>
-  <desc id="desc">A real CommitLore record from commit 4842356 passes through trust grading as a claim and is matched by guard with its reason intact.</desc>
-
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400" role="img" aria-labelledby="title desc">
+  <title id="title">CommitLore — Git remembers what changed. CommitLore remembers why.</title>
+  <desc id="desc">A Git-native decision record carries a rejected alternative and its reason to a fresh coding-agent session.</desc>
   <rect width="1200" height="400" rx="24" fill="#f7f5f0"/>
-  <path d="M48 48H1152M48 352H1152" stroke="#d8d3c8"/>
-
-  <g id="title-block" transform="translate(64 76)">
-    <text fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="18" font-weight="600" letter-spacing="2">GIT-NATIVE DECISION RECORDS</text>
-    <text y="78" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
-          font-size="64" font-weight="700" letter-spacing="-2">CommitLore</text>
-    <text y="126" fill="#3e3b35" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
-          font-size="24">Protocol first. CLI second.</text>
-    <text y="183" fill="#6d675e" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
-          font-size="20">No claimed behavior effect</text>
-    <text y="211" fill="#6d675e" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
-          font-size="20">without provenanced evidence.</text>
+  <path d="M48 48H1152M48 334H1152" stroke="#d8d3c8"/>
+  <g transform="translate(64 76)">
+    <text fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600" letter-spacing="2">GIT-NATIVE DECISION MEMORY</text>
+    <text y="66" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">Git remembers</text>
+    <text y="122" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">what changed.</text>
+    <text y="178" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">CommitLore</text>
+    <text y="234" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">remembers why.</text>
+    <text y="282" fill="#3e3b35" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="22">Reviewable decisions that travel with the code.</text>
   </g>
-
-  <g id="record" transform="translate(522 70)">
-    <rect width="356" height="232" rx="12" fill="#fffdf9" stroke="#bdb6aa"/>
-    <text x="24" y="36" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="18" font-weight="600">COMMIT 4842356</text>
-    <path d="M24 52H332" stroke="#ded9d0"/>
-    <text x="24" y="84" fill="#181714" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="20">Ruled-out:</text>
-    <text x="24" y="112" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="18">exempting datasets written</text>
-    <text x="24" y="138" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="18">before the fields existed</text>
-    <text x="24" y="174" fill="#181714" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="20">Record-Id: r-2b58d4</text>
-    <text x="24" y="207" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="18">reason stays with decision</text>
+  <g transform="translate(712 76)">
+    <rect width="424" height="246" rx="14" fill="#fffdf9" stroke="#bdb6aa"/>
+    <text x="28" y="40" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600">A FRESH AGENT SEES</text>
+    <path d="M28 58H396" stroke="#ded9d0"/>
+    <text x="28" y="94" fill="#181714" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700">Ruled-out:</text>
+    <text x="28" y="124" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">publish a -musl release target</text>
+    <text x="28" y="164" fill="#181714" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700">because:</text>
+    <text x="28" y="194" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">a release-matrix change, not a</text>
+    <text x="28" y="220" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">fix for this installer defect</text>
   </g>
-
-  <path d="M878 148H910" stroke="#9d968b" stroke-width="2"/>
-  <path d="M902 140L910 148L902 156" fill="none" stroke="#9d968b" stroke-width="2"/>
-
-  <g id="trust-grade" transform="translate(926 91)">
-    <text fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="18" font-weight="600">TRUST GRADE</text>
-    <rect y="24" width="202" height="66" rx="10" fill="#fbf0dc" stroke="#c79a54"/>
-    <text x="20" y="67" fill="#855719" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="24" font-weight="700">[claim]</text>
-  </g>
-
-  <g id="guard" transform="translate(926 218)">
-    <text fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="18" font-weight="600">GUARD</text>
-    <rect y="24" width="202" height="66" rx="10" fill="#e8f0eb" stroke="#70917c"/>
-    <circle cx="24" cy="57" r="7" fill="#36694d"/>
-    <text x="42" y="65" fill="#28533d" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-          font-size="22" font-weight="700">MATCH</text>
-  </g>
-
-  <text x="522" y="336" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
-        font-size="18">commit → grade → guard</text>
+  <text x="712" y="356" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">commit trailer → hook context</text>
 </svg>

--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ case "$os_raw" in
   Darwin) os=apple-darwin ;;
   Linux) os=unknown-linux-gnu ;;
   *)
-    die "unsupported OS \"$os_raw\" — only macOS and Linux release binaries are published (no Windows asset yet: the SEA build and the commit-msg hook shim are not verified there, see ADR-0015). Install from source instead: https://github.com/$REPO#install-from-the-clone" 1
+    die "unsupported OS \"$os_raw\" — only macOS and Linux release binaries are published (no Windows asset yet: the SEA build and the commit-msg hook shim are not verified there, see ADR-0015). Install from source instead: https://github.com/$REPO#install-from-source" 1
     ;;
 esac
 
@@ -60,7 +60,7 @@ case "$arch_raw" in
   arm64 | aarch64) arch=aarch64 ;;
   x86_64 | amd64) arch=x86_64 ;;
   *)
-    die "unsupported architecture \"$arch_raw\" — published binaries are aarch64 and x86_64 only. Install from source instead: https://github.com/$REPO#install-from-the-clone" 1
+    die "unsupported architecture \"$arch_raw\" — published binaries are aarch64 and x86_64 only. Install from source instead: https://github.com/$REPO#install-from-source" 1
     ;;
 esac
 
@@ -157,7 +157,7 @@ chmod +x "$work/commitlore"
 # into the same clear, attributed failure every other unsupported-platform
 # case in this script already gives.
 if ! "$work/commitlore" --version >/dev/null 2>&1; then
-  die "the downloaded binary for $target does not run on this machine (nothing was installed). This usually means a musl-libc host such as Alpine — only glibc (\"-gnu\") Linux binaries are published, and Alpine's dynamic linker cannot load them. Install from source instead: https://github.com/$REPO#install-from-the-clone" 1
+  die "the downloaded binary for $target does not run on this machine (nothing was installed). This usually means a musl-libc host such as Alpine — only glibc (\"-gnu\") Linux binaries are published, and Alpine's dynamic linker cannot load them. Install from source instead: https://github.com/$REPO#install-from-source" 1
 fi
 
 if [ -n "${COMMITLORE_INSTALL_DIR:-}" ]; then


### PR DESCRIPTION
## Summary

- Reposition CommitLore as Git-native decision memory with a runnable `inject --hook-input` proof.
- Lead with the supported product claim and the honest 112-experiment M4 null result.
- Update all four README translations, the local SVG hero, installer safety guidance, and the source-install anchor.

## Validation

- `node scripts/check-readme-numbers.mjs`
- `npx vitest run` — 39 files, 1,385 passed, 1 skipped
- `bash spec/verify.sh`
- README image/SVG audits, hook-demo execution, and `sh -n install.sh`
