### PR TITLE
Say what the install does, and what it costs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@
 
 ホスト型メモリサービスも、ベンダー固有のチャット履歴もありません。リポジトリが所有し、共に移動する、レビュー可能な意思決定コンテキストだけです。
 
-一度インストールしたら、普段どおりコミットしてください。CommitLore が残すのは、引き継ぐ価値のある意思決定だけです。
+一度インストールします。コーディングエージェントは引き継ぐ価値のある意思決定を記録でき、CommitLore はそれを検証して Git に保存します。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
@@ -34,6 +34,16 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install
 - record がある場合、commit-msg hook が検証します。record を作成することはありません。
 - エージェントは MCP で意思決定コンテキストを照会するか、`PreToolUse` hook から受け取ります。
 - path を変更する前に、active limit、ruled-out alternative、warning、verification gap を確認します。
+
+## リポジトリで試す
+
+```bash
+cd your-repository
+commitlore init
+commitlore context .
+```
+
+その後もコーディングエージェントと作業を続けます。変更に diff が保存できない意思決定コンテキストがあるときは、エージェントに CommitLore record をコミットへ含めるよう頼んでください。
 
 <details>
 <summary>インストールを確認または固定したいですか？</summary>
@@ -96,11 +106,36 @@ printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
 
 すべてのコミットに trailer を手書きする必要はありません。ほとんどのコミットには record がないべきです。外部制約、除外した代案、warning、verification gap のように、diff だけでは復元できない意思決定にだけ record を追加します。
 
-現在、record がコミットに届く方法は二つです。保存する価値がある意思決定コンテキストがあるとき、エージェントが `skills/commitlore-commits/` の指針に従って trailer block を作成するか、人が通常の Git trailer を手書きします。commit-msg hook はすでにある record を検証するだけです。record を発明したり、黙って追加したりしません。
+### コーディングエージェント経由
+
+エージェントには、普段どおりコミットし、diff では説明できない意思決定コンテキストだけを残すよう頼みます。
+
+> この変更をコミットしてください。diff で重要な制約、除外した代案、warning、または verification gap を復元できない場合にだけ、CommitLore record を追加してください。
+
+ほとんどのコミットには、やはり record は不要です。エージェント向けの指針は `skills/commitlore-commits/` にあり、commit hook はエージェントが追加した record を検証します。
+
+### 高度な経路: harvest
 
 `commitlore harvest` は session transcript と staged diff から prompt contract を作り、`commitlore harvest-verify` はそれに対する draft を検証します。これらは draft を支援しますが、自動でコミットしません。interactive record builder は未実装です。
 
-## 一つの記録
+### 手書き
+
+逃げ道として、人は通常の Git trailer を手書きできます。commit-msg hook はすでにある record を検証するだけで、record を発明したり黙って追加したりしません。
+
+## 最小の record
+
+record は小さくできます。失われるものだけを入れてください。
+
+```text
+Fix expired-token refresh
+
+Ruled-out: Extend token TTL to 24h | security policy violation
+Warn: Do not narrow the 4xx handler without verifying upstream behavior
+```
+
+ほとんどの record に protocol field のすべては不要です。意思決定が必要とするときは、identity、lifecycle、risk、provenance、verification field を使えます。
+
+## 完全な record
 
 この例は conformance fixture でもあります。Git trailer parser は、すべての翻訳 README で下の code block を同じように読みます。
 
@@ -163,6 +198,14 @@ text search ではなく Git trailer parser を使います。本文の `Key:` �
 ## Evidence: より狭い製品上の主張
 
 112 回の実験は記録されましたが、M4 には run ごとの `guard_exposure` 記録がありません。treatment があったか検証できないため、agent behavior の主張を検証も支持も反証もしていません。上記のより狭い製品上の主張は独立して検証可能な動作に基づきます。クリーンなデータセットと撤回については [M4 verdict](bench/VERDICT-M4.md) を読んでください。
