### PR TITLE
Price what a record costs to write, both ways

### DIFF
--- a/bench/deterministic.ts
+++ b/bench/deterministic.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import { digestDistTree } from './hooks-settings.ts';
+import { measureCaptureCost } from './deterministic/capture.ts';
 import { measureHookOverhead } from './deterministic/hooks.ts';
 import { measureNoiseExposure } from './deterministic/noise.ts';
 import { measureGuardQuality, measureInjectionDetection } from './deterministic/quality.ts';
@@ -29,6 +30,7 @@ const REQUIRED_METRICS: ReadonlySet<DeterministicRow['metric']> = new Set([
   'injection_detection',
   'guard_quality',
   'hook_overhead',
+  'capture_cost',
   'index_cost',
   'noise_exposure',
 ]);
@@ -109,6 +111,8 @@ const main = (): void => {
     const guard = measureGuardQuality(base, REPO_ROOT);
     process.stdout.write(`deterministic bench: hook overhead (${runs} runs per arm)\n`);
     const hooks = measureHookOverhead(base, scratch, runs);
+    process.stdout.write(`deterministic bench: record capture cost (${runs} runs per command)\n`);
+    const capture = measureCaptureCost(base, REPO_ROOT, runs);
     process.stdout.write('deterministic bench: irrelevant decision-context exposure\n');
     const exposure = measureNoiseExposure(base);
     const rows: readonly DeterministicRow[] = [
@@ -117,6 +121,7 @@ const main = (): void => {
       injection,
       guard,
       ...hooks,
+      capture,
       ...scale.index,
       ...exposure,
     ];

--- a/bench/deterministic/capture.ts
+++ b/bench/deterministic/capture.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { CHARS_PER_TOKEN } from '../../dist/core/inject.js';
+import { CLI_ENTRY } from '../hooks-settings.ts';
+import { command, timing } from './shared.ts';
+import type { CaptureCostRow, RowBase } from './types.ts';
+
+export interface CaptureTokenInputs {
+  readonly harvest_tokens: number;
+  readonly verify_tokens: number;
+  readonly accepted_records: number;
+}
+
+interface VerificationCounts {
+  readonly accepted: number;
+  readonly rejected: number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const fixturePath = (repoRoot: string, name: string): string =>
+  join(repoRoot, 'test', 'fixtures', 'harvest-verify', name);
+
+export const tokensForCharacters = (characters: number): number =>
+  Math.ceil(characters / CHARS_PER_TOKEN);
+
+export const floorTokensPerAcceptedRecord = (input: CaptureTokenInputs): number => {
+  if (input.accepted_records < 1) {
+    throw new Error('capture cost requires at least one accepted record');
+  }
+  return (input.harvest_tokens + input.verify_tokens) / input.accepted_records;
+};
+
+const verificationCounts = (output: string): VerificationCounts => {
+  const parsed: unknown = JSON.parse(output);
+  if (!isRecord(parsed)) {
+    throw new Error('harvest-verify --json did not produce an object');
+  }
+  const accepted = parsed['accepted'];
+  const rejected = parsed['rejected'];
+  const malformed = parsed['malformed'];
+  if (!Array.isArray(accepted) || !Array.isArray(rejected) || !Array.isArray(malformed)) {
+    throw new Error('harvest-verify --json did not produce verification counts');
+  }
+  return { accepted: accepted.length, rejected: rejected.length + malformed.length };
+};
+
+export const measureCaptureCost = (
+  base: RowBase,
+  repoRoot: string,
+  runs: number,
+): CaptureCostRow => {
+  const transcript = fixturePath(repoRoot, 'session-transcript.txt');
+  const diff = fixturePath(repoRoot, 'staged.diff');
+  const draft = fixturePath(repoRoot, 'draft-truthful.json');
+  const harvestArgs = ['harvest', '--prompt-only', '--transcript', transcript, '--diff', diff];
+  const verifyArgs = [
+    'harvest-verify',
+    '--json',
+    '--draft',
+    draft,
+    '--transcript',
+    transcript,
+    '--diff',
+    diff,
+  ];
+  const harvest = (): string =>
+    command(process.execPath, [CLI_ENTRY, ...harvestArgs], { cwd: repoRoot }).stdout;
+  const verify = (): string =>
+    command(process.execPath, [CLI_ENTRY, ...verifyArgs], { cwd: repoRoot }).stdout;
+  const harvestOutput = harvest();
+  const verifyOutput = verify();
+  const verification = verificationCounts(verifyOutput);
+  const draftInput = readFileSync(draft, 'utf8');
+  const cachedPrefix = [transcript, diff].map((path) => readFileSync(path, 'utf8'));
+  const verifyInput = [draftInput, ...cachedPrefix];
+  const harvestTokens = tokensForCharacters(harvestOutput.length);
+  const verifyTokens = tokensForCharacters(
+    verifyInput.reduce((characters, input) => characters + input.length, 0),
+  );
+  const cacheReadTokens = tokensForCharacters(
+    cachedPrefix.reduce((characters, input) => characters + input.length, 0),
+  );
+
+  return {
+    ...base,
+    metric: 'capture_cost',
+    fixture: 'test/fixtures/harvest-verify/draft-truthful.json',
+    accepted_records: verification.accepted,
+    rejected_records: verification.rejected,
+    harvest: {
+      output_bytes: Buffer.byteLength(harvestOutput),
+      output_tokens: harvestTokens,
+      timing: timing(harvest, runs),
+    },
+    verify: {
+      input_bytes: verifyInput.reduce((bytes, input) => bytes + Buffer.byteLength(input), 0),
+      input_tokens: verifyTokens,
+      timing: timing(verify, runs),
+    },
+    cache_read: {
+      input_bytes: cachedPrefix.reduce((bytes, input) => bytes + Buffer.byteLength(input), 0),
+      input_tokens: cacheReadTokens,
+    },
+    marginal_tokens_per_accepted_record: floorTokensPerAcceptedRecord({
+      harvest_tokens: harvestTokens,
+      verify_tokens: verifyTokens - cacheReadTokens,
+      accepted_records: verification.accepted,
+    }),
+    tokens_including_cache_reads_per_accepted_record: floorTokensPerAcceptedRecord({
+      harvest_tokens: harvestTokens,
+      verify_tokens: verifyTokens,
+      accepted_records: verification.accepted,
+    }),
+  };
+};

--- a/bench/deterministic/report.ts
+++ b/bench/deterministic/report.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from 'node:fs';
 
 import type {
+  CaptureCostRow,
   DeterministicRow,
   GuardQualityRow,
   HookOverheadRow,
@@ -70,6 +71,8 @@ export const assertSingleProvenance = (rows: readonly DeterministicRow[]): void 
 const fixed = (value: number, digits = 2): string => value.toFixed(digits);
 const percent = (value: number): string => `${fixed(value * 100, 1)}%`;
 const optionalPercent = (value: number | null): string => (value === null ? 'n/a' : percent(value));
+const COMMIT_MSG_P50_MS = 185.85;
+const PRE_TOOL_USE_P50_MS = 102.4;
 
 const latencySection = (rows: readonly QueryLatencyRow[]): string[] => {
   if (rows.length === 0) return [];
@@ -192,10 +195,52 @@ const hookSection = (rows: readonly HookOverheadRow[]): string[] => {
   ];
 };
 
+const captureSection = (rows: readonly CaptureCostRow[]): string[] => {
+  if (rows.length === 0) return [];
+  return [
+    '## 6. Record capture cost',
+    '',
+    'Method: run the shipped local `harvest --prompt-only` and `harvest-verify --json` commands against the truthful harvest-verifier fixture after one discarded warmup; the harvest contract is what the session receives and verification input is the draft, transcript, and diff it re-reads.',
+    '',
+    '| fixture | accepted / rejected records | harvest bytes / tokens | harvest p50 / p95 ms | verify bytes / tokens | verify p50 / p95 ms | cache-read bytes / tokens | marginal / including-cache tokens per accepted record |',
+    '|---|---:|---:|---:|---:|---:|---:|---:|',
+    ...rows.map(
+      (row) =>
+        `| ${row.fixture} | ${row.accepted_records} / ${row.rejected_records} | ` +
+        `${row.harvest.output_bytes} / ${row.harvest.output_tokens} | ` +
+        `${fixed(row.harvest.timing.p50_ms)} / ${fixed(row.harvest.timing.p95_ms)} | ` +
+        `${row.verify.input_bytes} / ${row.verify.input_tokens} | ` +
+        `${fixed(row.verify.timing.p50_ms)} / ${fixed(row.verify.timing.p95_ms)} | ` +
+        `${row.cache_read.input_bytes} / ${row.cache_read.input_tokens} | ` +
+        `${fixed(row.marginal_tokens_per_accepted_record)} / ` +
+        `${fixed(row.tokens_including_cache_reads_per_accepted_record)} |`,
+    ),
+    '',
+    'The two floors bracket the same deterministic work. Marginal tokens exclude the transcript and diff that verification re-reads after harvest already supplied them; including-cache tokens count that prefix again. A cache-aware bill charges such reads at a fraction of the full input rate, so the figures do not contradict each other.',
+    '',
+    'Model generation tokens are not measured: this benchmark makes no model call, so the model\'s cost to compose a draft sits on top of both floors.',
+    '',
+    ...rows.map(
+      (row) =>
+        `The denominator is ${row.accepted_records} accepted record(s); this fixture had ${row.rejected_records} rejected record(s). A rejected draft that is rewritten raises verification input tokens while the accepted-record denominator stays fixed.`,
+    ),
+    '',
+    ...rows.map(
+      (row) =>
+        `Common commit cost: a commit with no record pays the existing \`commit-msg\` p50 overhead of **${fixed(COMMIT_MSG_P50_MS)} ms**. ` +
+        `A record-bearing commit has a **${fixed(COMMIT_MSG_P50_MS + row.harvest.timing.p50_ms + row.verify.timing.p50_ms)} ms** serial p50 component sum ` +
+        '(commit-msg + harvest + verify); it is not a jointly sampled percentile. ' +
+        `The separate PreToolUse injection p50 is **${fixed(PRE_TOOL_USE_P50_MS)} ms**. ` +
+        'Both existing hook figures are cited from `bench/results/deterministic-20260727T174801Z.md`, not remeasured here.',
+    ),
+    '',
+  ];
+};
+
 const indexSection = (rows: readonly IndexCostRow[]): string[] => {
   if (rows.length === 0) return [];
   return [
-    '## 6. Index cost',
+    '## 7. Index cost',
     '',
     'Method: rebuild the derived index once in each fresh synthetic history, time the rebuild, then measure the on-disk database size after the process exits.',
     '',
@@ -213,7 +258,7 @@ const indexSection = (rows: readonly IndexCostRow[]): string[] => {
 const exposureSection = (rows: readonly NoiseExposureRow[]): string[] => {
   if (rows.length === 0) return [];
   return [
-    '## 7. Irrelevant decision-context exposure',
+    '## 8. Irrelevant decision-context exposure',
     '',
     EXPOSURE_SCOPE_SENTENCE,
     '',
@@ -255,6 +300,7 @@ export const renderDeterministicReport = (rows: readonly DeterministicRow[]): st
     ),
     ...guardSection(rows.filter((row): row is GuardQualityRow => row.metric === 'guard_quality')),
     ...hookSection(rows.filter((row): row is HookOverheadRow => row.metric === 'hook_overhead')),
+    ...captureSection(rows.filter((row): row is CaptureCostRow => row.metric === 'capture_cost')),
     ...indexSection(rows.filter((row): row is IndexCostRow => row.metric === 'index_cost')),
     ...exposureSection(rows.filter((row): row is NoiseExposureRow => row.metric === 'noise_exposure')),
   ];

--- a/bench/deterministic/types.ts
+++ b/bench/deterministic/types.ts
@@ -143,6 +143,36 @@ export interface HookOverheadRow extends BaseRow {
   readonly delta_p95_ms: number;
 }
 
+export interface HarvestCapture {
+  readonly output_bytes: number;
+  readonly output_tokens: number;
+  readonly timing: Timing;
+}
+
+export interface VerificationCapture {
+  readonly input_bytes: number;
+  readonly input_tokens: number;
+  readonly timing: Timing;
+}
+
+export interface CacheReadCapture {
+  readonly input_bytes: number;
+  readonly input_tokens: number;
+}
+
+export interface CaptureCostRow extends BaseRow {
+  readonly metric: 'capture_cost';
+  readonly fixture: string;
+  readonly accepted_records: number;
+  readonly rejected_records: number;
+  readonly harvest: HarvestCapture;
+  readonly verify: VerificationCapture;
+  /** Transcript + diff re-read by verification after harvest already supplied them. */
+  readonly cache_read: CacheReadCapture;
+  readonly marginal_tokens_per_accepted_record: number;
+  readonly tokens_including_cache_reads_per_accepted_record: number;
+}
+
 export type NoiseRoute =
   | 'inject-everything'
   | 'top-k-lexical'
@@ -167,6 +197,7 @@ export type DeterministicRow =
   | InjectionDetectionRow
   | GuardQualityRow
   | HookOverheadRow
+  | CaptureCostRow
   | NoiseExposureRow;
 
 export type RowBase = Pick<

--- a/test/deterministic-bench.test.ts
+++ b/test/deterministic-bench.test.ts
@@ -6,6 +6,10 @@ import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  floorTokensPerAcceptedRecord,
+  tokensForCharacters,
+} from '../bench/deterministic/capture.ts';
+import {
   assertSingleProvenance,
   percentile,
   renderDeterministicReport,
@@ -25,7 +29,9 @@ import {
 } from '../bench/deterministic/quality.ts';
 import { assertCleanCheckout, git } from '../bench/deterministic/shared.ts';
 import { measureSurvival } from '../bench/deterministic/survival.ts';
+import { CHARS_PER_TOKEN } from '../dist/core/inject.js';
 import type {
+  CaptureCostRow,
   GuardQualityRow,
   InjectionDetectionRow,
   NoiseExposureRow,
@@ -92,7 +98,60 @@ const guardRow = (): GuardQualityRow => {
   };
 };
 
+const captureRow = (overrides: Partial<CaptureCostRow> = {}): CaptureCostRow => ({
+  ...row(),
+  metric: 'capture_cost',
+  fixture: 'test/fixtures/harvest-verify/draft-truthful.json',
+  accepted_records: 1,
+  rejected_records: 0,
+  harvest: {
+    output_bytes: 40,
+    output_tokens: 10,
+    timing: { runs: 20, warmups: 1, p50_ms: 2, p95_ms: 3, min_ms: 1, max_ms: 4 },
+  },
+  verify: {
+    input_bytes: 80,
+    input_tokens: 20,
+    timing: { runs: 20, warmups: 1, p50_ms: 5, p95_ms: 6, min_ms: 4, max_ms: 7 },
+  },
+  cache_read: { input_bytes: 40, input_tokens: 10 },
+  marginal_tokens_per_accepted_record: 20,
+  tokens_including_cache_reads_per_accepted_record: 30,
+  ...overrides,
+});
+
 describe('deterministic benchmark reporting', () => {
+  it('uses the product token constant for capture measurements', () => {
+    expect(tokensForCharacters(CHARS_PER_TOKEN + 1)).toBe(2);
+  });
+
+  it('divides the deterministic floor by the stated accepted-record denominator', () => {
+    expect(
+      floorTokensPerAcceptedRecord({ harvest_tokens: 20, verify_tokens: 10, accepted_records: 2 }),
+    ).toBe(15);
+  });
+
+  it('charges a rejected draft to the record that was eventually accepted', () => {
+    const firstPass = floorTokensPerAcceptedRecord({
+      harvest_tokens: 20,
+      verify_tokens: 10,
+      accepted_records: 1,
+    });
+    const rewritten = floorTokensPerAcceptedRecord({
+      harvest_tokens: 20,
+      verify_tokens: 20,
+      accepted_records: 1,
+    });
+
+    expect(rewritten).toBeGreaterThan(firstPass);
+  });
+
+  it('states that model generation is not measured in the capture report', () => {
+    expect(renderDeterministicReport([captureRow()])).toContain(
+      'Model generation tokens are not measured',
+    );
+  });
+
   it('computes nearest-rank p50 and p95 when samples are unsorted', () => {
     const samples = [20, 1, 15, 9, 3, 11, 8, 19, 7, 12, 6, 13, 18, 17, 16, 14, 10, 5, 4, 2];
 


### PR DESCRIPTION
Closes #134. **No measurement is included** — see below.

`bench/types.ts` has declared CPAA since T-703 and nothing ever measured it. All 112 recorded runs carry `accepted_records` and nothing about what producing those records cost. The project could say what *reading* a record costs and not what *writing* one costs — the wrong way round, since the design-rationale literature identifies **intrusiveness of capture**, not difficulty of retrieval, as why rationale capture gets abandoned ([Horner & Atwood](https://research.cs.vt.edu/ns/cs5724papers/1.motivatingreuse.tpgap.atwood.drationale.pdf)).

The measurement prices the **deterministic floor** — the prompt contract `harvest` emits and the inputs `harvest-verify` consumes — in bytes and in tokens at the product's own `CHARS_PER_TOKEN`. The model's own generation cost sits on top of that floor and is **not** measured here, because measuring it needs a model call and this benchmark makes none. Reporting the floor as a total would be the defect this repository keeps finding.

Cache reads are priced **separately** rather than folded in. The headless driver excludes `cache_read_input_tokens` — counting them once made a single run report 719k tokens — and its comment nominates CPAA as the place for them. Both figures publish side by side; a cache-aware bill charges reads at a fraction of full rate, so the two bracket the real cost instead of contradicting each other.

## Why no numbers yet

The section has wall-clock components and this machine is at load 13 on 12 cores from unrelated work. A contended timing run already cost five hours today (#136). The run is deferred to a quiet machine; the code, its tests and both typechecks are ready now.

Both typechecks clean. All seven deterministic sections remain registered.