### PR TITLE
Extend the scale ceiling to 300k, and stop the guard refusing its own launcher

### DIFF
--- a/bench/deterministic.ts
+++ b/bench/deterministic.ts
@@ -45,11 +45,18 @@ const assertComplete = (rows: readonly DeterministicRow[]): void => {
 const assertNoConcurrentDeterministicBench = (): void => {
   const ps = spawnSync('ps', ['-axo', 'pid=,command='], { encoding: 'utf8' });
   if (ps.error !== undefined) throw ps.error;
+  // Match only a node process actually executing the bench, not every process
+  // whose command line mentions it. A shell that launched this run carries the
+  // path in its own argv, and so does the wrapper any CI or tool harness uses,
+  // so a substring test refuses the first honest run and teaches the user to
+  // delete the guard.
   const matches = ps.stdout
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => /\bbench\/deterministic\.ts\b/.test(line))
-    .filter((line) => Number(line.split(/\s+/, 1)[0]) !== process.pid);
+    .filter((line) => /\bnode\b[^\n]*\bbench\/deterministic\.ts\b/.test(line))
+    .filter((line) => !/\b(?:z|ba|)sh\b\s+-[a-z]*c\b/.test(line))
+    .filter((line) => Number(line.split(/\s+/, 1)[0]) !== process.pid)
+    .filter((line) => Number(line.split(/\s+/, 1)[0]) !== process.ppid);
   if (matches.length > 0) {
     throw new Error(`deterministic benchmark refused: another bench/deterministic process is running:\n${matches.join('\n')}`);
   }

--- a/bench/deterministic.ts
+++ b/bench/deterministic.ts
@@ -11,7 +11,7 @@ import {
   assertSingleProvenance,
   writeDeterministicReport,
 } from './deterministic/report.ts';
-import { measureScale } from './deterministic/scale.ts';
+import { measureScale, SCALE_SIZES } from './deterministic/scale.ts';
 import {
   assertCleanCheckout,
   git,
@@ -68,7 +68,7 @@ const main = (): void => {
     throw new Error(`${testOnlyOverride} is test-only; production measurements use the fixed protocol`);
   }
 
-  const sizes = parseSizes(process.env['COMMITLORE_DETERMINISTIC_SIZES'] ?? '1000,10000,100000');
+  const sizes = parseSizes(process.env['COMMITLORE_DETERMINISTIC_SIZES'] ?? SCALE_SIZES.join(','));
   const runs = parsePositiveInteger(
     'COMMITLORE_DETERMINISTIC_RUNS',
     process.env['COMMITLORE_DETERMINISTIC_RUNS'] ?? '20',

--- a/bench/deterministic/scale.ts
+++ b/bench/deterministic/scale.ts
@@ -16,7 +16,7 @@ interface SyntheticSummary {
   readonly trailerCommits: number;
 }
 
-export const SCALE_SIZES = [1_000, 10_000, 100_000, 1_000_000] as const;
+export const SCALE_SIZES = [1_000, 10_000, 100_000, 300_000] as const;
 
 const parseSummary = (stdout: string): SyntheticSummary => {
   const parsed: unknown = JSON.parse(stdout);

--- a/bench/deterministic/scale.ts
+++ b/bench/deterministic/scale.ts
@@ -16,6 +16,8 @@ interface SyntheticSummary {
   readonly trailerCommits: number;
 }
 
+export const SCALE_SIZES = [1_000, 10_000, 100_000, 1_000_000] as const;
+
 const parseSummary = (stdout: string): SyntheticSummary => {
   const parsed: unknown = JSON.parse(stdout);
   if (typeof parsed !== 'object' || parsed === null) {


### PR DESCRIPTION
Refs #131, refs #136. **No measurement is included** — see the blocker comment on #131.

Two changes, both verifiable without running a benchmark:

1. `SCALE_SIZES` extends to **300,000** commits. 1M was dropped as a feasibility call: the fixture build time extrapolated past the two-hour bound the ticket set, and a benchmark nobody can rerun is worth less than a smaller one anybody can.

2. The concurrency guard from #136 refused its own launching shell. It matched any process whose command line mentioned `bench/deterministic.ts`, which includes the `sh -c` wrapper every tool harness and CI runner uses — so it refused the first honest run and named the launcher as the offender. It now matches a node process actually executing the bench, and excludes its own parent as well as itself.

That guard then correctly refused a later attempt, catching two stale bench processes I had missed. It has now saved one contaminated measurement and cost one false refusal, which is the right side of that trade.

## Why there is no 300k figure here

Four attempts are logged on #131. The last reached load **136** on 12 cores; after killing every test process of mine it stayed at **117**, driven by macOS metadata indexing and the owner's own applications. Publishing a p50/p95 from that would be the third contaminated latency number today.

The **261x** extrapolation to 1M remains an extrapolation and is not published as measured anywhere.

Both typechecks clean.