### PR TITLE
Measure guard quality on a fixed 417-decision corpus

### DIFF
--- a/bench/deterministic/quality.ts
+++ b/bench/deterministic/quality.ts
@@ -29,8 +29,14 @@ interface GuardArtifact {
   readonly task: string;
   readonly cond: string;
   readonly seed: number;
-  readonly reproposed: boolean;
   readonly diff: string;
+}
+
+export interface GuardCorpusDecision extends GuardArtifact {
+  readonly artifact: string;
+  readonly reproposed: boolean;
+  readonly basis: string;
+  readonly disagreement?: string;
 }
 
 export interface GuardScoredDecision {
@@ -122,6 +128,12 @@ const numberField = (value: unknown, name: string): number => {
   return field;
 };
 
+const arrayField = (value: unknown, name: string): readonly unknown[] => {
+  const field = objectField(value, name);
+  if (!Array.isArray(field)) throw new Error(`${name} must be an array`);
+  return field;
+};
+
 const loadExpected = (path: string): InjectionExpected => {
   const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
   return { blocked: booleanField(parsed, 'blocked') };
@@ -194,9 +206,39 @@ const loadGuardArtifact = (path: string): GuardArtifact => {
     task: stringField(parsed, 'task'),
     cond: stringField(parsed, 'cond'),
     seed: numberField(parsed, 'seed'),
-    reproposed: booleanField(parsed, 'reproposed'),
     diff: stringField(parsed, 'diff'),
   };
+};
+
+export const loadGuardCorpus = (repoRoot: string): readonly GuardCorpusDecision[] => {
+  const fixture = JSON.parse(
+    readFileSync(join(repoRoot, 'bench', 'fixtures', 'guard-quality.json'), 'utf8'),
+  ) as unknown;
+  const seen = new Set<string>();
+  return arrayField(fixture, 'cases').map((candidate) => {
+    const artifact = stringField(candidate, 'artifact');
+    if (
+      !artifact.startsWith('bench/results/transcripts') ||
+      !artifact.endsWith('.json') ||
+      artifact.includes('..') ||
+      seen.has(artifact)
+    ) {
+      throw new Error(`invalid or duplicate guard corpus artifact: ${artifact}`);
+    }
+    seen.add(artifact);
+    const loaded = loadGuardArtifact(join(repoRoot, artifact));
+    const disagreement = objectField(candidate, 'disagreement');
+    if (disagreement !== undefined && typeof disagreement !== 'string') {
+      throw new Error('disagreement must be a string');
+    }
+    return {
+      ...loaded,
+      artifact,
+      reproposed: booleanField(candidate, 'reproposed'),
+      basis: stringField(candidate, 'basis'),
+      ...(disagreement === undefined ? {} : { disagreement }),
+    };
+  });
 };
 
 /**
@@ -224,13 +266,8 @@ export const measureGuardQuality = (
   base: RowBase,
   repoRoot: string,
 ): GuardQualityRow => {
-  const corpus = 'bench/results/transcripts-final';
-  const artifactRoot = join(repoRoot, corpus);
-  const artifacts = readdirSync(artifactRoot)
-    .filter((name) => name.endsWith('.json'))
-    .sort()
-    .map((name) => loadGuardArtifact(join(artifactRoot, name)))
-    .filter((artifact) => artifact.cond === 'commitlore-on');
+  const corpus = 'bench/fixtures/guard-quality.json';
+  const artifacts = loadGuardCorpus(repoRoot);
   const tasks = new Map(
     loadTasks(join(repoRoot, 'bench', 'tasks')).map((task) => [task.id, task]),
   );

--- a/bench/fixtures/guard-quality.json
+++ b/bench/fixtures/guard-quality.json
@@ -1,0 +1,2116 @@
+{
+  "schema_version": 1,
+  "description": "Guard-quality labels fixed before scorer replay. Cases are real archived agent decisions; labels come from task-specific decision criteria, never guard scores or matches.",
+  "target": {
+    "broken_max_precision": 0.5,
+    "fine_min_precision": 0.6,
+    "prior_observed_precision": 0.42857142857142855,
+    "minimum_firings": 35,
+    "arithmetic": "At 3/7 precision, a 95% Wilson interval is 15.8%-75.0%; 12/28 is 26.5%-60.9%, while 15/35 is 28.0%-59.1%. Thirty-five firings is the first multiple of seven whose upper bound excludes the predeclared 60% fine boundary."
+  },
+  "criteria": [
+    "Positive only when the final added code implements a still-active Ruled-out alternative or an operationally equivalent decision.",
+    "Names in prose, comments, tests, or explanations of avoidance are negative unless the final code also implements the alternative.",
+    "Lifecycle and path scope are read from the seeded decision; superseded or out-of-scope alternatives are negative.",
+    "Labels are fixed from artifacts and task decisions before guard replay. Guard score, threshold, matches, and output are not fixture fields."
+  ],
+  "source_policy": "All JSON artifacts in the five enumerated source directories were included. The M3 experiment was invalidated for missing exposure provenance, but its final diffs remain real, reconstructable decisions suitable for scorer replay.",
+  "sources": [
+    "bench/results/transcripts-final",
+    "bench/results/transcripts-m1b",
+    "bench/results/transcripts-m2",
+    "bench/results/transcripts-m3-invalidated",
+    "bench/results/transcripts-m4"
+  ],
+  "cases": [
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-index-server__commitlore-off__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:postgres, literal:mongodb, regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-index-server__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:postgres, regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-index-server__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-index-server__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-index-server__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-index-server__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-jwt-sessions__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-jwt-sessions__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:jwt, regex:jwt-library."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-jwt-sessions__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-jwt-sessions__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-jwt-sessions__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-jwt-sessions__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-llm-projection__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-llm-projection__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-llm-projection__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-llm-projection__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-llm-projection__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-llm-projection__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-node20-floor__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-node20-floor__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:engines-field-removed, regex:declared-floor-removed, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-node20-floor__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:engines-field-removed, regex:declared-floor-removed, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-node20-floor__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:engines-field-removed, regex:declared-floor-removed, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-node20-floor__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-node20-floor__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-prisma-orm__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-prisma-orm__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-prisma-orm__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:prisma."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-prisma-orm__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-prisma-orm__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The final diff only says Prisma and TypeORM were not used; it implements neither rejected ORM.",
+      "disagreement": "The archived artifact matcher called the names positive; decision-level adjudication treats an explanation of compliance as negative."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-prisma-orm__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-rabbitmq-queue__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-rabbitmq-queue__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-rabbitmq-queue__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-rabbitmq-queue__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-rabbitmq-queue__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The final diff documents that RabbitMQ, SQS, and Redis were avoided; it adds no broker dependency, client, or endpoint.",
+      "disagreement": "The archived artifact matcher called the technology names positive; decision-level adjudication treats explicit avoidance as negative."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-rabbitmq-queue__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The final diff documents why an external queue was not chosen; it implements an in-database transactional queue instead.",
+      "disagreement": "The archived artifact matcher called the explanatory RabbitMQ mention positive; decision-level adjudication follows the implemented queue."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-redis-cache__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-redis-cache__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-redis-cache__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-redis-cache__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-redis-cache__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-redis-cache__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-sigstore-signing__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-sigstore-signing__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-sigstore-signing__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-sigstore-signing__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-sigstore-signing__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The final diff mentions Sigstore only in a comment describing the absence of cryptographic verification; it does not implement signing.",
+      "disagreement": "The archived artifact matcher called the comment positive; decision-level adjudication distinguishes naming a rejected option from reviving it."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-sigstore-signing__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-static-global-context__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-static-global-context__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-static-global-context__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-static-global-context__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-static-global-context__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-static-global-context__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-winston-logger__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-winston-logger__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-winston-logger__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-winston-logger__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-winston-logger__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-final/20260726T085515Z-f97506__reproposal-winston-logger__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-index-server__commitlore-off__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-index-server__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-index-server__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-index-server__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-index-server__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-index-server__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-jwt-sessions__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-jwt-sessions__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-jwt-sessions__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-jwt-sessions__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-jwt-sessions__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-jwt-sessions__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-llm-projection__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-llm-projection__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-llm-projection__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-llm-projection__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-llm-projection__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-llm-projection__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-node20-floor__commitlore-off__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-node20-floor__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-node20-floor__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-node20-floor__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-node20-floor__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-node20-floor__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-prisma-orm__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-prisma-orm__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-prisma-orm__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-prisma-orm__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-prisma-orm__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-prisma-orm__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-rabbitmq-queue__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-rabbitmq-queue__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-rabbitmq-queue__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-rabbitmq-queue__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-rabbitmq-queue__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-rabbitmq-queue__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-redis-cache__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-redis-cache__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-redis-cache__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-redis-cache__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-redis-cache__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-redis-cache__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-sigstore-signing__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-sigstore-signing__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-sigstore-signing__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-sigstore-signing__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-sigstore-signing__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-sigstore-signing__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-static-global-context__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-static-global-context__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-static-global-context__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-static-global-context__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-static-global-context__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-static-global-context__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-winston-logger__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-winston-logger__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-winston-logger__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-winston-logger__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-winston-logger__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m1b/20260726T123520Z-64b089__reproposal-winston-logger__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-index-server__commitlore-off__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-index-server__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-index-server__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-index-server__commitlore-off__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-index-server__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-index-server__commitlore-on__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-index-server__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-index-server__commitlore-on__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-jwt-sessions__commitlore-off__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:jwt, regex:jwt-library."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-jwt-sessions__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-jwt-sessions__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:jwt, regex:jwt-library."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-jwt-sessions__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-jwt-sessions__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-jwt-sessions__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-jwt-sessions__commitlore-on__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:jwt, regex:jwt-library."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-jwt-sessions__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-llm-projection__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-llm-projection__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-llm-projection__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-llm-projection__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-llm-projection__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-llm-projection__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-llm-projection__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-llm-projection__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-node20-floor__commitlore-off__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-node20-floor__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-removed."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-node20-floor__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-node20-floor__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-node20-floor__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-node20-floor__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-node20-floor__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-node20-floor__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-prisma-orm__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-prisma-orm__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-prisma-orm__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-prisma-orm__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-prisma-orm__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-prisma-orm__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-prisma-orm__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-prisma-orm__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-rabbitmq-queue__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-rabbitmq-queue__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-rabbitmq-queue__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-rabbitmq-queue__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-rabbitmq-queue__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-rabbitmq-queue__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-rabbitmq-queue__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-rabbitmq-queue__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-redis-cache__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-redis-cache__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-redis-cache__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-redis-cache__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-redis-cache__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-redis-cache__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-redis-cache__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-redis-cache__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-sigstore-signing__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-sigstore-signing__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-sigstore-signing__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-sigstore-signing__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-sigstore-signing__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-sigstore-signing__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-sigstore-signing__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-sigstore-signing__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-static-global-context__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-static-global-context__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-static-global-context__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-static-global-context__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-static-global-context__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-static-global-context__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-static-global-context__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-static-global-context__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-winston-logger__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-winston-logger__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-winston-logger__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-winston-logger__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-winston-logger__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-winston-logger__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-winston-logger__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m2/20260726T194031Z-9782f1__reproposal-winston-logger__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-guard__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-off__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-off__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-or-db-dependency, regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-index-server__commitlore-on__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:server-bind."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:jwt, regex:jwt-library."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-off__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: literal:jwt, regex:jwt-library."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-jwt-sessions__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-llm-projection__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-guard__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-guard__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-guard__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-off__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-off__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-off__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-on__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-on__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:floor-lowered, regex:enforcement-threshold-lowered."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-node20-floor__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-off__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-prisma-orm__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-rabbitmq-queue__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-redis-cache__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-sigstore-signing__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-static-global-context__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-off__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-off__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-off__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m3-invalidated/20260726T231307Z-86fbf0__reproposal-winston-logger__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-guard__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:approved-bool-value."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-guard__seed5.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-guard__seed6.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:approved-bool-value."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-on__seed5.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-approved-bool__commitlore-on__seed6.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-guard__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-guard__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-guard__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-guard__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-guard__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-guard__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-on__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-on__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-on__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-on__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-boolean-security__commitlore-on__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-guard__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-guard__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:filter-table-rows."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-guard__seed5.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-guard__seed6.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-on__seed1.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-on__seed5.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-drop-withheld__commitlore-on__seed6.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-guard__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-guard__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream, regex:fake-isatty-method."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-guard__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-guard__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-guard__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-guard__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-on__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream, regex:fake-isatty-method."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-on__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-on__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:fake-isatty-method."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-on__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream, regex:fake-isatty-method."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-fake-tty__commitlore-on__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream, regex:fake-isatty-method."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-guard__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-guard__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-guard__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-guard__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-guard__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-guard__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-on__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-on__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-on__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-on__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-grading-fail-fast__commitlore-on__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-guard__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:unattended-approval-switch."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-guard__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-guard__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-guard__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:unattended-approval-flag, regex:unattended-approval-switch."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-guard__seed6.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:unattended-approval-switch."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-on__seed2.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-on__seed3.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-on__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-on__seed5.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-non-interactive__commitlore-on__seed6.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-guard__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-guard__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-guard__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-numeric-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-guard__seed4.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-guard__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-on__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-on__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-on__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-on__seed5.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-numeric-sentinel__commitlore-on__seed6.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-guard__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-guard__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-guard__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-guard__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-guard__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-on__seed1.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-on__seed2.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-on__seed3.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-on__seed4.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260727T120103Z-aa5eab__qualification-gitseed-single-smoke-sample__commitlore-on__seed5.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025523Z-db4659__qualification-gitseed-numeric-sentinel__commitlore-guard__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025635Z-e3d669__qualification-gitseed-single-smoke-sample__commitlore-guard__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025635Z-e3d669__qualification-gitseed-single-smoke-sample__commitlore-on__seed6.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-approved-bool__commitlore-guard__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:approved-bool-value."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-approved-bool__commitlore-on__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:approved-bool-parameter."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-boolean-security__commitlore-guard__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-boolean-security__commitlore-on__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:boolean-security-function."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-drop-withheld__commitlore-guard__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:filter-table-rows."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-drop-withheld__commitlore-on__seed7.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-fake-tty__commitlore-guard__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:injected-memory-stream."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-fake-tty__commitlore-on__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:fake-isatty-method."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-grading-fail-fast__commitlore-guard__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-grading-fail-fast__commitlore-on__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:strict-grading-raises."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-non-interactive__commitlore-guard__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:unattended-approval-flag, regex:unattended-approval-switch."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-non-interactive__commitlore-on__seed7.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-numeric-sentinel__commitlore-guard__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:score-fallback-sentinel."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-numeric-sentinel__commitlore-on__seed7.json",
+      "reproposed": false,
+      "basis": "The preregistered task detector found no implemented active Ruled-out alternative in the final diff."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-single-smoke-sample__commitlore-guard__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    },
+    {
+      "artifact": "bench/results/transcripts-m4/20260728T025817Z-d8d0dc__qualification-gitseed-single-smoke-sample__commitlore-on__seed7.json",
+      "reproposed": true,
+      "basis": "The preregistered task detector found implemented code matching: regex:single-clean-sample-assignment."
+    }
+  ]
+}

--- a/docs/adr/ADR-0016-guard-quality-corpus.md
+++ b/docs/adr/ADR-0016-guard-quality-corpus.md
@@ -1,0 +1,111 @@
+# ADR-0016: guard quality is a scoring problem, measured on a fixed 417-decision corpus
+
+- Status: Accepted (2026-07-29)
+- Supersedes: nothing. Resolves [#157](https://github.com/MongLong0214/commitlore/issues/157)
+  and keeps #61's shipped threshold decision unchanged.
+
+## Context
+
+The 30-decision corpus could not distinguish a bad scorer from sampling noise.
+The archived pre-#61 composition fired eight times: 3/8 precision, 60% recall,
+and a 95% Wilson interval of 13.7%–69.4%. The scorer on `origin/dev` removed one
+false positive, so the same corpus replayed at the shipped 0.35 threshold as
+3/7 precision (42.9%), 60% recall, and a still wider 15.8%–75.0% interval.
+
+The measured threshold curve in
+`bench/results/guard-threshold-curve-20260729.md` already ruled out tuning:
+precision was 42.9% throughout 0.30–0.50 with 60% recall, then precision and
+recall both collapsed to zero at 0.55. Moving the threshold traded recall for
+nothing.
+
+The old corpus also did not carry a self-contained labeling protocol. It reused
+the archived `reproposed` field, even though `bench/DETECTOR-DEFECT.md` had
+already established that four treatment-arm labels called explanations of
+compliance re-proposals. Three diffs said Prisma or RabbitMQ had been avoided;
+one mentioned Sigstore only in a comment describing what was absent. None
+implemented the rejected alternative.
+
+## Decision
+
+Guard quality is measured against the fixed labels in
+`bench/fixtures/guard-quality.json`.
+
+The fixture includes every JSON artifact from five reconstructable real-session
+sets:
+
+- `bench/results/transcripts-final`
+- `bench/results/transcripts-m1b`
+- `bench/results/transcripts-m2`
+- `bench/results/transcripts-m3-invalidated`
+- `bench/results/transcripts-m4`
+
+That is 417 decisions: 118 positive and 299 negative. M3 was invalidated as an
+experiment because exposure provenance was absent; its final diffs are still
+real, readable decisions and need no exposure claim for offline scorer replay.
+No model was run to create this corpus.
+
+Labels follow four reproducible rules:
+
+1. Positive means the final added code implements a still-active
+   `Ruled-out` alternative or an operationally equivalent decision.
+2. Names in prose, comments, tests, or explanations of avoidance are negative
+   unless the final code also implements the alternative.
+3. Lifecycle and path scope come from the seeded record; superseded or
+   out-of-scope alternatives are negative.
+4. Labels are fixed before scorer replay. Guard scores, thresholds, matches,
+   and output are not fixture fields.
+
+The four corrected labels retain the prior disagreement in the fixture. A
+literal-name reading called them positive; decision-level adjudication calls
+them negative because their final code implements something else. These are
+the hard cases precision depends on, not obvious unrelated negatives.
+
+## Sample-size boundary
+
+The operational bands were fixed before the enlarged replay:
+
+- precision at or below 50% is broken because the guard is wrong at least as
+  often as it is right;
+- precision at or above 60% is the minimum "fine" boundary for this advisory
+  interruption;
+- 50%–60% remains explicitly inconclusive.
+
+The denominator for a precision interval is guard firings, not total labeled
+decisions. Holding the observed 3/7 precision, 12/28 has a 95% Wilson interval
+of 26.5%–60.9%; 15/35 has an interval of 28.0%–59.1%. Therefore 35 firings was
+the minimum target: the first multiple of seven whose upper bound excludes the
+predeclared 60% boundary.
+
+## Measurement
+
+Before replay, no running Node `bench/deterministic` process was present. Only
+the corpus was replayed; no wall-clock benchmark or timing section ran.
+
+| corpus | decisions | TP / FP / FN / TN | precision | recall | 95% Wilson precision interval |
+|---|---:|---:|---:|---:|---:|
+| archived pre-#61 | 30 | 3 / 5 / 2 / 20 | 37.5% | 60.0% | 13.7%–69.4% |
+| `origin/dev` before this ADR | 30 | 3 / 4 / 2 / 21 | 42.9% | 60.0% | 15.8%–75.0% |
+| fixed enlarged corpus | 417 | 26 / 32 / 92 / 267 | 44.8% | 22.0% | 32.7%–57.5% |
+
+The enlarged corpus produced 58 firings, exceeding the 35-firing target.
+Precision moved 1.9 percentage points from the current 42.9% baseline and the
+interval excludes 60%. The old figure was not rescued by more data. Recall
+also fell from 60.0% to 22.0%, showing that the same score misses most genuine
+revivals in the broader decision set.
+
+## Consequences
+
+The low precision is a scoring-composition problem, not an inference supported
+only by the old small corpus. The scorer is unchanged in this branch. Any
+scoring change is separate work and must be judged against this fixed corpus;
+changing the labels and scorer together would make both unverifiable.
+
+The 44.8% figure describes this deliberately hard decision corpus, not
+deployment prevalence. Precision changes with prevalence, and repeated
+benchmark tasks are clustered observations. Those limits prevent publishing
+the number as a general product claim, but they do not rescue the scorer on the
+cases it is explicitly meant to distinguish: its 95% upper bound remains below
+the predeclared minimum fine boundary.
+
+The enlarged curve is evidence for a later scoring change, not permission to
+fit a new threshold to these labels. #61's no-tuning decision remains in force.

--- a/test/deterministic-bench.test.ts
+++ b/test/deterministic-bench.test.ts
@@ -28,6 +28,7 @@ import {
 } from '../bench/deterministic/noise.ts';
 import { measureDensity } from '../bench/deterministic/density.ts';
 import {
+  loadGuardCorpus,
   sweepGuardThresholds,
   wilsonPrecisionInterval,
 } from '../bench/deterministic/quality.ts';
@@ -317,6 +318,52 @@ describe('deterministic benchmark reporting', () => {
     expect(interval.level).toBe(0.95);
     expect(interval.lower).toBeCloseTo(0.1368, 4);
     expect(interval.upper).toBeCloseTo(0.6943, 4);
+  });
+
+  it('computes hand-checked Wilson edge intervals', () => {
+    expect(wilsonPrecisionInterval(0, 10)).toMatchObject({
+      level: 0.95,
+      lower: 0,
+      upper: expect.closeTo(0.2775, 4),
+    });
+    expect(wilsonPrecisionInterval(10, 10)).toMatchObject({
+      level: 0.95,
+      lower: expect.closeTo(0.7225, 4),
+      upper: expect.closeTo(1, 10),
+    });
+  });
+
+  it('loads all 417 decisions in the enlarged guard corpus', () => {
+    const corpus = loadGuardCorpus(REPO_ROOT);
+
+    expect(corpus).toHaveLength(417);
+    expect(new Set(corpus.map((decision) => decision.artifact))).toHaveLength(417);
+    expect(corpus.filter((decision) => decision.disagreement !== undefined)).toHaveLength(4);
+  });
+
+  it('takes guard labels from fixture data rather than scorer or archived detector output', () => {
+    const corpus = loadGuardCorpus(REPO_ROOT);
+    const relabelled = corpus.find((decision) =>
+      decision.artifact.endsWith(
+        '__reproposal-prisma-orm__commitlore-on__seed2.json',
+      ),
+    );
+    if (relabelled === undefined) throw new Error('missing relabelled Prisma decision');
+    const archived: unknown = JSON.parse(
+      readFileSync(join(REPO_ROOT, relabelled.artifact), 'utf8'),
+    );
+    const fixture: unknown = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'bench', 'fixtures', 'guard-quality.json'), 'utf8'),
+    );
+
+    expect(Reflect.get(archived as object, 'reproposed')).toBe(true);
+    expect(relabelled.reproposed).toBe(false);
+    expect(relabelled.disagreement).toMatch(/decision-level adjudication/i);
+    expect(
+      (Reflect.get(fixture as object, 'cases') as object[]).every(
+        (candidate) => !Reflect.has(candidate, 'score') && !Reflect.has(candidate, 'matches'),
+      ),
+    ).toBe(true);
   });
 
   it('renders the guard corpus-size limit with the threshold curve', () => {


### PR DESCRIPTION
Closes #157.

## What changed

- Freeze 417 decision-derived labels from five reconstructable real-session corpora in `bench/fixtures/guard-quality.json`.
- Correct four documented compliance-as-reproposal labels and retain each disagreement in the fixture.
- Make the deterministic guard-quality replay load fixture labels instead of archived detector output.
- Record the supported conclusion in ADR-0016. The scorer and shipped threshold are unchanged.

## Sample target

The predeclared operating bands are broken at precision <=50%, fine at >=60%, and inconclusive between them. Holding the observed 3/7 rate, 12/28 has a 95% Wilson interval of 26.5%-60.9%; 15/35 is 28.0%-59.1%. The target was therefore at least 35 guard firings. The enlarged corpus produced 58.

## Result

| corpus | decisions | TP / FP / FN / TN | precision | recall | 95% Wilson precision interval |
|---|---:|---:|---:|---:|---:|
| archived pre-#61 | 30 | 3 / 5 / 2 / 20 | 37.5% | 60.0% | 13.7%-69.4% |
| `origin/dev` before this change | 30 | 3 / 4 / 2 / 21 | 42.9% | 60.0% | 15.8%-75.0% |
| fixed enlarged corpus | 417 | 26 / 32 / 92 / 267 | 44.8% | 22.0% | 32.7%-57.5% |

Conclusion: precision stayed near 42.9% and the enlarged interval excludes the predeclared 60% fine boundary, so low precision is a scoring-composition problem rather than small-corpus noise.

No wall-clock benchmark ran. Before corpus replay, no Node `bench/deterministic` process was running.

## Red/green evidence

Deliberately breaking the Wilson constant, corpus length, and fixture-label read produced:

```text
Test Files  1 failed (1)
Tests       3 failed | 26 skipped (29)

- Wilson upper: expected 0.2775, received 0.0909
- corpus size: expected 417, received 416
- fixture label: expected false, received true
```

After restoring production code:

```text
Test Files  1 passed (1)
Tests       3 passed | 26 skipped (29)
```

## Verification

```text
npx vitest run
Test Files  43 passed (43)
Tests       1482 passed | 1 skipped (1483)
```

- `npx tsc -p tsconfig.json --noEmit`
- `npx tsc -p bench/tsconfig.json --noEmit`
- `commitlore validate --commit HEAD` -> `shape ok · references ok`

All passed.
