### PR TITLE
docs(readme): move See it work before evidence (#207)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -26,6 +26,37 @@
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
 ```
 
+
+## 実際に動かす
+
+**新しいエージェント、チャット履歴はゼロ。それでも明白な修正案がなぜ除外されたかを知っています。** 変更する前に path を照会します。
+
+```bash
+commitlore context install.sh
+```
+
+出力には、installer の欠陥の修正として `-musl` target を公開する案を除外した active record とその理由が含まれます。hook はコンテキストを返すものであり、編集を止めるとは主張しません。
+
+```console
+context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
+
+ruled-out
+  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
+
+warnings
+  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
+```
+
+<details>
+<summary>正確な PreToolUse hook path を再現する</summary>
+
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+</details>
+
 ## 検索はレコードを見つけられる。パス範囲は覆された意思決定を除外する。
 
 レコードを一つ取り逃がせば、モデルはコンテキストを失います。すでに覆された意思決定を渡せば、正しさを損ないます。この[検索測定](bench/retrieval/result.md)では、ノイズが 0 件から 10,000 件までのすべてのサイズで、BM25、embedding top-k、hybrid RRF、パスフィルター付き embedding がそれぞれ廃止済みのレコードを一つ返しました。lifecycle を伴う CommitLore のパス範囲は古いレコードをゼロにし、現在の二つのレコード (2/2) を返しました。
@@ -76,36 +107,6 @@ version=0.3.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
-```
-
-</details>
-
-## 実際に動かす
-
-**新しいエージェント、チャット履歴はゼロ。それでも明白な修正案がなぜ除外されたかを知っています。** 変更する前に path を照会します。
-
-```bash
-commitlore context install.sh
-```
-
-出力には、installer の欠陥の修正として `-musl` target を公開する案を除外した active record とその理由が含まれます。hook はコンテキストを返すものであり、編集を止めるとは主張しません。
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-<details>
-<summary>正確な PreToolUse hook path を再現する</summary>
-
-```bash
-printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
-  | node dist/commitlore.mjs inject --hook-input --budget 5000
 ```
 
 </details>

--- a/README.ko.md
+++ b/README.ko.md
@@ -26,6 +26,37 @@
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
 ```
 
+
+## 실제로 보기
+
+**새 에이전트, 채팅 이력은 0개. 그래도 뻔한 수정안이 왜 제외됐는지 안다.** 바꾸기 전에 path를 조회한다.
+
+```bash
+commitlore context install.sh
+```
+
+출력에는 installer 결함의 수정안으로 `-musl` target을 배포하는 방안을 제외한 활성 record와 그 이유가 들어 있다. hook은 맥락을 제공하며, 편집을 막는다고 주장하지 않는다.
+
+```console
+context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
+
+ruled-out
+  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
+
+warnings
+  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
+```
+
+<details>
+<summary>정확한 PreToolUse hook path 재현하기</summary>
+
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+</details>
+
 ## 검색은 레코드를 찾을 수 있습니다. 경로 범위는 뒤집힌 결정을 걸러냅니다.
 
 레코드 하나를 놓치면 모델은 맥락을 잃습니다. 이미 뒤집힌 결정을 건네면 정확성을 잃습니다. 이 [검색 측정](bench/retrieval/result.md)에서 방해 레코드가 0개부터 10,000개까지인 모든 크기에서 BM25, 임베딩 top-k, 하이브리드 RRF, 경로 필터를 적용한 임베딩은 각각 대체되어 폐기된 레코드 하나를 반환했습니다. 수명 주기를 적용한 CommitLore 경로 범위는 오래된 레코드를 0개 반환하고 현재 레코드 둘(2/2)을 모두 반환했습니다.
@@ -76,36 +107,6 @@ version=0.3.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
-```
-
-</details>
-
-## 실제로 보기
-
-**새 에이전트, 채팅 이력은 0개. 그래도 뻔한 수정안이 왜 제외됐는지 안다.** 바꾸기 전에 path를 조회한다.
-
-```bash
-commitlore context install.sh
-```
-
-출력에는 installer 결함의 수정안으로 `-musl` target을 배포하는 방안을 제외한 활성 record와 그 이유가 들어 있다. hook은 맥락을 제공하며, 편집을 막는다고 주장하지 않는다.
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-<details>
-<summary>정확한 PreToolUse hook path 재현하기</summary>
-
-```bash
-printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
-  | node dist/commitlore.mjs inject --hook-input --budget 5000
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,37 @@ Install once. Your coding agent can record the decisions worth carrying forward,
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
 ```
 
+
+## See it work
+
+**A fresh agent. Zero chat history. It still knows why the obvious fix was rejected.** Query a path before changing it:
+
+```bash
+commitlore context install.sh
+```
+
+The output includes the active record that ruled out publishing a `-musl` target as the fix for the installer defect, including its reason. The hook returns context; it does not claim to block the edit.
+
+```console
+context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
+
+ruled-out
+  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
+
+warnings
+  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
+```
+
+<details>
+<summary>Reproduce the exact PreToolUse hook path</summary>
+
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+</details>
+
 ## Retrieval can find records. Path scope keeps reversed decisions out.
 
 Missing a record costs the model context. Handing it a decision that was already reversed costs it correctness. In this [retrieval measurement](bench/retrieval/result.md), at every size from 0 to 10,000 distractors, BM25, embedding top-k, hybrid RRF, and embedding with a path filter each returned one superseded record. CommitLore path scope with lifecycle returned zero stale records and both current records (2/2).
@@ -76,36 +107,6 @@ version=0.3.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
-```
-
-</details>
-
-## See it work
-
-**A fresh agent. Zero chat history. It still knows why the obvious fix was rejected.** Query a path before changing it:
-
-```bash
-commitlore context install.sh
-```
-
-The output includes the active record that ruled out publishing a `-musl` target as the fix for the installer defect, including its reason. The hook returns context; it does not claim to block the edit.
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-<details>
-<summary>Reproduce the exact PreToolUse hook path</summary>
-
-```bash
-printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
-  | node dist/commitlore.mjs inject --hook-input --budget 5000
 ```
 
 </details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,37 @@
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
 ```
 
+
+## 看它实际运行
+
+**一个全新的代理，没有聊天历史。它仍知道为什么那个显而易见的修复被排除了。** 在改动前查询 path：
+
+```bash
+commitlore context install.sh
+```
+
+输出会包含一条 active record：它排除了把发布 `-musl` target 当作 installer 缺陷修复的做法，并说明原因。hook 提供上下文；它并不声称会阻止编辑。
+
+```console
+context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
+
+ruled-out
+  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
+
+warnings
+  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
+```
+
+<details>
+<summary>复现完全相同的 PreToolUse hook path</summary>
+
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+</details>
+
 ## 检索能找到记录。路径范围会排除已经推翻的决策。
 
 漏掉一条记录，模型损失的是上下文；交给它一项已经推翻的决策，损失的是正确性。在这项[检索测量](bench/retrieval/result.md)中，从 0 到 10,000 条干扰记录的每个规模，BM25、embedding top-k、hybrid RRF 与带路径过滤的 embedding 都各返回了一条已被替代的记录。带生命周期的 CommitLore 路径范围返回零条过时记录，并返回两条当前记录 (2/2)。
@@ -76,36 +107,6 @@ version=0.3.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
-```
-
-</details>
-
-## 看它实际运行
-
-**一个全新的代理，没有聊天历史。它仍知道为什么那个显而易见的修复被排除了。** 在改动前查询 path：
-
-```bash
-commitlore context install.sh
-```
-
-输出会包含一条 active record：它排除了把发布 `-musl` target 当作 installer 缺陷修复的做法，并说明原因。hook 提供上下文；它并不声称会阻止编辑。
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-<details>
-<summary>复现完全相同的 PreToolUse hook path</summary>
-
-```bash
-printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
-  | node dist/commitlore.mjs inject --hook-input --budget 5000
 ```
 
 </details>

--- a/test/readme-order.test.ts
+++ b/test/readme-order.test.ts
@@ -1,0 +1,149 @@
+/**
+ * T-1015 (#207): README section order — `See it work` sits after the install
+ * command and before the evidence section, across all four language files.
+ *
+ * Binding anchors from the CEO amendment:
+ *   product  → hero heading (decision-authority framing)
+ *   local-first → "No hosted memory service."
+ *   install promise → "Install once."
+ *   install command → the `curl` block
+ *   evidence → "Retrieval can find records. Path scope keeps reversed decisions out."
+ *
+ * The required order is:
+ *   product < local-first < install-promise < install-command < see-it-work < evidence
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+
+interface ReadmeAnchors {
+  file: string;
+  product: number;
+  localFirst: number;
+  installPromise: number;
+  installCommand: number;
+  seeItWork: number;
+  evidence: number;
+}
+
+function findAnchors(file: string): ReadmeAnchors {
+  const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+  const lines = content.split('\n');
+
+  // Product: the hero heading — the h2 with decision-authority framing
+  // Each language has its own version but it's always the first ## heading
+  const product = lines.findIndex(
+    (l) =>
+      l.startsWith('## ') &&
+      (l.includes('must not revive') ||
+        l.includes('되살려서는 안 된다') ||
+        l.includes('復活させてはならない') ||
+        l.includes('不得复活')),
+  );
+
+  // Local-first: "No hosted memory service." or equivalent
+  const localFirst = lines.findIndex(
+    (l) =>
+      l.includes('No hosted memory service') ||
+      l.includes('호스팅 메모리 서비스도') ||
+      l.includes('ホスト型メモリサービスも') ||
+      l.includes('没有托管记忆服务'),
+  );
+
+  // Install promise: "Install once." or equivalent
+  const installPromise = lines.findIndex(
+    (l) =>
+      l.includes('Install once.') ||
+      l.includes('한 번 설치한다') ||
+      l.includes('一度インストールします') ||
+      l.includes('安装一次'),
+  );
+
+  // Install command: the curl block
+  const installCommand = lines.findIndex((l) =>
+    l.includes('curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/'),
+  );
+
+  // See it work: the section heading
+  const seeItWork = lines.findIndex(
+    (l) =>
+      l === '## See it work' ||
+      l === '## 실제로 보기' ||
+      l === '## 実際に動かす' ||
+      l === '## 看它实际运行',
+  );
+
+  // Evidence: "Retrieval can find records..." heading or equivalent
+  const evidence = lines.findIndex(
+    (l) =>
+      l.includes('Retrieval can find records') ||
+      l.includes('검색은 레코드를 찾을 수 있습니다') ||
+      l.includes('検索はレコードを見つけられる') ||
+      l.includes('检索能找到记录'),
+  );
+
+  return { file, product, localFirst, installPromise, installCommand, seeItWork, evidence };
+}
+
+const FILES = ['README.md', 'README.ko.md', 'README.ja.md', 'README.zh-CN.md'] as const;
+
+describe('T-1015: README section order', () => {
+  const allAnchors = FILES.map((f) => findAnchors(f));
+
+  for (const anchors of allAnchors) {
+    describe(anchors.file, () => {
+      it('all anchors are found', () => {
+        expect(anchors.product).toBeGreaterThanOrEqual(0);
+        expect(anchors.localFirst).toBeGreaterThanOrEqual(0);
+        expect(anchors.installPromise).toBeGreaterThanOrEqual(0);
+        expect(anchors.installCommand).toBeGreaterThanOrEqual(0);
+        expect(anchors.seeItWork).toBeGreaterThanOrEqual(0);
+        expect(anchors.evidence).toBeGreaterThanOrEqual(0);
+      });
+
+      it('#167 order preserved: product < local-first < install-promise < install-command', () => {
+        expect(anchors.product).toBeLessThan(anchors.localFirst);
+        expect(anchors.localFirst).toBeLessThan(anchors.installPromise);
+        expect(anchors.installPromise).toBeLessThan(anchors.installCommand);
+      });
+
+      it('See it work sits after install command and before evidence', () => {
+        expect(anchors.installCommand).toBeLessThan(anchors.seeItWork);
+        expect(anchors.seeItWork).toBeLessThan(anchors.evidence);
+      });
+    });
+  }
+
+  it('all four files have consistent relative order', () => {
+    // Every file must have the same relative sequence
+    for (const anchors of allAnchors) {
+      expect(anchors.product).toBeLessThan(anchors.localFirst);
+      expect(anchors.localFirst).toBeLessThan(anchors.installPromise);
+      expect(anchors.installPromise).toBeLessThan(anchors.installCommand);
+      expect(anchors.installCommand).toBeLessThan(anchors.seeItWork);
+      expect(anchors.seeItWork).toBeLessThan(anchors.evidence);
+    }
+  });
+
+  it('BENCH block is present and intact in README.md', () => {
+    const content = fs.readFileSync(path.join(REPO_ROOT, 'README.md'), 'utf8');
+    expect(content).toContain('<!-- BENCH:BEGIN -->');
+    expect(content).toContain('<!-- BENCH:END -->');
+  });
+
+  it('exposure table is present in all files', () => {
+    for (const file of FILES) {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      // The exposure table has a "model-visible records" column (or translated equivalent)
+      expect(
+        content.includes('model-visible records') ||
+          content.includes('모델에 보인 레코드') ||
+          content.includes('モデルに見えるレコード') ||
+          content.includes('模型可见记录'),
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #207

## Summary

Moves the **See it work** section to sit after the install command and before the retrieval measurement (evidence) section, in all four language README files (EN, KO, JA, ZH-CN).

This matches the product-first order from the source review and satisfies the binding CEO section anchors:

```
product < local-first < install-promise < install-command < see-it-work < evidence
```

## What was tested

- **Focused**: `npx vitest run test/readme-order.test.ts` — 15 tests passed
- **Full suite**: 56 files, 1572 passed, 1 skipped, exit 0
- **Typechecks**: `npx tsc -p tsconfig.json --noEmit` exit 0; `npx tsc -p bench/tsconfig.json --noEmit` exit 0
- **BENCH block**: `node scripts/check-readme-numbers.mjs` exit 0 (39 lines, 2262 bytes — byte-identical)
- **Mutation oracles**: evidence-above-see-it-work → FAIL ✓; remove-see-it-work → FAIL ✓; correct state → PASS ✓
- **No `src/` or `dist/` changes** — confirmed via `git status`

## What is NOT changed

- Hero content (T-1014 owns that, already merged)
- Known limitations content (T-1021 owns that, already merged)
- Install one-liner and pin (T-1031 owns that, already merged)
- BENCH block (byte-checked by CI)
- Exposure table (preserved in all files)
- Section content (only position changed)