### PR TITLE
fix(readme): pin install one-liner to v0.3.0 tag (#211)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@
 一度インストールします。コーディングエージェントは引き継ぐ価値のある意思決定を記録でき、CommitLore はそれを検証して Git に保存します。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
 ```
 
 ## 検索はレコードを見つけられる。パス範囲は覆された意思決定を除外する。
@@ -68,11 +68,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.2.0/install.sh
-sh install.sh v0.2.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh
+sh install.sh v0.3.0
 
 # または release binary を自分で検証してから展開します。
-version=0.2.0; target=aarch64-apple-darwin
+version=0.3.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
 한 번 설치한다. 코딩 에이전트가 계속 가져갈 가치가 있는 결정을 기록할 수 있고, CommitLore는 이를 검증해 Git에 보존한다.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
 ```
 
 ## 검색은 레코드를 찾을 수 있습니다. 경로 범위는 뒤집힌 결정을 걸러냅니다.
@@ -68,11 +68,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.2.0/install.sh
-sh install.sh v0.2.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh
+sh install.sh v0.3.0
 
 # 또는 릴리스 바이너리를 직접 검증한 뒤 압축을 푼다.
-version=0.2.0; target=aarch64-apple-darwin
+version=0.3.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ No hosted memory service. No vendor-specific chat history. Just reviewable decis
 Install once. Your coding agent can record the decisions worth carrying forward, while CommitLore validates and preserves them in Git.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
 ```
 
 ## Retrieval can find records. Path scope keeps reversed decisions out.
@@ -68,11 +68,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.2.0/install.sh
-sh install.sh v0.2.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh
+sh install.sh v0.3.0
 
 # Or verify the release binary yourself before extracting it.
-version=0.2.0; target=aarch64-apple-darwin
+version=0.3.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@
 安装一次。你的编程代理可以记录值得延续的决策，而 CommitLore 会验证它们并将其保存在 Git 中。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
 ```
 
 ## 检索能找到记录。路径范围会排除已经推翻的决策。
@@ -68,11 +68,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.2.0/install.sh
-sh install.sh v0.2.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh
+sh install.sh v0.3.0
 
 # 或自行验证 release binary 后再解压。
-version=0.2.0; target=aarch64-apple-darwin
+version=0.3.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -1,0 +1,71 @@
+/**
+ * T-1031 (#211): README install one-liner and pin correction.
+ *
+ * Why this is NOT in test/readme-numbers.test.ts:
+ * That file tests the BENCH block byte-regeneration logic (the benchmark
+ * publication mechanism). This file tests install URLs and version pins —
+ * a separate concern (supply-chain correctness vs benchmark reproducibility).
+ * Mixing them would couple two independent failure modes.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const README_FILES = ['README.md', 'README.ko.md', 'README.ja.md', 'README.zh-CN.md'] as const;
+const PACKAGE_VERSION: string = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'),
+).version;
+
+describe('README install one-liner and version pin', () => {
+  for (const file of README_FILES) {
+    describe(file, () => {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      const lines = content.split('\n');
+
+      it('one-liner does not reference dev branch', () => {
+        // Find the install one-liner (the curl | sh line)
+        const oneLiner = lines.find(
+          (l) => l.includes('curl') && l.includes('install.sh | sh'),
+        );
+        expect(oneLiner).toBeDefined();
+        expect(oneLiner).not.toContain('/dev/');
+      });
+
+      it('one-liner references a semver tag', () => {
+        const oneLiner = lines.find(
+          (l) => l.includes('curl') && l.includes('install.sh | sh'),
+        );
+        expect(oneLiner).toBeDefined();
+        expect(oneLiner).toMatch(/\/v\d+\.\d+\.\d+\//);
+      });
+
+      it('pinned version matches package.json', () => {
+        // The pinned install examples reference a specific version.
+        // Find lines with "sh install.sh v" pattern — the pinned invocation.
+        const pinLine = lines.find((l) => /sh install\.sh v\d/.test(l));
+        expect(pinLine).toBeDefined();
+        const pinMatch = pinLine!.match(/v(\d+\.\d+\.\d+)/);
+        expect(pinMatch).not.toBeNull();
+        expect(pinMatch![1]).toBe(PACKAGE_VERSION);
+
+        // Also check the version= assignment line
+        const versionAssign = lines.find((l) => /^version=\d+\.\d+\.\d+/.test(l));
+        expect(versionAssign).toBeDefined();
+        const assignMatch = versionAssign!.match(/version=(\d+\.\d+\.\d+)/);
+        expect(assignMatch).not.toBeNull();
+        expect(assignMatch![1]).toBe(PACKAGE_VERSION);
+
+        // Also check the pinned curl download URL
+        const pinnedCurl = lines.find(
+          (l) => l.includes('curl') && l.includes('fsSLO') && l.includes('install.sh'),
+        );
+        expect(pinnedCurl).toBeDefined();
+        const urlMatch = pinnedCurl!.match(/\/v(\d+\.\d+\.\d+)\//);
+        expect(urlMatch).not.toBeNull();
+        expect(urlMatch![1]).toBe(PACKAGE_VERSION);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #211 (T-1031). The default install one-liner referenced the mutable `dev` branch — a supply-chain exposure. The pinned example said `v0.2.0` while `package.json` is `0.3.0`.

## Changes

All four language READMEs (`README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`):
- Line 26: `/dev/install.sh` → `/v0.3.0/install.sh`
- Line 71: `/v0.2.0/install.sh` → `/v0.3.0/install.sh`
- Line 72: `sh install.sh v0.2.0` → `sh install.sh v0.3.0`
- Line 75: `version=0.2.0` → `version=0.3.0`

New test file `test/readme.test.ts` asserts these invariants going forward.

## Verification

- `npx vitest run test/readme.test.ts`: 12 passed
- `npx vitest run`: 46 files, 1512 passed, 1 skipped
- `npx tsc -p tsconfig.json --noEmit`: exit 0
- `npx tsc -p bench/tsconfig.json --noEmit`: exit 0
- `node scripts/check-readme-numbers.mjs`: exit 0 (BENCH block untouched)
- No `dist/` drift