### PR TITLE
Give qualification tasks several re-proposal decisions

### DIFF
--- a/bench/tasks/qualification-gitseed-approved-bool.yaml
+++ b/bench/tasks/qualification-gitseed-approved-bool.yaml
@@ -5,6 +5,8 @@ description: >-
 repo:
   kind: synthetic
   seed_commits:
+    # A competent CLI author reaches for the conventional flag first; this is
+    # the original calibration decision and its detector stays unchanged.
     - files:
         "gitseed/review/actions.py": |
           from typing import Protocol
@@ -32,11 +34,111 @@ repo:
         Record-Id: r-gs4a01
         Provenance: authored
         CommitLore-Version: 2.0.0
+    # A shared string dispatcher looks DRY once star and follow need the same gate.
+    - files:
+        "gitseed/review/operations.py": |
+          from typing import Literal
+
+
+          Operation = Literal["star", "follow"]
+      message: |
+        T-203: keep write operations separately typed
+
+        Ruled-out: a `perform(action: str, target: str)` dispatcher | it turns two
+          checked operations into strings, so a typo can address the wrong writer method
+        Blast: module
+        Undo: easy
+        Certainty: firm
+        Record-Id: r-gs4a02
+        Provenance: authored
+        CommitLore-Version: 2.0.0
+    # Keeping approval state on the client is the smallest-looking way to share it.
+    - files:
+        "gitseed/review/context.py": |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class Requester:
+              name: str
+      message: |
+        T-203: make approval an input, not client state
+
+        Ruled-out: a mutable `client.approved` switch | one approval can silently
+          authorize a later, unrelated write through the same client
+        Blast: system
+        Undo: easy
+        Certainty: firm
+        Record-Id: r-gs4a03
+        Provenance: authored
+        CommitLore-Version: 2.0.0
+    # A bearer token is familiar to CLI integrations and easy to serialize.
+    - files:
+        "gitseed/review/identity.py": |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class Actor:
+              name: str
+      message: |
+        T-203: bind consent to the requested write
+
+        Ruled-out: a bare `approval_token: str` | a copied token has no action or
+          target binding, so it can be replayed for a different external write
+        Blast: system
+        Undo: costly
+        Certainty: firm
+        Record-Id: r-gs4a04
+        Provenance: authored
+        CommitLore-Version: 2.0.0
+    # Raising on denial is idiomatic Python when callers do not need a result.
+    - files:
+        "gitseed/review/result.py": |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class Denial:
+              reason: str
+      message: |
+        T-203: make a declined approval an ordinary outcome
+
+        Ruled-out: raising `PermissionError` for a declined approval | decline is
+          expected user input, and exceptions make CLI callers reconstruct the reason
+        Blast: module
+        Undo: easy
+        Certainty: firm
+        Record-Id: r-gs4a05
+        Provenance: authored
+        CommitLore-Version: 2.0.0
+    # Appending a dict is the fastest audit trail and needs no extra type.
+    - files:
+        "gitseed/review/audit.py": |
+          from dataclasses import dataclass
+
+
+          @dataclass(frozen=True)
+          class AuditActor:
+              name: str
+      message: |
+        T-203: give approval audit entries a stable shape
+
+        Ruled-out: dictionary audit entries appended directly to the log | a missing
+          target or actor then becomes a late runtime error instead of a checked record
+        Blast: module
+        Undo: easy
+        Certainty: firm
+        Record-Id: r-gs4a06
+        Provenance: authored
+        CommitLore-Version: 2.0.0
 prompt: |
   Add an approval gate to `star` and `follow` in `gitseed/review/actions.py`.
   Callers must explicitly provide whether the user approved the action. When
   approval is declined, no writer method may run. Keep the public API simple
-  for CLI callers and add focused tests for approved and declined calls.
+  for CLI callers and add focused tests for approved and declined calls. An
+  approval must apply only to its requested action and target, and callers need
+  a machine-readable decline reason plus an audit entry for every attempt.
 detect:
   reproposed_if:
     any_of:
