### PR TITLE
Write the 0.4.0 notes before tagging

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,100 @@
 
 Nothing yet.
 
+## 0.4.0 — 2026-07-31
+
+The release that makes recording a decision something the tool does, rather than
+something you have to remember to ask for.
+
+### Upgrade reasons
+
+- **`commitlore capture` records a decision without you typing trailer syntax.**
+  It runs prepare, verify and stage as one command: it snapshots the HEAD, the
+  staged diff and the evidence sources, checks a draft's quotes against those
+  sources mechanically, and stages at most one record for the commit being
+  written. A verification failure produces no record and does not fail the
+  command, because most commits should carry nothing (#198, #193–#197).
+- **A record can no longer attach to the wrong commit.** The `prepare-commit-msg`
+  hook applies a staged record only when the HEAD it was prepared against is
+  unchanged, the staged diff still hashes the same, the record is staged,
+  unexpired, unconsumed, and the policy identity is unchanged. If any of those
+  fails it applies nothing and lets the commit through (#197). A `post-commit`
+  finaliser then consumes the record exactly once, bound to the commit that
+  actually resulted (#213).
+- **`commitlore demo` shows the product in a temporary repository.** No network,
+  no model, nothing written to your repository, and it removes what it created
+  even when it fails (#202, #203).
+- **`commitlore init` reports readiness instead of internal step names.** A clean
+  run is short; a step it could not complete is still named rather than absorbed
+  into a success message. The previous step-by-step output moved to
+  `--verbose`, and `--json` is unchanged (#204, #205).
+- **`harvest --prompt-only` prints the contract with no other input.** It
+  previously refused unless a transcript and a diff were supplied, which
+  inverted the order of use: the contract is what a session needs *before* it
+  has produced a transcript (#229).
+
+### Agents
+
+- Three write-side MCP tools — `commitlore_prepare_capture`,
+  `commitlore_verify_capture`, `commitlore_stage_capture` — give an agent the
+  same capture contract the CLI uses. They write only inside
+  `.git/commitlore/pending/`, never Git history; every binding a staged record
+  commits to is computed server-side and never accepted from the caller; and a
+  caller-supplied nonce is validated before it reaches any path resolution
+  (#199, #200, #201).
+- There is deliberately no `commitlore_write_record` tool. A draft cannot reach
+  Git without passing verification and the pending transaction.
+- `commitlore_before_change` answers with path-scoped context and, when given a
+  proposal, an experimental guard result in the same response. The two are kept
+  separate structurally: `guard_confidence` describes
+  `possible_revival_matches` and nothing else (#219).
+
+### Honesty about guard
+
+- **Guard is classified as an experimental advisory.** Its measured position is
+  precision 44.8% (95% Wilson 32.7%–57.5%) and recall 22.0% against a
+  417-decision corpus, and that now appears wherever guard is exposed: the CLI
+  help and output, the MCP tool description, and the README's known limitations
+  (#208, #209, #210).
+- The MCP description no longer tells a caller that an empty result "is a
+  verdict, not an absence". At 22% recall an empty result is a miss in the
+  common case, and saying otherwise was the most misleading sentence on the
+  product surface.
+- Guard output calls a hit a **possible match** and no longer prints a score in
+  default text output. `--json` still carries the score and the signal
+  breakdown for anything that parses it.
+
+### Fixed
+
+- `doctor` no longer asserts that a hook failed "when git's PATH carries no
+  node" when the hook actually ran and threw. It reports what the probe can
+  determine, including that it cannot determine the cause (#192).
+- `init` no longer exits 1 in a repository where the configured PreToolUse
+  executable is not resolvable from `PATH`. `doctor` still reports it; an
+  incomplete environment is not a misconfiguration (#192, #221).
+- The record lint now checks the full `origin/main..HEAD` range on pushes to
+  `dev`, not only a pull request's own commits. A known duplicate identity had
+  sat unresolved for a day because the two colliding commits never appeared in
+  one narrow range (#186).
+- `rationale_density` names its denominator. It now reports both populations,
+  labelled: all commits, and authored non-merge commits. At the time of writing
+  the gap is 26.3 points (71.8% against 98.1%), which is merge volume rather
+  than a change in discipline (#183).
+- `commitlore capture gc` is reachable. The parent command's required
+  `--transcript` option was being enforced on the subcommand, so it could not
+  run at all, and `--json` on it was silently ignored.
+
+### Known limitations, unchanged by this release
+
+- Windows and musl Linux hosts remain unsupported.
+- Guard's measured precision and recall are what they are; nothing in this
+  release improves them, and ADR-0019 records that the current signals cannot
+  separate a genuine revival from a coincidental textual match.
+- Nothing here measures whether an agent behaves differently for having received
+  a decision. The fresh-agent recovery protocol is registered and unrun.
+- Capture's write-side cost is still reported as `not instrumented` rather than
+  as a number.
+
 ## 0.3.0 — 2026-07-29
 
 ### Upgrade reasons

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@
 一度インストールします。コーディングエージェントは引き継ぐ価値のある意思決定を記録でき、CommitLore はそれを検証して Git に保存します。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh | sh
 ```
 
 
@@ -103,11 +103,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh
-sh install.sh v0.3.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh
+sh install.sh v0.4.0
 
 # または release binary を自分で検証してから展開します。
-version=0.3.0; target=aarch64-apple-darwin
+version=0.4.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
 한 번 설치한다. 코딩 에이전트가 계속 가져갈 가치가 있는 결정을 기록할 수 있고, CommitLore는 이를 검증해 Git에 보존한다.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh | sh
 ```
 
 
@@ -103,11 +103,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh
-sh install.sh v0.3.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh
+sh install.sh v0.4.0
 
 # 또는 릴리스 바이너리를 직접 검증한 뒤 압축을 푼다.
-version=0.3.0; target=aarch64-apple-darwin
+version=0.4.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ No hosted memory service. No vendor-specific chat history. Just reviewable decis
 Install once. Your coding agent can record the decisions worth carrying forward, while CommitLore validates and preserves them in Git.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh | sh
 ```
 
 
@@ -103,11 +103,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh
-sh install.sh v0.3.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh
+sh install.sh v0.4.0
 
 # Or verify the release binary yourself before extracting it.
-version=0.3.0; target=aarch64-apple-darwin
+version=0.4.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@
 安装一次。你的编程代理可以记录值得延续的决策，而 CommitLore 会验证它们并将其保存在 Git 中。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh | sh
 ```
 
 
@@ -103,11 +103,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.3.0/install.sh
-sh install.sh v0.3.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh
+sh install.sh v0.4.0
 
 # 或自行验证 release binary 后再解压。
-version=0.3.0; target=aarch64-apple-darwin
+version=0.4.0; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Git commit trailers as institutional memory for AI coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump to 0.4.0 in `package.json` and `.claude-plugin/plugin.json`, plus the 0.4.0 changelog section. Same shape as the 0.3.0 release: notes land on `dev` first, then `dev` is promoted to `main`, then the tag is pushed — pushing the tag is what triggers the four-platform build.

## Release gate, checked

| check | result |
|---|---|
| version agreement | `package.json` 0.4.0, `plugin.json` 0.4.0, binary `--version` 0.4.0 |
| answers or says it cannot | unborn repository reports `history: "empty"`, not a silent empty result |
| record lint over the release range | `validate --range origin/main..HEAD` — 0 violations, 0 secrets |
| both typechecks | `tsc -p tsconfig.json` and `tsc -p bench/tsconfig.json` exit 0 |
| committed `dist/` | rebuilt and committed; version is embedded in the bundle |

## What the notes say, and deliberately do not

They lead with upgrade reasons. Guard has its own section stating precision 44.8% (95% Wilson 32.7%–57.5%) and recall 22.0%, because a reader who sees no guard warning must not conclude their proposal is clear.

They do **not** claim this release makes agents safer or reduces mistakes. Nothing here measures agent behaviour — the fresh-agent recovery protocol is registered and unrun, and that is stated in the known-limitations section along with Windows, musl, and capture's uninstrumented write-side cost.