+
+### コストと損益分岐
+
+guard が一回実行されるコストは、注入される context と測定した hook overhead です。commit-msg は p50 185.85 ms、injection hook は p50 102.40 ms です（[deterministic measurements](bench/results/deterministic-20260727T174801Z.md)）。
+
+測定した sensitivity range の中ほどでは、re-proposal の防止が 500-token の注入では 7.7%、3,000-token では 46.2%、12,000-token では 184.6% の頻度で起きて初めて損益分岐になります。この大きさでは費用を回収できません。
+
+guard がこれらの率のいずれかに達するかは確立されていません。これは測定済みコストに対する算術であり、効果の証拠ではありません。
 
 <details>
 <summary>完全な benchmark record（112 回の実験）</summary>

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,7 +20,7 @@
 
 호스팅 메모리 서비스도, 벤더 전용 채팅 기록도 없다. 저장소가 소유하고 함께 이동하는, 검토 가능한 결정 맥락만 있다.
 
-한 번 설치한 뒤 평소처럼 커밋하면 된다. CommitLore는 계속 가져갈 가치가 있는 결정만 보존한다.
+한 번 설치한다. 코딩 에이전트가 계속 가져갈 가치가 있는 결정을 기록할 수 있고, CommitLore는 이를 검증해 Git에 보존한다.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
@@ -34,6 +34,16 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install
 - record가 있으면 commit-msg hook이 검증한다. record를 만들지는 않는다.
 - 에이전트는 MCP로 결정 맥락을 조회하거나 `PreToolUse` hook으로 받는다.
 - path를 바꾸기 전에 active limit, ruled-out alternative, warning, verification gap을 본다.
+
+## 저장소에서 사용해 보기
+
+```bash
+cd your-repository
+commitlore init
+commitlore context .
+```
+
+그다음에도 코딩 에이전트와 계속 작업한다. 변경에 diff가 보존할 수 없는 결정 맥락이 있으면, 에이전트에게 커밋에 CommitLore record를 넣어 달라고 요청한다.
 
 <details>
 <summary>설치 내용을 살펴보거나 버전을 고정하고 싶나요?</summary>
@@ -96,11 +106,36 @@ printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
 
 모든 커밋에 trailer를 손으로 쓸 필요는 없다. 대부분의 커밋에는 record가 없어야 한다. 외부 제약, 제외한 대안, 경고, 검증 공백처럼 diff만으로 복구할 수 없는 결정에만 record를 추가한다.
 
-오늘 record가 커밋에 들어가는 방법은 두 가지다. 에이전트가 보존할 결정 맥락이 있을 때 `skills/commitlore-commits/` 지침에 따라 trailer block을 작성하거나, 사람이 평범한 Git trailer를 직접 쓴다. commit-msg hook은 이미 있는 record를 검증할 뿐이다. record를 발명하거나 조용히 추가하지 않는다.
+### 코딩 에이전트를 통해
+
+에이전트에게 평소대로 커밋하고 diff로 설명할 수 없는 결정 맥락만 보존하도록 요청한다.
+
+> 이 변경을 커밋해. diff로 중요한 제약, 제외한 대안, 경고 또는 검증 공백을 복구할 수 없을 때만 CommitLore record를 추가해.
+
+대부분의 커밋에는 여전히 record가 없어야 한다. 에이전트 지침은 `skills/commitlore-commits/`에 있고, commit hook은 에이전트가 추가한 record를 검증한다.
+
+### 고급 경로: harvest
 
 `commitlore harvest`는 session transcript와 staged diff에서 prompt contract를 만들고, `commitlore harvest-verify`는 그에 맞는 draft를 검증한다. 둘은 draft를 돕지만 자동 커밋하지 않는다. interactive record builder는 구현되지 않았다.
 
