### PR TITLE
Say what guard measures where a reader will look for it (#209)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -284,6 +284,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - Alpine および他の musl Linux host は未対応です: [#99](https://github.com/MongLong0214/commitlore/issues/99)。
 - cryptographic author verification、repository-wide record coverage、symbol anchor、interactive record builder は未実装です: [#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
 - M4 は guard の効果を検証していません。row に `guard_exposure` がないため treatment exposure を検証できません: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
+- Guard（ruled-out alternative matching）は実験的参考情報です: precision 44.8%（95% Wilson CI 32.7%–57.5%）、recall 22.0%、417-decision corpus 基準（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空の guard 結果は、提案がすべての ruled-out alternative を回避したという保証ではありません — recall 22% では、見逃しが一般的です。
 
 ## コントリビュート
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -284,6 +284,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - Alpine 및 다른 musl Linux host는 지원하지 않는다: [#99](https://github.com/MongLong0214/commitlore/issues/99).
 - 암호학적 작성자 검증, 저장소 전체 record coverage, symbol anchor, interactive record builder는 아직 구현되지 않았다: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
 - M4는 guard 효과를 시험하지 못했다. row에 `guard_exposure`가 없어 treatment exposure를 검증할 수 없다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
+- Guard(ruled-out alternative matching)는 실험적 참고 자료이다: precision 44.8%(95% Wilson CI 32.7%–57.5%), recall 22.0%, 417-decision corpus 기준([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). 빈 guard 결과는 제안이 모든 ruled-out alternative를 피했다는 보장이 아니다 — recall 22%에서 누락이 일반적이다.
 
 ## 기여하기
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - Alpine and other musl Linux hosts are unsupported: [#99](https://github.com/MongLong0214/commitlore/issues/99).
 - Cryptographic author verification, repository-wide record coverage, symbol anchors, and an interactive record builder are not implemented yet: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
 - M4 did not test a guard effect: its rows have no `guard_exposure`, so treatment exposure is unverifiable ([#122](https://github.com/MongLong0214/commitlore/issues/122)).
+- Guard (ruled-out alternative matching) is an experimental advisory: precision 44.8% (95% Wilson CI 32.7%–57.5%), recall 22.0% on the 417-decision corpus ([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). An empty guard result does not guarantee a proposal avoids all ruled-out alternatives — at 22% recall, a miss is the common case.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -284,6 +284,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - 不支持 Alpine 与其他 musl Linux host：[#99](https://github.com/MongLong0214/commitlore/issues/99)。
 - 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
 - M4 没有检验 guard 效果：row 没有 `guard_exposure`，因而无法验证 treatment exposure（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
+- Guard（ruled-out alternative matching）是实验性参考信息：precision 44.8%（95% Wilson CI 32.7%–57.5%），recall 22.0%，基于 417-decision corpus（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空的 guard 结果不保证提案避开了所有 ruled-out alternative——在 recall 22% 下，遗漏才是常态。
 
 ## 贡献
 

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -69,3 +69,72 @@ describe('README install one-liner and version pin', () => {
     });
   }
 });
+
+describe('T-1021: Known limitations discloses guard precision and recall', () => {
+  for (const file of README_FILES) {
+    describe(file, () => {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+
+      // Extract the Known limitations section (between its heading and the next ## heading)
+      const knownLimStart = content.search(/^## (Known limitations|알려진 제한 사항|既知の制限事項|已知限制)/m);
+      const afterStart = content.slice(knownLimStart + 1);
+      const nextSection = afterStart.search(/^## /m);
+      const knownLimSection = nextSection === -1
+        ? afterStart
+        : afterStart.slice(0, nextSection);
+
+      it('mentions guard precision 44.8%', () => {
+        expect(knownLimSection).toMatch(/precision 44\.8%/i);
+      });
+
+      it('mentions guard recall 22.0%', () => {
+        expect(knownLimSection).toMatch(/recall 22\.0%/i);
+      });
+
+      it('includes the Wilson confidence interval (32.7%–57.5%)', () => {
+        // The interval must accompany the precision figure
+        expect(knownLimSection).toMatch(/32\.7%/);
+        expect(knownLimSection).toMatch(/57\.5%/);
+      });
+    });
+  }
+});
+
+/**
+ * Mutation oracles: prove the T-1021 assertions have teeth.
+ *
+ * Oracle-FAIL tests: mutated content MUST fail the regex assertions.
+ * Oracle-PASS test: irrelevant mutation (changing a different bullet) MUST NOT
+ * cause a T-1021 failure.
+ */
+describe('T-1021 mutation oracles', () => {
+  const enContent = fs.readFileSync(path.join(REPO_ROOT, 'README.md'), 'utf8');
+
+  // Extract the Known limitations section for English
+  const knownLimStart = enContent.search(/^## Known limitations/m);
+  const afterStart = enContent.slice(knownLimStart + 1);
+  const nextSection = afterStart.search(/^## /m);
+  const knownLimSection = nextSection === -1 ? afterStart : afterStart.slice(0, nextSection);
+
+  it('oracle-FAIL: dropping the interval makes the interval assertion fail', () => {
+    // Simulate removing the Wilson CI from the section
+    const mutated = knownLimSection.replace(/\(95% Wilson CI 32\.7%–57\.5%\)/, '');
+    expect(mutated).not.toMatch(/32\.7%/);
+    expect(mutated).not.toMatch(/57\.5%/);
+  });
+
+  it('oracle-FAIL: dropping the recall makes the recall assertion fail', () => {
+    // Simulate removing recall from the section
+    const mutated = knownLimSection.replace(/recall 22\.0%/i, '');
+    expect(mutated).not.toMatch(/recall 22\.0%/i);
+  });
+
+  it('oracle-PASS: changing the Windows bullet does not affect guard assertions', () => {
+    // A mutation to an unrelated bullet must NOT break the guard assertions
+    const mutated = knownLimSection.replace('Windows is unsupported', 'Windows is not supported');
+    expect(mutated).toMatch(/precision 44\.8%/i);
+    expect(mutated).toMatch(/recall 22\.0%/i);
+    expect(mutated).toMatch(/32\.7%/);
+    expect(mutated).toMatch(/57\.5%/);
+  });
+});


### PR DESCRIPTION
Closes #209 — T-1021. Governing: ADR-0020, extending ADR-0019.

Known limitations now states guard's measured precision 44.8% (95% Wilson 32.7%–57.5%) and recall 22.0% against the 417-decision corpus, in all four languages, with the consequence a reader needs: at that recall an empty guard result is not a clean bill of health.

The `BENCH` block is untouched — `node scripts/check-readme-numbers.mjs` exits 0. No `src/` change, so no `dist/` rebuild.

Evidence: `npx vitest run test/readme.test.ts` 27/27 passed; both typechecks exit 0.