### PR TITLE
Register an outcome that can move, and refuse one that cannot

### DIFF
--- a/bench/detect.ts
+++ b/bench/detect.ts
@@ -14,6 +14,10 @@ export interface DetectionResult {
   readonly labels: readonly string[];
 }
 
+export interface ReproposalMatchResult extends DetectionResult {
+  readonly count: number;
+}
+
 /**
  * Case, unicode form and whitespace are not signal — an agent proposing
  * "Redis" and one proposing "redis  cache" made the same proposal.
@@ -108,6 +112,11 @@ export const evaluateGroup = (group: MatcherGroup | undefined, surfaces: Surface
   const allSatisfied = allHits.length === allOf.length;
   const labels = [...anyHits, ...allHits].map(labelOf);
   return { matched: anySatisfied && allSatisfied, labels };
+};
+
+export const countReproposalMatches = (group: MatcherGroup, surfaces: Surfaces): ReproposalMatchResult => {
+  const result = evaluateGroup(group, surfaces);
+  return { ...result, count: new Set(result.labels).size };
 };
 
 /** Violations are counted per matched clause, so one run can carry several. */

--- a/bench/metrics.ts
+++ b/bench/metrics.ts
@@ -359,9 +359,12 @@ export const parseRows = (file: string, contents: string): readonly RunRecord[] 
     for (const field of REQUIRED_FIELDS) {
       if (row[field] === undefined) throw new Error(`${file}:${index + 1}: missing field \`${field}\``);
     }
+    const reproposalMatches = row.reproposal_matches;
     if (
-      row.reproposal_matches !== undefined &&
-      (!Number.isInteger(row.reproposal_matches) || row.reproposal_matches < 0)
+      reproposalMatches !== undefined &&
+      (typeof reproposalMatches !== "number" ||
+        !Number.isInteger(reproposalMatches) ||
+        reproposalMatches < 0)
     ) {
       throw new Error(`${file}:${index + 1}: \`reproposal_matches\` must be a non-negative integer`);
     }

--- a/bench/metrics.ts
+++ b/bench/metrics.ts
@@ -14,6 +14,8 @@ import type { GuardExposure, RunRecord, StopReason } from "./types.ts";
  * this label everywhere a model is reported.
  */
 export const UNRECORDED_MODEL = "(unrecorded)";