-## 기록 하나
+### 직접 작성
+
+탈출구로 사람이 평범한 Git trailer를 직접 쓸 수 있다. commit-msg hook은 이미 있는 record를 검증할 뿐이며, record를 발명하거나 조용히 추가하지 않는다.
+
+## 최소 record
+
+record는 작을 수 있다. 그렇지 않으면 잃게 될 맥락만 넣는다.
+
+```text
+Fix expired-token refresh
+
+Ruled-out: Extend token TTL to 24h | security policy violation
+Warn: Do not narrow the 4xx handler without verifying upstream behavior
+```
+
+대부분의 record에는 모든 protocol field가 필요하지 않다. 결정에 필요할 때 identity, lifecycle, risk, provenance, verification field를 사용할 수 있다.
+
+## 완전한 record
 
 이 예시는 conformance fixture이기도 하다. Git trailer parser는 모든 번역 README에서 아래 code block을 동일하게 읽는다.
 
@@ -163,6 +198,14 @@ git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
 ## 근거: 더 좁은 제품 주장
 
 112회 실험은 기록됐지만 M4에는 run별 `guard_exposure` 기록이 없다. treatment가 있었는지 검증할 수 없으므로 agent behavior 주장을 시험하거나 뒷받침하거나 반박하지 못한다. 위의 더 좁은 제품 주장은 독립적으로 검증 가능한 동작에 근거한다. 깨끗한 데이터셋과 철회 내용은 [M4 verdict](bench/VERDICT-M4.md)에서 읽을 수 있다.
+
+### 비용과 손익분기점
+
+guard가 한 번 실행될 때 드는 비용은 주입된 context와 측정된 hook 오버헤드다. commit-msg는 p50 185.85 ms, injection hook은 p50 102.40 ms다([deterministic measurements](bench/results/deterministic-20260727T174801Z.md)).
+
+측정한 sensitivity range의 중간에서는 re-proposal 방지가 500-token 주입의 손익분기에는 7.7%, 3,000-token에는 46.2%, 12,000-token에는 184.6%의 빈도로 일어나야 한다. 마지막 크기에서는 비용을 회수할 수 없다.
+
+guard가 이 비율 중 어느 것에 도달하는지는 확립되지 않았다. 이는 측정된 비용에 대한 산술일 뿐이며, 효과의 증거가 아니다.
 
 <details>
 <summary>전체 benchmark 기록 (112회 실험)</summary>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 No hosted memory service. No vendor-specific chat history. Just reviewable decision context, owned by and portable with the repository.
 
-Install once, keep committing normally, and CommitLore preserves only the decisions worth carrying forward.
+Install once. Your coding agent can record the decisions worth carrying forward, while CommitLore validates and preserves them in Git.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
@@ -34,6 +34,16 @@ Then run `commitlore init` in each repository where you want validation hooks an
 - If a record is present, the commit-msg hook validates it; it never creates one.
 - Agents query decision context through MCP or receive it from the `PreToolUse` hook.
 - Before changing a path, they see its active limits, ruled-out alternatives, warnings, and verification gaps.
+
+## Try it in a repository
+
+```bash
+cd your-repository
+commitlore init
+commitlore context .
+```
+
+Then keep working through your coding agent. When a change contains decision context the diff cannot preserve, ask the agent to include a CommitLore record in the commit.
 
 <details>
 <summary>Prefer to inspect or pin the installation?</summary>
@@ -96,11 +106,36 @@ The authority is ordinary commit trailers and `refs/notes/commitlore`. Indexes a
 
 You do not hand-write a trailer for every commit. Most commits should carry no record at all. Add one only for a decision the diff cannot recover: an external constraint, a rejected alternative, a warning, or a verification gap.
 
-Today, records reach a commit in two ways: an agent authors the trailer block when there is decision context worth keeping, following `skills/commitlore-commits/`; or a human writes ordinary Git trailers by hand. The commit-msg hook validates records that are already present. It never invents or silently adds one.
+### Through a coding agent
+
+Ask the agent to commit normally and preserve only the decision context the diff cannot explain:
+
+> Commit this change. Add a CommitLore record only if the diff cannot recover an important constraint, rejected alternative, warning, or verification gap.
+
+Most commits should still carry no record. The agent instructions live in `skills/commitlore-commits/`, and the commit hook validates any record the agent adds.
+
+### Advanced: harvest
 
 `commitlore harvest` builds a prompt contract from a session transcript and staged diff; `commitlore harvest-verify` checks a draft against them. They support drafting, not automatic commits. Interactive record building is not implemented.
 
