### PR TITLE
Measure stale records across retrieval routes

### DIFF
--- a/bench/retrieval/compare.ts
+++ b/bench/retrieval/compare.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import { buildInjection } from '../../dist/core/inject.js';
+import { foldLifecycle } from '../../dist/core/stale.js';
 import {
   createNoiseFixture,
   destroyNoiseFixture,
@@ -13,10 +14,14 @@ import {
   TOP_K,
   TOP_K_QUERY,
 } from '../deterministic/noise.ts';
-import type { NoiseCorpus, NoiseFixture, NoiseRecord } from '../deterministic/noise.ts';
+import type { NoiseRecord } from '../deterministic/noise.ts';
+import { git } from '../deterministic/shared.ts';
 import {
   RETRIEVAL_ROUTES,
   type OllamaModel,
+  type RetrievalCorpus,
+  type RetrievalFixture,
+  type RetrievalRecord,
   type RetrievalRoute,
   type RetrievalRow,
   type RouteSelections,
@@ -27,12 +32,172 @@ const OLLAMA_URL = 'http://localhost:11434';
 const RESULT_PATH = new URL('./result.md', import.meta.url);
 const BATCH_SIZE = 128;
 const RRF_K = 60;
+const LIFECYCLE_AT = new Date('2026-01-01T00:00:00Z');
+const SAME_PATH_STALE_ID = 'r-stale01';
+const EXPIRED_ID = 'r-expire1';
+const ADVERSARIAL_STALE_ID = 'r-adverse';
 
 const terms = (text: string): readonly string[] => text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
 const document = (record: NoiseRecord): string => `${record.path}\n${record.message}`;
 
-export const retrievalCorpus = (distractors: number, seed = NOISE_SEED): NoiseCorpus =>
-  generateNoiseCorpus(distractors, seed);
+const staleRecords = (): readonly RetrievalRecord[] => [
+  {
+    recordId: SAME_PATH_STALE_ID,
+    path: TARGET_PATH,
+    relevant: false,
+    message: [
+      'Send every repository decision to the path-scoped context.',
+      '',
+      'Limit: Keep decision context repository-wide even when a path is known.',
+      'Ruled-out: path-only delivery | global context was assumed safer.',
+      'Warn: This decision was later replaced on the same path.',
+      'Blast: module',
+      'Undo: easy',
+      'Certainty: firm',
+      `Record-Id: ${SAME_PATH_STALE_ID}`,
+    ].join('\n'),
+  },
+  {
+    recordId: EXPIRED_ID,
+    path: TARGET_PATH,
+    relevant: false,
+    expiresAt: '2025-06-30',
+    message: [
+      'Keep a temporary decision-context compatibility branch.',
+      '',
+      'Limit: Preserve the compatibility branch until the June migration completes.',
+      'Warn: Remove this temporary path after its fixed expiry.',
+      'Expires: 2025-06-30',
+      'Blast: module',
+      'Undo: easy',
+      'Certainty: firm',
+      `Record-Id: ${EXPIRED_ID}`,
+    ].join('\n'),
+  },
+  {
+    recordId: ADVERSARIAL_STALE_ID,
+    path: TARGET_PATH,
+    relevant: false,
+    adversarial: true,
+    message: [
+      `${TARGET_PATH} active lifecycle decision context path scope`,
+      '',
+      `Limit: ${TARGET_PATH} active lifecycle decision context path scope.`,
+      'Ruled-out: semantic successor wording | active lifecycle decision context path scope must repeat the query vocabulary.',
+      `Warn: Retrieve ${TARGET_PATH} active lifecycle decision context path scope.`,
+      'Blast: module',
+      'Undo: easy',
+      'Certainty: firm',
+      `Record-Id: ${ADVERSARIAL_STALE_ID}`,
+    ].join('\n'),
+  },
+];
+
+const successor = (record: NoiseRecord, supersedes: string): RetrievalRecord => ({
+  ...record,
+  supersedes: [supersedes],
+  message: record.message.replace(
+    `Record-Id: ${record.recordId}`,
+    `Supersedes: ${supersedes}\nRecord-Id: ${record.recordId}`,
+  ),
+});
+
+export const retrievalCorpus = (
+  distractors: number,
+  seed = NOISE_SEED,
+): RetrievalCorpus => {
+  const base = generateNoiseCorpus(distractors, seed);
+  const [first, second, ...distractorRecords] = base.records;
+  if (first === undefined || second === undefined) {
+    throw new Error('retrieval corpus needs two active records');
+  }
+  return {
+    ...base,
+    records: [
+      successor(first, SAME_PATH_STALE_ID),
+      successor(second, ADVERSARIAL_STALE_ID),
+      ...staleRecords(),
+      ...distractorRecords,
+    ],
+  };
+};
+
+const commitFixtureRecord = (
+  fixture: RetrievalFixture,
+  record: RetrievalRecord,
+  stamp: number,
+): void => {
+  const parent = git(fixture.dir, ['rev-parse', 'HEAD']).stdout.trim();
+  const content = `${record.path} retrieval fixture ${record.recordId}\n`;
+  const stream = [
+    'commit refs/heads/main',
+    'author CommitLore Bench <bench@commitlore.local> ' + stamp + ' +0000',
+    'committer CommitLore Bench <bench@commitlore.local> ' + stamp + ' +0000',
+    `data ${Buffer.byteLength(record.message)}`,
+    record.message,
+    `from ${parent}`,
+    `M 100644 inline ${record.path}`,
+    `data ${Buffer.byteLength(content)}`,
+    content,
+    'done',
+    '',
+  ].join('\n');
+  git(fixture.dir, ['fast-import', '--quiet'], { input: stream });
+};
+
+export const createRetrievalFixture = (
+  distractors: number,
+  seed = NOISE_SEED,
+): RetrievalFixture => {
+  const base = createNoiseFixture(distractors, seed);
+  const fixture: RetrievalFixture = { ...base, corpus: retrievalCorpus(distractors, seed) };
+  try {
+    for (const record of fixture.corpus.records.filter((candidate) =>
+      candidate.recordId === SAME_PATH_STALE_ID ||
+      candidate.recordId === EXPIRED_ID ||
+      candidate.recordId === ADVERSARIAL_STALE_ID
+    )) {
+      commitFixtureRecord(fixture, record, 1_746_057_600);
+    }
+    for (const record of fixture.corpus.records.filter((candidate) =>
+      candidate.supersedes !== undefined
+    )) {
+      commitFixtureRecord(fixture, record, 1_760_100_000);
+    }
+    return fixture;
+  } catch (error) {
+    destroyNoiseFixture(fixture);
+    throw error;
+  }
+};
+
+export const staleRecordIds = (
+  records: readonly RetrievalRecord[],
+  at = LIFECYCLE_AT,
+): ReadonlySet<string> =>
+  new Set(
+    foldLifecycle(
+      records.map((record) => ({
+        sha: record.recordId,
+        trailers: [
+          { key: 'Record-Id', value: record.recordId },
+          ...(record.supersedes ?? []).map((value) => ({ key: 'Supersedes', value })),
+          ...(record.expiresAt === undefined
+            ? []
+            : [{ key: 'Expires', value: record.expiresAt }]),
+        ],
+      })),
+      { at },
+    ).filter(({ lifecycle }) => lifecycle !== 'active').map(({ recordId }) => recordId),
+  );
+
+export const countStaleRecords = (
+  selected: readonly RetrievalRecord[],
+  corpus: readonly RetrievalRecord[],
+): number => {
+  const stale = staleRecordIds(corpus);
+  return selected.filter(({ recordId }) => stale.has(recordId)).length;
+};
 
 export const bm25Scores = (
   query: string,
@@ -66,10 +231,10 @@ export const bm25Scores = (
 };
 
 const rank = (
-  records: readonly NoiseRecord[],
+  records: readonly RetrievalRecord[],
   scores: readonly number[],
   budget: number,
-): readonly NoiseRecord[] => {
+): readonly RetrievalRecord[] => {
   if (scores.length !== records.length) throw new Error('record and score counts differ');
   return records.map((record, index) => ({ record, score: scores[index] ?? Number.NEGATIVE_INFINITY }))
     .sort((left, right) =>
@@ -80,9 +245,9 @@ const rank = (
 };
 
 export const rankBm25 = (
-  records: readonly NoiseRecord[],
+  records: readonly RetrievalRecord[],
   budget: number,
-): readonly NoiseRecord[] =>
+): readonly RetrievalRecord[] =>
   rank(records, bm25Scores(TOP_K_QUERY, records.map(document)), budget);
 
 const cosine = (left: readonly number[], right: readonly number[]): number => {
@@ -103,12 +268,12 @@ const cosine = (left: readonly number[], right: readonly number[]): number => {
 };
 
 export const rankEmbedding = (
-  records: readonly NoiseRecord[],
+  records: readonly RetrievalRecord[],
   embeddings: readonly (readonly number[])[],
   queryEmbedding: readonly number[],
   budget: number,
   filterPath: string | null = null,
-): readonly NoiseRecord[] => {
+): readonly RetrievalRecord[] => {
   if (embeddings.length !== records.length) throw new Error('record and embedding counts differ');
   const candidates = records.map((record, index) => ({
     record,
@@ -122,10 +287,10 @@ export const rankEmbedding = (
 };
 
 const reciprocalRankFuse = (
-  rankings: readonly (readonly NoiseRecord[])[],
+  rankings: readonly (readonly RetrievalRecord[])[],
   budget: number,
-): readonly NoiseRecord[] => {
-  const records = new Map<string, NoiseRecord>();
+): readonly RetrievalRecord[] => {
+  const records = new Map<string, RetrievalRecord>();
   const scores = new Map<string, number>();
   for (const ranking of rankings) {
     ranking.forEach((record, index) => {
@@ -140,9 +305,9 @@ const reciprocalRankFuse = (
 };
 
 export const retrieveCommitLore = (
-  fixture: NoiseFixture,
+  fixture: RetrievalFixture,
   budget = TOP_K,
-): readonly NoiseRecord[] => {
+): readonly RetrievalRecord[] => {
   const text = buildInjection({ cwd: fixture.dir, path: TARGET_PATH }).text;
   return fixture.corpus.records
     .filter((record) => text.includes(record.recordId))
@@ -150,7 +315,7 @@ export const retrieveCommitLore = (
 };
 
 export const retrieveRoutes = (
-  records: readonly NoiseRecord[],
+  records: readonly RetrievalRecord[],
   embeddings: readonly (readonly number[])[],
   queryEmbedding: readonly number[],
   commitLoreRecords: readonly NoiseRecord[],
@@ -281,6 +446,8 @@ const renderReport = (
   model: OllamaModel,
   dimension: number,
   ollamaVersion: string,
+  adversarialBm25: readonly [number, number],
+  adversarialCosine: readonly [number, number],
 ): string => {
   const routeLabels: Readonly<Record<RetrievalRoute, string>> = {
     bm25: 'BM25',
@@ -293,8 +460,25 @@ const renderReport = (
     route !== 'commitlore-path-lifecycle' &&
     NOISE_SIZES.every((size) =>
       resultFor(rows, size, route).relevantRecords >=
+      resultFor(rows, size, 'commitlore-path-lifecycle').relevantRecords
+    )
+  );
+  const recallWinners = RETRIEVAL_ROUTES.filter((route) =>
+    route !== 'commitlore-path-lifecycle' &&
+    NOISE_SIZES.some((size) =>
+      resultFor(rows, size, route).relevantRecords >
         resultFor(rows, size, 'commitlore-path-lifecycle').relevantRecords
     )
+  );
+  const staleWinners = RETRIEVAL_ROUTES.filter((route) =>
+    route !== 'commitlore-path-lifecycle' &&
+    NOISE_SIZES.some((size) =>
+      resultFor(rows, size, route).staleRecords <
+        resultFor(rows, size, 'commitlore-path-lifecycle').staleRecords
+    )
+  );
+  const staleRoutes = RETRIEVAL_ROUTES.filter((route) =>
+    NOISE_SIZES.some((size) => resultFor(rows, size, route).staleRecords > 0)
   );
   return [
     '# Retrieval route comparison',
@@ -303,7 +487,7 @@ const renderReport = (
     '',
     'This measures exposure and recall at a fixed two-record output budget. It does not measure token cost, billed cost, accuracy, or agent behaviour. Timing was not taken.',
     '',
-    `Corpus: \`generateNoiseCorpus\`, seed ${NOISE_SEED}, distractor sizes ${NOISE_SIZES.join(', ')}.`,
+    `Corpus: \`generateNoiseCorpus\` extended with two superseded predecessors and one expired record, seed ${NOISE_SEED}, distractor sizes ${NOISE_SIZES.join(', ')}.`,
     `Query: \`${TOP_K_QUERY}\``,
     `Harness source SHA-256: \`${sourceDigest()}\``,
     '',
@@ -322,23 +506,52 @@ const renderReport = (
     'The deterministic benchmark’s current `top-k lexical` scorer is a case-insensitive, unweighted count of every query-token occurrence in `path + record message`, with `recordId` as the tie-break. BM25 is a fairer baseline from the same lexical-retrieval family, but it is a different scorer: it adds inverse document frequency, term-frequency saturation, and document-length normalization.',
     'This BM25 uses lowercase ASCII-alphanumeric tokens, unique query terms, k1=1.2, and b=0.75. Embedding routes rank cosine similarity over `path + record message`; hybrid applies reciprocal-rank fusion with k=60 to the complete BM25 and embedding rankings before the two-record budget; the path filter keeps exact-path candidates before embedding ranking.',
     '',
+    '## Adversarial lifecycle case',
+    '',
+    `The superseded record \`${ADVERSARIAL_STALE_ID}\` deliberately repeats the query’s subject and vocabulary more closely than its successor \`r-expose002\`; both records are on \`${TARGET_PATH}\`, so path-filtered similarity retrieval can select the reversed decision.`,
+    `Construction check: BM25 ${adversarialBm25[0].toFixed(6)} > ${adversarialBm25[1].toFixed(6)} and pinned-model cosine ${adversarialCosine[0].toFixed(6)} > ${adversarialCosine[1].toFixed(6)} for stale record versus successor.`,
+    'Zero-stale embedding retrieval was still a possible outcome: yes. The harness does not force either record into an embedding result or alter its score; both compete normally for the fixed budget.',
+    '',
     '## Results',
     '',
     `Routes matching or beating CommitLore path scope at every reported size: ${
       comparable.length === 0 ? 'none' : comparable.map((route) => `\`${routeLabels[route]}\``).join(', ')
     }. This statement compares only the recall counts in the table.`,
+    `Routes with strictly higher recall than CommitLore path + lifecycle at any reported size: ${
+      recallWinners.length === 0
+        ? 'none'
+        : recallWinners.map((route) => `\`${routeLabels[route]}\``).join(', ')
+    }.`,
+    `Routes with fewer stale records than CommitLore path + lifecycle at any reported size: ${
+      staleWinners.length === 0
+        ? 'none'
+        : staleWinners.map((route) => `\`${routeLabels[route]}\``).join(', ')
+    }.`,
     '',
-    `| distractors | corpus records | ${RETRIEVAL_ROUTES.map((route) => routeLabels[route]).join(' | ')} |`,
-    `|---:|---:|${RETRIEVAL_ROUTES.map(() => '---:').join('|')}|`,
+    `| distractors | corpus records | ${
+      RETRIEVAL_ROUTES.flatMap((route) => [
+        `${routeLabels[route]} recall`,
+        `${routeLabels[route]} stale`,
+      ]).join(' | ')
+    } |`,
+    `|---:|---:|${RETRIEVAL_ROUTES.flatMap(() => ['---:', '---:']).join('|')}|`,
     ...NOISE_SIZES.map((size) => {
       const first = resultFor(rows, size, 'bm25');
       return `| ${size} | ${first.corpusRecords} | ${
-        RETRIEVAL_ROUTES.map((route) => {
+        RETRIEVAL_ROUTES.flatMap((route) => {
           const row = resultFor(rows, size, route);
-          return `${row.relevantRecords}/${row.relevantTotal}`;
+          return [`${row.relevantRecords}/${row.relevantTotal}`, row.staleRecords];
         }).join(' | ')
       } |`;
     }),
+    '',
+    '## Conclusion',
+    '',
+    staleRoutes.length === 0
+      ? 'No route returned a stale record in this corpus; the separate recall columns show the context each route omitted.'
+      : `${
+        staleRoutes.map((route) => routeLabels[route]).join(', ')
+      } returned at least one stale record in this corpus; the separate recall columns show the context each route omitted.`,
     '',
   ].join('\n');
 };
@@ -355,10 +568,38 @@ export const runComparison = async (): Promise<string> => {
   if (corpusEmbeddings.some((embedding) => embedding.length !== dimension)) {
     throw new Error('Ollama returned inconsistent embedding dimensions');
   }
+  const adversarial = largestCorpus.records.find(({ adversarial }) => adversarial === true);
+  const adversarialSuccessor = largestCorpus.records.find(({ supersedes }) =>
+    supersedes?.includes(ADVERSARIAL_STALE_ID)
+  );
+  if (adversarial === undefined || adversarialSuccessor === undefined) {
+    throw new Error('adversarial stale record and successor are missing');
+  }
+  const adversarialIndex = largestCorpus.records.indexOf(adversarial);
+  const successorIndex = largestCorpus.records.indexOf(adversarialSuccessor);
+  const adversarialEmbedding = corpusEmbeddings[adversarialIndex];
+  const successorEmbedding = corpusEmbeddings[successorIndex];
+  if (adversarialEmbedding === undefined || successorEmbedding === undefined) {
+    throw new Error('adversarial embeddings are missing');
+  }
+  const [adversarialBm25Score, successorBm25Score] = bm25Scores(
+    TOP_K_QUERY,
+    [document(adversarial), document(adversarialSuccessor)],
+  );
+  const adversarialCosineScore = cosine(queryEmbedding, adversarialEmbedding);
+  const successorCosineScore = cosine(queryEmbedding, successorEmbedding);
+  if (
+    adversarialBm25Score === undefined ||
+    successorBm25Score === undefined ||
+    adversarialBm25Score <= successorBm25Score ||
+    adversarialCosineScore <= successorCosineScore
+  ) {
+    throw new Error('adversarial stale record does not outrank its successor');
+  }
 
   const rows: RetrievalRow[] = [];
   for (const distractors of NOISE_SIZES) {
-    const fixture = createNoiseFixture(distractors, NOISE_SEED);
+    const fixture = createRetrievalFixture(distractors, NOISE_SEED);
     try {
       const expectedCorpus = retrievalCorpus(distractors, NOISE_SEED);
       if (JSON.stringify(fixture.corpus) !== JSON.stringify(expectedCorpus)) {
@@ -382,13 +623,21 @@ export const runComparison = async (): Promise<string> => {
           visibleRecords: selected.length,
           relevantRecords: selected.filter((record) => record.relevant).length,
           relevantTotal: 2,
+          staleRecords: countStaleRecords(selected, fixture.corpus.records),
         });
       }
     } finally {
       destroyNoiseFixture(fixture);
     }
   }
-  return renderReport(rows, model, dimension, ollamaVersion);
+  return renderReport(
+    rows,
+    model,
+    dimension,
+    ollamaVersion,
+    [adversarialBm25Score, successorBm25Score],
+    [adversarialCosineScore, successorCosineScore],
+  );
 };
 
 if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {

--- a/bench/retrieval/result.md
+++ b/bench/retrieval/result.md
@@ -1,12 +1,12 @@
 # Retrieval route comparison
 
-Measured at: 2026-07-29T09:17:25.181Z
+Measured at: 2026-07-29T12:05:31.164Z
 
 This measures exposure and recall at a fixed two-record output budget. It does not measure token cost, billed cost, accuracy, or agent behaviour. Timing was not taken.
 
-Corpus: `generateNoiseCorpus`, seed 1422026, distractor sizes 0, 10, 100, 1000, 10000.
+Corpus: `generateNoiseCorpus` extended with two superseded predecessors and one expired record, seed 1422026, distractor sizes 0, 10, 100, 1000, 10000.
 Query: `src/core/decision-context.ts active lifecycle decision context path scope`
-Harness source SHA-256: `206b3527cb7cfc7bba09bc437f83a13db28dfc68532abbee487e60330115801a`
+Harness source SHA-256: `f8ddea11f0250056606da8338135adf1a1fcb78b7e423e62eab2090b137c0fcd`
 
 ## Embedding provenance
 
@@ -23,14 +23,26 @@ A rerun is reproducible only with the same model artifact, query, corpus seed, a
 The deterministic benchmark’s current `top-k lexical` scorer is a case-insensitive, unweighted count of every query-token occurrence in `path + record message`, with `recordId` as the tie-break. BM25 is a fairer baseline from the same lexical-retrieval family, but it is a different scorer: it adds inverse document frequency, term-frequency saturation, and document-length normalization.
 This BM25 uses lowercase ASCII-alphanumeric tokens, unique query terms, k1=1.2, and b=0.75. Embedding routes rank cosine similarity over `path + record message`; hybrid applies reciprocal-rank fusion with k=60 to the complete BM25 and embedding rankings before the two-record budget; the path filter keeps exact-path candidates before embedding ranking.
 
+## Adversarial lifecycle case
+
+The superseded record `r-adverse` deliberately repeats the query’s subject and vocabulary more closely than its successor `r-expose002`; both records are on `src/core/decision-context.ts`, so path-filtered similarity retrieval can select the reversed decision.
+Construction check: BM25 4.569424 > 1.586191 and pinned-model cosine 0.931950 > 0.815043 for stale record versus successor.
+Zero-stale embedding retrieval was still a possible outcome: yes. The harness does not force either record into an embedding result or alter its score; both compete normally for the fixed budget.
+
 ## Results
 
-Routes matching or beating CommitLore path scope at every reported size: `Embedding top-k`, `Embedding + path filter`. This statement compares only the recall counts in the table.
+Routes matching or beating CommitLore path scope at every reported size: none. This statement compares only the recall counts in the table.
+Routes with strictly higher recall than CommitLore path + lifecycle at any reported size: none.
+Routes with fewer stale records than CommitLore path + lifecycle at any reported size: none.
 
-| distractors | corpus records | BM25 | Embedding top-k | Hybrid RRF | Embedding + path filter | CommitLore path + lifecycle |
-|---:|---:|---:|---:|---:|---:|---:|
-| 0 | 2 | 2/2 | 2/2 | 2/2 | 2/2 | 2/2 |
-| 10 | 12 | 0/2 | 2/2 | 1/2 | 2/2 | 2/2 |
-| 100 | 102 | 0/2 | 2/2 | 0/2 | 2/2 | 2/2 |
-| 1000 | 1002 | 0/2 | 2/2 | 2/2 | 2/2 | 2/2 |
-| 10000 | 10002 | 0/2 | 2/2 | 1/2 | 2/2 | 2/2 |
+| distractors | corpus records | BM25 recall | BM25 stale | Embedding top-k recall | Embedding top-k stale | Hybrid RRF recall | Hybrid RRF stale | Embedding + path filter recall | Embedding + path filter stale | CommitLore path + lifecycle recall | CommitLore path + lifecycle stale |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 0 | 5 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
+| 10 | 15 | 0/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
+| 100 | 105 | 0/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
+| 1000 | 1005 | 0/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
+| 10000 | 10005 | 0/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
+
+## Conclusion
+
+BM25, Embedding top-k, Hybrid RRF, Embedding + path filter returned at least one stale record in this corpus; the separate recall columns show the context each route omitted.

--- a/bench/retrieval/types.ts
+++ b/bench/retrieval/types.ts
@@ -1,4 +1,4 @@
-import type { NoiseRecord } from '../deterministic/noise.ts';
+import type { NoiseCorpus, NoiseFixture, NoiseRecord } from '../deterministic/noise.ts';
 
 export const RETRIEVAL_ROUTES = [
   'bm25',
@@ -9,8 +9,23 @@ export const RETRIEVAL_ROUTES = [
 ] as const;
 
 export type RetrievalRoute = (typeof RETRIEVAL_ROUTES)[number];
+
+export interface RetrievalRecord extends NoiseRecord {
+  readonly supersedes?: readonly string[];
+  readonly expiresAt?: string;
+  readonly adversarial?: true;
+}
+
+export interface RetrievalCorpus extends Omit<NoiseCorpus, 'records'> {
+  readonly records: readonly RetrievalRecord[];
+}
+
+export interface RetrievalFixture extends Omit<NoiseFixture, 'corpus'> {
+  readonly corpus: RetrievalCorpus;
+}
+
 export type RouteSelections = {
-  readonly [Route in RetrievalRoute]: readonly NoiseRecord[];
+  readonly [Route in RetrievalRoute]: readonly RetrievalRecord[];
 };
 
 export interface OllamaModel {
@@ -26,4 +41,5 @@ export interface RetrievalRow {
   readonly visibleRecords: number;
   readonly relevantRecords: number;
   readonly relevantTotal: 2;
+  readonly staleRecords: number;
 }

--- a/test/bench-retrieval.test.ts
+++ b/test/bench-retrieval.test.ts
@@ -3,15 +3,17 @@ import { describe, expect, it } from 'vitest';
 import {
   assertPinnedModel,
   bm25Scores,
+  countStaleRecords,
+  createRetrievalFixture,
   PINNED_MODEL,
   rankEmbedding,
   retrievalCorpus,
   retrieveCommitLore,
   retrieveRoutes,
+  staleRecordIds,
 } from '../bench/retrieval/compare.ts';
 import { RETRIEVAL_ROUTES } from '../bench/retrieval/types.ts';
 import {
-  createNoiseFixture,
   destroyNoiseFixture,
   generateNoiseCorpus,
   TARGET_PATH,
@@ -20,7 +22,7 @@ import {
 
 describe('retrieval route comparison', () => {
   it('returns exactly the shared output budget from every route', () => {
-    const fixture = createNoiseFixture(10, 142);
+    const fixture = createRetrievalFixture(10, 142);
     try {
       const embeddings = fixture.corpus.records.map((_, index) => [index + 1, 1]);
       const routes = retrieveRoutes(
@@ -68,6 +70,51 @@ describe('retrieval route comparison', () => {
   });
 
   it('uses the identical fixed-seed corpus in both harnesses', () => {
-    expect(retrievalCorpus(1, 142)).toEqual(generateNoiseCorpus(1, 142));
+    const generated = generateNoiseCorpus(1, 142);
+    const retrieval = retrievalCorpus(1, 142);
+
+    expect(retrieval.records.filter(({ recordId }) => recordId.startsWith('r-noise')))
+      .toEqual(generated.records.filter(({ recordId }) => recordId.startsWith('r-noise')));
+  });
+
+  it('identifies a superseded record as stale', () => {
+    const corpus = retrievalCorpus(0, 142);
+    const stale = corpus.records.find(({ recordId }) => recordId === 'r-stale01');
+
+    expect(stale).toBeDefined();
+    expect(staleRecordIds(corpus.records)).toContain(stale?.recordId);
+  });
+
+  it('identifies an expired record as stale', () => {
+    const corpus = retrievalCorpus(0, 142);
+    const expired = corpus.records.find(({ expiresAt }) => expiresAt !== undefined);
+
+    expect(expired).toBeDefined();
+    expect(staleRecordIds(corpus.records)).toContain(expired?.recordId);
+  });
+
+  it('contains a deliberately more similar superseded predecessor', () => {
+    const corpus = retrievalCorpus(0, 142);
+    const stale = corpus.records.find(({ adversarial }) => adversarial === true);
+    const successor = corpus.records.find(({ supersedes }) =>
+      stale !== undefined && supersedes?.includes(stale.recordId)
+    );
+
+    expect(stale).toMatchObject({ path: TARGET_PATH, relevant: false });
+    expect(successor).toBeDefined();
+    const scores = bm25Scores(
+      `${TARGET_PATH} active lifecycle decision context path scope`,
+      [stale, successor].map((record) => `${record?.path}\n${record?.message}`),
+    );
+    expect(scores[0]).toBeGreaterThan(scores[1] ?? Number.POSITIVE_INFINITY);
+  });
+
+  it('computes stale count from corpus lifecycle, not a route label', () => {
+    const corpus = retrievalCorpus(0, 142);
+    const stale = corpus.records.filter(({ recordId, expiresAt }) =>
+      recordId === 'r-stale01' || expiresAt !== undefined
+    );
+
+    expect(countStaleRecords(stale, corpus.records)).toBe(2);
   });
 });


### PR DESCRIPTION
Closes #173.

## What changed

- Extended the existing #166 retrieval corpus instead of creating a second harness.
- Added a same-path superseded predecessor, a fixed-date expired record, and a deliberately adversarial superseded predecessor whose query vocabulary and pinned-model embedding are closer than its successor.
- Reported recall and stale-record count separately for the same five routes, fixed two-record budget, sizes, seed, and pinned embedding model.
- Kept lifecycle status route-independent by folding it from the complete corpus before counting each route's selections.

The adversarial construction was verified, not assumed: stale versus successor scored BM25 `4.569424 > 1.586191` and pinned-model cosine `0.931950 > 0.815043`. Zero stale exposure remained reachable because no embedding score or selection was forced.

## Result

| distractors | corpus records | BM25 recall | BM25 stale | Embedding top-k recall | Embedding top-k stale | Hybrid RRF recall | Hybrid RRF stale | Embedding + path filter recall | Embedding + path filter stale | CommitLore path + lifecycle recall | CommitLore path + lifecycle stale |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 5 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
| 10 | 15 | 0/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
| 100 | 105 | 0/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
| 1000 | 1005 | 0/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |
| 10000 | 10005 | 0/2 | 1 | 1/2 | 1 | 1/2 | 1 | 1/2 | 1 | 2/2 | 0 |

Conclusion: BM25, embedding top-k, hybrid RRF, and embedding + path filter returned one stale record at every size, while CommitLore path + lifecycle returned zero; recall is reported separately in the table.

No route had strictly higher recall or fewer stale records than CommitLore path + lifecycle at any reported size. No `bench/deterministic` process was running before the work, and no wall-clock benchmark was run.

## Provenance

- Local baseline: `origin/dev` at `d47b46b451195b907677b6f257a95bb4eac7f8df`
- Corpus seed: `1422026`
- Output budget: `2`
- Provider: Ollama `0.17.4`
- Model: `qwen3-embedding:0.6b`
- Manifest digest: `ac6da0dfba84a81fdbfbaf330198c33cd77c4cdfc53e8bc50eb581914a15621d`
- Embedding dimension: `1024`

## Checks

- `npx vitest run` — 44 files passed; 1,494 tests passed, 1 skipped
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsc -p bench/tsconfig.json --noEmit`
- `git diff --check`

The targeted baseline on local `origin/dev` was 5/5 passing tests. Each new lifecycle test was then observed red by deliberately removing the lifecycle records from production code, followed by green after restoration.

<details>
<summary>Deliberate failing output</summary>

```text
 RUN  v2.1.9 /Users/isaac/projects/wt/p173

 ❯ test/bench-retrieval.test.ts (9 tests | 5 failed) 106ms
   × retrieval route comparison > returns exactly the shared output budget from every route 100ms
     → ENOENT: no such file or directory, open '/var/folders/7v/f0gkv1mn70v5254_p50xrmsh0000gn/T/commitlore-noise-TaGWKK/src/core/decision-context.ts'
   × retrieval route comparison > identifies a superseded record as stale 0ms
     → expected undefined to be defined
   × retrieval route comparison > identifies an expired record as stale 0ms
     → expected undefined to be defined
   × retrieval route comparison > contains a deliberately more similar superseded predecessor 2ms
     → expected undefined to match object { …(2) }
   × retrieval route comparison > computes stale count from corpus lifecycle, not a route label 1ms
     → expected +0 to be 2 // Object.is equality

 Test Files  1 failed (1)
      Tests  5 failed | 4 passed (9)
   Start at  20:37:46
   Duration  409ms (transform 111ms, setup 0ms, collect 127ms, tests 106ms, environment 0ms, prepare 54ms)
```

</details>

<details>
<summary>Restored passing output</summary>

```text
 RUN  v2.1.9 /Users/isaac/projects/wt/p173

 ✓ test/bench-retrieval.test.ts (9 tests) 1069ms
   ✓ retrieval route comparison > returns exactly the shared output budget from every route 1066ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  20:38:11
   Duration  1.41s (transform 99ms, setup 0ms, collect 134ms, tests 1.07s, environment 0ms, prepare 36ms)
```

</details>
