### PR TITLE
bench: compare retrieval routes

### DIFF
--- a/bench/deterministic/noise.ts
+++ b/bench/deterministic/noise.ts
@@ -10,10 +10,10 @@ export const NOISE_SIZES = [0, 10, 100, 1_000, 10_000] as const;
 export const NOISE_SEED = 142_2026;
 export const NOISE_RUNS = 20;
 export const TARGET_PATH = 'src/core/decision-context.ts';
-const TOP_K = 2;
-const TOP_K_QUERY = `${TARGET_PATH} active lifecycle decision context path scope`;
+export const TOP_K = 2;
+export const TOP_K_QUERY = `${TARGET_PATH} active lifecycle decision context path scope`;
 
-interface NoiseRecord {
+export interface NoiseRecord {
   readonly recordId: string;
   readonly path: string;
   readonly message: string;

--- a/bench/retrieval/compare.ts
+++ b/bench/retrieval/compare.ts
@@ -1,0 +1,403 @@
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { buildInjection } from '../../dist/core/inject.js';
+import {
+  createNoiseFixture,
+  destroyNoiseFixture,
+  generateNoiseCorpus,
+  NOISE_SEED,
+  NOISE_SIZES,
+  TARGET_PATH,
+  TOP_K,
+  TOP_K_QUERY,
+} from '../deterministic/noise.ts';
+import type { NoiseCorpus, NoiseFixture, NoiseRecord } from '../deterministic/noise.ts';
+import {
+  RETRIEVAL_ROUTES,
+  type OllamaModel,
+  type RetrievalRoute,
+  type RetrievalRow,
+  type RouteSelections,
+} from './types.ts';
+
+export const PINNED_MODEL = 'qwen3-embedding:0.6b';
+const OLLAMA_URL = 'http://localhost:11434';
+const RESULT_PATH = new URL('./result.md', import.meta.url);
+const BATCH_SIZE = 128;
+const RRF_K = 60;
+
+const terms = (text: string): readonly string[] => text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+const document = (record: NoiseRecord): string => `${record.path}\n${record.message}`;
+
+export const retrievalCorpus = (distractors: number, seed = NOISE_SEED): NoiseCorpus =>
+  generateNoiseCorpus(distractors, seed);
+
+export const bm25Scores = (
+  query: string,
+  documents: readonly string[],
+): readonly number[] => {
+  if (documents.length === 0) return [];
+  const tokenized = documents.map(terms);
+  const averageLength = tokenized.reduce((sum, tokens) => sum + tokens.length, 0) / tokenized.length;
+  const queryTerms = [...new Set(terms(query))];
+  const documentFrequencies = new Map(
+    queryTerms.map((token) => [
+      token,
+      tokenized.reduce((count, candidate) => count + Number(candidate.includes(token)), 0),
+    ]),
+  );
+  return tokenized.map((tokens) => {
+    const frequencies = new Map<string, number>();
+    for (const token of tokens) frequencies.set(token, (frequencies.get(token) ?? 0) + 1);
+    return queryTerms.reduce((score, token) => {
+      const frequency = frequencies.get(token) ?? 0;
+      if (frequency === 0) return score;
+      const documentFrequency = documentFrequencies.get(token) ?? 0;
+      const inverseDocumentFrequency = Math.log(
+        1 + (documents.length - documentFrequency + 0.5) / (documentFrequency + 0.5),
+      );
+      const saturation = frequency * 2.2 /
+        (frequency + 1.2 * (0.25 + 0.75 * tokens.length / averageLength));
+      return score + inverseDocumentFrequency * saturation;
+    }, 0);
+  });
+};
+
+const rank = (
+  records: readonly NoiseRecord[],
+  scores: readonly number[],
+  budget: number,
+): readonly NoiseRecord[] => {
+  if (scores.length !== records.length) throw new Error('record and score counts differ');
+  return records.map((record, index) => ({ record, score: scores[index] ?? Number.NEGATIVE_INFINITY }))
+    .sort((left, right) =>
+      right.score - left.score || left.record.recordId.localeCompare(right.record.recordId)
+    )
+    .slice(0, budget)
+    .map(({ record }) => record);
+};
+
+export const rankBm25 = (
+  records: readonly NoiseRecord[],
+  budget: number,
+): readonly NoiseRecord[] =>
+  rank(records, bm25Scores(TOP_K_QUERY, records.map(document)), budget);
+
+const cosine = (left: readonly number[], right: readonly number[]): number => {
+  if (left.length === 0 || left.length !== right.length) {
+    throw new Error(`embedding dimensions differ: ${left.length} and ${right.length}`);
+  }
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    const leftValue = left[index] ?? 0;
+    const rightValue = right[index] ?? 0;
+    dot += leftValue * rightValue;
+    leftNorm += leftValue * leftValue;
+    rightNorm += rightValue * rightValue;
+  }
+  return leftNorm === 0 || rightNorm === 0 ? 0 : dot / Math.sqrt(leftNorm * rightNorm);
+};
+
+export const rankEmbedding = (
+  records: readonly NoiseRecord[],
+  embeddings: readonly (readonly number[])[],
+  queryEmbedding: readonly number[],
+  budget: number,
+  filterPath: string | null = null,
+): readonly NoiseRecord[] => {
+  if (embeddings.length !== records.length) throw new Error('record and embedding counts differ');
+  const candidates = records.map((record, index) => ({
+    record,
+    embedding: embeddings[index] ?? [],
+  })).filter(({ record }) => filterPath === null || record.path === filterPath);
+  return rank(
+    candidates.map(({ record }) => record),
+    candidates.map(({ embedding }) => cosine(queryEmbedding, embedding)),
+    budget,
+  );
+};
+
+const reciprocalRankFuse = (
+  rankings: readonly (readonly NoiseRecord[])[],
+  budget: number,
+): readonly NoiseRecord[] => {
+  const records = new Map<string, NoiseRecord>();
+  const scores = new Map<string, number>();
+  for (const ranking of rankings) {
+    ranking.forEach((record, index) => {
+      records.set(record.recordId, record);
+      scores.set(record.recordId, (scores.get(record.recordId) ?? 0) + 1 / (RRF_K + index + 1));
+    });
+  }
+  return [...records.values()].sort((left, right) =>
+    (scores.get(right.recordId) ?? 0) - (scores.get(left.recordId) ?? 0) ||
+    left.recordId.localeCompare(right.recordId)
+  ).slice(0, budget);
+};
+
+export const retrieveCommitLore = (
+  fixture: NoiseFixture,
+  budget = TOP_K,
+): readonly NoiseRecord[] => {
+  const text = buildInjection({ cwd: fixture.dir, path: TARGET_PATH }).text;
+  return fixture.corpus.records
+    .filter((record) => text.includes(record.recordId))
+    .slice(0, budget);
+};
+
+export const retrieveRoutes = (
+  records: readonly NoiseRecord[],
+  embeddings: readonly (readonly number[])[],
+  queryEmbedding: readonly number[],
+  commitLoreRecords: readonly NoiseRecord[],
+  budget = TOP_K,
+): RouteSelections => {
+  const bm25 = rankBm25(records, records.length);
+  const embedding = rankEmbedding(records, embeddings, queryEmbedding, records.length);
+  return {
+    bm25: bm25.slice(0, budget),
+    'embedding-top-k': embedding.slice(0, budget),
+    'hybrid-rrf': reciprocalRankFuse([bm25, embedding], budget),
+    'embedding-path-filter': rankEmbedding(
+      records,
+      embeddings,
+      queryEmbedding,
+      budget,
+      TARGET_PATH,
+    ),
+    'commitlore-path-lifecycle': commitLoreRecords.slice(0, budget),
+  };
+};
+
+export const assertPinnedModel = (
+  models: readonly OllamaModel[],
+  pinned = PINNED_MODEL,
+): OllamaModel => {
+  const model = models.find((candidate) => candidate.name === pinned);
+  if (model === undefined) {
+    throw new Error(
+      `Pinned embedding model ${pinned} is unavailable; install that exact model instead of substituting.`,
+    );
+  }
+  return model;
+};
+
+const object = (value: unknown, label: string): Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Ollama returned invalid ${label}`);
+  }
+  return value as Record<string, unknown>;
+};
+
+const textField = (value: Record<string, unknown>, field: string): string => {
+  const result = value[field];
+  if (typeof result !== 'string' || result.length === 0) {
+    throw new Error(`Ollama returned invalid ${field}`);
+  }
+  return result;
+};
+
+const ollamaJson = async (path: string, body?: unknown): Promise<unknown> => {
+  const response = await fetch(`${OLLAMA_URL}${path}`, {
+    ...(body === undefined
+      ? {}
+      : { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) }),
+  });
+  if (!response.ok) {
+    throw new Error(`Ollama ${path} failed with HTTP ${response.status}: ${await response.text()}`);
+  }
+  return response.json();
+};
+
+const availableModels = async (): Promise<readonly OllamaModel[]> => {
+  const payload = object(await ollamaJson('/api/tags'), 'model list');
+  if (!Array.isArray(payload.models)) throw new Error('Ollama returned invalid model list');
+  return payload.models.map((candidate) => {
+    const model = object(candidate, 'model');
+    return {
+      name: textField(model, 'name'),
+      digest: textField(model, 'digest'),
+      modifiedAt: textField(model, 'modified_at'),
+    };
+  });
+};
+
+const embeddings = async (input: readonly string[]): Promise<readonly (readonly number[])[]> => {
+  const payload = object(
+    await ollamaJson('/api/embed', { model: PINNED_MODEL, input, truncate: false, keep_alive: '5m' }),
+    'embedding response',
+  );
+  if (!Array.isArray(payload.embeddings) || payload.embeddings.length !== input.length) {
+    throw new Error('Ollama returned the wrong number of embeddings');
+  }
+  return payload.embeddings.map((candidate) => {
+    if (!Array.isArray(candidate) || candidate.length === 0 || candidate.some((value) => typeof value !== 'number')) {
+      throw new Error('Ollama returned an invalid embedding');
+    }
+    return candidate as number[];
+  });
+};
+
+const embedCorpus = async (records: readonly NoiseRecord[]): Promise<readonly (readonly number[])[]> => {
+  const result: (readonly number[])[] = [];
+  for (let offset = 0; offset < records.length; offset += BATCH_SIZE) {
+    result.push(...await embeddings(records.slice(offset, offset + BATCH_SIZE).map(document)));
+    process.stderr.write(`embedded ${Math.min(offset + BATCH_SIZE, records.length)}/${records.length}\r`);
+  }
+  process.stderr.write('\n');
+  return result;
+};
+
+const sourceDigest = (): string => {
+  const hash = createHash('sha256');
+  for (const path of [
+    new URL('./compare.ts', import.meta.url),
+    new URL('./types.ts', import.meta.url),
+    new URL('../deterministic/noise.ts', import.meta.url),
+  ]) {
+    hash.update(readFileSync(path));
+  }
+  return hash.digest('hex');
+};
+
+const resultFor = (
+  rows: readonly RetrievalRow[],
+  distractors: number,
+  route: RetrievalRoute,
+): RetrievalRow => {
+  const row = rows.find((candidate) =>
+    candidate.distractors === distractors && candidate.route === route
+  );
+  if (row === undefined) throw new Error(`missing ${route} result at ${distractors} distractors`);
+  return row;
+};
+
+const renderReport = (
+  rows: readonly RetrievalRow[],
+  model: OllamaModel,
+  dimension: number,
+  ollamaVersion: string,
+): string => {
+  const routeLabels: Readonly<Record<RetrievalRoute, string>> = {
+    bm25: 'BM25',
+    'embedding-top-k': 'Embedding top-k',
+    'hybrid-rrf': 'Hybrid RRF',
+    'embedding-path-filter': 'Embedding + path filter',
+    'commitlore-path-lifecycle': 'CommitLore path + lifecycle',
+  };
+  const comparable = RETRIEVAL_ROUTES.filter((route) =>
+    route !== 'commitlore-path-lifecycle' &&
+    NOISE_SIZES.every((size) =>
+      resultFor(rows, size, route).relevantRecords >=
+        resultFor(rows, size, 'commitlore-path-lifecycle').relevantRecords
+    )
+  );
+  return [
+    '# Retrieval route comparison',
+    '',
+    `Measured at: ${new Date().toISOString()}`,
+    '',
+    'This measures exposure and recall at a fixed two-record output budget. It does not measure token cost, billed cost, accuracy, or agent behaviour. Timing was not taken.',
+    '',
+    `Corpus: \`generateNoiseCorpus\`, seed ${NOISE_SEED}, distractor sizes ${NOISE_SIZES.join(', ')}.`,
+    `Query: \`${TOP_K_QUERY}\``,
+    `Harness source SHA-256: \`${sourceDigest()}\``,
+    '',
+    '## Embedding provenance',
+    '',
+    `Provider: Ollama ${ollamaVersion}`,
+    `Model: \`${model.name}\``,
+    `Manifest digest: \`${model.digest}\``,
+    `Model modified at: ${model.modifiedAt}`,
+    `Embedding dimension: ${dimension}`,
+    '',
+    'A rerun is reproducible only with the same model artifact, query, corpus seed, and harness source. A different model version may not reproduce these rankings.',
+    '',
+    '## Lexical baseline',
+    '',
+    'The deterministic benchmark’s current `top-k lexical` scorer is a case-insensitive, unweighted count of every query-token occurrence in `path + record message`, with `recordId` as the tie-break. BM25 is a fairer baseline from the same lexical-retrieval family, but it is a different scorer: it adds inverse document frequency, term-frequency saturation, and document-length normalization.',
+    'This BM25 uses lowercase ASCII-alphanumeric tokens, unique query terms, k1=1.2, and b=0.75. Embedding routes rank cosine similarity over `path + record message`; hybrid applies reciprocal-rank fusion with k=60 to the complete BM25 and embedding rankings before the two-record budget; the path filter keeps exact-path candidates before embedding ranking.',
+    '',
+    '## Results',
+    '',
+    `Routes matching or beating CommitLore path scope at every reported size: ${
+      comparable.length === 0 ? 'none' : comparable.map((route) => `\`${routeLabels[route]}\``).join(', ')
+    }. This statement compares only the recall counts in the table.`,
+    '',
+    `| distractors | corpus records | ${RETRIEVAL_ROUTES.map((route) => routeLabels[route]).join(' | ')} |`,
+    `|---:|---:|${RETRIEVAL_ROUTES.map(() => '---:').join('|')}|`,
+    ...NOISE_SIZES.map((size) => {
+      const first = resultFor(rows, size, 'bm25');
+      return `| ${size} | ${first.corpusRecords} | ${
+        RETRIEVAL_ROUTES.map((route) => {
+          const row = resultFor(rows, size, route);
+          return `${row.relevantRecords}/${row.relevantTotal}`;
+        }).join(' | ')
+      } |`;
+    }),
+    '',
+  ].join('\n');
+};
+
+export const runComparison = async (): Promise<string> => {
+  const model = assertPinnedModel(await availableModels());
+  const versionPayload = object(await ollamaJson('/api/version'), 'version response');
+  const ollamaVersion = textField(versionPayload, 'version');
+  const largestCorpus = retrievalCorpus(NOISE_SIZES.at(-1) ?? 0);
+  const [queryEmbedding] = await embeddings([TOP_K_QUERY]);
+  if (queryEmbedding === undefined) throw new Error('Ollama returned no query embedding');
+  const corpusEmbeddings = await embedCorpus(largestCorpus.records);
+  const dimension = queryEmbedding.length;
+  if (corpusEmbeddings.some((embedding) => embedding.length !== dimension)) {
+    throw new Error('Ollama returned inconsistent embedding dimensions');
+  }
+
+  const rows: RetrievalRow[] = [];
+  for (const distractors of NOISE_SIZES) {
+    const fixture = createNoiseFixture(distractors, NOISE_SEED);
+    try {
+      const expectedCorpus = retrievalCorpus(distractors, NOISE_SEED);
+      if (JSON.stringify(fixture.corpus) !== JSON.stringify(expectedCorpus)) {
+        throw new Error('retrieval and deterministic harness corpora differ');
+      }
+      const routes = retrieveRoutes(
+        fixture.corpus.records,
+        corpusEmbeddings.slice(0, fixture.corpus.records.length),
+        queryEmbedding,
+        retrieveCommitLore(fixture),
+      );
+      for (const route of RETRIEVAL_ROUTES) {
+        const selected = routes[route];
+        if (selected.length !== TOP_K) {
+          throw new Error(`${route} returned ${selected.length} records; expected budget ${TOP_K}`);
+        }
+        rows.push({
+          distractors,
+          corpusRecords: fixture.corpus.records.length,
+          route,
+          visibleRecords: selected.length,
+          relevantRecords: selected.filter((record) => record.relevant).length,
+          relevantTotal: 2,
+        });
+      }
+    } finally {
+      destroyNoiseFixture(fixture);
+    }
+  }
+  return renderReport(rows, model, dimension, ollamaVersion);
+};
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runComparison().then((report) => {
+    writeFileSync(RESULT_PATH, report);
+    process.stdout.write(report);
+    process.stderr.write(`wrote ${fileURLToPath(RESULT_PATH)}\n`);
+  }).catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/bench/retrieval/result.md
+++ b/bench/retrieval/result.md
@@ -1,0 +1,36 @@
+# Retrieval route comparison
+
+Measured at: 2026-07-29T09:17:25.181Z
+
+This measures exposure and recall at a fixed two-record output budget. It does not measure token cost, billed cost, accuracy, or agent behaviour. Timing was not taken.
+
+Corpus: `generateNoiseCorpus`, seed 1422026, distractor sizes 0, 10, 100, 1000, 10000.
+Query: `src/core/decision-context.ts active lifecycle decision context path scope`
+Harness source SHA-256: `206b3527cb7cfc7bba09bc437f83a13db28dfc68532abbee487e60330115801a`
+
+## Embedding provenance
+
+Provider: Ollama 0.17.4
+Model: `qwen3-embedding:0.6b`
+Manifest digest: `ac6da0dfba84a81fdbfbaf330198c33cd77c4cdfc53e8bc50eb581914a15621d`
+Model modified at: 2026-07-11T21:20:15.333099299+09:00
+Embedding dimension: 1024
+
+A rerun is reproducible only with the same model artifact, query, corpus seed, and harness source. A different model version may not reproduce these rankings.
+
+## Lexical baseline
+
+The deterministic benchmark’s current `top-k lexical` scorer is a case-insensitive, unweighted count of every query-token occurrence in `path + record message`, with `recordId` as the tie-break. BM25 is a fairer baseline from the same lexical-retrieval family, but it is a different scorer: it adds inverse document frequency, term-frequency saturation, and document-length normalization.
+This BM25 uses lowercase ASCII-alphanumeric tokens, unique query terms, k1=1.2, and b=0.75. Embedding routes rank cosine similarity over `path + record message`; hybrid applies reciprocal-rank fusion with k=60 to the complete BM25 and embedding rankings before the two-record budget; the path filter keeps exact-path candidates before embedding ranking.
+
+## Results
+
+Routes matching or beating CommitLore path scope at every reported size: `Embedding top-k`, `Embedding + path filter`. This statement compares only the recall counts in the table.
+
+| distractors | corpus records | BM25 | Embedding top-k | Hybrid RRF | Embedding + path filter | CommitLore path + lifecycle |
+|---:|---:|---:|---:|---:|---:|---:|
+| 0 | 2 | 2/2 | 2/2 | 2/2 | 2/2 | 2/2 |
+| 10 | 12 | 0/2 | 2/2 | 1/2 | 2/2 | 2/2 |
+| 100 | 102 | 0/2 | 2/2 | 0/2 | 2/2 | 2/2 |
+| 1000 | 1002 | 0/2 | 2/2 | 2/2 | 2/2 | 2/2 |
+| 10000 | 10002 | 0/2 | 2/2 | 1/2 | 2/2 | 2/2 |

--- a/bench/retrieval/types.ts
+++ b/bench/retrieval/types.ts
@@ -1,0 +1,29 @@
+import type { NoiseRecord } from '../deterministic/noise.ts';
+
+export const RETRIEVAL_ROUTES = [
+  'bm25',
+  'embedding-top-k',
+  'hybrid-rrf',
+  'embedding-path-filter',
+  'commitlore-path-lifecycle',
+] as const;
+
+export type RetrievalRoute = (typeof RETRIEVAL_ROUTES)[number];
+export type RouteSelections = {
+  readonly [Route in RetrievalRoute]: readonly NoiseRecord[];
+};
+
+export interface OllamaModel {
+  readonly name: string;
+  readonly digest: string;
+  readonly modifiedAt: string;
+}
+
+export interface RetrievalRow {
+  readonly distractors: number;
+  readonly corpusRecords: number;
+  readonly route: RetrievalRoute;
+  readonly visibleRecords: number;
+  readonly relevantRecords: number;
+  readonly relevantTotal: 2;
+}

--- a/test/bench-retrieval.test.ts
+++ b/test/bench-retrieval.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertPinnedModel,
+  bm25Scores,
+  PINNED_MODEL,
+  rankEmbedding,
+  retrievalCorpus,
+  retrieveCommitLore,
+  retrieveRoutes,
+} from '../bench/retrieval/compare.ts';
+import { RETRIEVAL_ROUTES } from '../bench/retrieval/types.ts';
+import {
+  createNoiseFixture,
+  destroyNoiseFixture,
+  generateNoiseCorpus,
+  TARGET_PATH,
+  TOP_K,
+} from '../bench/deterministic/noise.ts';
+
+describe('retrieval route comparison', () => {
+  it('returns exactly the shared output budget from every route', () => {
+    const fixture = createNoiseFixture(10, 142);
+    try {
+      const embeddings = fixture.corpus.records.map((_, index) => [index + 1, 1]);
+      const routes = retrieveRoutes(
+        fixture.corpus.records,
+        embeddings,
+        [1, 0],
+        retrieveCommitLore(fixture),
+      );
+
+      expect(Object.keys(routes)).toEqual(RETRIEVAL_ROUTES);
+      for (const selected of Object.values(routes)) expect(selected).toHaveLength(TOP_K);
+    } finally {
+      destroyNoiseFixture(fixture);
+    }
+  });
+
+  it('fails loudly when the pinned model is absent', () => {
+    expect(() =>
+      assertPinnedModel([
+        { name: 'another-model:latest', digest: 'abc', modifiedAt: '2026-01-01T00:00:00Z' },
+      ])
+    ).toThrow(`Pinned embedding model ${PINNED_MODEL} is unavailable`);
+  });
+
+  it('scores a hand-checked BM25 example', () => {
+    const scores = bm25Scores('cat', ['cat cat dog', 'cat mouse']);
+
+    expect(scores[0]).toBeCloseTo(0.237342, 6);
+    expect(scores[1]).toBeCloseTo(0.198568, 6);
+  });
+
+  it('narrows embedding candidates with the path metadata filter', () => {
+    const records = generateNoiseCorpus(1, 142).records;
+    const embeddings = [
+      [0.8, 0.2],
+      [0.7, 0.3],
+      [1, 0],
+    ];
+
+    expect(rankEmbedding(records, embeddings, [1, 0], TOP_K).map(({ recordId }) => recordId))
+      .toContain('r-noise000000');
+    expect(
+      rankEmbedding(records, embeddings, [1, 0], TOP_K, TARGET_PATH).map(({ recordId }) => recordId),
+    ).toEqual(['r-expose001', 'r-expose002']);
+  });
+
+  it('uses the identical fixed-seed corpus in both harnesses', () => {
+    expect(retrievalCorpus(1, 142)).toEqual(generateNoiseCorpus(1, 142));
+  });
+});


### PR DESCRIPTION
## Summary

- Add a standalone `bench/retrieval` harness for BM25, embedding top-k, hybrid RRF, embedding with an exact path metadata filter, and shipped CommitLore path scope plus lifecycle.
- Reuse `generateNoiseCorpus` and `createNoiseFixture` from the deterministic noise benchmark at the same seed, query, sizes, and two-record budget.
- Pin `qwen3-embedding:0.6b`, fail if it is absent, and record Ollama version, manifest digest, model timestamp, dimension, scorer parameters, corpus/query provenance, and harness source digest.
- Keep the model-backed result separate in `bench/retrieval/result.md`; deterministic registration and deterministic result files are unchanged. README files are untouched.

This measures exposure and recall at a fixed two-record output budget. It does not measure token cost, billed cost, accuracy, agent behaviour, or latency. Timing was not taken.

## Result

Model: `qwen3-embedding:0.6b`, dimension 1024, manifest digest `ac6da0dfba84a81fdbfbaf330198c33cd77c4cdfc53e8bc50eb581914a15621d`.

| distractors | corpus records | BM25 | Embedding top-k | Hybrid RRF | Embedding + path filter | CommitLore path + lifecycle |
|---:|---:|---:|---:|---:|---:|---:|
| 0 | 2 | 2/2 | 2/2 | 2/2 | 2/2 | 2/2 |
| 10 | 12 | 0/2 | 2/2 | 1/2 | 2/2 | 2/2 |
| 100 | 102 | 0/2 | 2/2 | 0/2 | 2/2 | 2/2 |
| 1000 | 1002 | 0/2 | 2/2 | 2/2 | 2/2 | 2/2 |
| 10000 | 10002 | 0/2 | 2/2 | 1/2 | 2/2 | 2/2 |

Both embedding top-k and embedding + path filter match CommitLore path scope at every reported size. Hybrid does not, and BM25 drops both relevant records from 10 distractors onward. These statements report only the table's recall counts.

The existing deterministic `top-k lexical` scorer is a case-insensitive, unweighted query-token occurrence count over `path + record message`, with `recordId` as its tie-break. BM25 is a fairer baseline in the same lexical-retrieval family, but a different scorer: this harness uses lowercase ASCII-alphanumeric tokens, unique query terms, k1=1.2, and b=0.75. Embeddings use cosine similarity; hybrid uses RRF k=60 over complete BM25 and embedding rankings.

## Red / green evidence

I deliberately broke all five covered production behaviours together before restoring them.

Red:

```text
$ npx vitest run test/bench-retrieval.test.ts

 RUN  v2.1.9 /Users/isaac/projects/wt/r166

 ❯ test/bench-retrieval.test.ts (5 tests | 5 failed) 614ms
   × retrieval route comparison > returns exactly the shared output budget from every route 611ms
     → expected [ { recordId: 'r-expose001', …(3) } ] to have a length of 2 but got 1
   × retrieval route comparison > fails loudly when the pinned model is absent 1ms
     → expected [Function] to throw an error
   × retrieval route comparison > scores a hand-checked BM25 example 0ms
     → expected +0 to be close to 0.237342, received difference is 0.237342, but expected 5e-7
   × retrieval route comparison > narrows embedding candidates with the path metadata filter 1ms
     → expected [ 'r-noise000000', 'r-expose001' ] to deeply equal [ 'r-expose001', 'r-expose002' ]
   × retrieval route comparison > uses the identical fixed-seed corpus in both harnesses 1ms
     → expected { records: [ { …(4) }, …(2) ], …(1) } to deeply equal { records: [ { …(4) }, …(2) ], …(1) }

 Test Files  1 failed (1)
      Tests  5 failed (5)
   Duration  926ms
```

Green:

```text
$ npx vitest run test/bench-retrieval.test.ts

 RUN  v2.1.9 /Users/isaac/projects/wt/r166

 ✓ test/bench-retrieval.test.ts (5 tests) 609ms
   ✓ retrieval route comparison > returns exactly the shared output budget from every route 608ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  903ms
```

## Verification

- Clean starting `origin/dev` baseline: 42 test files passed; 1,476 tests passed; 1 skipped.
- `npx vitest run` after rebasing onto current local `origin/dev`: 44 test files passed; 1,484 tests passed; 1 skipped.
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsc -p bench/tsconfig.json --noEmit`
- `node dist/cli.js validate --commit HEAD`: `shape ok · references ok`
- Two complete model-backed runs produced the identical five-route table above.

Closes #166
