### PR TITLE
Keep benchmark provenance across rebases

### DIFF
--- a/bench/deterministic/shared.ts
+++ b/bench/deterministic/shared.ts
@@ -48,6 +48,74 @@ export const git = (
   options: Omit<CommandOptions, 'cwd'> = {},
 ): CommandResult => command('git', args, { cwd, ...options });
 
+const HARNESS_PATHS = ['bench/deterministic.ts', 'bench/deterministic'] as const;
+const GIT_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+
+export const harnessTreeDigest = (repoRoot: string, ref = 'HEAD'): string => {
+  const manifest = git(repoRoot, [
+    'ls-tree', '-r', '--full-tree', ref, '--', ...HARNESS_PATHS,
+  ]).stdout;
+  if (manifest === '') throw new Error(`no deterministic harness found at ${ref}`);
+  return git(repoRoot, ['hash-object', '--stdin'], { input: manifest }).stdout.trim();
+};
+
+export interface HarnessProvenance {
+  readonly harness_commit: string;
+  readonly harness_digest?: string;
+}
+
+export interface HarnessVerification {
+  readonly historyRef: string;
+  readonly verifiedBy: 'commit' | 'digest';
+  readonly message: string;
+}
+
+export const verifyHarnessProvenance = (
+  repoRoot: string,
+  provenance: HarnessProvenance,
+): HarnessVerification => {
+  if (!GIT_OBJECT_ID.test(provenance.harness_commit)) {
+    throw new Error(`invalid harness commit ${JSON.stringify(provenance.harness_commit)}`);
+  }
+  const resolved = git(
+    repoRoot,
+    ['rev-parse', '--verify', '--quiet', `${provenance.harness_commit}^{commit}`],
+    { allowed: [0, 1] },
+  );
+  if (resolved.status === 0) {
+    const message =
+      `benchmark provenance: verified by harness commit ${provenance.harness_commit}; ` +
+      `re-deriving from that commit's history`;
+    process.stdout.write(`${message}\n`);
+    return { historyRef: provenance.harness_commit, verifiedBy: 'commit', message };
+  }
+
+  if (provenance.harness_digest === undefined) {
+    throw new Error(
+      `benchmark provenance failed: harness commit ${provenance.harness_commit} is unresolvable ` +
+        'and no harness digest was recorded; this result cannot be re-derived',
+    );
+  }
+  if (!GIT_OBJECT_ID.test(provenance.harness_digest)) {
+    throw new Error(`invalid harness digest ${JSON.stringify(provenance.harness_digest)}`);
+  }
+  const currentDigest = harnessTreeDigest(repoRoot);
+  if (currentDigest !== provenance.harness_digest) {
+    throw new Error(
+      `benchmark provenance failed: harness commit ${provenance.harness_commit} is unresolvable ` +
+        `and harness digest does not match HEAD (recorded ${provenance.harness_digest}, ` +
+        `${currentDigest}); this result cannot be re-derived`,
+    );
+  }
+
+  const message =
+    `benchmark provenance: WARNING: harness commit ${provenance.harness_commit} is unresolvable; ` +
+    `verified by harness digest ${provenance.harness_digest} at HEAD. ` +
+    'The digest proves the harness code is identical, not that the recorded commit existed';
+  process.stdout.write(`${message}\n`);
+  return { historyRef: 'HEAD', verifiedBy: 'digest', message };
+};
+
 export const assertCleanCheckout = (repoRoot: string): void => {
   const status = git(repoRoot, ['status', '--porcelain=v1', '--untracked-files=all']).stdout.trim();
   if (status !== '') {
@@ -100,6 +168,7 @@ export const rowBase = (
 ): RowBase => ({
   schema_version: 1,
   harness_commit: harnessCommit,
+  harness_digest: harnessTreeDigest(repoRoot, harnessCommit),
   dist_digest: distDigest,
   measured_at: measuredAt,
   machine: machine(repoRoot),

--- a/bench/deterministic/types.ts
+++ b/bench/deterministic/types.ts
@@ -12,6 +12,7 @@ export interface Machine {
 export interface BaseRow {
   readonly schema_version: 1;
   readonly harness_commit: string;
+  readonly harness_digest: string;
   readonly dist_digest: string;
   readonly measured_at: string;
   readonly machine: Machine;
@@ -215,5 +216,5 @@ export type DeterministicRow =
 
 export type RowBase = Pick<
   BaseRow,
-  'schema_version' | 'harness_commit' | 'dist_digest' | 'measured_at' | 'machine'
+  'schema_version' | 'harness_commit' | 'harness_digest' | 'dist_digest' | 'measured_at' | 'machine'
 >;

--- a/docs/adr/ADR-0018-benchmark-provenance-after-rewrites.md
+++ b/docs/adr/ADR-0018-benchmark-provenance-after-rewrites.md
@@ -1,0 +1,81 @@
+# ADR-0018: benchmark provenance survives branch rewrites with two identifiers
+
+- Status: Accepted (2026-07-29)
+- Resolves [#161](https://github.com/MongLong0214/commitlore/issues/161).
+  Related: [#163](https://github.com/MongLong0214/commitlore/issues/163).
+
+## Context
+
+Each deterministic result recorded the commit at `HEAD` when it was measured.
+The reproducibility test then used that commit's history to re-derive the
+result. This is the strongest available provenance while the commit resolves.
+
+Branch commits are temporary in this repository. A rebase, amend, or squash
+replaces the commit even when the harness files are byte-identical. The
+recorded identifier then becomes unresolvable, so the result fails
+reproducibility before its code can merge. This happened twice during one
+session in which seven branches were rebased onto `dev`.
+
+The failure must remain loud. Issue #163 showed the other side of the same
+boundary: two figures that look comparable may describe different work. A
+fallback that quietly substitutes current code would preserve the artifact
+while discarding the information a reader needs to judge it.
+
+The existing `dist_digest` does not solve this problem. It hashes the built
+product bytes that the harness executed and detects a mid-run rebuild. Harness
+identity and product identity are separate provenance claims.
+
+## Decision
+
+New deterministic result rows record both:
+
+- `harness_commit`: the commit at `HEAD` when measurement began;
+- `harness_digest`: Git's object digest of a canonical manifest containing
+  `bench/deterministic.ts` and every tracked file under `bench/deterministic/`.
+
+The manifest is produced by `git ls-tree` and digested by `git hash-object`.
+This reuses Git's content-addressing rather than adding another filesystem hash
+implementation beside `digestDistTree`. A history rewrite changes the commit
+identifier but leaves the harness digest unchanged when no harness file
+changed.
+
+Verification uses the identifiers in this order:
+
+1. If `harness_commit` resolves, re-derive the result from that commit's
+   history and report that commit verification was used.
+2. If the commit is unresolvable, compare the recorded `harness_digest` with
+   the harness at current `HEAD`.
+3. On a digest match, re-derive from `HEAD` and print a warning that names the
+   digest. The warning states that the match proves identical harness code, not
+   that the recorded commit existed.
+4. If the commit is unresolvable and the digest is absent or mismatched, fail.
+   That result cannot be re-derived from an identified commit or identical
+   harness code.
+
+Existing results without `harness_digest` remain verifiable while their
+recorded commit resolves. They have no fallback after that commit is lost.
+
+## Ruled out
+
+- Run benchmarks only on `dev` after merge | simpler permanent commit identity,
+  but reviewers lose the ability to examine a measurement beside the code that
+  produced it.
+- Record only the harness digest | preserves code identity across rewrites but
+  no longer names which commit and history produced the result.
+- Regenerate results after every rewrite | honest but turns each rebase into a
+  benchmark run; one affected session had already spent five hours measuring,
+  and the machine is not always available.
+- Accept current `HEAD` silently when the commit is missing | converts a loud
+  provenance failure into a quiet weakening that readers cannot distinguish.
+
+## Consequences
+
+A normal verification retains the prior guarantee: the named commit exists and
+its history reproduces the result. Digest fallback is explicitly weaker and
+explicitly labeled. It establishes that the deterministic harness code is
+identical at `HEAD`; it does not establish that the old commit ever existed on
+a published ref.
+
+The product bytes remain independently pinned by `dist_digest`. Changes outside
+the deterministic harness manifest are not certified by `harness_digest`; if
+they alter the re-derived value, the existing result comparison still fails.

--- a/test/deterministic-bench.test.ts
+++ b/test/deterministic-bench.test.ts
@@ -1,5 +1,12 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -32,7 +39,12 @@ import {
   sweepGuardThresholds,
   wilsonPrecisionInterval,
 } from '../bench/deterministic/quality.ts';
-import { assertCleanCheckout, git } from '../bench/deterministic/shared.ts';
+import {
+  assertCleanCheckout,
+  git,
+  harnessTreeDigest,
+  verifyHarnessProvenance,
+} from '../bench/deterministic/shared.ts';
 import { measureSurvival } from '../bench/deterministic/survival.ts';
 import { CHARS_PER_TOKEN } from '../dist/core/inject.js';
 import type {
@@ -49,6 +61,7 @@ const DENSITY_RESULTS_DIR = join(REPO_ROOT, 'bench', 'results');
 const row = (overrides: Partial<InjectionDetectionRow> = {}): InjectionDetectionRow => ({
   schema_version: 1,
   harness_commit: '1111111111111111111111111111111111111111',
+  harness_digest: '3333333333333333333333333333333333333333',
   dist_digest: '2222222222222222222222222222222222222222222222222222222222222222',
   measured_at: '2026-07-27T00:00:00.000Z',
   machine: {
@@ -130,6 +143,7 @@ const captureRow = (overrides: Partial<CaptureCostRow> = {}): CaptureCostRow => 
 const densityRow = (overrides: Partial<DensityRow> = {}): DensityRow => ({
   schema_version: 1,
   harness_commit: '1111111111111111111111111111111111111111',
+  harness_digest: '3333333333333333333333333333333333333333',
   dist_digest: '2222222222222222222222222222222222222222222222222222222222222222',
   measured_at: '2026-07-27T00:00:00.000Z',
   machine: row().machine,
@@ -147,6 +161,7 @@ const densityRow = (overrides: Partial<DensityRow> = {}): DensityRow => ({
 
 interface RecordedDensity {
   readonly harness_commit: string;
+  readonly harness_digest?: string;
   readonly commits_examined: number;
   readonly record_bearing_commits: number;
   readonly structured_trailers: number;
@@ -175,6 +190,10 @@ const recordedDensity = (path: string): RecordedDensity => {
   if (typeof parsed !== 'object' || parsed === null) throw new Error('density result is not an object');
   const text = Reflect.get(parsed, 'harness_commit');
   if (typeof text !== 'string') throw new Error('density result has an invalid harness commit');
+  const digest = Reflect.get(parsed, 'harness_digest');
+  if (digest !== undefined && typeof digest !== 'string') {
+    throw new Error('density result has an invalid harness digest');
+  }
   const number = (field: string): number => {
     const value = Reflect.get(parsed, field);
     if (typeof value !== 'number') throw new Error(`density result has invalid ${field}`);
@@ -182,6 +201,7 @@ const recordedDensity = (path: string): RecordedDensity => {
   };
   return {
     harness_commit: text,
+    ...(digest === undefined ? {} : { harness_digest: digest }),
     commits_examined: number('commits_examined'),
     record_bearing_commits: number('record_bearing_commits'),
     structured_trailers: number('structured_trailers'),
@@ -190,6 +210,55 @@ const recordedDensity = (path: string): RecordedDensity => {
     trailers_per_commit: number('trailers_per_commit'),
     structured_trailer_line_share: number('structured_trailer_line_share'),
   };
+};
+
+interface RebasedHarnessRepo {
+  readonly dir: string;
+  readonly originalCommit: string;
+  readonly rebasedCommit: string;
+  readonly harnessDigest: string;
+}
+
+const createRebasedHarnessRepo = (): RebasedHarnessRepo => {
+  const dir = mkdtempSync(join(tmpdir(), 'commitlore-harness-rebase-test-'));
+  git(dir, ['init', '--quiet', '--initial-branch=main']);
+  git(dir, ['config', 'user.name', 'CommitLore Bench']);
+  git(dir, ['config', 'user.email', 'bench@commitlore.local']);
+  mkdirSync(join(dir, 'bench', 'deterministic'), { recursive: true });
+  writeFileSync(join(dir, 'bench', 'deterministic.ts'), 'export {};\n');
+  writeFileSync(join(dir, 'bench', 'deterministic', 'measure.ts'), 'export const measure = 1;\n');
+  writeFileSync(join(dir, 'base.txt'), 'base\n');
+  git(dir, ['add', '.']);
+  git(dir, ['commit', '--quiet', '-m', 'base']);
+
+  git(dir, ['checkout', '--quiet', '-b', 'feature']);
+  writeFileSync(join(dir, 'feature.txt'), 'feature\n');
+  git(dir, ['add', 'feature.txt']);
+  git(dir, ['commit', '--quiet', '-m', 'feature']);
+  const originalCommit = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
+  const harnessDigest = harnessTreeDigest(dir, originalCommit);
+
+  git(dir, ['checkout', '--quiet', 'main']);
+  writeFileSync(join(dir, 'base.txt'), 'rebased base\n');
+  git(dir, ['add', 'base.txt']);
+  git(dir, ['commit', '--quiet', '-m', 'move base']);
+  git(dir, ['checkout', '--quiet', 'feature']);
+  git(dir, ['rebase', 'main']);
+  const rebasedCommit = git(dir, ['rev-parse', 'HEAD']).stdout.trim();
+
+  return { dir, originalCommit, rebasedCommit, harnessDigest };
+};
+
+const pruneRebaseSource = (fixture: RebasedHarnessRepo): void => {
+  git(fixture.dir, ['reflog', 'expire', '--expire=now', '--all']);
+  git(fixture.dir, ['gc', '--prune=now']);
+  expect(
+    git(
+      fixture.dir,
+      ['rev-parse', '--verify', '--quiet', `${fixture.originalCommit}^{commit}`],
+      { allowed: [0, 1] },
+    ).status,
+  ).toBe(1);
 };
 
 describe('deterministic benchmark reporting', () => {
@@ -410,9 +479,13 @@ describe('deterministic benchmark reporting', () => {
     for (const citation of DENSITY_CITATIONS) expect(markdown).toContain(citation);
   });
 
-  it('recomputes the committed density result from its recorded history', () => {
+  it('verifies a resolvable result by commit and recomputes its recorded history', () => {
     const recorded = recordedDensity(densityResultPath());
-    const measured = measureDensity(row(), REPO_ROOT, recorded.harness_commit);
+    const verification = verifyHarnessProvenance(REPO_ROOT, recorded);
+    const measured = measureDensity(row(), REPO_ROOT, verification.historyRef);
+
+    expect(verification.verifiedBy).toBe('commit');
+    expect(verification.message).toContain(recorded.harness_commit);
 
     expect({
       commits_examined: measured.commits_examined,
@@ -431,6 +504,62 @@ describe('deterministic benchmark reporting', () => {
       trailers_per_commit: recorded.trailers_per_commit,
       structured_trailer_line_share: recorded.structured_trailer_line_share,
     });
+  });
+
+  it('verifies an orphaned result by digest and states the narrower guarantee', () => {
+    const fixture = createRebasedHarnessRepo();
+
+    try {
+      pruneRebaseSource(fixture);
+      const verification = verifyHarnessProvenance(fixture.dir, {
+        harness_commit: fixture.originalCommit,
+        harness_digest: fixture.harnessDigest,
+      });
+
+      expect(verification).toMatchObject({
+        historyRef: 'HEAD',
+        verifiedBy: 'digest',
+      });
+      expect(verification.message).toMatch(
+        /verified by harness digest.*proves the harness code is identical, not that the recorded commit existed/i,
+      );
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails when the result commit is orphaned and the harness digest changed', () => {
+    const fixture = createRebasedHarnessRepo();
+
+    try {
+      writeFileSync(
+        join(fixture.dir, 'bench', 'deterministic', 'measure.ts'),
+        'export const measure = 2;\n',
+      );
+      git(fixture.dir, ['add', 'bench/deterministic/measure.ts']);
+      git(fixture.dir, ['commit', '--quiet', '-m', 'change harness']);
+      pruneRebaseSource(fixture);
+
+      expect(() =>
+        verifyHarnessProvenance(fixture.dir, {
+          harness_commit: fixture.originalCommit,
+          harness_digest: fixture.harnessDigest,
+        }),
+      ).toThrow(/commit .* unresolvable.*digest does not match HEAD.*cannot be re-derived/i);
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the harness digest across a rebase that changes no harness file', () => {
+    const fixture = createRebasedHarnessRepo();
+
+    try {
+      expect(fixture.rebasedCommit).not.toBe(fixture.originalCommit);
+      expect(harnessTreeDigest(fixture.dir, fixture.rebasedCommit)).toBe(fixture.harnessDigest);
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
   });
 
   it('refuses uncommitted benchmark inputs', () => {


### PR DESCRIPTION
Closes #161. **ADR-0018.** Related provenance failure: #163.

A result named the commit that produced it, and every rebase of its own branch orphaned that commit. It happened twice in one sitting and CI caught both.

Rows now record two identifiers:

- `harness_commit` — the commit at `HEAD` when measurement began
- `harness_digest` — Git's object digest of a manifest of `bench/deterministic.ts` and every tracked file under `bench/deterministic/`

The manifest comes from `git ls-tree` and is digested by `git hash-object`, reusing Git's content-addressing instead of adding another filesystem hash implementation.

**The commit id says which commit; the digest says which code.** A rewrite changes the first and not the second.

## The fallback is loud

```
benchmark provenance: WARNING: harness commit <sha> is unresolvable; verified by harness digest <digest> at HEAD. The digest proves the harness code is identical, not that the recorded commit existed
```

A check that silently verifies against the weaker identifier trades a loud failure for a quiet one. A matching digest proves identical harness code, not that the recorded commit existed; the output states that narrower guarantee.

An unresolvable commit and a mismatched or absent digest still fail. That is a result nobody can re-derive.

## Verification

- `npx vitest run`: 44 files passed; 1,490 tests passed; 1 skipped
- `npx tsc -p tsconfig.json --noEmit`: passed
- `npx tsc -p bench/tsconfig.json --noEmit`: passed
- Four targeted red/green checks deliberately broke production behavior before restoring it
- No benchmark was run and no existing result file was changed
