### PR TITLE
Land the Gate 2 amendments

### DIFF
--- a/docs/adr/ADR-0021-capture-pending-transaction.md
+++ b/docs/adr/ADR-0021-capture-pending-transaction.md
@@ -52,7 +52,7 @@ where `<nonce>` is 16 bytes of `crypto.randomBytes` hex-encoded (32 characters).
   "version": 1,
   "nonce": "<hex>",
   "created_at": "<ISO 8601 UTC>",
-  "expires_at": "<ISO 8601 UTC>",
+  "expires_at": null,          // null until stage succeeds; then staged_at + 5 minutes
   "phase": "prepared" | "verified" | "staged" | "applied" | "consumed",
   "consumed": false,
   "verified_at": null,
@@ -105,7 +105,10 @@ still-unconsumed `phase: "applied"` record from an aborted commit attempt,
 1. **HEAD unchanged**: current HEAD equals `base_head`.
 2. **Staged diff unchanged**: SHA-256 of the current `git diff --cached` output
    equals `staged_diff_hash`.
-3. **Unexpired**: `now < expires_at` (default expiry: 5 minutes from creation).
+3. **Unexpired**: `now < expires_at`. `expires_at` is **null while the record is `prepared`
+   or `verified`** and is stamped only when stage succeeds, as `staged_at + 5 minutes`. A
+   record whose `expires_at` is null has not been staged and therefore fails gate 4 before
+   expiry is ever consulted — expiry never expires work that is still being verified.
 4. **Unconsumed**: `consumed === false`.
 5. **Policy unchanged**: SHA-256 of the current policy identity equals
    `policy_identity_hash`.

--- a/docs/tickets/F10-first-run-experience.md
+++ b/docs/tickets/F10-first-run-experience.md
@@ -461,6 +461,21 @@ lifecycle outcome.
 - Do not modify `scripts/check-readme-numbers.mjs`
 - Do not change the content of any section — only its position relative to others
 
