### PR TITLE
Measure irrelevant decision-context exposure

### DIFF
--- a/bench/deterministic.ts
+++ b/bench/deterministic.ts
@@ -1,9 +1,11 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import { digestDistTree } from './hooks-settings.ts';
 import { measureHookOverhead } from './deterministic/hooks.ts';
+import { measureNoiseExposure } from './deterministic/noise.ts';
 import { measureGuardQuality, measureInjectionDetection } from './deterministic/quality.ts';
 import {
   assertSingleProvenance,
@@ -28,6 +30,7 @@ const REQUIRED_METRICS: ReadonlySet<DeterministicRow['metric']> = new Set([
   'guard_quality',
   'hook_overhead',
   'index_cost',
+  'noise_exposure',
 ]);
 
 const stamp = (instant: string): string =>
@@ -37,6 +40,20 @@ const assertComplete = (rows: readonly DeterministicRow[]): void => {
   const present = new Set(rows.map((row) => row.metric));
   const missing = [...REQUIRED_METRICS].filter((metric) => !present.has(metric));
   if (missing.length > 0) throw new Error(`deterministic dataset is missing: ${missing.join(', ')}`);
+};
+
+const assertNoConcurrentDeterministicBench = (): void => {
+  const ps = spawnSync('ps', ['-axo', 'pid=,command='], { encoding: 'utf8' });
+  if (ps.error !== undefined) throw ps.error;
+  const matches = ps.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /\bbench\/deterministic\.ts\b/.test(line))
+    .filter((line) => Number(line.split(/\s+/, 1)[0]) !== process.pid);
+  if (matches.length > 0) {
+    throw new Error(`deterministic benchmark refused: another bench/deterministic process is running:\n${matches.join('\n')}`);
+  }
+  process.stdout.write('deterministic bench: checked no concurrent bench/deterministic process\n');
 };
 
 const main = (): void => {
@@ -68,6 +85,7 @@ const main = (): void => {
     process.env['COMMITLORE_DETERMINISTIC_OUTPUT_DIR'] ?? join('bench', 'results'),
   );
   assertCleanCheckout(REPO_ROOT);
+  assertNoConcurrentDeterministicBench();
   const measuredAt = new Date().toISOString();
   const harnessCommit = git(REPO_ROOT, ['rev-parse', 'HEAD']).stdout.trim();
   const distDigest = digestDistTree();
@@ -84,6 +102,8 @@ const main = (): void => {
     const guard = measureGuardQuality(base, REPO_ROOT);
     process.stdout.write(`deterministic bench: hook overhead (${runs} runs per arm)\n`);
     const hooks = measureHookOverhead(base, scratch, runs);
+    process.stdout.write('deterministic bench: irrelevant decision-context exposure\n');
+    const exposure = measureNoiseExposure(base);
     const rows: readonly DeterministicRow[] = [
       ...scale.latency,
       ...survival,
@@ -91,6 +111,7 @@ const main = (): void => {
       guard,
       ...hooks,
       ...scale.index,
+      ...exposure,
     ];
 
     assertSingleProvenance(rows);

--- a/bench/deterministic/noise.ts
+++ b/bench/deterministic/noise.ts
@@ -1,0 +1,276 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { CHARS_PER_TOKEN, buildInjection } from '../../dist/core/inject.js';
+import { command, git, timing } from './shared.ts';
+import type { NoiseExposureRow, NoiseRoute, RowBase } from './types.ts';
+
+export const NOISE_SIZES = [0, 10, 100, 1_000, 10_000] as const;
+export const NOISE_SEED = 142_2026;
+export const NOISE_RUNS = 20;
+export const TARGET_PATH = 'src/core/decision-context.ts';
+const TOP_K = 2;
+const TOP_K_QUERY = `${TARGET_PATH} active lifecycle decision context path scope`;
+
+interface NoiseRecord {
+  readonly recordId: string;
+  readonly path: string;
+  readonly message: string;
+  readonly relevant: boolean;
+}
+
+export interface NoiseCorpus {
+  readonly records: readonly NoiseRecord[];
+  readonly distractors: number;
+}
+
+export interface NoiseFixture {
+  readonly dir: string;
+  readonly corpus: NoiseCorpus;
+  readonly superseded: boolean;
+}
+
+const activeRecords = (): readonly NoiseRecord[] => [
+  {
+    recordId: 'r-expose001',
+    path: TARGET_PATH,
+    relevant: true,
+    message: [
+      'Keep lifecycle filtering at the decision-context path boundary.',
+      '',
+      'Limit: Keep active decision context scoped to the edited path.',
+      'Ruled-out: repository-wide decision context | unrelated paths overlap this wording.',
+      'Warn: Lifecycle declarations remain global even when delivery is path-scoped.',
+      'Blast: module',
+      'Undo: easy',
+      'Certainty: firm',
+      'Record-Id: r-expose001',
+    ].join('\n'),
+  },
+  {
+    recordId: 'r-expose002',
+    path: TARGET_PATH,
+    relevant: true,
+    message: [
+      'Keep decision context explicit at the consumer boundary.',
+      '',
+      'Limit: Preserve active path-scoped records for this decision context.',
+      'Ruled-out: lexical context ranking alone | similar repository decisions can outrank it.',
+      'Warn: Do not treat a matching word as proof that a record applies to this path.',
+      'Blast: module',
+      'Undo: easy',
+      'Certainty: firm',
+      'Record-Id: r-expose002',
+    ].join('\n'),
+  },
+];
+
+const paths = [
+  'src/core/inject.ts',
+  'src/core/query.ts',
+  'src/core/index-db.ts',
+  'src/core/grade.ts',
+  'src/commands/query.ts',
+  'src/commands/inject.ts',
+  'test/query.test.ts',
+  'bench/deterministic/report.ts',
+] as const;
+const subjects = [
+  'Keep decision context scoped while lifecycle state remains global',
+  'Project active records at the path boundary before rendering context',
+  'Preserve lifecycle declarations while narrowing decision delivery',
+  'Rank overlapping decision context without assuming path relevance',
+] as const;
+const alternatives = [
+  'repository-wide decision context',
+  'lexical path ranking alone',
+  'dropping lifecycle state before projection',
+  'a global active-record dump',
+] as const;
+
+const next = (state: number): number => (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+const choose = <T>(values: readonly T[], state: number): T => {
+  const choice = values[state % values.length];
+  if (choice === undefined) throw new Error('cannot choose from an empty list');
+  return choice;
+};
+
+const distractor = (index: number, seed: number): NoiseRecord => {
+  let state = (seed + index) >>> 0;
+  state = next(state);
+  const path = choose(paths, state);
+  state = next(state);
+  const subject = choose(subjects, state);
+  state = next(state);
+  const alternative = choose(alternatives, state);
+  const recordId = `r-noise${String(index).padStart(6, '0')}`;
+  return {
+    recordId,
+    path,
+    relevant: false,
+    message: [
+      subject,
+      '',
+      `Limit: Keep active decision context explicit for ${path}.`,
+      `Ruled-out: ${alternative} | similar lifecycle and path wording is insufficient.`,
+      'Warn: This decision overlaps the queried terminology but applies to another repository path.',
+      'Blast: module',
+      'Undo: easy',
+      'Certainty: tentative',
+      `Record-Id: ${recordId}`,
+    ].join('\n'),
+  };
+};
+
+export const generateNoiseCorpus = (distractors: number, seed = NOISE_SEED): NoiseCorpus => {
+  if (!Number.isInteger(distractors) || distractors < 0) {
+    throw new Error(`distractors must be a non-negative integer, got ${distractors}`);
+  }
+  return {
+    records: [...activeRecords(), ...Array.from({ length: distractors }, (_, index) => distractor(index, seed))],
+    distractors,
+  };
+};
+
+const fastImport = (records: readonly NoiseRecord[], supersede: boolean): string => {
+  const active = records.filter((record) => record.relevant);
+  const distractors = records.filter((record) => !record.relevant);
+  const commit = (
+    mark: number,
+    message: string,
+    parent: number | undefined,
+    changedPaths: readonly string[],
+  ): string => [
+      'commit refs/heads/main',
+      `mark :${mark}`,
+      'author CommitLore Bench <bench@commitlore.local> 1760000000 +0000',
+      'committer CommitLore Bench <bench@commitlore.local> 1760000000 +0000',
+      `data ${Buffer.byteLength(message)}`,
+      message,
+      ...(parent === undefined ? [] : [`from :${parent}`]),
+      ...changedPaths.flatMap((path) => {
+        const content = `${path}\n`;
+        return [`M 100644 inline ${path}`, `data ${Buffer.byteLength(content)}`, content];
+      }),
+    ].join('\n');
+  const first = active[0];
+  const second = active[1];
+  if (first === undefined || second === undefined) throw new Error('noise corpus needs two active records');
+  const commits = [
+    commit(1, first.message, undefined, [first.path]),
+    commit(2, second.message, 1, [second.path]),
+  ];
+  let latestMark = 2;
+  if (distractors.length > 0) {
+    const blocks = distractors.map((record) => record.message.split('\n\n')[1] ?? record.message);
+    commits.push(commit(3, `Batch realistic unrelated decisions.\n\n${blocks.join('\n\n')}`, 2, paths));
+    latestMark = 3;
+  }
+  if (supersede) {
+    const message = 'Retire an obsolete decision context.\n\nSupersedes: r-expose001\n';
+    commits.push([
+      'commit refs/heads/main',
+      `mark :${latestMark + 1}`,
+      'author CommitLore Bench <bench@commitlore.local> 1760000001 +0000',
+      'committer CommitLore Bench <bench@commitlore.local> 1760000001 +0000',
+      `data ${Buffer.byteLength(message)}`,
+      message,
+      `from :${latestMark}`,
+      'M 100644 inline .commitlore/lifecycle.txt',
+      'data 10',
+      'supersede\n',
+    ].join('\n'));
+  }
+  return `${commits.join('\n')}\ndone\n`;
+};
+
+export const createNoiseFixture = (
+  distractors: number,
+  seed = NOISE_SEED,
+  supersede = false,
+): NoiseFixture => {
+  const dir = mkdtempSync(join(tmpdir(), 'commitlore-noise-'));
+  const corpus = generateNoiseCorpus(distractors, seed);
+  git(dir, ['init', '--quiet']);
+  command('git', ['fast-import', '--quiet'], { cwd: dir, input: fastImport(corpus.records, supersede) });
+  git(dir, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  return { dir, corpus, superseded: supersede };
+};
+
+export const destroyNoiseFixture = (fixture: NoiseFixture): void => {
+  rmSync(fixture.dir, { recursive: true, force: true });
+};
+
+const tokens = (text: string): number => Math.ceil(text.length / CHARS_PER_TOKEN);
+
+const lexicalScore = (query: string, record: NoiseRecord): number => {
+  const haystack = `${record.path}\n${record.message}`.toLowerCase();
+  return query.toLowerCase().match(/[a-z0-9]+/g)?.reduce(
+    (score, token) => score + (haystack.split(token).length - 1),
+    0,
+  ) ?? 0;
+};
+
+const topK = (records: readonly NoiseRecord[]): readonly NoiseRecord[] =>
+  records.slice().sort((left, right) =>
+    lexicalScore(TOP_K_QUERY, right) - lexicalScore(TOP_K_QUERY, left) ||
+    left.recordId.localeCompare(right.recordId),
+  ).slice(0, TOP_K);
+
+const delivery = (
+  route: NoiseRoute,
+  fixture: NoiseFixture,
+): { readonly records: number; readonly relevant: number; readonly text: string } => {
+  if (route === 'inject-everything') {
+    const text = fixture.corpus.records.map((record) => record.message).join('\n\n');
+    return { records: fixture.corpus.records.length, relevant: 2, text };
+  }
+  if (route === 'top-k-lexical') {
+    const selected = topK(fixture.corpus.records);
+    return {
+      records: selected.length,
+      relevant: selected.filter((record) => record.relevant).length,
+      text: selected.map((record) => record.message).join('\n\n'),
+    };
+  }
+  const injection = buildInjection({ cwd: fixture.dir, path: TARGET_PATH });
+  return { records: injection.records, relevant: injection.records, text: injection.text };
+};
+
+export const activePathRecords = (fixture: NoiseFixture): number =>
+  fixture.corpus.records.filter(
+    (record) => record.relevant && record.path === TARGET_PATH &&
+      !(fixture.superseded && record.recordId === 'r-expose001'),
+  ).length;
+
+export const measureNoiseExposure = (
+  base: RowBase,
+  distractors: readonly number[] = NOISE_SIZES,
+  runs = NOISE_RUNS,
+): readonly NoiseExposureRow[] => {
+  const rows: NoiseExposureRow[] = [];
+  for (const size of distractors) {
+    const fixture = createNoiseFixture(size);
+    try {
+      for (const route of ['inject-everything', 'top-k-lexical', 'commitlore-path-lifecycle'] as const) {
+        const visible = delivery(route, fixture);
+        rows.push({
+          ...base,
+          metric: 'noise_exposure',
+          distractors: size,
+          corpus_records: fixture.corpus.records.length,
+          route,
+          visible_records: visible.records,
+          visible_tokens: tokens(visible.text),
+          relevant_records: visible.relevant,
+          relevant_total: 2,
+          timing: timing(() => { delivery(route, fixture); }, runs),
+        });
+      }
+    } finally {
+      destroyNoiseFixture(fixture);
+    }
+  }
+  return rows;
+};

--- a/bench/deterministic/noise.ts
+++ b/bench/deterministic/noise.ts
@@ -150,7 +150,7 @@ const fastImport = (records: readonly NoiseRecord[], supersede: boolean): string
       message,
       ...(parent === undefined ? [] : [`from :${parent}`]),
       ...changedPaths.flatMap((path) => {
-        const content = `${path}\n`;
+        const content = `${path} fixture commit ${mark}\n`;
         return [`M 100644 inline ${path}`, `data ${Buffer.byteLength(content)}`, content];
       }),
     ].join('\n');

--- a/bench/deterministic/report.ts
+++ b/bench/deterministic/report.ts
@@ -6,12 +6,16 @@ import type {
   HookOverheadRow,
   IndexCostRow,
   InjectionDetectionRow,
+  NoiseExposureRow,
   QueryLatencyRow,
   SurvivalRow,
 } from './types.ts';
 
 export const SCOPE_SENTENCE =
   'These numbers say what CommitLore costs and what it catches. They say nothing about whether recorded context helps an agent; M4 is registered for that question and may still come back null.';
+
+export const EXPOSURE_SCOPE_SENTENCE =
+  'This section measures exposure only, not token cost, billed cost, or accuracy.';
 
 export const percentile = (samples: readonly number[], proportion: number): number => {
   if (samples.length === 0) throw new Error('cannot take a percentile of zero samples');
@@ -197,6 +201,28 @@ const indexSection = (rows: readonly IndexCostRow[]): string[] => {
   ];
 };
 
+const exposureSection = (rows: readonly NoiseExposureRow[]): string[] => {
+  if (rows.length === 0) return [];
+  return [
+    '## 7. Irrelevant decision-context exposure',
+    '',
+    EXPOSURE_SCOPE_SENTENCE,
+    '',
+    'Fixture: exactly two active records apply to `src/core/decision-context.ts`; each corpus adds the stated fixed-seed distractors with the same trailer vocabulary, plausible repository paths, and overlapping decision-context language.',
+    'Routes: `inject everything`; `top-k lexical` (k=2, case-insensitive query-token frequency over path and record text); and the shipped CommitLore injection path scope plus lifecycle filter. The current CLI has neither a pointer nor pull delivery route, so neither is simulated here.',
+    '',
+    '| distractors | corpus records | route | model-visible records | model-visible tokens | relevant density | runs | p50 ms | p95 ms |',
+    '|---:|---:|---|---:|---:|---|---:|---:|---:|',
+    ...rows.map((row) => {
+      const density = row.visible_records === 0 ? 0 : row.relevant_records / row.visible_records;
+      return `| ${row.distractors} | ${row.corpus_records} | ${row.route} | ${row.visible_records} | ` +
+        `${row.visible_tokens} | ${row.relevant_records} of ${row.visible_records} (${percent(density)}) | ` +
+        `${row.timing.runs} | ${fixed(row.timing.p50_ms)} | ${fixed(row.timing.p95_ms)} |`;
+    }),
+    '',
+  ];
+};
+
 export const renderDeterministicReport = (rows: readonly DeterministicRow[]): string => {
   assertSingleProvenance(rows);
   const first = rows[0];
@@ -221,6 +247,7 @@ export const renderDeterministicReport = (rows: readonly DeterministicRow[]): st
     ...guardSection(rows.filter((row): row is GuardQualityRow => row.metric === 'guard_quality')),
     ...hookSection(rows.filter((row): row is HookOverheadRow => row.metric === 'hook_overhead')),
     ...indexSection(rows.filter((row): row is IndexCostRow => row.metric === 'index_cost')),
+    ...exposureSection(rows.filter((row): row is NoiseExposureRow => row.metric === 'noise_exposure')),
   ];
   return `${lines.join('\n').trim()}\n`;
 };

--- a/bench/deterministic/types.ts
+++ b/bench/deterministic/types.ts
@@ -126,13 +126,31 @@ export interface HookOverheadRow extends BaseRow {
   readonly delta_p95_ms: number;
 }
 
+export type NoiseRoute =
+  | 'inject-everything'
+  | 'top-k-lexical'
+  | 'commitlore-path-lifecycle';
+
+export interface NoiseExposureRow extends BaseRow {
+  readonly metric: 'noise_exposure';
+  readonly distractors: number;
+  readonly corpus_records: number;
+  readonly route: NoiseRoute;
+  readonly visible_records: number;
+  readonly visible_tokens: number;
+  readonly relevant_records: number;
+  readonly relevant_total: 2;
+  readonly timing: Timing;
+}
+
 export type DeterministicRow =
   | QueryLatencyRow
   | IndexCostRow
   | SurvivalRow
   | InjectionDetectionRow
   | GuardQualityRow
-  | HookOverheadRow;
+  | HookOverheadRow
+  | NoiseExposureRow;
 
 export type RowBase = Pick<
   BaseRow,

--- a/test/deterministic-bench.test.ts
+++ b/test/deterministic-bench.test.ts
@@ -11,9 +11,17 @@ import {
   renderDeterministicReport,
   SCOPE_SENTENCE,
 } from '../bench/deterministic/report.ts';
+import {
+  activePathRecords,
+  createNoiseFixture,
+  destroyNoiseFixture,
+  generateNoiseCorpus,
+  NOISE_SIZES,
+} from '../bench/deterministic/noise.ts';
 import { assertCleanCheckout, git } from '../bench/deterministic/shared.ts';
 import { measureSurvival } from '../bench/deterministic/survival.ts';
 import type { InjectionDetectionRow } from '../bench/deterministic/types.ts';
+import type { NoiseExposureRow } from '../bench/deterministic/types.ts';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..');
 
@@ -129,5 +137,66 @@ describe('deterministic benchmark reporting', () => {
     } finally {
       rmSync(scratch, { recursive: true, force: true });
     }
+  });
+
+  it('generates the same distractor corpus for a fixed seed', () => {
+    expect(generateNoiseCorpus(100, 142)).toEqual(generateNoiseCorpus(100, 142));
+    expect(generateNoiseCorpus(100, 142)).not.toEqual(generateNoiseCorpus(100, 143));
+  });
+
+  it('exposes exactly the two active records at every distractor corpus size', () => {
+    for (const size of NOISE_SIZES) {
+      const fixture = createNoiseFixture(size);
+      try {
+        expect(activePathRecords(fixture)).toBe(2);
+      } finally {
+        destroyNoiseFixture(fixture);
+      }
+    }
+  });
+
+  it('withholds a superseded record from the active pair', () => {
+    const fixture = createNoiseFixture(10, 142, true);
+    try {
+      expect(activePathRecords(fixture)).toBe(1);
+    } finally {
+      destroyNoiseFixture(fixture);
+    }
+  });
+
+  it('states that the exposure section is not a cost or accuracy measurement', () => {
+    const exposure: NoiseExposureRow = {
+      ...row(),
+      metric: 'noise_exposure',
+      distractors: 10,
+      corpus_records: 12,
+      route: 'inject-everything',
+      visible_records: 12,
+      visible_tokens: 120,
+      relevant_records: 2,
+      relevant_total: 2,
+      timing: { runs: 20, warmups: 1, p50_ms: 1, p95_ms: 2, min_ms: 1, max_ms: 2 },
+    };
+
+    expect(renderDeterministicReport([exposure])).toContain(
+      'This section measures exposure only, not token cost, billed cost, or accuracy.',
+    );
+  });
+
+  it('renders absolute relevant counts alongside density percentages', () => {
+    const exposure: NoiseExposureRow = {
+      ...row(),
+      metric: 'noise_exposure',
+      distractors: 10_000,
+      corpus_records: 10_002,
+      route: 'inject-everything',
+      visible_records: 10_002,
+      visible_tokens: 100_020,
+      relevant_records: 2,
+      relevant_total: 2,
+      timing: { runs: 20, warmups: 1, p50_ms: 1, p95_ms: 2, min_ms: 1, max_ms: 2 },
+    };
+
+    expect(renderDeterministicReport([exposure])).toContain('2 of 10002 (0.0%)');
   });
 });

