### PR TITLE
Remove modelled break-even figures

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -203,9 +203,7 @@ text search ではなく Git trailer parser を使います。本文の `Key:` �
 
 guard が一回実行されるコストは、注入される context と測定した hook overhead です。commit-msg は p50 185.85 ms、injection hook は p50 102.40 ms です（[deterministic measurements](bench/results/deterministic-20260727T174801Z.md)）。
 
-測定した sensitivity range の中ほどでは、re-proposal の防止が 500-token の注入では 7.7%、3,000-token では 46.2%、12,000-token では 184.6% の頻度で起きて初めて損益分岐になります。この大きさでは費用を回収できません。
-
-guard がこれらの率のいずれかに達するかは確立されていません。これは測定済みコストに対する算術であり、効果の証拠ではありません。
+損益分岐の数値を再び示すには、プロバイダー報告のターンごとのトークン使用量台帳と、リポジトリがすでに却下した代案に費やした作業の観測済みコストが必要です。
 
 <details>
 <summary>完全な benchmark record（112 回の実験）</summary>

--- a/README.ko.md
+++ b/README.ko.md
@@ -203,9 +203,7 @@ git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
 
 guard가 한 번 실행될 때 드는 비용은 주입된 context와 측정된 hook 오버헤드다. commit-msg는 p50 185.85 ms, injection hook은 p50 102.40 ms다([deterministic measurements](bench/results/deterministic-20260727T174801Z.md)).
 
-측정한 sensitivity range의 중간에서는 re-proposal 방지가 500-token 주입의 손익분기에는 7.7%, 3,000-token에는 46.2%, 12,000-token에는 184.6%의 빈도로 일어나야 한다. 마지막 크기에서는 비용을 회수할 수 없다.
-
-guard가 이 비율 중 어느 것에 도달하는지는 확립되지 않았다. 이는 측정된 비용에 대한 산술일 뿐이며, 효과의 증거가 아니다.
+손익분기 수치를 다시 제시하려면 제공업체가 보고한 턴별 토큰 사용량 원장과 저장소가 이미 배제한 대안에 쓴 작업의 관측된 비용이 필요하다.
 
 <details>
 <summary>전체 benchmark 기록 (112회 실험)</summary>

--- a/README.md
+++ b/README.md
@@ -203,9 +203,7 @@ These are product claims about Git-bound, human-verifiable decision history. The
 
 The guard costs injected context plus measured hook overhead: 185.85 ms p50 for commit-msg and 102.40 ms p50 for the injection hook ([deterministic measurements](bench/results/deterministic-20260727T174801Z.md)).
 
-At the middle of the measured sensitivity range, preventing a re-proposal must occur in 7.7% of cases for a 500-token injection to break even, 46.2% for 3,000 tokens, and 184.6% for 12,000 tokens. At that size it cannot pay for itself.
-
-Whether the guard reaches any of those rates is not established. This is arithmetic on measured costs, not evidence of an effect.
+A break-even figure would require a per-turn ledger of provider-reported token usage and an observed cost for work spent on an alternative the repository had already rejected.
 
 <details>
 <summary>Full benchmark record (112 experiments)</summary>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,9 +203,7 @@ git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
 
 guard 每次运行的成本是注入的 context 加上测得的 hook overhead：commit-msg 的 p50 为 185.85 ms，injection hook 的 p50 为 102.40 ms（[deterministic measurements](bench/results/deterministic-20260727T174801Z.md)）。
 
-在测得的 sensitivity range 中间，防止 re-proposal 必须以 7.7% 的频率发生，500-token 注入才能盈亏平衡；3,000-token 为 46.2%，12,000-token 为 184.6%。在这一大小下，它无法收回成本。
-
-guard 是否能达到其中任何一个比率尚未确立。这是基于测得成本的算术，而不是效果的证据。
+要重新给出盈亏平衡数值，需要一份逐轮记录、由提供商报告的令牌用量账本，以及为仓库已经否决的替代方案所花工作的观测成本。
 
 <details>
 <summary>完整 benchmark 记录（112 次实验）</summary>


### PR DESCRIPTION
Removes the modelled break-even percentages from all four public READMEs while retaining the measured context and hook-overhead costs. Adds the observations required before a future figure can be published: provider-reported per-turn token usage and observed avoided-work cost for an already-rejected alternative.\n\nChecks: node scripts/check-readme-numbers.mjs; npx vitest run; npx tsc -p tsconfig.json --noEmit.