### PR TITLE
Make an unexposed benchmark arm detectable and refused

### DIFF
--- a/bench/metrics.ts
+++ b/bench/metrics.ts
@@ -436,6 +436,26 @@ const assertUniformProvenance = (rows: readonly RunRecord[]): void => {
   );
 };
 
+const cellOf = (row: RunRecord): string => `${row.task}\u0000${row.seed}`;
+
+const assertDifferentialExposure = (rows: readonly RunRecord[]): void => {
+  const conditions = [...new Set(rows.map((row) => row.cond))];
+  if (conditions.length !== 2 || !conditions.includes("commitlore-guard")) return;
+  const comparator = conditions.find((condition) => condition !== "commitlore-guard");
+  if (comparator === undefined) return;
+  const treatment = new Map(
+    rows.filter((row) => row.cond === "commitlore-guard").map((row) => [cellOf(row), guardExposureState(row)]),
+  );
+  const baseline = rows.filter((row) => row.cond === comparator);
+  const paired = baseline.filter((row) => treatment.has(cellOf(row)));
+  if (paired.length > 0 && paired.every((row) => treatment.get(cellOf(row)) === guardExposureState(row))) {
+    throw new Error(
+      `refusing to summarize a void benchmark: treatment exposure does not differ from comparator exposure ` +
+        `in ${paired.length} paired (task, seed) cell(s)`,
+    );
+  }
+};
+
 export const compare = (rows: readonly RunRecord[], excluded: number): Comparison | null => {
   const arms = pickArms([...new Set(rows.map((row) => row.cond))].sort());
   if (arms === null) return null;
@@ -449,8 +469,7 @@ export const compare = (rows: readonly RunRecord[], excluded: number): Compariso
     d: baseline.filter((row) => row.reproposed !== true).length,
   };
 
-  const cellsOf = (arm: readonly RunRecord[]): Set<string> =>
-    new Set(arm.map((row) => `${row.task}\u0000${row.seed}`));
+  const cellsOf = (arm: readonly RunRecord[]): Set<string> => new Set(arm.map(cellOf));
   const treatmentCells = cellsOf(treatment);
   const pairedCells = [...cellsOf(baseline)].filter((cell) => treatmentCells.has(cell)).length;
 
@@ -494,6 +513,7 @@ export const summarize = (rows: readonly RunRecord[], files: readonly string[]):
   const unknownExposureRows = usable.filter((row) => guardExposureState(row) === "unknown").length;
   const comparisonUnavailableBecause =
     unknownExposureRows === 0 ? null : `guard exposure is unknown for ${unknownExposureRows} analysis rows`;
