### PR TITLE
Record the demo as bytes a check can compare (#212)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,6 +29,10 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/inst
 
 ## 実際に動かす
 
+<p align="center">
+  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
+</p>
+
 **新しいエージェント、チャット履歴はゼロ。それでも明白な修正案がなぜ除外されたかを知っています。** 変更する前に path を照会します。
 
 ```bash

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,6 +29,10 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/inst
 
 ## 실제로 보기
 
+<p align="center">
+  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
+</p>
+
 **새 에이전트, 채팅 이력은 0개. 그래도 뻔한 수정안이 왜 제외됐는지 안다.** 바꾸기 전에 path를 조회한다.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/inst
 
 ## See it work
 
+<p align="center">
+  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
+</p>
+
 **A fresh agent. Zero chat history. It still knows why the obvious fix was rejected.** Query a path before changing it:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,10 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/inst
 
 ## 看它实际运行
 
+<p align="center">
+  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
+</p>
+
 **一个全新的代理，没有聊天历史。它仍知道为什么那个显而易见的修复被排除了。** 在改动前查询 path：
 
 ```bash

--- a/assets/readme/commitlore-demo.svg
+++ b/assets/readme/commitlore-demo.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 704 488" width="704" height="488" role="img" aria-label="commitlore demo: lifecycle filtering shows only active decisions">
+  <!-- T-1016: deterministic animated SVG — do not edit by hand; regenerate with: node scripts/record-demo.mjs -->
+  <rect width="100%" height="100%" rx="8" fill="#1d1f21"/>
+  <!-- Title bar -->
+  <rect width="100%" height="32" rx="8" fill="#282a2e"/>
+  <circle cx="20" cy="16" r="6" fill="#cc6666"/>
+  <circle cx="38" cy="16" r="6" fill="#f0c674"/>
+  <circle cx="56" cy="16" r="6" fill="#b5bd68"/>
+  <text x="352" y="20" text-anchor="middle" fill="#969896" font-family="monospace" font-size="12">commitlore demo</text>
+  <style>
+    text { font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace; font-size: 13px; }
+  </style>
+  <g id="frame-0" visibility="visible">
+    <text x="16" y="62" fill="#81a2be" id="frame-0-line0">$ commitlore demo</text>
+    <set attributeName="visibility" to="visible" begin="0.00s" dur="1.83s" fill="remove"/>
+    <set attributeName="visibility" to="hidden" begin="1.83s" fill="remove"/>
+  </g>
+  <g id="frame-1" visibility="hidden">
+    <text x="16" y="62" fill="#81a2be" id="frame-1-line0">$ commitlore demo</text>
+    <text x="16" y="98" fill="#b5bd68" id="frame-1-line2">─── commitlore demo ───</text>
+    <text x="16" y="134" fill="#c5c8c6" id="frame-1-line4">Scenario: two decisions recorded for src/services/cache.ts</text>
+    <text x="16" y="152" fill="#b294bb" id="frame-1-line5">  1. &quot;Use Redis for session cache&quot; (later superseded)</text>
+    <text x="16" y="170" fill="#c5c8c6" id="frame-1-line6">  2. &quot;Switch to SQLite&quot; (supersedes the first — now active)</text>
+    <text x="16" y="206" fill="#c5c8c6" id="frame-1-line8">An agent proposes reverting to Redis. CommitLore answers:</text>
+    <set attributeName="visibility" to="visible" begin="1.83s" dur="1.83s" fill="remove"/>
+    <set attributeName="visibility" to="hidden" begin="3.66s" fill="remove"/>
+  </g>
+  <g id="frame-2" visibility="hidden">
+    <text x="16" y="62" fill="#81a2be" id="frame-2-line0">$ commitlore demo</text>
+    <text x="16" y="98" fill="#b5bd68" id="frame-2-line2">─── commitlore demo ───</text>
+    <text x="16" y="134" fill="#c5c8c6" id="frame-2-line4">Scenario: two decisions recorded for src/services/cache.ts</text>
+    <text x="16" y="152" fill="#b294bb" id="frame-2-line5">  1. &quot;Use Redis for session cache&quot; (later superseded)</text>
+    <text x="16" y="170" fill="#c5c8c6" id="frame-2-line6">  2. &quot;Switch to SQLite&quot; (supersedes the first — now active)</text>
+    <text x="16" y="206" fill="#c5c8c6" id="frame-2-line8">An agent proposes reverting to Redis. CommitLore answers:</text>
+    <text x="16" y="242" fill="#b5bd68" id="frame-2-line10">  Record-Id: r-demo02 [active]</text>
+    <text x="16" y="260" fill="#cc6666" id="frame-2-line11">    Limit: single-writer constraint requires careful connection pooling</text>
+    <text x="16" y="278" fill="#cc6666" id="frame-2-line12">    Ruled-out: Redis cluster | cost and complexity disproportionate to traffic</text>
+    <text x="16" y="314" fill="#c5c8c6" id="frame-2-line14">Only the active decision (r-demo02) is shown.</text>
+    <text x="16" y="332" fill="#b294bb" id="frame-2-line15">The superseded Redis decision is filtered out — the agent cannot revive it.</text>
+    <set attributeName="visibility" to="visible" begin="3.67s" fill="freeze"/>
+  </g>
+</svg>

--- a/scripts/record-demo.mjs
+++ b/scripts/record-demo.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * T-1016 (#212): Deterministic README demo recording.
+ *
+ * Generates an animated SVG showing the `commitlore demo` scenario using only
+ * Node.js stdlib. The output is byte-exact across runs because:
+ *   - All frame content comes from the static fixture (no runtime data)
+ *   - Font metrics are hardcoded (monospace, fixed char width/height)
+ *   - Viewport dimensions, padding, and timing are constants
+ *   - No timestamps, random values, or environment-dependent data
+ *
+ * Usage:
+ *   node scripts/record-demo.mjs           # generate the SVG asset
+ *   node scripts/record-demo.mjs --check   # regenerate to temp, compare bytes
+ */
+
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const ASSET_PATH = join(REPO_ROOT, 'assets', 'readme', 'commitlore-demo.svg');
+
+// ---------------------------------------------------------------------------
+// Fixed terminal dimensions and font metrics
+// ---------------------------------------------------------------------------
+
+const COLS = 80;
+const ROWS = 24;
+const CHAR_W = 8.4;     // px per character (monospace)
+const CHAR_H = 18;      // px per line height
+const PAD_X = 16;       // horizontal padding
+const PAD_Y = 12;       // vertical padding
+const TITLE_H = 32;     // title bar height
+const WIDTH = Math.ceil(COLS * CHAR_W + PAD_X * 2);
+const HEIGHT = ROWS * CHAR_H + PAD_Y * 2 + TITLE_H;
+
+// Frame timing (seconds)
+const FRAME_PAUSE = 1.5;    // pause between frames
+const TYPING_DELAY = 0.06;  // per-character typing delay (visual only)
+
+// ---------------------------------------------------------------------------
+// Static frame content — derived from T-1010 fixture, not generated at runtime
+// ---------------------------------------------------------------------------
+
+const FRAMES = [
+  {
+    label: 'prompt',
+    lines: [
+      '$ commitlore demo',
+    ],
+  },
+  {
+    label: 'scenario',
+    lines: [
+      '$ commitlore demo',
+      '',
+      '─── commitlore demo ───',
+      '',
+      'Scenario: two decisions recorded for src/services/cache.ts',
+      '  1. "Use Redis for session cache" (later superseded)',
+      '  2. "Switch to SQLite" (supersedes the first — now active)',
+      '',
+      'An agent proposes reverting to Redis. CommitLore answers:',
+    ],
+  },
+  {
+    label: 'result',
+    lines: [
+      '$ commitlore demo',
+      '',
+      '─── commitlore demo ───',
+      '',
+      'Scenario: two decisions recorded for src/services/cache.ts',
+      '  1. "Use Redis for session cache" (later superseded)',
+      '  2. "Switch to SQLite" (supersedes the first — now active)',
+      '',
+      'An agent proposes reverting to Redis. CommitLore answers:',
+      '',
+      '  Record-Id: r-demo02 [active]',
+      '    Limit: single-writer constraint requires careful connection pooling',
+      '    Ruled-out: Redis cluster | cost and complexity disproportionate to traffic',
+      '',
+      'Only the active decision (r-demo02) is shown.',
+      'The superseded Redis decision is filtered out — the agent cannot revive it.',
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// SVG rendering
+// ---------------------------------------------------------------------------
+
+/** Escape XML special characters */
+function esc(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Render a single frame's text lines as SVG <text> elements */
+function renderFrameText(lines, groupId) {
+  const parts = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === '') continue;
+    const y = TITLE_H + PAD_Y + (i + 1) * CHAR_H;
+    const x = PAD_X;
+
+    // Color coding
+    let fill = '#c5c8c6'; // default: light gray
+    if (line.startsWith('$')) fill = '#81a2be'; // prompt: blue
+    else if (line.startsWith('───')) fill = '#b5bd68'; // header: green
+    else if (line.includes('[active]')) fill = '#b5bd68'; // active: green
+    else if (line.startsWith('  Record-Id:')) fill = '#f0c674'; // record id: yellow
+    else if (line.includes('Limit:') || line.includes('Ruled-out:')) fill = '#cc6666'; // constraints: red
+    else if (line.includes('superseded') || line.includes('filtered out')) fill = '#b294bb'; // lifecycle: purple
+    else if (line.startsWith('Scenario:') || line.startsWith('An agent')) fill = '#c5c8c6'; // narrative: default
+
+    parts.push(`    <text x="${x}" y="${y}" fill="${fill}" id="${groupId}-line${i}">${esc(line)}</text>`);
+  }
+  return parts.join('\n');
+}
+
+function generateSvg() {
+  // Calculate total animation duration
+  const totalDuration = FRAMES.length * FRAME_PAUSE + (FRAMES.length - 1) * 0.5;
+  const frameDuration = totalDuration / FRAMES.length;
+
+  // Build frame groups with visibility animations
+  const frameGroups = [];
+  const animations = [];
+
+  for (let i = 0; i < FRAMES.length; i++) {
+    const frame = FRAMES[i];
+    const groupId = `frame-${i}`;
+    const textContent = renderFrameText(frame.lines, groupId);
+
+    // Each frame is visible for frameDuration, starting at i * frameDuration
+    const begin = (i * frameDuration).toFixed(2);
+    const dur = frameDuration.toFixed(2);
+    const visible = i === FRAMES.length - 1 ? 'visible' : 'hidden';
+
+    frameGroups.push(`  <g id="${groupId}" visibility="${i === 0 ? 'visible' : 'hidden'}">
+${textContent}
+    <set attributeName="visibility" to="visible" begin="${begin}s" dur="${dur}s" fill="remove"/>
+    <set attributeName="visibility" to="hidden" begin="${(parseFloat(begin) + parseFloat(dur)).toFixed(2)}s" fill="${i === FRAMES.length - 1 ? 'freeze' : 'remove'}"/>
+  </g>`);
+  }
+
+  // The last frame stays visible (freeze)
+  // Override: make last frame visible after its start and freeze
+  frameGroups[FRAMES.length - 1] = `  <g id="frame-${FRAMES.length - 1}" visibility="hidden">
+${renderFrameText(FRAMES[FRAMES.length - 1].lines, `frame-${FRAMES.length - 1}`)}
+    <set attributeName="visibility" to="visible" begin="${((FRAMES.length - 1) * frameDuration).toFixed(2)}s" fill="freeze"/>
+  </g>`;
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="${WIDTH}" height="${HEIGHT}" role="img" aria-label="commitlore demo: lifecycle filtering shows only active decisions">
+  <!-- T-1016: deterministic animated SVG — do not edit by hand; regenerate with: node scripts/record-demo.mjs -->
+  <rect width="100%" height="100%" rx="8" fill="#1d1f21"/>
+  <!-- Title bar -->
+  <rect width="100%" height="${TITLE_H}" rx="8" fill="#282a2e"/>
+  <circle cx="20" cy="16" r="6" fill="#cc6666"/>
+  <circle cx="38" cy="16" r="6" fill="#f0c674"/>
+  <circle cx="56" cy="16" r="6" fill="#b5bd68"/>
+  <text x="${WIDTH / 2}" y="20" text-anchor="middle" fill="#969896" font-family="monospace" font-size="12">commitlore demo</text>
+  <style>
+    text { font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace; font-size: 13px; }
+  </style>
+${frameGroups.join('\n')}
+</svg>
+`;
+
+  return svg;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const isCheck = args.includes('--check');
+
+const generated = generateSvg();
+
+if (isCheck) {
+  // Compare with the committed asset
+  let existing;
+  try {
+    existing = readFileSync(ASSET_PATH, 'utf8');
+  } catch {
+    process.stderr.write(`record-demo --check: asset not found at ${ASSET_PATH}\n`);
+    process.stderr.write('Run `node scripts/record-demo.mjs` to generate it first.\n');
+    process.exitCode = 1;
+    process.exit(1);
+  }
+
+  if (existing === generated) {
+    process.stdout.write('record-demo --check: asset is byte-identical to a fresh render. OK\n');
+    process.exitCode = 0;
+  } else {
+    // Find first differing byte for diagnostics
+    let diffPos = -1;
+    const minLen = Math.min(existing.length, generated.length);
+    for (let i = 0; i < minLen; i++) {
+      if (existing[i] !== generated[i]) { diffPos = i; break; }
+    }
+    if (diffPos === -1) diffPos = minLen; // length difference
+
+    process.stderr.write(`record-demo --check: MISMATCH\n`);
+    process.stderr.write(`  committed: ${existing.length} bytes\n`);
+    process.stderr.write(`  generated: ${generated.length} bytes\n`);
+    process.stderr.write(`  first difference at byte ${diffPos}\n`);
+    process.stderr.write(`  committed[${diffPos}]: ${JSON.stringify(existing.slice(diffPos, diffPos + 40))}\n`);
+    process.stderr.write(`  generated[${diffPos}]: ${JSON.stringify(generated.slice(diffPos, diffPos + 40))}\n`);
+    process.stderr.write('\nRegenerate with: node scripts/record-demo.mjs\n');
+    process.exitCode = 1;
+    process.exit(1);
+  }
+} else {
+  writeFileSync(ASSET_PATH, generated, 'utf8');
+  process.stdout.write(`record-demo: wrote ${generated.length} bytes to ${ASSET_PATH}\n`);
+  process.exitCode = 0;
+}

--- a/test/demo-recording.test.ts
+++ b/test/demo-recording.test.ts
@@ -1,0 +1,89 @@
+/**
+ * T-1016 (#212): Deterministic README demo recording.
+ *
+ * Asserts:
+ *   1. The recorded SVG asset exists
+ *   2. It is byte-reproducible (re-render matches committed file)
+ *   3. All four READMEs reference the same asset path
+ *   4. The SVG contains no private identifiers (absolute paths, usernames, hostnames)
+ *   5. The SVG uses the canonical fixture identifiers from T-1010
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const ASSET_PATH = path.join(REPO_ROOT, 'assets', 'readme', 'commitlore-demo.svg');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts', 'record-demo.mjs');
+const READMES = ['README.md', 'README.ko.md', 'README.ja.md', 'README.zh-CN.md'];
+const ASSET_REF = 'assets/readme/commitlore-demo.svg';
+
+describe('T-1016: deterministic demo recording', () => {
+  it('SVG asset exists', () => {
+    expect(fs.existsSync(ASSET_PATH)).toBe(true);
+  });
+
+  it('--check mode exits 0 (byte-reproducible)', () => {
+    const result = execFileSync(process.execPath, [SCRIPT_PATH, '--check'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    expect(result).toContain('byte-identical');
+  });
+
+  it('all four READMEs reference the same asset', () => {
+    for (const readme of READMES) {
+      const content = fs.readFileSync(path.join(REPO_ROOT, readme), 'utf8');
+      expect(content).toContain(ASSET_REF);
+    }
+  });
+
+  it('SVG contains canonical fixture identifiers', () => {
+    const svg = fs.readFileSync(ASSET_PATH, 'utf8');
+    // From T-1010: the active record id
+    expect(svg).toContain('r-demo02');
+    // The target path from the fixture
+    expect(svg).toContain('src/services/cache.ts');
+  });
+
+  it('SVG contains no private identifiers', () => {
+    const svg = fs.readFileSync(ASSET_PATH, 'utf8');
+    // No absolute paths
+    expect(svg).not.toMatch(/\/Users\/[a-zA-Z]/);
+    expect(svg).not.toMatch(/\/home\/[a-zA-Z]/);
+    expect(svg).not.toMatch(/\/tmp\/commitlore-demo-/);
+    // No hostnames or tokens
+    expect(svg).not.toMatch(/hostname|\.local/i);
+    // No environment-variable-looking tokens
+    expect(svg).not.toMatch(/[A-Z_]{5,}=[^\s]+/);
+  });
+
+  it('re-rendering produces identical bytes (second run)', () => {
+    // Generate to a temp location and compare
+    const tmpDir = fs.mkdtempSync(path.join(REPO_ROOT, '.tmp-demo-check-'));
+    try {
+      const tmpAsset = path.join(tmpDir, 'check.svg');
+      // Run the script without --check to capture output, redirect manually
+      const generated = execFileSync(process.execPath, [SCRIPT_PATH], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      // Read the asset that was just (re)written
+      const first = fs.readFileSync(ASSET_PATH, 'utf8');
+      // Run again
+      execFileSync(process.execPath, [SCRIPT_PATH], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const second = fs.readFileSync(ASSET_PATH, 'utf8');
+      expect(first).toBe(second);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #212 — T-1016. Governing: PRD-F10.

**CEO amendment honoured**: a Node-stdlib animated SVG with fixed environment, viewport and frame timing, checked byte-exactly by `--check`. No recorder dependency, no manifest fallback.

The `BENCH` block is untouched — `node scripts/check-readme-numbers.mjs` exits 0. T-1014's hero and T-1015's section order are preserved.

Evidence: `npx vitest run test/demo-recording.test.ts` 6/6; both typechecks exit 0; no `src/` change so no `dist/` rebuild.