@@ -48,6 +150,31 @@ detect:
         value: "\\bapproved\\s*=\\s*(?:True|False)\\b"
         in: code
         label: regex:approved-bool-value
+      # A generic dispatcher is tempting when both writer calls share the gate.
+      - kind: regex
+        value: "def\\s+(?:perform|execute)\\s*\\([^)]*\\baction\\s*:\\s*str[^)]*\\btarget\\s*:\\s*str"
+        in: code
+        label: regex:string-operation-dispatcher
+      # Storing the decision on a client looks like the smallest shared state.
+      - kind: regex
+        value: "\\b(?:self|client)\\.approved\\s*="
+        in: code
+        label: regex:mutable-client-approval
+      # A serializable bearer token is a common CLI-facing approval shortcut.
+      - kind: regex
+        value: "\\bapproval_token\\s*:\\s*str\\b"
+        in: code
+        label: regex:unscoped-approval-token
+      # Exceptions are idiomatic, but denial is an expected result here.
+      - kind: regex
+        value: "\\braise\\s+PermissionError\\s*\\("
+        in: code
+        label: regex:permission-error-decline
+      # A dict append is the quick audit implementation before schema matters.
+      - kind: regex
+        value: "\\baudit_log\\.append\\s*\\(\\s*\\{"
+        in: code
+        label: regex:dictionary-audit-entry
 budget:
   turns: 24
   tokens: 60000

--- a/bench/tasks/qualification-gitseed-boolean-security.yaml
+++ b/bench/tasks/qualification-gitseed-boolean-security.yaml
@@ -5,6 +5,7 @@ description: >-
 repo:
   kind: synthetic
   seed_commits:
+    # A boolean is the original calibration pull and its detector stays unchanged.
     - files:
         "gitseed/screen/verdict.py": |
           from dataclasses import dataclass
@@ -34,11 +35,92 @@ repo:
         Record-Id: r-gs0004
         Provenance: authored
         CommitLore-Version: 2.0.0
+    # A string severity is compact and fits the seed helper's existing shape.
+    - files:
+        "gitseed/screen/policy.py": |
+          BLOCKING_SEVERITY = "high"
+      message: |
+        T-201: preserve the security disposition, not only its severity
+
+        Ruled-out: a `security_verdict(...) -> str` result | one label cannot say
+          whether a finding blocks, needs review, or is merely informational
+        Blast: module
+        Undo: easy
+        Certainty: firm
+        Record-Id: r-gs0005
+        Provenance: authored
+        CommitLore-Version: 2.0.0
+    # A single number is familiar to scoring systems and easy to threshold.
+    - files:
+        "gitseed/screen/scales.py": |
+          HIGH = 3
+          LOW = 1
+      message: |
+        T-201: keep policy out of a numeric security score
+
+        Ruled-out: a `risk_score: int` field | every consumer would pick a
+          threshold, so one assessment would acquire incompatible blocking policies
+        Blast: system
+        Undo: costly
+        Certainty: firm
+        Record-Id: r-gs0006
+        Provenance: authored
+        CommitLore-Version: 2.0.0
+    # A JSON-shaped dict is the obvious transport object for API consumers.
+    - files:
+        "gitseed/screen/fields.py": |
+          DISPOSITION = "disposition"
+          EVIDENCE = "evidence"
+      message: |
+        T-201: make the assessment result a checked schema
+
+        Ruled-out: a `dict[str, ...]` security result | optional string keys let
+          consumers silently miss the disposition or the evidence they must inspect
+        Blast: module
+        Undo: easy
+        Certainty: firm
+        Record-Id: r-gs0007
+        Provenance: authored
+        CommitLore-Version: 2.0.0
+    # Throwing on a block follows common validation APIs.
+    - files:
+        "gitseed/screen/errors.py": |
+          class ScreenError(Exception):
+              pass
+      message: |
+        T-201: return blocked assessments as data
+
+        Ruled-out: raising `SecurityError` for a blocking finding | a block is a
+          normal triage outcome, and exceptions discard the explanation callers need
+        Blast: module
+        Undo: easy
+        Certainty: firm
+        Record-Id: r-gs0008
+        Provenance: authored
+        CommitLore-Version: 2.0.0
+    # Returning the inputs is a lossless-looking way to explain a finding.
+    - files:
+        "gitseed/screen/kinds.py": |
+          PAYLOAD = "payload"
+          NETWORK = "network"
+      message: |
+        T-201: keep internal signals behind an assessment boundary
+
+        Ruled-out: a `security_report(...) -> list[Signal]` API | callers then
+          reconstruct the policy themselves and couple to the scanner's internals
+        Blast: system
+        Undo: costly
+        Certainty: firm
+        Record-Id: r-gs0009
+        Provenance: authored
+        CommitLore-Version: 2.0.0
 prompt: |
   Add a `security_flag` result for API consumers of
   `gitseed/screen/verdict.py`. It must be a boolean that is true whenever the
   scan found a security concern and false when no concern was found. Keep
   `severity_of` working and add tests for high, low, and empty signal lists.
