### PR TITLE
Release v0.4.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 Nothing yet.
 
+## 0.4.1 — 2026-07-31
+
+### Upgrade reasons
+
+- **The documented install no longer reports a failure after succeeding.**
+  Running the one-liner over an existing install exited 137 because the
+  installer's own post-install `commitlore --version` was killed by a signal,
+  after the binary had already been installed correctly. The verification now
+  retries once and, if it still cannot run, says the binary is installed but
+  unverified in this shell rather than failing the install (#256).
+- The binary is written beside its destination and renamed into place instead of
+  overwritten. Rename is atomic, so a reader sees either the old binary or the
+  new one and never a partially written executable.
+
+The root cause of the signal kill is not established, and #256 records what was
+ruled out: overwriting an already-executed ad-hoc-signed copy of the same binary
+in place and re-executing it exits 0, so cached-signature invalidation alone does
+not explain it. This release makes the installer honest about a verification it
+cannot complete; it does not claim to have fixed the kill.
+
 ## 0.4.0 — 2026-07-31
 
 The release that makes recording a decision something the tool does, rather than

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@
 一度インストールします。コーディングエージェントは引き継ぐ価値のある意思決定を記録でき、CommitLore はそれを検証して Git に保存します。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
 ```
 
 
@@ -103,11 +103,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh
-sh install.sh v0.4.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
+sh install.sh v0.4.1
 
 # または release binary を自分で検証してから展開します。
-version=0.4.0; target=aarch64-apple-darwin
+version=0.4.1; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
 한 번 설치한다. 코딩 에이전트가 계속 가져갈 가치가 있는 결정을 기록할 수 있고, CommitLore는 이를 검증해 Git에 보존한다.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
 ```
 
 
@@ -103,11 +103,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh
-sh install.sh v0.4.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
+sh install.sh v0.4.1
 
 # 또는 릴리스 바이너리를 직접 검증한 뒤 압축을 푼다.
-version=0.4.0; target=aarch64-apple-darwin
+version=0.4.1; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ No hosted memory service. No vendor-specific chat history. Just reviewable decis
 Install once. Your coding agent can record the decisions worth carrying forward, while CommitLore validates and preserves them in Git.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
 ```
 
 
@@ -103,11 +103,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh
-sh install.sh v0.4.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
+sh install.sh v0.4.1
 
 # Or verify the release binary yourself before extracting it.
-version=0.4.0; target=aarch64-apple-darwin
+version=0.4.1; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@
 安装一次。你的编程代理可以记录值得延续的决策，而 CommitLore 会验证它们并将其保存在 Git 中。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
 ```
 
 
@@ -103,11 +103,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.0/install.sh
-sh install.sh v0.4.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
+sh install.sh v0.4.1
 
 # 或自行验证 release binary 后再解压。
-version=0.4.0; target=aarch64-apple-darwin
+version=0.4.1; target=aarch64-apple-darwin
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
 curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
 grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -

--- a/install.sh
+++ b/install.sh
@@ -188,11 +188,36 @@ if [ -e "$dest" ]; then
 fi
 
 mkdir -p "$dest_dir"
-cp "$work/commitlore" "$dest"
-chmod +x "$dest"
+# Write beside the destination and rename, rather than `cp` over it. An
+# in-place overwrite leaves the destination inode holding new bytes, and this
+# file already uses write-temp-then-rename for config merges below. Rename is
+# atomic, so a reader either sees the old binary or the new one and never a
+# half-written 100 MB executable.
+dest_tmp="$dest.commitlore-install.$$"
+cleanup_dest_tmp() { rm -f "$dest_tmp"; }
+trap cleanup_dest_tmp EXIT
+cp "$work/commitlore" "$dest_tmp"
+chmod +x "$dest_tmp"
+mv "$dest_tmp" "$dest"
+trap - EXIT
 
 log "installed to $dest"
-"$dest" --version
+
+# The install is already complete. A verification that cannot run says so; it
+# does not retroactively fail an install that succeeded. On macOS the first
+# exec of a freshly written large binary has been observed being killed by a
+# signal (see #256) while the second succeeds, so a single failure is retried
+# before it is reported.
+if ! installed_version=$("$dest" --version 2>/dev/null); then
+  sleep 1
+  installed_version=$("$dest" --version 2>/dev/null) || installed_version=""
+fi
+if [ -n "$installed_version" ]; then
+  printf '%s\n' "$installed_version"
+else
+  log "installed, but could not run \"$dest --version\" in this shell to confirm it."
+  log "the binary is in place; verify it yourself with: $dest --version"
+fi
 
 path_file="$HOME/.profile"
 case "${SHELL:-}" in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Git commit trailers as institutional memory for AI coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Patch release for #256. Promotes `dev` to `main` for the v0.4.1 tag.

**Why this cannot wait for the next feature release**: the install command the v0.4.0 README documents exits 137 when it upgrades over an existing install, and `install.sh` is fetched from the tag — so the fix on `dev` reaches nobody until a tag carries it.

## What changed

- A killed post-install verification no longer becomes the installer's exit code. It retries once, and if it still cannot run it says the binary is installed but unverified in this shell and gives the command to check by hand.
- The binary is written beside its destination and renamed into place rather than overwritten.

Verified on both paths in an isolated install dir: fresh install exit 0, **upgrade over it exit 0** (was 137), no temp file left behind, installed binary reports its version.

## What it does not claim

The root cause of the signal kill is **not established**. Overwriting an already-executed ad-hoc-signed copy of the same binary in place and re-executing it exits 0, so cached-signature invalidation alone does not explain it. #256 records what was ruled out and remains the place for the cause. This release makes the installer honest about a verification it cannot complete.