+  if (comparisonUnavailableBecause === null) assertDifferentialExposure(usable);
 
   return {
     rows: rows.length,

--- a/test/bench-exposure.test.ts
+++ b/test/bench-exposure.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 import { describe, expect, it } from "vitest";
 
@@ -31,7 +32,38 @@ const row = (overrides: Partial<RunRecord> = {}): RunRecord => ({
   ...overrides,
 });
 
+const repoRoot = new URL("..", import.meta.url).pathname;
+const hookRunningClaude = `#!/usr/bin/env node\nconst{readFileSync}=require("node:fs"),{spawnSync}=require("node:child_process"),args=process.argv.slice(2);if(args.includes("--help")){process.stdout.write("--max-turns --strict-mcp-config --setting-sources --no-session-persistence\\n");process.exit()}const settings=JSON.parse(readFileSync(args[args.indexOf("--settings")+1],"utf8")),hook=spawnSync(settings.hooks.PreToolUse[0].hooks[0].command,{shell:true,cwd:process.cwd(),encoding:"utf8",input:JSON.stringify({tool_input:{file_path:"src/cache.ts",new_string:"rename the cache helper"}})});if(hook.status!==0)process.exit(hook.status??1);process.stdout.write(JSON.stringify({result:"completed edit",num_turns:1,usage:{input_tokens:1,output_tokens:1}}));`;
+
 describe("benchmark guard exposure", () => {
+  it("records a guard shim execution on the row from a hook-plan arm", () => {
+    const dir = mkdtempSync(join(tmpdir(), "commitlore-hook-exposure-"));
+    const privateDist = join(dir, "dist");
+    const out = join(dir, "rows.jsonl");
+    cpSync(join(repoRoot, "dist"), privateDist, { recursive: true });
+    writeFileSync(join(dir, "claude"), hookRunningClaude, { mode: 0o755 });
+
+    try {
+      execFileSync(
+        process.execPath,
+        ["--experimental-strip-types", join(repoRoot, "bench", "runner.ts"), "--tasks", join(repoRoot, "bench", "tasks"), "--out", out, "--task", "reproposal-redis-cache", "--cond", "commitlore-guard", "--seed", "1", "--driver", "claude-headless", "--model", "hook-test", "--timeout-ms", "5000"],
+        {
+          cwd: repoRoot,
+          env: {
+            ...process.env,
+            COMMITLORE_BENCH_DIST_DIR: privateDist,
+            PATH: `${dir}:${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+      const [record] = parseRows("hook-plan.jsonl", readFileSync(out, "utf8"));
+
+      expect(record?.guard_exposure).toMatchObject({ complete: true, executed: true, checks: 1, fires: 0 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("records an actual guard fire even when the synthetic agent complies", () => {
     const tasks = loadTasks(new URL("../bench/tasks", import.meta.url).pathname);
     const task = tasks.find((candidate) => candidate.id === "reproposal-redis-cache");
@@ -216,5 +248,32 @@ describe("benchmark guard exposure", () => {
     expect(output).toContain("guard exposure  yes=0 no=0 unknown=1 checks=0 fires=0");
     expect(output).toContain("not computed — guard exposure is unknown for 1 analysis rows");
     expect(output).not.toContain("Fisher exact (two-tailed)");
+  });
+
+  it("refuses analysis when treatment exposure is identical to its comparator", () => {
+    // Given: two usable arms with complete, known, identical no-exposure observations.
+    const rows = [
+      row({
+        cond: "commitlore-guard",
+        guard_exposure: { complete: true, executed: true, checks: 1, fires: 0, matches: [] },
+      }),
+      row({
+        cond: "commitlore-on",
+        guard_exposure: { complete: true, executed: false, checks: 0, fires: 0, matches: [] },
+      }),
+    ];
+
+    // When/Then: analysis refuses the void comparison instead of estimating an effect.
+    expect(() => summarize(rows, ["identical-exposure.jsonl"])).toThrow(/treatment exposure.*does not differ/i);
+  });
+
+  it("refuses rows without guard exposure as unknown rather than analysing them", () => {
+    const summary = summarize(
+      [row({ cond: "commitlore-guard" }), row({ cond: "commitlore-on" })],
+      ["absent-exposure.jsonl"],
+    );
+
+    expect(summary.comparison).toBeNull();
+    expect(summary.comparison_unavailable_because).toBe("guard exposure is unknown for 2 analysis rows");
   });
 });


### PR DESCRIPTION
M4 ran both arms through the hook injector and recorded nothing about whether the injector fired. Rows and provenance looked clean; the experiment was unanswerable and nothing noticed.

- a hook-plan arm now proves the shim **executed**, asserted on execution rather than on the field being present
- analysis refuses a dataset whose treatment exposure equals its comparator's, paired by `(task, seed)`
- rows with **no** exposure field are refused as unknown rather than passed through as differing — M4's exact shape

Exposure means the guard *fired*, not that the shim ran: an arm that checked and matched nothing delivered nothing to the agent.

Verified by breaking `guardShim` so it exits before reading stdin — 4 tests fail, and pass on restoration. The first attempt broke `ablationShim` instead and everything passed, which would have certified a test that tests nothing.

1388 tests pass. Closes #122