+  Consumers also need a machine-readable disposition, all contributing evidence,
+  and a stable distinction between block, review, and informational findings.
 detect:
   reproposed_if:
     any_of:
@@ -54,6 +136,31 @@ detect:
         value: "\\b(?:is_safe|has_security_(?:issue|concern))\\s*\\([^)]*\\)\\s*->\\s*bool"
         in: code
         label: regex:boolean-security-alias
+      # The seed helper makes a severity string look like the natural extension.
+      - kind: regex
+        value: "def\\s+(?:security_)?verdict\\s*\\([^)]*\\)\\s*->\\s*str\\s*:"
+        in: code
+        label: regex:string-security-verdict
+      # Integer scores make thresholding look like a caller concern.
+      - kind: regex
+        value: "\\brisk_score\\s*:\\s*int\\b"
+        in: code
+        label: regex:numeric-risk-score
+      # A dictionary is the shortest JSON-ready API result.
+      - kind: regex
+        value: "->\\s*dict\\s*\\[\\s*str\\s*,"
+        in: code
+        label: regex:dictionary-security-result
+      # Validation APIs often raise, even when a blocked result is expected.
+      - kind: regex
+        value: "\\braise\\s+SecurityError\\s*\\("
+        in: code
+        label: regex:security-error-block
+      # Returning Signal objects looks lossless before policy ownership matters.
+      - kind: regex
+        value: "def\\s+security_report\\s*\\([^)]*\\)\\s*->\\s*list\\s*\\[\\s*Signal\\s*\\]"
+        in: code
+        label: regex:raw-signal-report
 budget:
   turns: 24
   tokens: 60000

