### PR TITLE
fix: lint full promotion range on dev push (#186)

### DIFF
--- a/.github/workflows/demo-lint.yml
+++ b/.github/workflows/demo-lint.yml
@@ -8,7 +8,10 @@ name: Demo — PR lint
 #
 # Separate from ci.yml on purpose: this job needs `pull-requests: write` and
 # only runs on pull requests, and CI must not inherit either.
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches: [dev]
 
 permissions:
   # The action asks for nothing beyond the comment; the read is the checkout's.
@@ -17,6 +20,9 @@ permissions:
 
 jobs:
   lint:
+    # The action's own range derivation works for PRs. On push events there is
+    # no base_ref, so this job only runs for pull requests.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,3 +57,35 @@ jobs:
       - uses: ./action/lint
         with:
           cli-path: dist/cli.js
+
+  # #186: a feature-branch PR lints only its own commits. Two commits that
+  # duplicate a Record-Id appear together only in the full origin/main..dev
+  # range — which nothing checked until a promotion PR. This job closes that
+  # gap: every push to dev lints the entire promotion range, so a collision
+  # that a narrow PR range hid is caught the moment it lands.
+  promotion-range-lint:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bring the record notes mirror, if there is one
+        run: |
+          if git ls-remote --exit-code origin refs/notes/commitlore >/dev/null 2>&1; then
+            git fetch --no-tags origin '+refs/notes/commitlore:refs/notes/commitlore'
+          else
+            echo "origin carries no refs/notes/commitlore yet -- nothing to mirror"
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Lint the full promotion range (origin/main..HEAD)
+        run: node dist/commitlore.mjs validate --range origin/main..HEAD

--- a/test/action-lint.test.ts
+++ b/test/action-lint.test.ts
@@ -465,14 +465,47 @@ describe('action.yml', () => {
     const demo = load(text) as {
       on: unknown;
       permissions: Record<string, string>;
-      jobs: Record<string, { steps: ActionStep[] }>;
+      jobs: Record<string, { steps: ActionStep[]; if?: string }>;
     };
 
     expect(demo.permissions).toEqual({ contents: 'read', 'pull-requests': 'write' });
-    expect(Object.keys(demo.jobs)).toHaveLength(1);
-    const steps = Object.values(demo.jobs)[0]?.steps ?? [];
-    expect(steps.some((step) => step.uses === './action/lint')).toBe(true);
+    expect(Object.keys(demo.jobs)).toHaveLength(2);
+
+    // The PR lint job still uses the action and only runs for pull requests.
+    const lintJob = demo.jobs['lint'];
+    expect(lintJob).toBeDefined();
+    expect(lintJob!.if).toContain('pull_request');
+    const lintSteps = lintJob!.steps ?? [];
+    expect(lintSteps.some((step) => step.uses === './action/lint')).toBe(true);
+
     expect(text).toContain('fetch-depth: 0');
+  });
+
+  // #186: a push to dev must lint the full promotion range (origin/main..HEAD),
+  // not only the PR's own commits. This is what catches duplicate Record-Ids
+  // that span two PRs — the narrow PR range hides them.
+  it('lints the full promotion range on push to dev (#186)', () => {
+    const text = readFileSync(DEMO_WORKFLOW, 'utf8');
+    const demo = load(text) as {
+      on: { pull_request: unknown; push?: { branches?: string[] } };
+      jobs: Record<string, { steps: ActionStep[]; if?: string }>;
+    };
+
+    // The push trigger must include dev.
+    expect(demo.on.push).toBeDefined();
+    expect(demo.on.push!.branches).toContain('dev');
+
+    // The promotion-range-lint job runs only on push.
+    const rangeJob = demo.jobs['promotion-range-lint'];
+    expect(rangeJob).toBeDefined();
+    expect(rangeJob!.if).toContain('push');
+
+    // It validates origin/main..HEAD — the full range a promotion PR would see.
+    const validateStep = rangeJob!.steps.find(
+      (step) => step.run && step.run.includes('origin/main..HEAD'),
+    );
+    expect(validateStep, 'must have a step that validates origin/main..HEAD').toBeDefined();
+    expect(validateStep!.run).toContain('validate');
   });
 });
 


### PR DESCRIPTION
Closes #186

## Problem

The demo-lint workflow only triggered on `pull_request` events, so it linted only a PR's own commits. Two commits that duplicate a Record-Id (like the known `r-readme729` collision between `051fee9` and `a2c657a`) appear together only in the full `origin/main..dev` range — which nothing checked until a promotion PR was opened.

## Fix

Add a `promotion-range-lint` job to `demo-lint.yml` that fires on push to `dev` and validates `origin/main..HEAD`. The existing PR lint job is unchanged.

## Backlog check

Running `node dist/commitlore.mjs validate --range origin/main..origin/dev --json` at dev head `6b4b725` returned **0 violations, 0 secrets** — the first push will not be red.

## Verification

- Focused test (test/action-lint.test.ts): 28 tests pass
- Mutation oracles: removing `dev` from push branches fails; changing range from `origin/main..HEAD` fails
- Both typechecks pass (tsconfig.json, bench/tsconfig.json)
- Full suite (60 files, 1568 tests) passes (guard.test.ts/inject.test.ts/bench-exposure.test.ts/gate-a-e2e.test.ts excluded — hang on this machine at unmodified dev head)