+export const PRIMARY_OUTCOME = "reproposal_matches";
+export type PrimaryOutcome = typeof PRIMARY_OUTCOME;
 
 const modelOf = (row: RunRecord): string => {
   const value = row.model;
@@ -60,6 +62,44 @@ export const guardExposureState = (row: RunRecord): GuardExposureState => {
     return "unknown";
   }
   return exposure.fires > 0 ? "yes" : "no";
+};
+
+export const assertPrimaryOutcomeCanBeRegistered = (
+  outcome: PrimaryOutcome,
+  rows: readonly RunRecord[],
+  structuralMaximums: ReadonlyMap<string, number>,
+): void => {
+  if (rows.length === 0) throw new Error(`refusing to register primary outcome \`${outcome}\`: no pilot rows`);
+  const unexposed = rows.filter((row) => guardExposureState(row) === "unknown");
+  if (unexposed.length > 0) {
+    throw new Error(
+      `refusing to register primary outcome \`${outcome}\`: guard exposure is unknown for ${unexposed.length} pilot row(s)`,
+    );
+  }
+
+  const counts: number[] = [];
+  const taskMaxima: number[] = [];
+  for (const row of rows) {
+    const count = row.reproposal_matches;
+    if (typeof count !== "number" || !Number.isInteger(count) || count < 0) {
+      throw new Error(`refusing to register primary outcome \`${outcome}\`: it is not a non-negative integer on every pilot row`);
+    }
+    const maximum = structuralMaximums.get(row.task);
+    if (typeof maximum !== "number" || !Number.isInteger(maximum) || maximum < 0) {
+      throw new Error(`refusing to register primary outcome \`${outcome}\`: structural maximum is missing for a pilot task`);
+    }
+    counts.push(count);
+    taskMaxima.push(maximum);
+  }
+  const failures: string[] = [];
+  if (new Set(counts).size === 1) failures.push("zero variance");
+  if (counts.every((count) => count === 0)) failures.push("pinned at 0 on every row");
+  if (counts.every((count, index) => count === taskMaxima[index])) {
+    failures.push("pinned at its structural maximum on every row");
+  }
+  if (failures.length > 0) {
+    throw new Error(`refusing to register primary outcome \`${outcome}\`: ${failures.join("; ")}`);
+  }
 };
 
 /**
@@ -318,6 +358,12 @@ export const parseRows = (file: string, contents: string): readonly RunRecord[] 
     const row = parsed as Record<string, unknown>;
     for (const field of REQUIRED_FIELDS) {
       if (row[field] === undefined) throw new Error(`${file}:${index + 1}: missing field \`${field}\``);
+    }
+    if (
+      row.reproposal_matches !== undefined &&
+      (!Number.isInteger(row.reproposal_matches) || row.reproposal_matches < 0)
+    ) {
+      throw new Error(`${file}:${index + 1}: \`reproposal_matches\` must be a non-negative integer`);
     }
     rows.push(parsed as RunRecord);
   });

--- a/bench/runner.ts
+++ b/bench/runner.ts
@@ -7,7 +7,7 @@ import { Command } from "commander";
 
 import { assembleContext, collectRuledOutAlternatives } from "./context.ts";
 import { digestDistTree, HOOK_PLANS, noGuardExposure, readGuardExposure, writeArmSettings } from "./hooks-settings.ts";
-import { countViolations, evaluateGroup } from "./detect.ts";
+import { countReproposalMatches, countViolations } from "./detect.ts";
 import { createDriver, DRIVER_NAMES } from "./drivers/registry.ts";
 import type { DriverResult } from "./drivers/types.ts";
 import { readCommits } from "./git.ts";
@@ -249,6 +249,7 @@ const main = async (): Promise<number> => {
             seed,
             model: recordedModel,
             reproposed: false,
+            reproposal_matches: 0,
             violations: 0,
             turns: 0,
             tokens: 0,
@@ -299,7 +300,7 @@ const main = async (): Promise<number> => {
           });
 
           const surfaces = collectSurfaces(workspace, result.transcript);
-          const reproposed = evaluateGroup(task.detect.reproposed_if, surfaces);
+          const reproposed = countReproposalMatches(task.detect.reproposed_if, surfaces);
           const violations = countViolations(task.detect.violation_if, surfaces);
 
           // A detector verdict nobody can re-read is a verdict nobody can
@@ -318,6 +319,7 @@ const main = async (): Promise<number> => {
                   cond: condition.id,
                   seed,
                   reproposed: reproposed.matched,
+                  reproposal_matches: reproposed.count,
                   matched: [...reproposed.labels, ...violations.labels],
                   injected_context: injectedContext,
                   ...surfaces,
@@ -340,6 +342,7 @@ const main = async (): Promise<number> => {
             seed,
             model: recordedModel,
             reproposed: reproposed.matched,
+            reproposal_matches: reproposed.count,
             violations: violations.labels.length,
             turns: result.turns,
             tokens: result.tokens,
@@ -365,6 +368,7 @@ const main = async (): Promise<number> => {
             seed,
             model: recordedModel,
             reproposed: false,
+            reproposal_matches: 0,
             violations: 0,
             turns: 0,
             tokens: 0,
@@ -385,7 +389,7 @@ const main = async (): Promise<number> => {
 
         fs.appendFileSync(outPath, `${JSON.stringify(record)}\n`);
         process.stderr.write(
-          `${label} reproposed=${record.reproposed} violations=${record.violations} ` +
+          `${label} reproposed=${record.reproposed} reproposal_matches=${record.reproposal_matches} violations=${record.violations} ` +
             `turns=${record.turns} tokens=${record.tokens} stopped_by=${record.stopped_by}\n`,
         );
       }

--- a/bench/types.ts
+++ b/bench/types.ts
@@ -233,6 +233,7 @@ export interface RunRecord {
   readonly seed: number;
   readonly model?: string;
   readonly reproposed: boolean;
+  readonly reproposal_matches?: number;
   readonly violations: number;
   readonly turns: number;
   readonly tokens: number;

--- a/docs/MEASUREMENT-PROTOCOL.md
+++ b/docs/MEASUREMENT-PROTOCOL.md
@@ -11,15 +11,31 @@ test statistic, confidence level, pairing key, clustering key, count rule,
 power simulation, multiplicity family, and exposure gate. Any later divergence
 is recorded without editing the registered rule.
 
-## 1. Primary outcome: re-proposal violation count
+## 1. Primary outcome: re-proposal label count
 
-The primary outcome is `RunRecord.violations`, the non-negative count of
-distinct, mechanically detected re-proposal clauses matched in one run. The
-benchmark-specific registration defines `violation_if` with one labelled clause
-per prohibited re-proposal, fixes the match surface before collection, and
-includes fixtures proving that one matched clause scores 1 and five matched
-clauses score 5. `RunRecord.matched` retains the evidence for each counted
-clause.
+The primary outcome is `RunRecord.reproposal_matches`, the non-negative count
+of distinct, mechanically detected `reproposed_if` labels matched in one run.
+A label matched more than once still counts once. The runner records this field
+directly from `reproposed_if`; it does not derive it from `matched`, because
+`matched` combines re-proposal and `violation_if` evidence.
+
+The previous registration named `RunRecord.violations` and described it as a
+re-proposal count. That field does not measure what that description claimed:
+it counts task-specific `violation_if` clause matches. It remains recorded as
+instrumentation only. This corrects the registration's measurement label; it
+does not change the hypothesis mid-study.
+
+Before this outcome can be registered, the current-harness pilot is checked for
+non-zero variance, for not being zero on every row, and for not being at each
+task's structural maximum on every row. Refusal names the outcome and every
+failed condition. A task's structural maximum is its number of distinct
+`reproposed_if` labels, not the length of `matched`.
+
+M5 cannot be registered from M4's data. M4 recorded no per-run
+`guard_exposure`, so its rows cannot establish that a treatment was applied
+(issue #122 and `bench/VERDICT-M4.md`). A pilot on the current harness, whose
+rows carry `guard_exposure`, is required first; the registration guard runs on
+that pilot.
 
 This is a count rather than the old `reproposed: boolean`. Dichotomizing a count
 loses granularity and reduced power in small cross-over studies, while
@@ -29,8 +45,8 @@ ceiling/floor compression makes a measure insensitive to real differences
 2019](https://pmc.ncbi.nlm.nih.gov/articles/PMC6699673/)). That loss occurred in
 M4: a run with one re-proposal and a run with five both scored `true`.
 
-This choice uses fields that `bench/types.ts` already defines: the integer
-`violations` count and optional `matched` evidence. The type also carries
+This choice uses the integer `reproposal_matches` count and optional `matched`
+evidence. The type also carries
 numeric effort measures (`turns`, `tokens`, and `duration_ms`), but not the turn
 or time of the first re-proposal or an ordered severity judgment.
 

--- a/test/bench-metrics.test.ts
+++ b/test/bench-metrics.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { countReproposalMatches } from "../bench/detect.ts";
+import { assertPrimaryOutcomeCanBeRegistered } from "../bench/metrics.ts";
+import type { RunRecord } from "../bench/types.ts";
+
+const row = (overrides: Partial<RunRecord> = {}): RunRecord => ({
+  run_id: "metrics-test",
+  harness_commit: "1111111111111111111111111111111111111111",
+  dist_digest: "2222222222222222222222222222222222222222222222222222222222222222",
+  task: "task-a",
+  cond: "commitlore-on",
+  seed: 1,
+  reproposed: false,
+  violations: 0,
+  turns: 1,
+  tokens: 1,
+  stopped_by: "completed",
+  duration_ms: 1,
+  driver: "synthetic",
+  started_at: "2026-07-28T00:00:00.000Z",
+  simulated: false,
+  guard_exposure: { complete: true, executed: false, checks: 0, fires: 0, matches: [] },
+  ...overrides,
+});
+
+const rowWithoutExposure = (): RunRecord => {
+  const result = { ...row() };
+  delete result.guard_exposure;
+  return result;
+};
+
+describe("reproposal primary outcome", () => {
+  it("counts each matched reproposal label once", () => {
+    const result = countReproposalMatches(
+      {
+        any_of: [
+          { kind: "literal", value: "redis", label: "redis" },
+          { kind: "literal", value: "Redis", label: "redis" },
+        ],
+      },
+      { transcript: "", diff: "+ add Redis\n", commits: "" },
+    );
+
+    expect(result.count).toBe(1);
+  });
+
+  it("refuses an all-zero primary outcome", () => {
+    expect(() =>
+      assertPrimaryOutcomeCanBeRegistered(
+        "reproposal_matches",
+        [row({ reproposal_matches: 0 }), row({ seed: 2, reproposal_matches: 0 })],
+        new Map([["task-a", 2]]),
+      ),
+    ).toThrow(/reproposal_matches.*zero variance.*pinned at 0/i);
+  });
+
+  it("refuses an outcome at every task structural maximum", () => {
+    expect(() =>
+      assertPrimaryOutcomeCanBeRegistered(
+        "reproposal_matches",
+        [row({ reproposal_matches: 1 }), row({ task: "task-b", seed: 2, reproposal_matches: 2 })],
+        new Map([
+          ["task-a", 1],
+          ["task-b", 2],
+        ]),
+      ),
+    ).toThrow(/reproposal_matches.*structural maximum/i);
+  });
+
+  it("accepts a primary outcome with genuine spread", () => {
+    expect(() =>
+      assertPrimaryOutcomeCanBeRegistered(
+        "reproposal_matches",
+        [
+          row({ reproposal_matches: 0 }),
+          row({ seed: 2, reproposal_matches: 1 }),
+          row({ task: "task-b", seed: 3, reproposal_matches: 2 }),
+        ],
+        new Map([
+          ["task-a", 2],
+          ["task-b", 3],
+        ]),
+      ),
+    ).not.toThrow();
+  });
+
+  it("refuses registration with no pilot rows", () => {
+    expect(() => assertPrimaryOutcomeCanBeRegistered("reproposal_matches", [], new Map())).toThrow(
+      "refusing to register primary outcome `reproposal_matches`: no pilot rows",
+    );
+  });
+
+  it("refuses registration when pilot guard exposure is missing or incomplete", () => {
+    expect(() =>
+      assertPrimaryOutcomeCanBeRegistered(
+        "reproposal_matches",
+        [
+          rowWithoutExposure(),
+          row({
+            seed: 2,
+            guard_exposure: { complete: false, executed: false, checks: 0, fires: 0, matches: [] },
+          }),
+        ],
+        new Map([["task-a", 2]]),
+      ),
+    ).toThrow(
+      "refusing to register primary outcome `reproposal_matches`: guard exposure is unknown for 2 pilot row(s)",
+    );
+  });
+
+  it("refuses registration when an outcome is not a non-negative integer", () => {
+    expect(() =>
+      assertPrimaryOutcomeCanBeRegistered(
+        "reproposal_matches",
+        [row({ reproposal_matches: -1 })],
+        new Map([["task-a", 2]]),
+      ),
+    ).toThrow(
+      "refusing to register primary outcome `reproposal_matches`: it is not a non-negative integer on every pilot row",
+    );
+  });
+
+  it("refuses registration when a pilot task has no structural maximum", () => {
+    expect(() =>
+      assertPrimaryOutcomeCanBeRegistered("reproposal_matches", [row({ reproposal_matches: 1 })], new Map()),
+    ).toThrow(
+      "refusing to register primary outcome `reproposal_matches`: structural maximum is missing for a pilot task",
+    );
+  });
+});


### PR DESCRIPTION
Closes #121.

M5 was registered against `RunRecord.violations`, described as a re-proposal count. It counts `violation_if` matches, is **0 on all 112 rows**, and `PREREGISTRATION.md` already called that clause instrumented-only. An outcome pinned at zero cannot produce a non-null result under any test or sample size.

- primary outcome is now `reproposal_matches`, recorded as its own field rather than derived from `matched` — deriving it works only while `violations` stays broken
- registration refuses an outcome with **no variance**, **pinned at 0**, or **pinned at its structural maximum**
- registration also refuses a pilot whose **guard exposure is unknown** — M4's exact shape

Four of the five refusals were initially unreachable by any test; disabling them changed nothing. All four are now covered and each was watched to fail before it passed.

1396 tests pass (1388 on dev).