-## A record
+### By hand
+
+As an escape hatch, a human can write ordinary Git trailers by hand. The commit-msg hook validates records that are already present; it never invents or silently adds one.
+
+## A minimal record
+
+A record can be small. Include only the context that would otherwise be lost:
+
+```text
+Fix expired-token refresh
+
+Ruled-out: Extend token TTL to 24h | security policy violation
+Warn: Do not narrow the 4xx handler without verifying upstream behavior
+```
+
+Most records do not need every protocol field. Identity, lifecycle, risk, provenance, and verification fields are available when the decision needs them.
+
+## A complete record
 
 This example is also a conformance fixture. Git's trailer parser reads the code block identically in every translated README.
 
@@ -163,6 +198,14 @@ These are product claims about Git-bound, human-verifiable decision history. The
 ## Evidence: a narrower product claim
 
 112 experiments were recorded, but M4 recorded no per-run guard exposure. Whether the treatment was present is unverifiable, so it does not test, support, or refute the agent-behavior claim. The narrower product claim above rests on independently testable behavior; read the [M4 verdict](bench/VERDICT-M4.md) for the clean dataset and withdrawal.
+
+### Cost and break-even
+
+The guard costs injected context plus measured hook overhead: 185.85 ms p50 for commit-msg and 102.40 ms p50 for the injection hook ([deterministic measurements](bench/results/deterministic-20260727T174801Z.md)).
+
+At the middle of the measured sensitivity range, preventing a re-proposal must occur in 7.7% of cases for a 500-token injection to break even, 46.2% for 3,000 tokens, and 184.6% for 12,000 tokens. At that size it cannot pay for itself.
+
+Whether the guard reaches any of those rates is not established. This is arithmetic on measured costs, not evidence of an effect.
 
 <details>
 <summary>Full benchmark record (112 experiments)</summary>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@
 
 没有托管记忆服务，也没有特定供应商的聊天历史。只有由仓库拥有并随仓库流转、可供审查的决策上下文。
 
-安装一次后，照常提交即可。CommitLore 只保留值得延续的决策。
+安装一次。你的编程代理可以记录值得延续的决策，而 CommitLore 会验证它们并将其保存在 Git 中。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
@@ -34,6 +34,16 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install
 - 如果已有 record，commit-msg hook 会验证它；不会创建 record。
 - 代理通过 MCP 查询决策上下文，或从 `PreToolUse` hook 接收它。
 - 更改 path 前，它们会看到 active limit、ruled-out alternative、warning 和 verification gap。
+
+## 在仓库中试用
+
+```bash
+cd your-repository
+commitlore init
+commitlore context .
+```
+
+然后继续通过编程代理工作。若某项更改包含 diff 无法保存的决策上下文，请让代理在提交中加入 CommitLore record。
 
 <details>
 <summary>想检查或固定安装版本？</summary>
@@ -96,11 +106,36 @@ printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
 
 不必为每次提交手写 trailer。绝大多数提交都不应带 record。只在 diff 无法还原的决策中添加 record：外部限制、排除的方案、warning 或 verification gap。
 
-当前 record 有两种进入提交的方式：当有值得保留的决策上下文时，代理按照 `skills/commitlore-commits/` 的指引编写 trailer block；或由人手写普通 Git trailer。commit-msg hook 只验证已经存在的 record；它不会凭空创建或静默添加 record。
+### 通过编程代理
+
+让代理照常提交，只保留 diff 无法解释的决策上下文：
+
+> 提交这项更改。只有当 diff 无法还原重要限制、排除的方案、warning 或 verification gap 时，才添加 CommitLore record。
+
+绝大多数提交仍不应带 record。代理说明位于 `skills/commitlore-commits/`，commit hook 会验证代理添加的任何 record。
+
+### 高级路径：harvest
 
 `commitlore harvest` 从 session transcript 和 staged diff 构建 prompt contract；`commitlore harvest-verify` 据此检查 draft。它们支持起草，而不会自动提交。interactive record builder 尚未实现。
 
