### PR TITLE
Report the guard threshold curve

### DIFF
--- a/bench/deterministic/quality.ts
+++ b/bench/deterministic/quality.ts
@@ -9,7 +9,9 @@ import { parseCommitMessage } from '../../dist/core/trailers.js';
 import type {
   GuardQualityRow,
   GuardScoreBand,
+  GuardThresholdPoint,
   InjectionDetectionRow,
+  PrecisionInterval,
   RowBase,
 } from './types.ts';
 
@@ -30,6 +32,74 @@ interface GuardArtifact {
   readonly reproposed: boolean;
   readonly diff: string;
 }
+
+export interface GuardScoredDecision {
+  readonly reproposed: boolean;
+  readonly score: number | undefined;
+}
+
+export const GUARD_THRESHOLD_STEP = 0.05;
+const WILSON_Z_95 = 1.959963984540054;
+
+export const wilsonPrecisionInterval = (
+  successes: number,
+  trials: number,
+): PrecisionInterval => {
+  if (!Number.isInteger(successes) || !Number.isInteger(trials) || successes < 0 || successes > trials || trials === 0) {
+    throw new Error('Wilson interval needs integer successes between zero and a positive number of trials');
+  }
+  const proportion = successes / trials;
+  const zSquared = WILSON_Z_95 ** 2;
+  const denominator = 1 + zSquared / trials;
+  const center = (proportion + zSquared / (2 * trials)) / denominator;
+  const margin =
+    (WILSON_Z_95 * Math.sqrt(proportion * (1 - proportion) / trials + zSquared / (4 * trials ** 2))) /
+    denominator;
+  return { level: 0.95, lower: center - margin, upper: center + margin };
+};
+
+export const sweepGuardThresholds = (
+  decisions: readonly GuardScoredDecision[],
+  step = GUARD_THRESHOLD_STEP,
+): readonly GuardThresholdPoint[] => {
+  if (!(Number.isFinite(step) && step >= 0.01 && step <= 1)) {
+    throw new Error('guard threshold step must be between 0.01 and 1');
+  }
+  const positives = decisions.filter((decision) => decision.reproposed).length;
+  if (positives === 0) throw new Error('guard corpus needs at least one positive label');
+  const points: GuardThresholdPoint[] = [];
+  const steps = Math.ceil(1 / step);
+  for (let index = 0; index <= steps; index += 1) {
+    const threshold = Number(Math.min(index * step, 1).toFixed(12));
+    let truePositives = 0;
+    let falsePositives = 0;
+    let falseNegatives = 0;
+    let trueNegatives = 0;
+    for (const decision of decisions) {
+      const detected = decision.score !== undefined && decision.score >= threshold;
+      if (decision.reproposed && detected) truePositives += 1;
+      else if (decision.reproposed) falseNegatives += 1;
+      else if (detected) falsePositives += 1;
+      else trueNegatives += 1;
+    }
+    const firings = truePositives + falsePositives;
+    const precision = firings === 0 ? null : truePositives / firings;
+    const recall = truePositives / positives;
+    points.push({
+      threshold,
+      true_positives: truePositives,
+      false_positives: falsePositives,
+      false_negatives: falseNegatives,
+      true_negatives: trueNegatives,
+      precision,
+      recall,
+      f1: precision === null || precision + recall === 0 ? null : 2 * precision * recall / (precision + recall),
+      firings,
+      correct_silences: trueNegatives,
+    });
+  }
+  return points;
+};
 
 const objectField = (value: unknown, name: string): unknown =>
   typeof value === 'object' && value !== null ? Reflect.get(value, name) : undefined;
@@ -166,10 +236,7 @@ export const measureGuardQuality = (
   );
   const workspaces = new Map<string, string>();
 