+**Section anchors (CEO amendment — binding, not the implementer's to choose).** #167's five
+abstract labels map to these concrete `README.md` headings, and to their translated equivalents:
+
+| #167 label | concrete anchor |
+|---|---|
+| product | `Git remembers what changed. CommitLore remembers why.` |
+| local-first | `No hosted memory service.` |
+| install promise | `Install once.` |
+| install command | the `curl` block |
+| evidence | `Retrieval can find records. Path scope keeps reversed decisions out.` |
+
+**`See it work` moves to sit after the install command and before evidence.** The RED assertion is
+that the current order is wrong: at the canonical head evidence precedes `See it work`, so a test
+asserting the amended sequence fails until the sections move.
+
 **RED test**
 
 - File: `test/readme-order.test.ts`
@@ -556,6 +571,13 @@ instead of maintaining a second hand-authored story.
   command behaviour
 - Do not introduce a browser/runtime dependency solely for recording if a
   repository-native terminal renderer already suffices
+
+**Recording mechanism (CEO amendment — binding).** A **Node-stdlib animated SVG**. No recorder
+dependency and no manifest fallback: the artifact is the SVG and it is checked byte-exactly.
+Environment, viewport and frame timing are fixed so the output is reproducible, and
+`--check` re-renders and compares bytes, failing on one differing byte. There is no
+“approximately equal” mode — a frame manifest was considered and rejected, because a check that
+tolerates drift stops detecting the thing it exists to detect.
 
 **RED test**
 

--- a/docs/tickets/F11-guard-classification.md
+++ b/docs/tickets/F11-guard-classification.md
@@ -6,7 +6,11 @@
 
 ---
 
-## T-1020 MCP guard tool description: disclose measured limits (S) — #208 · depends on ADR-0020, and merges after T-1009
+## T-1020 MCP guard tool description: disclose measured limits (S) — #208 · depends on ADR-0020
+
+> Merge ordering on `src/mcp/server.ts` is a file-contention constraint, not a prerequisite:
+> see the shared-file section in `docs/GATE-A-ACCEPTANCE.md`. This ticket is startable as soon
+> as ADR-0020 is accepted.
 
 **Merge sequencing**: this ticket also edits `src/mcp/server.ts`. It merges
 last, after T-1007, T-1008 and T-1009 — not in parallel with any of them. See
@@ -89,7 +93,10 @@ last, after T-1007, T-1008 and T-1009 — not in parallel with any of them. See
 
 ---
 
-## T-1021 README Known limitations: disclose guard precision and recall (S) — #209 · depends on ADR-0020, ordering with T-1014/T-1015
+## T-1021 README Known limitations: disclose guard precision and recall (S) — #209 · depends on ADR-0020
+
+> Ordering against T-1014 and T-1015 is file contention on the four README files, not a
+> prerequisite. This ticket is startable as soon as ADR-0020 is accepted.
 
 **Owns**
 
@@ -260,7 +267,11 @@ last, after T-1007, T-1008 and T-1009 — not in parallel with any of them. See
 
 ---
 
-## T-1024 Unified `commitlore_before_change` MCP tool (M) — #219 · depends on T-1007, T-1008, T-1009, T-1020
+## T-1024 Unified `commitlore_before_change` MCP tool (M) — #219 · depends on T-1020
+
+> T-1007, T-1008 and T-1009 are `src/mcp/server.ts` merge-order constraints, not
+> prerequisites: this tool composes the existing context projection and guard, not the capture
+> pipeline.
 
 Ticketed to close acceptance row `P0-8`, which stays OPEN work until this ticket's acceptance
 criteria are met. The source review asks for one tool an agent has to remember
@@ -281,13 +292,18 @@ them.
 
 **Owns**: `src/core/before-change.ts` (new — composes the existing context projection and guard match; contains no new scoring logic of its own), `src/mcp/server.ts` (register one additional tool), `test/before-change.test.ts` (new).
 
-**Depends on**: T-1020 (#208) — guard's measured limits must already be stated on the MCP surface before a second tool exposes the same signal, or this ticket ships the overclaim ADR-0020 removes. Also T-1007 (#199), T-1008 (#200), T-1009 (#201) for `src/mcp/server.ts` merge ordering only: this ticket is last in that queue and adds nothing to the capture pipeline.
+**Depends on**: T-1020 (#208) only — guard's measured limits must already be stated on the MCP surface before a second tool exposes the same signal, or this ticket ships the overclaim ADR-0020 removes. T-1007 (#199), T-1008 (#200) and T-1009 (#201) are merge-order constraints on `src/mcp/server.ts`, not prerequisites.
 
 **Forbidden scope**: No new scoring, weighting or threshold logic — ADR-0019 closed re-weighting, and this ticket must not reopen it by the back door. Do not change `src/core/guard.ts`, the context projection's own output, `src/commands/guard.ts`, the release gate, `bench/fixtures/`, `README*`, or any version string. Do not make the tool blocking, and do not give it a write side.
 
 **RED test**: `test/before-change.test.ts` — "the response carries exactly `active_decisions`, `verification_gaps`, `possible_revival_matches`, `guard_confidence`, `cache_key`; `guard_confidence` is `\"experimental\"` when a proposal is supplied and `\"not-run\"` when none is; and the two context fields are byte-identical across both calls at one HEAD". It must fail before the change because `commitlore_before_change` is not registered and `src/core/before-change.ts` does not exist.
 
 **Minimum GREEN**: Export `beforeChange({ path, proposal? })` from `src/core/before-change.ts` returning `{ active_decisions, verification_gaps, possible_revival_matches, guard_confidence, cache_key }`. The five fields are exactly those named above; adding a sixth is out of scope.
+
+`verification_gaps` is a closed, ordered set derived from the checks this codebase already
+performs — not a new concept: **`history-unavailable`, `shallow-history`, `notes-unfetched`**,
+always emitted in that order. An empty array means all three were checked and none applied; it
+never means the checks were skipped.
 
 `guard_confidence` is an enum over that one field: `"not-run"` when no `proposal` was supplied, `"experimental"` when the guard ran, `"timed-out"` when it was cut short. `"not-run"` does not violate the context-only contract — it is the honest value of a field describing a list that is empty because nothing was asked, and it exists so that an empty `possible_revival_matches` is never readable as "checked and clear". The context fields are populated identically whether or not a proposal was supplied.
 

--- a/docs/tickets/F9-unified-capture.md
+++ b/docs/tickets/F9-unified-capture.md
@@ -13,6 +13,11 @@
 
 **Forbidden scope**: Release gate, `bench/fixtures/`, `README*`, any version string, `src/mcp/server.ts`, `src/hooks/prepare-commit-msg.ts`, `src/commands/`.
 
+**Trust boundary (CEO amendment)**: a nonce arriving from any caller is untrusted input. The
+store validates it against `^[0-9a-f]{32}$` — lowercase hex, exactly 32 characters — **before**
+it is used in any path resolution. A nonce failing that pattern is rejected without touching
+the filesystem, so no caller-supplied string can reach a path join.
+
 **RED test**: `test/pending.test.ts` — "createPending creates a phase-prepared JSON file under .git/commitlore/pending/ with all required fields". Must fail before the change because `src/core/pending.ts` does not exist and no `createPending` function is exported.
 
 **Minimum GREEN**: Export `createPending(opts): string` (returns nonce), `readPending(nonce): PendingRecord | null`, `storeVerification(nonce, result): boolean`, `stagePending(nonce): boolean`, `markApplied(nonce, recordHash): boolean`, and `consumePending(nonce, commitSha): boolean` from `src/core/pending.ts`. Every mutation is an atomic rename and enforces the monotonic phase transition from ADR-0021. `createPending` writes `phase:"prepared"` and source/state hashes. `readPending` returns `null` only when the file is absent; corrupt or unknown-version content raises a typed `PendingFormatError`. `storeVerification` is the only API that may write accepted records/evidence. `stagePending` accepts a nonce only. `markApplied` records `applied_at` and `applied_record_hash` for the canonical trailer block, not the editable subject/body. `consumePending` may set `consumed:true` and `consumed_by` only for an applied record.
@@ -184,7 +189,12 @@
 
 **RED test**: `test/capture-stage.test.ts` — "stageCaptureRecord writes a pending file with expiry and records". Must fail before the change because `src/core/capture-stage.ts` does not exist.
 
-**Minimum GREEN**: Export `stageCaptureRecord(opts: { nonce: string, cwd: string, expiryMinutes?: number }): string | null` that:
+**Minimum GREEN (CEO amendment)**: on success, stage stamps **both** `staged_at` and
+`expires_at = staged_at + 5 minutes`. `expires_at` is `null` for every record in `prepared` or
+`verified` phase, so a capture being verified slowly can never expire. `expiryMinutes?` overrides
+the 5-minute window only; it never changes the anchor, which is always stage success.
+
+Export `stageCaptureRecord(opts: { nonce: string, cwd: string, expiryMinutes?: number }): string | null` that:
 1. Re-reads the transaction by nonce and requires `phase:"verified"`.
 2. If stored `validation_result === "empty"` or `incomplete === true`, returns `null` (nothing to stage).
 3. If the stored accepted-record count exceeds `max_records_per_commit`, throws.
@@ -292,7 +302,11 @@ Default expiry: 5 minutes.
 
 **RED test**: `test/capture.test.ts` — "commitlore capture --transcript <f> --diff <f> --draft <f> produces a pending file". Must fail before the change because no `capture` command is registered in the CLI.
 
-**Minimum GREEN**: Register `commitlore capture` with options `--transcript <f>`, `--diff <f>`, `--draft <f>`, `--out <f>` (optional), `--json` (optional). The command:
+**Minimum GREEN (CEO amendment)**: the CLI passes **the nonce and nothing else** to stage. It
+never forwards a caller-supplied `base_head`, diff hash, policy hash or timestamp — every binding
+is recomputed server-side by the store, so the CLI cannot widen the trust boundary.
+
+Register `commitlore capture` with options `--transcript <f>`, `--diff <f>`, `--draft <f>`, `--out <f>` (optional), `--json` (optional). The command:
 1. Calls `prepareCaptureContext({ cwd })` (T-1002).
 2. If `--draft` is provided, calls `parseDraft` then `verifyCaptureRecords` (T-1003) with the transcript and diff.
 3. If `--draft` is not provided, prints the prompt contract to stdout (same as `harvest --prompt-only`) and exits 0.
@@ -446,7 +460,7 @@ constraint".
 **RED test**: `test/mcp-capture.test.ts` — "calling commitlore_stage_capture with a valid prepare result and verify result writes a pending file". Must fail before the change because the tool is not registered.
 
 **Minimum GREEN**: Add to `src/mcp/server.ts`:
-1. A tool declaration `commitlore_stage_capture` with `inputSchema` accepting only `{ nonce: string }` and annotations `{ readOnlyHint: false, destructiveHint: false, openWorldHint: false }`.
+1. A tool declaration `commitlore_stage_capture` with `inputSchema` accepting only `{ nonce: string }`, the nonce validated against `^[0-9a-f]{32}$` before any path resolution, and every binding it writes (`base_head`, `staged_diff_hash`, `policy_identity_hash`, `staged_at`, `expires_at`) computed **server-side** — never accepted from the caller and annotations `{ readOnlyHint: false, destructiveHint: false, openWorldHint: false }`.
 2. A handler that calls `stageCaptureRecord({ nonce, cwd: root })`, trusting only the verified result already stored in that transaction, and returns `{ staged: true, nonce }` or `{ staged: false, reason }`.
 
 The tool writes only to the nonce transaction under `.git/commitlore/pending/`. It never touches Git history.

--- a/docs/tickets/release.md
+++ b/docs/tickets/release.md
@@ -33,6 +33,11 @@
 - Do NOT alter exit codes or the `check()` function signature
 - A root-cause fix for the intermittency is NOT guaranteed by this ticket
 
+**Scope (CEO amendment — binding).** This ticket is **diagnostic honesty only**. It does not
+explain, reproduce or fix the intermittent failure, and it **may not close #192 on its own**:
+#192 has been split, and the node-22 intermittency is tracked separately. Closing this ticket
+means the probe stops asserting a cause it cannot determine — nothing more.
+
 **RED test**
 
 - File: `test/doctor.test.ts` (new or addition to existing)


### PR DESCRIPTION
Lands the Gate 2 amendments the owner made binding at `dev` `a333e76f59493ec90e100d1d44c833d7d9e5f093`. Planning documents only — no product code, nothing merged, nothing tagged.

## Amendments

**Expiry anchor.** `expires_at` is `null` while a record is `prepared` or `verified`; stage success stamps `staged_at` and `expires_at = staged_at + 5 minutes`. Two audits had disagreed. The old "5 minutes from creation" would have expired a capture that was still being verified, and the staleness it guarded against is already caught by the staged-diff-hash gate. ADR-0021 §3 gate 3 and T-1004's Minimum GREEN both say so now.

**Two conflated headings.** T-1020 and T-1021 depend only on ADR-0020; T-1024 only on T-1020. The `src/mcp/server.ts` and README orderings are file contention and are labelled as such. Read literally, the old wording pushed T-1020 from wave 1 to wave 6, T-1021 to wave 3 and T-1024 to wave 7 — this is the throughput fix.

**Write-path trust boundary.** A caller-supplied nonce is validated against `^[0-9a-f]{32}$` before it reaches any path resolution (T-1001). `commitlore capture` forwards the nonce and nothing else (T-1006). Every binding a staged record carries — `base_head`, `staged_diff_hash`, `policy_identity_hash`, `staged_at`, `expires_at` — is recomputed server-side, never accepted from the caller (T-1009).

**T-1015 section anchors.** #167's five abstract labels are pinned to concrete headings, and `See it work` moves to sit after the install command and before evidence. The RED assertion is that the current order is wrong.

**T-1016 recording mechanism.** A Node-stdlib animated SVG, fixed environment, viewport and frame timing, `--check` comparing bytes exactly. No recorder dependency and no manifest fallback.

**T-1024 `verification_gaps`.** A closed, ordered set: `history-unavailable`, `shallow-history`, `notes-unfetched`. An empty array means all three were checked and none applied — never that the checks were skipped.

**T-1030 scope.** Diagnostic honesty only. It may not close #192 alone; the node-22 intermittency is now #221.

## Verified

- `git status` — five planning documents changed, nothing under `src/`, `test/`, `bench/`, `README*`, `package.json`, `CHANGELOG.md` or `.github/workflows/`.
- Commit-msg hook validated the record: `shape ok · references ok`.
- No source file touched, so no `dist/` rebuild was required and none occurred.

Requesting the merge gate: I cannot merge this myself, and the wave-1 tickets need these amendments on `dev`.