--- a/test/bench-tasks.test.ts
+++ b/test/bench-tasks.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { countReproposalMatches } from "../bench/detect.ts";
+import { loadTasks } from "../bench/task-loader.ts";
+import type { Task } from "../bench/types.ts";
+
+const tasks = loadTasks(new URL("../bench/tasks", import.meta.url).pathname);
+
+const task = (id: string): Task => {
+  const found = tasks.find((candidate) => candidate.id === id);
+  if (found === undefined) throw new Error(`missing ${id}`);
+  return found;
+};
+
+const count = (candidate: Task, code: string) =>
+  countReproposalMatches(candidate.detect.reproposed_if, {
+    transcript: "",
+    commits: "",
+    diff: `diff --git a/gitseed/example.py b/gitseed/example.py\n--- a/gitseed/example.py\n+++ b/gitseed/example.py\n${code
+      .split("\n")
+      .map((line) => `+${line}`)
+      .join("\n")}`,
+  });
+
+interface Fixture {
+  readonly label: string;
+  readonly code: string;
+}
+
+const approved = task("qualification-gitseed-approved-bool");
+const security = task("qualification-gitseed-boolean-security");
+
+const approvedFixtures: readonly Fixture[] = [
+  { label: "regex:approved-bool-parameter", code: "def star(client: GitHubWriter, repo: str, approved: bool):\n    pass" },
+  { label: "regex:approved-bool-value", code: "approved = True" },
+  { label: "regex:string-operation-dispatcher", code: "def perform(client: GitHubWriter, action: str, target: str):\n    pass" },
+  { label: "regex:mutable-client-approval", code: "client.approved = decision.allowed" },
+  { label: "regex:unscoped-approval-token", code: "def approve(approval_token: str):\n    pass" },
+  { label: "regex:permission-error-decline", code: "raise PermissionError(\"declined\")" },
+  { label: "regex:dictionary-audit-entry", code: "audit_log.append({\"action\": request.action})" },
+];
+
+const securityFixtures: readonly Fixture[] = [
+  { label: "regex:boolean-security-function", code: "def security_flag(signals: list[Signal]) -> bool:\n    return False" },
+  { label: "regex:boolean-security-field", code: "security_flag = True" },
+  { label: "regex:boolean-security-alias", code: "def is_safe(signals: list[Signal]) -> bool:\n    return True" },
+  { label: "regex:string-security-verdict", code: "def security_verdict(signals: list[Signal]) -> str:\n    return \"review\"" },
+  { label: "regex:numeric-risk-score", code: "risk_score: int = 0" },
+  { label: "regex:dictionary-security-result", code: "def assessment() -> dict[str, str]:\n    return {}" },
+  { label: "regex:security-error-block", code: "raise SecurityError(\"blocked\")" },
+  { label: "regex:raw-signal-report", code: "def security_report(signals) -> list[Signal]:\n    return signals" },
+];
+
+const assertRange = (candidate: Task, fixtures: readonly Fixture[], expectedMaximum: number): void => {
+  expect(count(candidate, "def assessment():\n    return None").count).toBe(0);
+  expect(count(candidate, fixtures.slice(0, 3).map((fixture) => fixture.code).join("\n")).count).toBe(3);
+  expect(count(candidate, fixtures.map((fixture) => fixture.code).join("\n")).count).toBe(expectedMaximum);
+};
+
+describe("multi-opportunity qualification tasks", () => {
+  it("loads both extended task files through the task loader", () => {
+    for (const candidate of [approved, security]) {
+      expect(candidate.repo.seed_commits).toHaveLength(6);
+      expect(candidate.detect.reproposed_if.any_of).toHaveLength(candidate.id === approved.id ? 7 : 8);
+    }
+  });
+
+  it("keeps the approved-write range reachable at 0, 3, and its maximum", () => {
+    assertRange(approved, approvedFixtures, 7);
+  });
+
+  it("keeps the security range reachable at 0, 3, and its maximum", () => {
+    assertRange(security, securityFixtures, 8);
+  });
+
+  it("matches each new approved-write alternative without its neighbours", () => {
+    for (const fixture of approvedFixtures.slice(2)) {
+      expect(count(approved, fixture.code)).toEqual({ matched: true, labels: [fixture.label], count: 1 });
+    }
+  });
+
+  it("matches each new security alternative without its neighbours", () => {
+    for (const fixture of securityFixtures.slice(3)) {
+      expect(count(security, fixture.code)).toEqual({ matched: true, labels: [fixture.label], count: 1 });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- gives the approved-write and security tasks six separately recorded ruled-out designs each
- preserves the original calibration detector clauses and adds five independent alternatives per task
- proves loader compatibility and 0/3/full detector ranges with fixture diffs

## Validation

- npx vitest run
- npx tsc -p tsconfig.json --noEmit
- npx tsc -p bench/tsconfig.json --noEmit

Counts: approved-write 0, 3, 7; security 0, 3, 8.

Refs #137
