### PR TITLE
Withdraw M4's null on unverifiability, not on non-delivery

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -162,7 +162,7 @@ text search ではなく Git trailer parser を使います。本文の `Key:` �
 
 ## Evidence: より狭い製品上の主張
 
-112 回の実験は記録されましたが、M4 はどちらの arm にも record を届けませんでした。したがって agent behavior の主張を検証も支持も反証もしていません。上記のより狭い製品上の主張は独立して検証可能な動作に基づきます。クリーンなデータセットと撤回については [M4 verdict](bench/VERDICT-M4.md) を読んでください。
+112 回の実験は記録されましたが、M4 には run ごとの `guard_exposure` 記録がありません。treatment があったか検証できないため、agent behavior の主張を検証も支持も反証もしていません。上記のより狭い製品上の主張は独立して検証可能な動作に基づきます。クリーンなデータセットと撤回については [M4 verdict](bench/VERDICT-M4.md) を読んでください。
 
 <details>
 <summary>完全な benchmark record（112 回の実験）</summary>
@@ -224,7 +224,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - Windows は未対応です: [#95](https://github.com/MongLong0214/commitlore/issues/95)。
 - Alpine および他の musl Linux host は未対応です: [#99](https://github.com/MongLong0214/commitlore/issues/99)。
 - cryptographic author verification、repository-wide record coverage、symbol anchor、interactive record builder は未実装です: [#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
-- M4 は guard の効果を検証していません。どちらの arm にも injected record が届きませんでした: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
+- M4 は guard の効果を検証していません。row に `guard_exposure` がないため treatment exposure を検証できません: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
 
 ## コントリビュート
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -162,7 +162,7 @@ git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
 
 ## 근거: 더 좁은 제품 주장
 
-112회 실험은 기록됐지만 M4는 어느 arm에도 record를 전달하지 않았다. 따라서 에이전트 행동 주장을 시험하거나 뒷받침하거나 반박하지 못한다. 위의 더 좁은 제품 주장은 독립적으로 검증 가능한 동작에 근거한다. 깨끗한 데이터셋과 철회 내용은 [M4 verdict](bench/VERDICT-M4.md)에서 읽을 수 있다.
+112회 실험은 기록됐지만 M4에는 run별 `guard_exposure` 기록이 없다. treatment가 있었는지 검증할 수 없으므로 agent behavior 주장을 시험하거나 뒷받침하거나 반박하지 못한다. 위의 더 좁은 제품 주장은 독립적으로 검증 가능한 동작에 근거한다. 깨끗한 데이터셋과 철회 내용은 [M4 verdict](bench/VERDICT-M4.md)에서 읽을 수 있다.
 
 <details>
 <summary>전체 benchmark 기록 (112회 실험)</summary>
@@ -224,7 +224,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - Windows는 지원하지 않는다: [#95](https://github.com/MongLong0214/commitlore/issues/95).
 - Alpine 및 다른 musl Linux host는 지원하지 않는다: [#99](https://github.com/MongLong0214/commitlore/issues/99).
 - 암호학적 작성자 검증, 저장소 전체 record coverage, symbol anchor, interactive record builder는 아직 구현되지 않았다: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
-- M4는 guard 효과를 시험하지 못했다. 어느 arm도 injected record를 받지 못했다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
+- M4는 guard 효과를 시험하지 못했다. row에 `guard_exposure`가 없어 treatment exposure를 검증할 수 없다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
 
 ## 기여하기
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ These are product claims about Git-bound, human-verifiable decision history. The
 
 ## Evidence: a narrower product claim
 
-112 experiments were recorded, but M4 delivered records in neither arm. It did not test, support, or refute the agent-behavior claim. The narrower product claim above rests on independently testable behavior; read the [M4 verdict](bench/VERDICT-M4.md) for the clean dataset and withdrawal.
+112 experiments were recorded, but M4 recorded no per-run guard exposure. Whether the treatment was present is unverifiable, so it does not test, support, or refute the agent-behavior claim. The narrower product claim above rests on independently testable behavior; read the [M4 verdict](bench/VERDICT-M4.md) for the clean dataset and withdrawal.
 
 <details>
 <summary>Full benchmark record (112 experiments)</summary>
@@ -224,7 +224,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - Windows is unsupported: [#95](https://github.com/MongLong0214/commitlore/issues/95).
 - Alpine and other musl Linux hosts are unsupported: [#99](https://github.com/MongLong0214/commitlore/issues/99).
 - Cryptographic author verification, repository-wide record coverage, symbol anchors, and an interactive record builder are not implemented yet: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
-- M4 did not test a guard effect: neither arm received injected records ([#122](https://github.com/MongLong0214/commitlore/issues/122)).
+- M4 did not test a guard effect: its rows have no `guard_exposure`, so treatment exposure is unverifiable ([#122](https://github.com/MongLong0214/commitlore/issues/122)).
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -162,7 +162,7 @@ git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
 
 ## Evidence：更窄的产品主张
 
-已记录 112 次实验，但 M4 没有向任何 arm 交付 record。因此它没有检验、支持或反驳 agent behavior 的主张。上面更窄的产品主张基于可独立验证的行为。关于干净的数据集和撤回，请见 [M4 verdict](bench/VERDICT-M4.md)。
+已记录 112 次实验，但 M4 没有逐次运行的 `guard_exposure` 记录。无法验证 treatment 是否存在，因此它没有检验、支持或反驳 agent behavior 的主张。上面更窄的产品主张基于可独立验证的行为。关于干净的数据集和撤回，请见 [M4 verdict](bench/VERDICT-M4.md)。
 
 <details>
 <summary>完整 benchmark 记录（112 次实验）</summary>
@@ -224,7 +224,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - 不支持 Windows：[#95](https://github.com/MongLong0214/commitlore/issues/95)。
 - 不支持 Alpine 与其他 musl Linux host：[#99](https://github.com/MongLong0214/commitlore/issues/99)。
 - 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
-- M4 没有检验 guard 效果：没有任何 arm 收到 injected record（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
+- M4 没有检验 guard 效果：row 没有 `guard_exposure`，因而无法验证 treatment exposure（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
 
 ## 贡献
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -3,17 +3,18 @@
 **M4 is a citable, clean-provenance dataset, not a guard test.**
 `bench/results/t702-m4-final.jsonl` records the harness commit and `dist/`
 digest for every row, and `bench/report.ts` summarizes it. M3 was voided for
-lacking that provenance (§15); M4 has it. But M4's 112 transcripts contain no
-injected context in either arm, so its valid data do not answer the guard
-question. The withdrawal and the corrected statistics as observations about
-the data are in `bench/VERDICT-M4.md`. Every earlier dataset (M1, M1-b, M2)
+lacking that provenance (§15); M4 has it. But none of M4's 112 rows records
+`guard_exposure`, so its valid data cannot establish whether the treatment was
+present and do not answer the guard question. The withdrawal and the corrected
+statistics as observations about the data are in `bench/VERDICT-M4.md`. Every earlier dataset (M1, M1-b, M2)
 still lacks the fields and is not pooled into the generated block for that
 reason, not because it was withdrawn as a record; each has its own verdict
 document.
 
 The benchmark is designed to ask whether an agent that receives recorded
 decisions stops re-proposing approaches a team already rejected. M4 did not
-deliver those decisions, so it does not answer that question.
+record whether that treatment reached a run, so it does not answer that
+question.
 
 - Design: `docs/adr/ADR-0007-commitlorebench.md`
 - Requirements: `docs/prd/PRD-F7-commitlorebench.md`
@@ -83,8 +84,9 @@ Planned arms are rejected at CLI parse time with a pointer to their ticket.
 
 **M4 correction:** although its labels were `commitlore-on` and
 `commitlore-guard`, all 112 stored M4 transcripts have `injected_context: null`.
-The condition table describes the intended harness behavior; M4 did not receive
-the treatment and is not evidence about it.
+For hook arms that null is the designed delivery-route signature, and the
+transcript holds only a final assistant message rather than a conversation log.
+M4 has no `guard_exposure` rows, so it is not evidence about the guard.
 
 `--cond both` is the two arms of the primary comparison and `--cond all` is
 every supported arm. Until T-703 those were the same list; they are not any
@@ -945,7 +947,7 @@ registered, but it does not provide a valid hypothesis test for paired data.
 The original number remains part of the historical report; the registered
 replacement is in `docs/MEASUREMENT-PROTOCOL.md`. M4's paired/clustered
 statistics are preserved in `bench/VERDICT-M4.md` as descriptions of rows that
-did not receive the treatment, not as a correction of a guard estimate.
+do not record treatment exposure, not as a correction of a guard estimate.
 
 ### What makes the measured effect a floor — one thing, not two
 

--- a/bench/VERDICT-M4.md
+++ b/bench/VERDICT-M4.md
@@ -1,42 +1,45 @@
-# M4 verdict — valid data; null withdrawn as guard evidence
+# M4 verdict — valid data; null withdrawn because guard exposure is unverifiable
 
 > **Historical executed report and correction.** M4's 112 rows and their
 > provenance remain valid. Its null is retained as an observation about those
-> rows, but withdrawn as evidence about the guard: neither arm received the
-> records that defined the comparison.
+> rows, but withdrawn as evidence about the guard: M4 recorded no per-run guard
+> exposure, so the rows cannot establish whether the treatment was present.
 
-M4 was registered as a comparison of `commitlore-guard` and `commitlore-on`,
-two arms defined by receiving records. The committed transcripts show
-`injected_context: null` on **0 of 112** runs: 0/56 `commitlore-guard` and
-0/56 `commitlore-on`. This is not a field that was never used: the earlier
-`bench/results/transcripts-final/` set has injected context on 30 of 60 runs.
+M4 was registered as a comparison of `commitlore-guard` and `commitlore-on`.
+Three verified facts overturn the previous basis for withdrawing its null:
 
-The pinned M4 harness (`081d858c1667455f90b6d012e62a2cd2a549c50c`) was restored
-and probed under M4's conditions. It again produced `injected_context: None`
-and `matched: []`; the agent transcript contained none of `commitlore`,
-`Ruled-out`, `Limit:`, or active records. A recording gap would leave the
-delivered context in that transcript. Nothing was delivered.
+1. In the runner, `injectedContext` is `null` whenever an arm uses a hook
+   settings path. The shipped injector then runs per edit and path-scoped, as
+   the product does; only an arm without that path uses the harness's
+   session-start block. For a hook arm, `injected_context: null` is therefore
+   the designed signature of that delivery route, not evidence of a failure.
+2. Each M4 transcript artifact stores only the final assistant message (roughly
+   1.5 KB), not a conversation log. Record text cannot be expected to appear in
+   that field, so its absence establishes neither treatment nor non-treatment.
+3. `bench/results/t702-m4-final.jsonl` has 112 rows and no
+   `guard_exposure` field on any of them. `guard_exposure` and
+   `readGuardExposure` were added later by issue #113, after M4 ran.
 
-The two M4 arms therefore compared **nothing against nothing**. Its null is
-not a weak result about the guard, and it is not a result about the guard at
-all.
+M4 therefore records outcomes without recording exposure. Whether either label
+applied the treatment is unverifiable from these artifacts. Its null is not a
+weak result about the guard, and it is not a result about the guard at all.
 
 ## What remains valid
 
 **n = 56 per arm, 7 of 7 seeds on all 8 tasks, 112 rows.** The dataset is not
-retracted and M4 is not called invalid. It faithfully records what the harness
-ran; what it ran was both arms without records.
+retracted and M4 is not called invalid. It faithfully records the outcomes and
+provenance it was built to record; exposure was not among those things.
 
 Provenance remains clean: every row has the single
 `harness_commit: 081d858c1667455f90b6d012e62a2cd2a549c50c` and the single
 `dist_digest: f658927cae15c92a1cba2b7f0dc21119f47e2d72aea412d90489c42eb890b75e`.
-There are 112 rows and no mid-run rebuild. The failure is upstream of
-provenance. The harness recorded faithfully what it did, and what it did was
-run both arms without records.
+There are 112 rows and no mid-run rebuild. The gap is instrumentation, not
+provenance: the harness recorded faithfully what it was built to record, and
+exposure was not among those things.
 
 Data: `bench/results/t702-m4-final.jsonl`, with 112 committed transcripts at
 `bench/results/transcripts-m4/`. No manifest was written; the model provenance
-limitation remains separate from this delivery failure.
+limitation remains separate from the missing exposure instrumentation.
 
 ## Observed M4 data, not a guard effect
 
@@ -50,13 +53,14 @@ is −10.7pp (`on` minus `guard`), with Newcombe interval [−27.1pp, +6.5pp] an
 odds ratio 0.6098. Violations were 0/56 in both arms.
 
 Those are correct descriptions of the recorded data. They do not estimate a
-guard effect, because neither label received the treatment it names.
+guard effect, because the exposure that such an estimate requires was never
+recorded.
 
 ## Corrected statistical analysis still describes the data
 
 The statistical correction already made for M4 remains correct arithmetic on
-the rows and is irrelevant as evidence about the guard. Both statements are
-true.
+the rows and is irrelevant as evidence about the guard, because the exposure it
+would be evidence about was never recorded. Both statements are true.
 
 The 56 seed × task cells are paired. On the recorded outcomes, the paired table
 is:
@@ -68,26 +72,27 @@ is:
 
 There are 10 discordant pairs, giving **McNemar's exact two-sided p = 0.1094**.
 The original Fisher calculation is not the right test for paired rows; neither
-calculation answers the guard question without delivered records.
+calculation answers the guard question without recorded exposure.
 
 The task clustering correction also remains true about the data:
 
 ```
 ICC = 0.581 · cluster size 14 · DEFF = 1 + (14-1)×0.581 = 8.56
-effective n = 112 / 8.56 ≈ 13, against a nominal 112
+n_eff = n / DEFF = 112 / 8.56 ≈ 13, against a nominal 112
 ```
 
 The independence-based Newcombe interval [−27.1pp, +6.5pp] is therefore not a
-valid confidence interval for a treatment effect. Scaling its half-widths by
+valid confidence interval for a treatment effect. While n_eff = n / DEFF,
+standard error scales by √DEFF: scaling the interval's half-widths by
 √8.56 ≈ 2.92 gives the existing illustrative corrected interval, roughly
 **[−58.7pp, +39.6pp]**. It remains an interval over the observed label groups,
-not evidence about a guard that was never delivered.
+not evidence about a guard whose exposure was not recorded.
 
 Four tasks were saturated at 7/7 in both recorded labels:
 `qualification-gitseed-boolean-security`, `-fake-tty`,
 `-grading-fail-fast`, and `-single-smoke-sample`. That saturation remains an
 observation about the data. It cannot be used to explain or qualify a guard
-effect that M4 did not measure.
+effect whose exposure M4 did not record.
 
 ## What does not change
 
@@ -97,7 +102,15 @@ effect that M4 did not measure.
 - The dataset may be cited for its recorded outcomes and clean provenance, but
   never as a test, null, or estimate of a guard effect.
 
+## What would settle the guard question
+
+The current harness on `dev` records `guard_exposure` per run: the runner reads
+it with `readGuardExposure` and writes it into each row. `metrics.ts` refuses a
+comparison when treatment exposure cannot be distinguished from its comparator,
+including when any analysis-row exposure is unknown. A rerun on that harness can
+answer the guard question. M4's rows cannot be retrofitted because the field
+does not exist in them.
+
 The product claim remains the independently testable one: CommitLore binds
 decision history to Git and preserves it in a human-verifiable form. M4 neither
-supports nor refutes an agent-behavior claim; a repaired delivery path must be
-verified before a new experiment can address that question.
+supports nor refutes an agent-behavior claim.

--- a/docs/ROADMAP-TO-DONE.md
+++ b/docs/ROADMAP-TO-DONE.md
@@ -39,18 +39,20 @@ Current: `dev` default branch, CI green, 1171 tests/33 files, 10/10 review block
 | Phase | Work | Gate |
 |---|---|---|
 | **3** | Plugin manifest redeclares conventional-location `hooks` — double registration likely. No manifest tests | Manifest suite green + clone contains every declared file |
-| **4** | ~~Design and run M4~~ **Executed; withdrawn as guard evidence.** Repair and verify context delivery before a new guard experiment | A treatment arm demonstrably receives records, then all 6 gate sections pass and CI is green at that commit |
+| **4** | ~~Design and run M4~~ **Executed; withdrawn as guard evidence.** Run a new instrumented guard experiment | Per-run guard exposure is recorded, then all 6 gate sections pass and CI is green at that commit |
 
-### M4 — valid data, no delivered treatment
+### M4 — valid data, unrecorded guard exposure
 
 **Executed, with clean provenance.** `bench/PREREGISTRATION.md` §16 ran 8 qualifying
 tasks × 7 seeds × 2 labels = 112 rows, all with one `harness_commit` and one
-`dist_digest`. But both labels were defined by receiving records and none of the
-112 transcripts has injected context. The recorded 62.5% and 73.2% rates, and
+`dist_digest`. M4 recorded no `guard_exposure` on any of its 112 rows, while its
+transcript field is only a final assistant message and hook-path
+`injected_context: null` is by design. The recorded 62.5% and 73.2% rates, and
 their corrected paired/clustered analysis, remain true about the data and say
-nothing about the guard. M4 is neither retracted nor invalidated: the failure
-is upstream of provenance, because the harness faithfully recorded two arms
-without records. See `bench/VERDICT-M4.md` and [#122](https://github.com/MongLong0214/commitlore/issues/122).
+nothing about the guard. M4 is neither retracted nor invalidated: the gap is
+instrumentation, not provenance. The harness faithfully recorded what it was
+built to record, but exposure was not among those things. See
+`bench/VERDICT-M4.md` and [#122](https://github.com/MongLong0214/commitlore/issues/122).
 
 **Diagnosis (measured)**: of 10 tasks, **7 have a control base rate of 0**. Even without CommitLore,
 the agent does not propose the rejected approach. Tasks with nothing to block made up 70% of the
@@ -85,8 +87,8 @@ Power is governed more by the base rate than the sample. For an effect that cuts
 Every section of `RELEASE-GATE.md` has been executed and passed, CI is green **at that commit**,
 and every remaining issue is a feature on a defensible axis rather than a defect.
 
-**A positive benchmark is not required.** M4 did not apply its treatment, so it
-establishes nothing about agent behavior. The product claim is not "makes agents
+**A positive benchmark is not required.** M4 did not record whether its treatment
+was applied, so it establishes nothing about agent behavior. The product claim is not "makes agents
 better," but **"binds decision history to git and preserves it in a
 human-verifiable form."** The latter is already proven by tests and remains
 true independent of the benchmark.


### PR DESCRIPTION
Replaces the basis of the M4 withdrawal. The conclusion stands; the reason does not.

`injected_context: null` is the designed signature of the hook delivery path (`bench/runner.ts`), the saved `transcript` field holds only the final assistant message so it could never have shown injected context, and M4's rows carry no exposure field at all because `guard_exposure` arrived later with #113.

We did not show the treatment was absent. We showed the experiment cannot demonstrate it was present.

Statistics and provenance paragraphs are unchanged. Propagated to the four READMEs, `bench/README.md` and `docs/ROADMAP-TO-DONE.md`. 1385 tests pass; `check-readme-numbers.mjs` exits 0.

Refs #122