### PR TITLE
Count work spent on a rejected path, not mentions of one

### DIFF
--- a/bench/detect.ts
+++ b/bench/detect.ts
@@ -126,3 +126,152 @@ export const countViolations = (group: MatcherGroup | undefined, surfaces: Surfa
   const hits = clauses.filter((m) => matches(m, surfaces)).map(labelOf);
   return { matched: hits.length > 0, labels: hits };
 };
+
+// ---------------------------------------------------------------------------
+// Rejected-path work (bug #141)
+// ---------------------------------------------------------------------------
+//
+// `reproposed`/`reproposal_matches` above answer "did this run's output match
+// the rejected alternative's signature", on any surface the task names —
+// including a transcript, a commit message, or a comment, all of which an
+// agent can use to *explain* that it declined the alternative rather than to
+// pursue it. That is why `code` exists: added lines, minus documentation and
+// comments, so implementing an alternative counts and explaining that it was
+// avoided does not.
+//
+// What `code` cannot say is *how much*. A run that types one declining
+// sentence and a run that edits three files toward the rejected alternative
+// before reverting both produce zero characters of surviving "code" evidence
+// — one because it never touched the path, the other because the harness only
+// reads the final diff. Of the two, only the second one cost something. The
+// functions below attribute the diff's hunks to `reproposed_if`, hunk by
+// hunk, so that magnitude is countable instead of collapsed into the same
+// boolean.
+
+/** Dependency manifests: an added line here declares a package, not application code. */
+const DEPENDENCY_MANIFEST =
+  /(^|\/)(package\.json|requirements(-[\w.-]+)?\.txt|pyproject\.toml|Pipfile|Cargo\.toml|go\.mod|Gemfile|composer\.json)$/i;
+
+export interface DiffHunk {
+  readonly file: string;
+  readonly isManifest: boolean;
+  readonly addedLines: readonly string[];
+  readonly removedLines: readonly string[];
+}
+
+/**
+ * Splits a unified diff into per-hunk added/removed lines, tagged with the
+ * file each hunk belongs to. `codeText` answers "is there a match anywhere in
+ * the diff"; this answers "which hunk", so a match can be attributed to a
+ * specific edit rather than to the diff as a whole.
+ */
+export const parseDiffHunks = (diff: string): readonly DiffHunk[] => {
+  const hunks: DiffHunk[] = [];
+  let file = "";
+  let isManifest = false;
+  let added: string[] = [];
+  let removed: string[] = [];
+  let open = false;
+
+  const flush = (): void => {
+    if (open) hunks.push({ file, isManifest, addedLines: added, removedLines: removed });
+    added = [];
+    removed = [];
+    open = false;
+  };
+
+  for (const line of diff.split("\n")) {
+    // `+++ b/path` opens a file, the same signal `codeText` reads its doc-file
+    // flag from; here it decides `isManifest` instead.
+    if (line.startsWith("+++ ")) {
+      flush();
+      file = line.slice(4).replace(/^b\//, "").trim();
+      isManifest = DEPENDENCY_MANIFEST.test(file);
+      continue;
+    }
+    if (line.startsWith("--- ") || line.startsWith("diff --git")) continue;
+    if (line.startsWith("@@")) {
+      flush();
+      open = true;
+      continue;
+    }
+    if (!open) continue;
+    if (line.startsWith("+")) added.push(line.slice(1));
+    else if (line.startsWith("-")) removed.push(line.slice(1));
+  }
+  flush();
+  return hunks;
+};
+
+/**
+ * Reconstructs a hunk (or a single line of one) as a synthetic one-hunk diff,
+ * so it can be run back through `evaluateGroup` — the same literal/regex
+ * matching, including the `code` surface's doc-file and comment stripping —
+ * rather than a second, parallel matcher that could disagree with a task
+ * author's actual `reproposed_if` clauses.
+ */
+const syntheticDiffSurfaces = (
+  file: string,
+  addedLines: readonly string[],
+  removedLines: readonly string[],
+): Surfaces => ({
+  transcript: "",
+  commits: "",
+  diff: [
+    `diff --git a/${file} b/${file}`,
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    "@@ -0,0 +0,0 @@",
+    ...addedLines.map((line) => `+${line}`),
+    ...removedLines.map((line) => `-${line}`),
+  ].join("\n"),
+});
+
+export interface RejectedPathWork {
+  /** Hunks whose added code matched `group` — editing toward it, not mentioning it. */
+  readonly editHunks: number;
+  /** Added and removed lines inside the hunks counted above. */
+  readonly linesChanged: number;
+  /** Added lines in a recognized dependency manifest that matched `group`. */
+  readonly dependencyAdditions: number;
+  /** 1 if any of the above happened at all, 0 if none did. */
+  readonly firstEditOccurred: 0 | 1;
+}
+
+/**
+ * Rejected-path work: how much a diff pursued `group` (normally a task's
+ * `reproposed_if`) rather than merely mentioning it (bug #141).
+ *
+ * A hunk counts on its **added** lines only — reads only added lines, so
+ * deleting the rejected code is not proposing it, the same rule `codeText`
+ * already applies to the whole-diff detector. Removed lines still count
+ * toward `linesChanged` once a hunk has matched, because they are part of the
+ * same edit's cost.
+ */
+export const countRejectedPathWork = (group: MatcherGroup, diff: string): RejectedPathWork => {
+  const hunks = parseDiffHunks(diff);
+  let editHunks = 0;
+  let linesChanged = 0;
+  let dependencyAdditions = 0;
+
+  for (const hunk of hunks) {
+    if (hunk.isManifest) {
+      for (const line of hunk.addedLines) {
+        if (evaluateGroup(group, syntheticDiffSurfaces(hunk.file, [line], [])).matched) {
+          dependencyAdditions += 1;
+        }
+      }
+    }
+    if (evaluateGroup(group, syntheticDiffSurfaces(hunk.file, hunk.addedLines, [])).matched) {
+      editHunks += 1;
+      linesChanged += hunk.addedLines.length + hunk.removedLines.length;
+    }
+  }
+
+  return {
+    editHunks,
+    linesChanged,
+    dependencyAdditions,
+    firstEditOccurred: editHunks > 0 || dependencyAdditions > 0 ? 1 : 0,
+  };
+};

--- a/bench/metrics.ts
+++ b/bench/metrics.ts
@@ -64,10 +64,27 @@ export const guardExposureState = (row: RunRecord): GuardExposureState => {
   return exposure.fires > 0 ? "yes" : "no";
 };
 
-export const assertPrimaryOutcomeCanBeRegistered = (
-  outcome: PrimaryOutcome,
+/**
+ * The refusal gate behind `assertPrimaryOutcomeCanBeRegistered`, generalized
+ * over an accessor instead of reading `reproposal_matches` directly.
+ *
+ * Bug #141 replaced the single re-proposal outcome with six rejected-path
+ * counts rather than one composite (a weighted figure invites argument about
+ * the weights; six plain counts do not), and every one of them has to be
+ * refused the same way `reproposal_matches` already was — a pilot whose guard
+ * exposure cannot be read, or an outcome with no variance to test, answers
+ * nothing regardless of which field is being registered. Duplicating the four
+ * checks per new count would let one of them drift from the others; reading
+ * the count through an accessor keeps them identical by construction.
+ * `assertPrimaryOutcomeCanBeRegistered` is this function with
+ * `reproposal_matches` as the accessor, and keeps its own name and signature
+ * so nothing that already calls it has to change.
+ */
+export const assertOutcomeCanBeRegistered = (
+  outcome: string,
   rows: readonly RunRecord[],
   structuralMaximums: ReadonlyMap<string, number>,
+  accessor: (row: RunRecord) => unknown,
 ): void => {
   if (rows.length === 0) throw new Error(`refusing to register primary outcome \`${outcome}\`: no pilot rows`);
   const unexposed = rows.filter((row) => guardExposureState(row) === "unknown");
@@ -80,7 +97,7 @@ export const assertPrimaryOutcomeCanBeRegistered = (
   const counts: number[] = [];
   const taskMaxima: number[] = [];
   for (const row of rows) {
-    const count = row.reproposal_matches;
+    const count = accessor(row);
     if (typeof count !== "number" || !Number.isInteger(count) || count < 0) {
       throw new Error(`refusing to register primary outcome \`${outcome}\`: it is not a non-negative integer on every pilot row`);
     }
@@ -101,6 +118,12 @@ export const assertPrimaryOutcomeCanBeRegistered = (
     throw new Error(`refusing to register primary outcome \`${outcome}\`: ${failures.join("; ")}`);
   }
 };
+
+export const assertPrimaryOutcomeCanBeRegistered = (
+  outcome: PrimaryOutcome,
+  rows: readonly RunRecord[],
+  structuralMaximums: ReadonlyMap<string, number>,
+): void => assertOutcomeCanBeRegistered(outcome, rows, structuralMaximums, (row) => row.reproposal_matches);
 
 /**
  * A row that failed carries no measurement — the runner writes `reproposed:
@@ -344,6 +367,18 @@ const REQUIRED_FIELDS = [
   "simulated",
 ] as const;
 
+/**
+ * Optional fields validated as a non-negative integer when present, the same
+ * treatment `reproposal_matches` already got. `rejected_path_first_edit` is
+ * checked separately below — it is a 0/1 flag, not an unbounded count.
+ */
+const NON_NEGATIVE_INTEGER_FIELDS = [
+  "reproposal_matches",
+  "rejected_path_edit_hunks",
+  "rejected_path_lines_changed",
+  "rejected_path_dependency_additions",
+] as const;
+
 export const parseRows = (file: string, contents: string): readonly RunRecord[] => {
   const rows: RunRecord[] = [];
   contents.split("\n").forEach((line, index) => {
@@ -359,14 +394,15 @@ export const parseRows = (file: string, contents: string): readonly RunRecord[] 
     for (const field of REQUIRED_FIELDS) {
       if (row[field] === undefined) throw new Error(`${file}:${index + 1}: missing field \`${field}\``);
     }
-    const reproposalMatches = row.reproposal_matches;
-    if (
-      reproposalMatches !== undefined &&
-      (typeof reproposalMatches !== "number" ||
-        !Number.isInteger(reproposalMatches) ||
-        reproposalMatches < 0)
-    ) {
-      throw new Error(`${file}:${index + 1}: \`reproposal_matches\` must be a non-negative integer`);
+    for (const field of NON_NEGATIVE_INTEGER_FIELDS) {
+      const value = row[field];
+      if (value !== undefined && (typeof value !== "number" || !Number.isInteger(value) || value < 0)) {
+        throw new Error(`${file}:${index + 1}: \`${field}\` must be a non-negative integer`);
+      }
+    }
+    const firstEdit = row.rejected_path_first_edit;
+    if (firstEdit !== undefined && firstEdit !== 0 && firstEdit !== 1) {
+      throw new Error(`${file}:${index + 1}: \`rejected_path_first_edit\` must be 0 or 1`);
     }
     rows.push(parsed as RunRecord);
   });

--- a/bench/runner.ts
+++ b/bench/runner.ts
@@ -7,7 +7,7 @@ import { Command } from "commander";
 
 import { assembleContext, collectRuledOutAlternatives } from "./context.ts";
 import { digestDistTree, HOOK_PLANS, noGuardExposure, readGuardExposure, writeArmSettings } from "./hooks-settings.ts";
-import { countReproposalMatches, countViolations } from "./detect.ts";
+import { countReproposalMatches, countRejectedPathWork, countViolations } from "./detect.ts";
 import { createDriver, DRIVER_NAMES } from "./drivers/registry.ts";
 import type { DriverResult } from "./drivers/types.ts";
 import { readCommits } from "./git.ts";
@@ -259,6 +259,10 @@ const main = async (): Promise<number> => {
             started_at: startedAt,
             simulated: driver.simulated,
             guard_exposure: noGuardExposure(),
+            rejected_path_edit_hunks: 0,
+            rejected_path_lines_changed: 0,
+            rejected_path_dependency_additions: 0,
+            rejected_path_first_edit: 0,
             error: `global token cap of ${maxTokens} exhausted before this run started`,
           };
           fs.appendFileSync(outPath, `${JSON.stringify(record)}\n`);
@@ -302,6 +306,7 @@ const main = async (): Promise<number> => {
           const surfaces = collectSurfaces(workspace, result.transcript);
           const reproposed = countReproposalMatches(task.detect.reproposed_if, surfaces);
           const violations = countViolations(task.detect.violation_if, surfaces);
+          const rejectedPathWork = countRejectedPathWork(task.detect.reproposed_if, surfaces.diff);
 
           // A detector verdict nobody can re-read is a verdict nobody can
           // challenge — and a bare literal cannot tell "use Redis" from
@@ -354,6 +359,10 @@ const main = async (): Promise<number> => {
             ...(guardExposure === undefined ? {} : { guard_exposure: guardExposure }),
             matched: [...reproposed.labels, ...violations.labels],
             accepted_records: acceptedRecords,
+            rejected_path_edit_hunks: rejectedPathWork.editHunks,
+            rejected_path_lines_changed: rejectedPathWork.linesChanged,
+            rejected_path_dependency_additions: rejectedPathWork.dependencyAdditions,
+            rejected_path_first_edit: rejectedPathWork.firstEditOccurred,
             ...(result.error === undefined ? {} : { error: result.error }),
           };
         } catch (error) {
@@ -378,6 +387,10 @@ const main = async (): Promise<number> => {
             started_at: startedAt,
             simulated: driver.simulated,
             ...(guardExposure === undefined ? {} : { guard_exposure: guardExposure }),
+            rejected_path_edit_hunks: 0,
+            rejected_path_lines_changed: 0,
+            rejected_path_dependency_additions: 0,
+            rejected_path_first_edit: 0,
             error: (error as Error).message,
           };
         } finally {

--- a/bench/types.ts
+++ b/bench/types.ts
@@ -232,6 +232,19 @@ export interface RunRecord {
   readonly cond: string;
   readonly seed: number;
   readonly model?: string;
+  /**
+   * Whether the run matched `detect.reproposed_if` on any surface.
+   *
+   * Instrumented-only (bug #141), the way `violations` already was: a boolean
+   * that fires on a diff, a commit message or a code comment alike cannot tell
+   * "implemented the rejected alternative" from "explained, correctly, that it
+   * declined the rejected alternative" — the second is the guard working as
+   * designed, not a failure, and this field records both as the same `true`.
+   * `reproposal_matches` narrows the same signal to a count and inherits the
+   * same conflation. Kept for diagnosis, not read as the outcome; see the
+   * rejected-path fields below for what replaced it as the thing worth
+   * measuring.
+   */
   readonly reproposed: boolean;
   readonly reproposal_matches?: number;
   readonly violations: number;
@@ -284,6 +297,64 @@ export interface RunRecord {
    * repository whose team never wrote a record.
    */
   readonly accepted_records?: number;
+
+  // --- Rejected-path work (bug #141) ---
+  //
+  // `reproposed`/`reproposal_matches` answer "did the output match a rejected
+  // alternative's signature", and a correct refusal can match that signature
+  // too, on a surface that includes the agent's own explanation of why it
+  // declined. Neither can say whether the agent spent anything *pursuing* the
+  // rejected path before it stopped, which is the number a reader actually
+  // wants: a run that writes "I considered Redis, but the record rules it out"
+  // costs nothing, and a run that edits three files toward Redis and then
+  // reverts cost three files' worth of wasted work, even though both score
+  // `reproposed: false`.
+  //
+  // The issue asked for six counts, reported separately rather than combined
+  // into one weighted figure so a reader can weight them for their own
+  // situation. Four are derivable from what this harness already records —
+  // the diff and the task's own `reproposed_if` clauses — and are below. Two
+  // are not, and are not approximated in their place:
+  //
+  //   - rejected-path tool actions: `DriverResult.transcript` is the `claude`
+  //     CLI's final `result` text (`--output-format json`), not a transcript
+  //     of tool calls, so there is no tool-call log to count actions from.
+  //     `drivers/claude-headless.ts` would need `--output-format stream-json`
+  //     (or an equivalent capture) recording each tool_use block to make this
+  //     observable.
+  //   - turns spent before abandoning the rejected path: `turns` below is the
+  //     run's total turn count (`num_turns` from that same final JSON), with
+  //     no attribution of which turn did what. Seeing "abandoned after N
+  //     turns" needs the same per-turn capture as the item above, keyed by
+  //     turn index.
+  //
+  // Every field below is optional for the reason `reproposal_matches` is: a
+  // row written before this harness computed it carries none of them, and a
+  // row that carries none of them is "not instrumented", not zero.
+
+  /**
+   * Diff hunks whose added code matches `detect.reproposed_if` — editing
+   * toward the rejected alternative, not mentioning it.
+   */
+  readonly rejected_path_edit_hunks?: number;
+  /** Added and removed lines inside the hunks counted above. */
+  readonly rejected_path_lines_changed?: number;
+  /**
+   * Added lines in a recognized dependency manifest (e.g. `package.json`)
+   * that match `detect.reproposed_if` — installing the rejected package, not
+   * discussing it.
+   */
+  readonly rejected_path_dependency_additions?: number;
+  /**
+   * 1 if any rejected-path edit survived to the final diff, 0 if none did.
+   *
+   * Scoped to what persisted: a hunk written toward the rejected alternative
+   * and then reverted before the run ended leaves no trace in the diff this
+   * harness reads, the same blind spot `reproposed` itself has always had
+   * against an end-state comparison. See the "turns spent abandoning" note
+   * above for what would be needed to see a reverted attempt at all.
+   */
+  readonly rejected_path_first_edit?: 0 | 1;
 }
 
 export interface GuardExposureMatch {

--- a/test/bench-rejected-path.test.ts
+++ b/test/bench-rejected-path.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Rejected-path work (bug #141).
+ *
+ * `reproposed`/`reproposal_matches` answer "did the output match the rejected
+ * alternative's signature", and a correct refusal can match that signature too
+ * — an agent that explains, in prose, that it declined the rejected
+ * alternative was scored the same as one that implemented it. This suite
+ * covers the replacement: separate observable counts of how much a diff
+ * actually pursued the rejected path, derived from the diff and a task's own
+ * `reproposed_if` clauses rather than from a new parallel matcher.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { countRejectedPathWork } from "../bench/detect.ts";
+import { assertOutcomeCanBeRegistered } from "../bench/metrics.ts";
+import type { MatcherGroup, RunRecord } from "../bench/types.ts";
+
+const REDIS_GROUP: MatcherGroup = {
+  any_of: [{ kind: "literal", value: "redis", in: "code" }],
+};
+
+const row = (overrides: Partial<RunRecord> = {}): RunRecord => ({
+  run_id: "rejected-path-test",
+  harness_commit: "1111111111111111111111111111111111111111",
+  dist_digest: "2222222222222222222222222222222222222222222222222222222222222222",
+  task: "reproposal-redis-cache",
+  cond: "commitlore-on",
+  seed: 1,
+  reproposed: false,
+  violations: 0,
+  turns: 1,
+  tokens: 1,
+  stopped_by: "completed",
+  duration_ms: 1,
+  driver: "synthetic",
+  started_at: "2026-07-28T00:00:00.000Z",
+  simulated: false,
+  guard_exposure: { complete: true, executed: false, checks: 0, fires: 0, matches: [] },
+  ...overrides,
+});
+
+describe("rejected-path work", () => {
+  it("scores zero when the diff only explains that the alternative was declined", () => {
+    // Same shape as reproposal-rabbitmq-queue seed 2 (test/bench-detect.test.ts):
+    // the alternative is named, but only in a comment explaining it was avoided.
+    // No line here implements Redis, so none of the four counts should move.
+    const diff = [
+      "diff --git a/src/session.ts b/src/session.ts",
+      "--- a/src/session.ts",
+      "+++ b/src/session.ts",
+      "@@ -1,2 +1,3 @@",
+      "+// Extending the TTL would also work, but a shared Redis cache was ruled",
+      "+// out on security policy, so this keeps the in-process map.",
+      " export const readSession = (id: string): string | null => get(`session:${id}`);",
+    ].join("\n");
+
+    const work = countRejectedPathWork(REDIS_GROUP, diff);
+
+    expect(work).toEqual({
+      editHunks: 0,
+      linesChanged: 0,
+      dependencyAdditions: 0,
+      firstEditOccurred: 0,
+    });
+  });
+
+  it("counts hunks and lines when the diff edits toward the rejected alternative", () => {
+    const diff = [
+      "diff --git a/src/cache.ts b/src/cache.ts",
+      "--- a/src/cache.ts",
+      "+++ b/src/cache.ts",
+      "@@ -1,2 +1,4 @@",
+      "-const store = new Map<string, Entry>();",
+      '+import Redis from "ioredis";',
+      "+",
+      "+const client = new Redis(process.env.REDIS_URL);",
+    ].join("\n");
+
+    const work = countRejectedPathWork(REDIS_GROUP, diff);
+
+    expect(work.editHunks).toBe(1);
+    // 1 removed + 3 added lines in the one matched hunk.
+    expect(work.linesChanged).toBe(4);
+    expect(work.firstEditOccurred).toBe(1);
+  });
+
+  it("counts a dependency added to a manifest separately from edit hunks", () => {
+    const diff = [
+      "diff --git a/package.json b/package.json",
+      "--- a/package.json",
+      "+++ b/package.json",
+      "@@ -3,6 +3,7 @@",
+      '     "commander": "^15.0.0",',
+      '+    "ioredis": "^5.4.1",',
+      '     "js-yaml": "^5.2.2",',
+    ].join("\n");
+
+    const work = countRejectedPathWork(REDIS_GROUP, diff);
+
+    expect(work.dependencyAdditions).toBe(1);
+    expect(work.firstEditOccurred).toBe(1);
+  });
+
+  it("reads only added lines, so deleting the rejected code is not pursuing it", () => {
+    const diff = [
+      "diff --git a/src/cache.ts b/src/cache.ts",
+      "--- a/src/cache.ts",
+      "+++ b/src/cache.ts",
+      "@@ -1,2 +1,1 @@",
+      '-import Redis from "ioredis";',
+      "+const store = new Map<string, Entry>();",
+    ].join("\n");
+
+    const work = countRejectedPathWork(REDIS_GROUP, diff);
+
+    expect(work).toEqual({
+      editHunks: 0,
+      linesChanged: 0,
+      dependencyAdditions: 0,
+      firstEditOccurred: 0,
+    });
+  });
+
+  it("does not fabricate a turn count for abandoning the rejected path", () => {
+    // Bug #141 named six counts. Two are not observable with what this harness
+    // records today:
+    //   - rejected-path tool actions: the driver's transcript is the CLI's
+    //     final result text, not a tool-call log.
+    //   - turns spent before abandoning the rejected path: `RunRecord.turns` is
+    //     a single run-total (`num_turns`), with no per-turn attribution.
+    // This test is the contract that a future change does not quietly invent
+    // either of them: `countRejectedPathWork` returns exactly the four counts
+    // that are derivable from the diff, and nothing shaped like a turn index
+    // or an action tally.
+    const work = countRejectedPathWork(REDIS_GROUP, "");
+
+    expect(Object.keys(work).sort()).toEqual(
+      ["dependencyAdditions", "editHunks", "firstEditOccurred", "linesChanged"].sort(),
+    );
+  });
+
+  it("refuses the new outcome at registration when it has zero variance", () => {
+    expect(() =>
+      assertOutcomeCanBeRegistered(
+        "rejected_path_edit_hunks",
+        [
+          row({ rejected_path_edit_hunks: 0 }),
+          row({ seed: 2, rejected_path_edit_hunks: 0 }),
+        ],
+        new Map([["reproposal-redis-cache", 3]]),
+        (r) => r.rejected_path_edit_hunks,
+      ),
+    ).toThrow(/rejected_path_edit_hunks.*zero variance.*pinned at 0/i);
+  });
+
+  it("accepts the new outcome at registration when it has genuine spread", () => {
+    expect(() =>
+      assertOutcomeCanBeRegistered(
+        "rejected_path_edit_hunks",
+        [
+          row({ rejected_path_edit_hunks: 0 }),
+          row({ seed: 2, rejected_path_edit_hunks: 1 }),
+          row({ seed: 3, rejected_path_edit_hunks: 2 }),
+        ],
+        new Map([["reproposal-redis-cache", 3]]),
+        (r) => r.rejected_path_edit_hunks,
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #141. Refs #137.

`reproposed: true` fired on an agent that said *"extending the TTL would also work, but the record shows it was ruled out on security policy, so I will not use it"* — **the guard working as intended, scored as a failure.**

**Four** counts replace it, recorded separately rather than weighted: rejected-path edit hunks, lines changed, dependency additions (scoped to recognized manifest files), and whether a first rejected edit occurred.

**Two of the six the ticket asked for are not recorded**, and the code says which and why rather than estimating them: tool actions need a tool-call log, and the headless driver runs `--output-format json` so the transcript is only the final result text; turns-before-abandonment needs per-turn attribution and `turns` is a single run total.

Detection reuses each task's own `reproposed_if` clauses — `parseDiffHunks` rebuilds every hunk as a synthetic one-hunk diff and runs it back through `evaluateGroup`, rather than adding a second matcher that could drift from the first. Registration goes through the same accessor-based refusal as every other outcome.

`reproposed` and `reproposal_matches` stay recorded as instrumented-only, the way `violations` already is.

Verified by replacing the detector's return with fixed counts: **5 tests fail**, and pass on restoration. 1417 passed / 1 skipped locally.

Stated limit: the counts read the diff, so an agent that pursued a rejected approach entirely in conversation and committed nothing registers zero.

## Correction

An earlier version of this description and its commit message said *three* counts and gave "hunks are not ordered" as the reason first-rejected-edit was omitted. Both were wrong — the code records it as `rejected_path_first_edit`, wired in `runner.ts` and covered by tests. Caught in review; the record has been corrected rather than left to stand.