### PR TITLE
bench: state the measured economic boundary

### DIFF
--- a/bench/deterministic/economics.ts
+++ b/bench/deterministic/economics.ts
@@ -1,0 +1,19 @@
+const SOURCE = 'bench/results/deterministic-20260729T032652Z.md';
+
+/** The measured cost boundary; avoided rejected-path work has not been measured. */
+export const renderEconomicCase = (): readonly string[] => [
+  '## 10. Economic case: measured costs, unmeasured benefit',
+  '',
+  `Source: \`${SOURCE}\`. These are deterministic measurements, not a benefit estimate.`,
+  '',
+  '- Capture one accepted record: the harvest prompt contract is **6,110 bytes / 1,524 tokens / 105.18 ms p50**; `harvest-verify` is **132.05 ms p50**.',
+  '- Per commit: the `commit-msg` hook adds **228.48 ms p50** and the injection hook adds **119.53 ms p50**.',
+  '- Query: indexed `context` at 100,000 commits is **496.15 ms p50**.',
+  '',
+  'The capture measurement also has 923 verify-input tokens and 330 cache-read tokens; it does not measure model generation tokens.',
+  '',
+  'Threshold form, in a cost unit you choose: **prevented re-proposals required = measured cost / your estimate of work saved by one prevented re-proposal**. The measured numerator is the applicable capture, hook, or query cost above. The denominator is intentionally not supplied.',
+  '',
+  'That benefit term is unmeasured: this project has not observed a re-proposal being prevented. Issue #141 added rejected-path counters to make the work observable, but no run has used them. No computed break-even value is published.',
+  '',
+];

--- a/bench/deterministic/report.ts
+++ b/bench/deterministic/report.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from 'node:fs';
 
+import { renderEconomicCase } from './economics.ts';
 import type {
   CaptureCostRow,
   DensityRow,
@@ -341,6 +342,7 @@ export const renderDeterministicReport = (rows: readonly DeterministicRow[]): st
     ...indexSection(rows.filter((row): row is IndexCostRow => row.metric === 'index_cost')),
     ...exposureSection(rows.filter((row): row is NoiseExposureRow => row.metric === 'noise_exposure')),
     ...densitySection(rows.filter((row): row is DensityRow => row.metric === 'rationale_density')),
+    ...renderEconomicCase(),
   ];
   return `${lines.join('\n').trim()}\n`;
 };

--- a/docs/MEASUREMENT-PROTOCOL.md
+++ b/docs/MEASUREMENT-PROTOCOL.md
@@ -263,3 +263,16 @@ If a registered analysis is found to be invalid after results are visible:
 
 This rule distinguishes correction from choosing a favourable analysis after
 seeing the data.
+
+## 9. Economic benefit evidence
+
+The deterministic report measures record capture, hook, and query costs. It
+does not measure the work avoided when a rejected alternative is not pursued,
+so it publishes no computed break-even value.
+
+Before any economic benefit claim, run #141's rejected-path counters against a
+task pool that passes #109's registered inclusive 4/6–5/6 qualification band
+on the primary comparator. Report the counters as their separate observed
+components, not a weighted composite. This is registered before such evidence
+exists: the current pool has **0 of 8** qualifying tasks, so no run can close
+the gap today.

--- a/test/economics.test.ts
+++ b/test/economics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderEconomicCase } from '../bench/deterministic/economics.ts';
+
+const output = (): string => renderEconomicCase().join('\n');
+
+describe('economic case renderer', () => {
+  it('states the measured capture, hook, and query costs', () => {
+    expect(output()).toContain('6,110 bytes / 1,524 tokens / 105.18 ms p50');
+    expect(output()).toContain('`harvest-verify` is **132.05 ms p50**');
+    expect(output()).toContain('`commit-msg` hook adds **228.48 ms p50**');
+    expect(output()).toContain('indexed `context` at 100,000 commits is **496.15 ms p50**');
+  });
+
+  it('states that the benefit term is unmeasured', () => {
+    expect(output()).toContain('benefit term is unmeasured');
+    expect(output()).toContain('has not observed a re-proposal being prevented');
+  });
+
+  it('publishes no computed break-even value', () => {
+    expect(output()).toContain('No computed break-even value is published.');
+    expect(output()).not.toMatch(/\b\d+(?:\.\d+)?%/);
+  });
+});


### PR DESCRIPTION
Closes #127

- renders the measured capture, hook, and indexed-query costs alongside the economic boundary
- publishes a threshold shape but no computed break-even value because prevented rejected-path work is unmeasured
- preregisters the #141-on-#109-qualified-pool evidence needed to close the gap

Verification:
- npx vitest run
- npx tsc -p tsconfig.json --noEmit
- npx tsc -p bench/tsconfig.json --noEmit

Note: the cited deterministic result records harvest-verify at 132.05 ms p50; it does not contain a 36 ms value.