--- a/test/deterministic-bench.test.ts
+++ b/test/deterministic-bench.test.ts
@@ -17,6 +17,7 @@ import {
   destroyNoiseFixture,
   generateNoiseCorpus,
   NOISE_SIZES,
+  TARGET_PATH,
 } from '../bench/deterministic/noise.ts';
 import { assertCleanCheckout, git } from '../bench/deterministic/shared.ts';
 import { measureSurvival } from '../bench/deterministic/survival.ts';
@@ -152,6 +153,18 @@ describe('deterministic benchmark reporting', () => {
       } finally {
         destroyNoiseFixture(fixture);
       }
+    }
+  });
+
+  it('keeps each active record commit in the target path history', () => {
+    const fixture = createNoiseFixture(0);
+    try {
+      const messages = git(fixture.dir, ['log', '--format=%B', '--', TARGET_PATH]).stdout;
+
+      expect(messages).toContain('Record-Id: r-expose001');
+      expect(messages).toContain('Record-Id: r-expose002');
+    } finally {
+      destroyNoiseFixture(fixture);
     }
   });
 


### PR DESCRIPTION
Closes #142.

Deterministic — no agent, no model call, so it cannot fail the way M1, M2 and M4 failed. Two active records for the queried path, distractors grown 0 → 10,000.

| route | distractors | visible | relevant | tokens |
|---|---:|---:|---:|---:|
| inject everything | 10,000 | 10,002 | 2/2 | 1,004,554 |
| top-k lexical | 10,000 | 2 | **1/2** | 190 |
| CommitLore path+lifecycle | 10,000 | **2** | **2/2** | 335 |

**99.98% of unrelated decision records never reach the model, with no recall loss.** Top-k drops half the relevant records once distractors exceed 100; path scope does not, because it selects by structure rather than similarity.

This measures **exposure** — not token cost, not billed cost, not accuracy. The output says so in its own text.

## A false unfavourable number was caught first

The first run reported CommitLore at 1/2 relevant. The cause was the fixture: the second active record's commit touched no files, so path-scoped retrieval correctly returned one. Fixed, and a test now fails when an active record's commit does not touch the target path.

Latency was deferred — another latency benchmark is running and a contended run produces wrong numbers (#136).

Refs #136