### PR TITLE
Stop a killed verification from failing a successful install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -188,11 +188,36 @@ if [ -e "$dest" ]; then
 fi
 
 mkdir -p "$dest_dir"
-cp "$work/commitlore" "$dest"
-chmod +x "$dest"
+# Write beside the destination and rename, rather than `cp` over it. An
+# in-place overwrite leaves the destination inode holding new bytes, and this
+# file already uses write-temp-then-rename for config merges below. Rename is
+# atomic, so a reader either sees the old binary or the new one and never a
+# half-written 100 MB executable.
+dest_tmp="$dest.commitlore-install.$$"
+cleanup_dest_tmp() { rm -f "$dest_tmp"; }
+trap cleanup_dest_tmp EXIT
+cp "$work/commitlore" "$dest_tmp"
+chmod +x "$dest_tmp"
+mv "$dest_tmp" "$dest"
+trap - EXIT
 
 log "installed to $dest"
-"$dest" --version
+
+# The install is already complete. A verification that cannot run says so; it
+# does not retroactively fail an install that succeeded. On macOS the first
+# exec of a freshly written large binary has been observed being killed by a
+# signal (see #256) while the second succeeds, so a single failure is retried
+# before it is reported.
+if ! installed_version=$("$dest" --version 2>/dev/null); then
+  sleep 1
+  installed_version=$("$dest" --version 2>/dev/null) || installed_version=""
+fi
+if [ -n "$installed_version" ]; then
+  printf '%s\n' "$installed_version"
+else
+  log "installed, but could not run \"$dest --version\" in this shell to confirm it."
+  log "the binary is in place; verify it yourself with: $dest --version"
+fi
 
 path_file="$HOME/.profile"
 case "${SHELL:-}" in


### PR DESCRIPTION
Closes #256.

Found by running the exact one-liner the shipped v0.4.0 README documents, upgrading over an existing 0.3.0 install on macOS arm64:

```
commitlore-install: checksum verified (37e951af…)
commitlore-install: upgrading existing install (0.3.0 -> 0.4.0)
commitlore-install: installed to /Users/…/.local/bin/commitlore
install.sh: line 195: 86754 Killed: 9    "$dest" --version
$ echo $?
137
```

The install succeeded — the same binary runs and prints `0.4.0` immediately afterwards. What failed was the installer's own verification, and its signal kill became the installer's exit code.

## Changes

1. **Atomic rename.** The binary is written beside its destination and `mv`d into place instead of `cp`-ing over it. This file already used write-temp-then-rename for config merges; the binary was the last in-place overwrite.
2. **The verification no longer decides the exit code.** It retries once; if it still cannot run, it says the binary is installed but unverified in this shell and prints the command to check by hand.

## On the root cause

**Not established, and not guessed at in the code.** My first hypothesis — in-place overwrite invalidating the cached ad-hoc signature — does not hold: overwriting an already-exec'd copy of this same binary in place and re-exec'ing it exits 0. Tested against a fresh-write control and an atomic-rename case; all three printed `0.4.0`. #256 records that, and stays open for the cause.

## Verified

| path | exit | notes |
|---|---|---|
| fresh install into an isolated dir | 0 | |
| **upgrade over that install** (the failing path) | **0** | was 137 |
| temp file left behind | none | `ls -a` shows only `commitlore` |
| installed binary | `0.4.0` | |

`sh -n install.sh` clean.

## This needs a patch release to reach users

The documented one-liner fetches `install.sh` **from the tag** (`…/v0.4.0/install.sh`), so fixing `dev` does not fix what a user gets today. A v0.4.1 is needed for this to take effect.