-## 一条记录
+### 手写
+
+作为逃生出口，人可以手写普通 Git trailer。commit-msg hook 只验证已经存在的 record；它不会凭空创建或静默添加 record。
+
+## 最小 record
+
+record 可以很小。只包含否则会丢失的上下文：
+
+```text
+Fix expired-token refresh
+
+Ruled-out: Extend token TTL to 24h | security policy violation
+Warn: Do not narrow the 4xx handler without verifying upstream behavior
+```
+
+绝大多数 record 不需要所有 protocol field。决策需要时，可以使用 identity、lifecycle、risk、provenance 和 verification field。
+
+## 完整 record
 
 这个示例也是 conformance fixture。Git trailer parser 会在所有翻译版 README 中以相同方式读取下面的 code block。
 
@@ -163,6 +198,14 @@ git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
 ## Evidence：更窄的产品主张
 
 已记录 112 次实验，但 M4 没有逐次运行的 `guard_exposure` 记录。无法验证 treatment 是否存在，因此它没有检验、支持或反驳 agent behavior 的主张。上面更窄的产品主张基于可独立验证的行为。关于干净的数据集和撤回，请见 [M4 verdict](bench/VERDICT-M4.md)。
+
+### 成本与盈亏平衡
+
+guard 每次运行的成本是注入的 context 加上测得的 hook overhead：commit-msg 的 p50 为 185.85 ms，injection hook 的 p50 为 102.40 ms（[deterministic measurements](bench/results/deterministic-20260727T174801Z.md)）。
+
+在测得的 sensitivity range 中间，防止 re-proposal 必须以 7.7% 的频率发生，500-token 注入才能盈亏平衡；3,000-token 为 46.2%，12,000-token 为 184.6%。在这一大小下，它无法收回成本。
+
+guard 是否能达到其中任何一个比率尚未确立。这是基于测得成本的算术，而不是效果的证据。
 
 <details>
 <summary>完整 benchmark 记录（112 次实验）</summary>

--- a/spec/verify.sh
+++ b/spec/verify.sh
@@ -120,7 +120,7 @@ for readme in "$REPO_ROOT"/README.md "$REPO_ROOT"/README.*.md; do
     const fs = require("fs");
     const md = fs.readFileSync(process.argv[1], "utf8");
     const fixture = fs.readFileSync(process.argv[2], "utf8");
-    const m = md.match(/```text\n([\s\S]*?)\n```/);
+    const m = [...md.matchAll(/```text\n([\s\S]*?)\n```/g)].at(-1);
     if (!m) { console.error("no ```text example block"); process.exit(1); }
     if (m[1] + "\n" !== fixture) {
       console.error("README example drifted from spec/fixtures/valid/11-readme-example.txt");


### PR DESCRIPTION
Five README corrections, propagated to all three translations.

1. **install promise** — the old line read as automatic capture. `src/hooks/commit-msg.ts` has no record-generating code; it validates and never inserts one. The new line separates authoring from validation.
2. **agent prompt** — "How records get created" now leads with what a user actually types, before harvest and by-hand.
3. **minimal record before complete** — `## A record` → `## A complete record`. The new two-line example was checked against `commitlore validate` (`shape ok`, exit 0) rather than written to look plausible.
4. **post-install CTA** — `commitlore init` then `commitlore context .`; both that form and the bare form verified exit 0.
5. **cost and break-even** — three paragraphs in order: what it costs (186ms / 102ms measured), the break-even rate (**7.7%** at 500 tokens, **46.2%** at 3,000, **184.6%** at 12,000 — which cannot pay for itself), and that reaching any of those rates **is not established**.

No claim of token saving, cost reduction, or behavioural effect appears anywhere — verified by grep across all four files.

`check-readme-numbers.mjs` exits 0; the BENCH block is untouched.