-  let truePositives = 0;
-  let falsePositives = 0;
-  let falseNegatives = 0;
-  let trueNegatives = 0;
+  const decisions: GuardScoredDecision[] = [];
   const bandFirings = new Array<number>(GUARD_SCORE_BAND_EDGES.length - 1).fill(0);
   const bandCorrect = new Array<number>(GUARD_SCORE_BAND_EDGES.length - 1).fill(0);
   try {
@@ -186,17 +253,13 @@ export const measureGuardQuality = (
       const matches = guard({
         proposal: artifact.diff,
         cwd: workspace,
-        threshold: DEFAULT_THRESHOLD,
+        threshold: 0,
         noIndex: true,
       }).matches;
       const topScore = matches[0]?.score;
-      const detected = topScore !== undefined;
-      if (artifact.reproposed && detected) truePositives += 1;
-      else if (artifact.reproposed) falseNegatives += 1;
-      else if (detected) falsePositives += 1;
-      else trueNegatives += 1;
+      decisions.push({ reproposed: artifact.reproposed, score: topScore });
 
-      if (detected) {
+      if (topScore !== undefined && topScore >= DEFAULT_THRESHOLD) {
         const band = bandIndexOf(topScore);
         bandFirings[band] = (bandFirings[band] ?? 0) + 1;
         if (artifact.reproposed) bandCorrect[band] = (bandCorrect[band] ?? 0) + 1;
@@ -206,10 +269,10 @@ export const measureGuardQuality = (
     for (const workspace of workspaces.values()) destroyWorkspace(workspace);
   }
 
-  const predictedPositive = truePositives + falsePositives;
-  const actualPositive = truePositives + falseNegatives;
-  if (predictedPositive === 0 || actualPositive === 0) {
-    throw new Error('guard corpus produced an undefined precision or recall');
+  const curve = sweepGuardThresholds(decisions);
+  const defaultPoint = curve.find((point) => point.threshold === DEFAULT_THRESHOLD);
+  if (defaultPoint === undefined || defaultPoint.precision === null) {
+    throw new Error('guard corpus produced an undefined default precision');
   }
   const bands: GuardScoreBand[] = [];
   for (let index = 0; index < GUARD_SCORE_BAND_EDGES.length - 1; index += 1) {
@@ -225,13 +288,16 @@ export const measureGuardQuality = (
     metric: 'guard_quality',
     corpus,
     threshold: DEFAULT_THRESHOLD,
-    true_positives: truePositives,
-    false_positives: falsePositives,
-    false_negatives: falseNegatives,
-    true_negatives: trueNegatives,
-    precision: truePositives / predictedPositive,
-    recall: truePositives / actualPositive,
-    firings: predictedPositive,
+    true_positives: defaultPoint.true_positives,
+    false_positives: defaultPoint.false_positives,
+    false_negatives: defaultPoint.false_negatives,
+    true_negatives: defaultPoint.true_negatives,
+    precision: defaultPoint.precision,
+    recall: defaultPoint.recall,
+    firings: defaultPoint.firings,
     bands,
+    curve_step: GUARD_THRESHOLD_STEP,
+    curve,
+    precision_interval: wilsonPrecisionInterval(defaultPoint.true_positives, defaultPoint.firings),
   };
 };

--- a/bench/deterministic/report.ts
+++ b/bench/deterministic/report.ts
@@ -69,6 +69,7 @@ export const assertSingleProvenance = (rows: readonly DeterministicRow[]): void 
 
 const fixed = (value: number, digits = 2): string => value.toFixed(digits);
 const percent = (value: number): string => `${fixed(value * 100, 1)}%`;
+const optionalPercent = (value: number | null): string => (value === null ? 'n/a' : percent(value));
 
 const latencySection = (rows: readonly QueryLatencyRow[]): string[] => {
   if (rows.length === 0) return [];
@@ -142,11 +143,17 @@ const guardSection = (rows: readonly GuardQualityRow[]): string[] => {
   return [
     '## 4. Guard precision and recall',
     '',
-    `Method: replay the existing labelled task artifacts in \`${row.corpus}\` through the shipped guard at threshold **${row.threshold}**.`,
+    `Method: replay the existing labelled task artifacts in \`${row.corpus}\` through the shipped guard across the full **0.00–1.00** score range in **${row.curve_step.toFixed(2)}** steps. The shipped default is **${row.threshold}**.`,
     '',
-    `Precision is reported by score band, never as one figure (issue #61): a rate computed from a ` +
-      'handful of firings has a wide interval, and a single number invites reading it as more ' +
-      `precise than it is. **Firings: ${row.firings}** (of ${row.true_positives + row.false_positives + row.false_negatives + row.true_negatives} replayed decisions).`,
+    `Corpus limit: **${row.true_positives + row.false_positives + row.false_negatives + row.true_negatives} labelled decisions**. At the default, precision is ${row.true_positives}/${row.firings}; its 95% Wilson interval is **${percent(row.precision_interval.lower)}–${percent(row.precision_interval.upper)}**.`,
+    '',
+    '| threshold | precision | recall | F1 | firings | correct silences |',
+    '|---:|---:|---:|---:|---:|---:|',
+    ...row.curve.map(
+      (entry) =>
+        `| ${fixed(entry.threshold)} | ${optionalPercent(entry.precision)} | ${percent(entry.recall)} | ` +
+        `${optionalPercent(entry.f1)} | ${entry.firings} | ${entry.correct_silences} |`,
+    ),
     '',
     '| score band | firings | correct |',
     '|---|---:|---:|',
@@ -158,7 +165,7 @@ const guardSection = (rows: readonly GuardQualityRow[]): string[] => {
           `| [${band(entry.min)}, ${band(entry.max)}${entry.max >= 1 ? ']' : ')'} | ${entry.firings} | ${entry.correct} |`,
       ),
     '',
-    `Recall: **${percent(row.recall)}** (${row.true_positives} TP, ${row.false_negatives} FN). ` +
+    `Default-point recall: **${percent(row.recall)}** (${row.true_positives} TP, ${row.false_negatives} FN). ` +
       `Correct silence: ${row.true_negatives}.`,
     'Ground truth is the frozen corpus label; the suite does not relabel archived agent output after seeing the guard result.',
     'No guard precision figure is carried into the README until the corpus is large enough for one to mean something.',

--- a/bench/deterministic/types.ts
+++ b/bench/deterministic/types.ts
@@ -95,6 +95,25 @@ export interface GuardScoreBand {
   readonly correct: number;
 }
 
+export interface GuardThresholdPoint {
+  readonly threshold: number;
+  readonly true_positives: number;
+  readonly false_positives: number;
+  readonly false_negatives: number;
+  readonly true_negatives: number;
+  readonly precision: number | null;
+  readonly recall: number;
+  readonly f1: number | null;
+  readonly firings: number;
+  readonly correct_silences: number;
+}
+
+export interface PrecisionInterval {
+  readonly level: 0.95;
+  readonly lower: number;
+  readonly upper: number;
+}
+
 export interface GuardQualityRow extends BaseRow {
   readonly metric: 'guard_quality';
   readonly corpus: string;
@@ -103,17 +122,14 @@ export interface GuardQualityRow extends BaseRow {
   readonly false_positives: number;
   readonly false_negatives: number;
   readonly true_negatives: number;
-  /**
-   * Kept for programmatic use (trend tracking as the corpus grows). Never
-   * rendered alone in the report: issue #61 decided precision is reported by
-   * score band, because a rate computed from a handful of firings has a wide
-   * interval and a single number invites reading it as more than it is.
-   */
   readonly precision: number;
   readonly recall: number;
   /** True positives + false positives; the denominator the bands partition. */
   readonly firings: number;
   readonly bands: readonly GuardScoreBand[];
+  readonly curve_step: number;
+  readonly curve: readonly GuardThresholdPoint[];
+  readonly precision_interval: PrecisionInterval;
 }
 
 export type HookName = 'commit-msg' | 'pre-tool-use-inject';

--- a/bench/results/guard-threshold-curve-20260729.md
+++ b/bench/results/guard-threshold-curve-20260729.md
@@ -1,0 +1,45 @@
+# Guard threshold curve
+
+This is a deterministic replay of the frozen labelled corpus only. It collects no wall-clock measurements.
+
+## Baseline confirmed before this change
+
+The archived report `bench/results/deterministic-20260727T083941Z.md` is retained in local Git object `8bfcd43576de8890686b256911592cf96a5fce15`. At the old and current shipped threshold, **0.35**, it recorded **3 true positives, 5 false positives, 2 false negatives, and 20 correct silences**: precision **3/8 (37.5%)**, recall **60.0%**.
+
+The 95% Wilson score interval for that 3/8 precision is **13.7%–69.4%**. Thirty labelled decisions and eight firings are too small to describe 37.5% as a precise estimate.
+
+## Current replay
+
+Source scorer: `origin/dev` at `7f823bd66cac51e3e4dceeac49435bd5e39fc0f4`. The #61 scoring-composition repair already merged on that branch removes one archived false positive without changing the default threshold. The current default point is therefore **3 TP, 4 FP, 2 FN, and 21 correct silences**: precision **3/7 (42.9%)**, recall **60.0%**, with a 95% Wilson interval of **15.8%–75.0%**.
+
+Method: replay all 30 frozen `commitlore-on` artifacts in `bench/results/transcripts-final` through the shipped guard. Scores span their usable 0.00–1.00 range; this table uses a fixed 0.05 step. Precision is `n/a` only when the guard does not fire; F1 is `n/a` when both precision and recall are zero.
+
+| threshold | precision | recall | F1 | firings | correct silences |
+|---:|---:|---:|---:|---:|---:|
+| 0.00 | 33.3% | 60.0% | 42.9% | 9 | 19 |
+| 0.05 | 33.3% | 60.0% | 42.9% | 9 | 19 |
+| 0.10 | 33.3% | 60.0% | 42.9% | 9 | 19 |
+| 0.15 | 37.5% | 60.0% | 46.2% | 8 | 20 |
+| 0.20 | 37.5% | 60.0% | 46.2% | 8 | 20 |
+| 0.25 | 37.5% | 60.0% | 46.2% | 8 | 20 |
+| 0.30 | 42.9% | 60.0% | 50.0% | 7 | 21 |
+| 0.35 | 42.9% | 60.0% | 50.0% | 7 | 21 |
+| 0.40 | 42.9% | 60.0% | 50.0% | 7 | 21 |
+| 0.45 | 42.9% | 60.0% | 50.0% | 7 | 21 |
+| 0.50 | 42.9% | 60.0% | 50.0% | 7 | 21 |
+| 0.55 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 0.60 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 0.65 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 0.70 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 0.75 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 0.80 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 0.85 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 0.90 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 0.95 | 0.0% | 0.0% | n/a | 2 | 23 |
+| 1.00 | 0.0% | 0.0% | n/a | 2 | 23 |
+
+## Decision
+
+Keep the shipped default at **0.35**. This advisory guard's false positive consumes attention during an otherwise correct edit, so this decision weights false positives more heavily than false negatives; it does not select the F1 maximum. Lower thresholds add false positives. Raising the threshold to 0.55 or above removes all three true positives while retaining two false positives. The 0.30–0.50 plateau has identical observed counts, so the curve provides no reason to move 0.35 within it.
+
+No threshold reaches a defensible precision for an advisory guard that interrupts attention: the best observed precision is only 42.9%, and its interval is wide. This is a finding, not a search for a favorable cutoff. The corpus remains frozen and unrelabeled; resolving the uncertainty requires more independently labelled cases, not a different step size or metric.

--- a/test/deterministic-bench.test.ts
+++ b/test/deterministic-bench.test.ts
@@ -19,10 +19,17 @@ import {
   NOISE_SIZES,
   TARGET_PATH,
 } from '../bench/deterministic/noise.ts';
+import {
+  sweepGuardThresholds,
+  wilsonPrecisionInterval,
+} from '../bench/deterministic/quality.ts';
 import { assertCleanCheckout, git } from '../bench/deterministic/shared.ts';
 import { measureSurvival } from '../bench/deterministic/survival.ts';
-import type { InjectionDetectionRow } from '../bench/deterministic/types.ts';
-import type { NoiseExposureRow } from '../bench/deterministic/types.ts';
+import type {
+  GuardQualityRow,
+  InjectionDetectionRow,
+  NoiseExposureRow,
+} from '../bench/deterministic/types.ts';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..');
 
@@ -53,6 +60,37 @@ const row = (overrides: Partial<InjectionDetectionRow> = {}): InjectionDetection
   false_positive_rate: 0.2,
   ...overrides,
 });
+
+const guardRow = (): GuardQualityRow => {
+  const curve = sweepGuardThresholds(
+    [
+      { reproposed: true, score: 0.8 },
+      { reproposed: false, score: 0.6 },
+      { reproposed: true, score: 0.4 },
+      { reproposed: false, score: undefined },
+    ],
+    0.2,
+  );
+  const point = curve.find((entry) => entry.threshold === 0.6);
+  if (point === undefined) throw new Error('hand-checked curve fixture is missing 0.60');
+  return {
+    ...row(),
+    metric: 'guard_quality',
+    corpus: 'bench/results/transcripts-final',
+    threshold: 0.6,
+    true_positives: point.true_positives,
+    false_positives: point.false_positives,
+    false_negatives: point.false_negatives,
+    true_negatives: point.true_negatives,
+    precision: point.precision,
+    recall: point.recall,
+    firings: point.firings,
+    bands: [],
+    curve_step: 0.2,
+    curve,
+    precision_interval: wilsonPrecisionInterval(point.true_positives, point.firings),
+  };
+};
 
 describe('deterministic benchmark reporting', () => {
   it('computes nearest-rank p50 and p95 when samples are unsorted', () => {
@@ -85,6 +123,77 @@ describe('deterministic benchmark reporting', () => {
 
   it('states that the measurements do not establish agent benefit', () => {
     expect(renderDeterministicReport([row()])).toContain(SCOPE_SENTENCE);
+  });
+
+  it('keeps guard firing counts monotonic as the threshold rises', () => {
+    const curve = sweepGuardThresholds(
+      [
+        { reproposed: true, score: 0.8 },
+        { reproposed: false, score: 0.6 },
+        { reproposed: true, score: 0.4 },
+        { reproposed: false, score: undefined },
+      ],
+      0.2,
+    );
+
+    for (let index = 1; index < curve.length; index += 1) {
+      expect(curve[index - 1]?.firings).toBeGreaterThanOrEqual(curve[index]?.firings ?? 0);
+    }
+  });
+
+  it('rejects threshold steps that would make an unboundedly large report', () => {
+    expect(() =>
+      sweepGuardThresholds(
+        [{ reproposed: true, score: 0.8 }],
+        0.001,
+      ),
+    ).toThrow(/step must be between 0.01 and 1/i);
+  });
+
+  it('includes the 1.00 endpoint when the threshold step does not divide the range', () => {
+    const curve = sweepGuardThresholds([{ reproposed: true, score: 0.8 }], 0.3);
+
+    expect(curve.map((entry) => entry.threshold)).toEqual([0, 0.3, 0.6, 0.9, 1]);
+  });
+
+  it('computes guard precision, recall, and F1 from a hand-checked fixture', () => {
+    const curve = sweepGuardThresholds(
+      [
+        { reproposed: true, score: 0.8 },
+        { reproposed: false, score: 0.6 },
+        { reproposed: true, score: 0.4 },
+        { reproposed: false, score: undefined },
+      ],
+      0.2,
+    );
+    const point = curve.find((entry) => entry.threshold === 0.6);
+
+    expect(point).toMatchObject({
+      true_positives: 1,
+      false_positives: 1,
+      false_negatives: 1,
+      true_negatives: 1,
+      precision: 0.5,
+      recall: 0.5,
+      f1: 0.5,
+      firings: 2,
+      correct_silences: 1,
+    });
+  });
+
+  it('computes the 95% Wilson interval for the archived 3-of-8 precision', () => {
+    const interval = wilsonPrecisionInterval(3, 8);
+
+    expect(interval.level).toBe(0.95);
+    expect(interval.lower).toBeCloseTo(0.1368, 4);
+    expect(interval.upper).toBeCloseTo(0.6943, 4);
+  });
+
+  it('renders the guard corpus-size limit with the threshold curve', () => {
+    const report = renderDeterministicReport([guardRow()]);
+
+    expect(report).toContain('4 labelled decisions');
+    expect(report).toContain('| threshold | precision | recall | F1 | firings | correct silences |');
   });
 
   it('refuses uncommitted benchmark inputs', () => {


### PR DESCRIPTION
Refs #61.

## Summary

- Adds a full deterministic 0.05 threshold curve in `bench/results/guard-threshold-curve-20260729.md`.
- Reports precision, recall, F1, firings, and correct silences at every 0.00–1.00 point.
- Keeps the advisory guard default at 0.35: lower thresholds add false positives; 0.55+ loses all true positives while retaining two false positives.

## Measurement limits

The archived 0.35 point was 3 TP / 5 FP / 2 FN / 20 correct silences, with a 95% Wilson interval of 13.7%–69.4% for 3/8 precision. The current scorer is 3 / 4 / 2 / 21 after the existing scoring-composition repair. The corpus remains frozen and unrelabeled.

## Validation

- npm run build
- npx vitest run
- npx tsc -p tsconfig.json --noEmit
- npx tsc -p bench/tsconfig.json --noEmit
- Five final-SHA review lanes passed
- Deterministic replay only; no wall-clock benchmark was run.