### PR TITLE
Record that a killed bounded run is not a hang

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -222,6 +222,25 @@ still at the ceiling, just a higher one.
 
 ## Traps that cost real time
 
+**A bounded test run that dies at its timeout is not a hang.** `test/guard.test.ts`
+takes about **440 seconds on a loaded machine** — 66 tests, each spawning the
+bundled CLI as a subprocess — against 148 seconds in CI. I wrapped local runs in a
+480-second watchdog, watched it get killed with zero test results reported, and
+concluded the file hung on unmodified `dev`. It does not: it passes 66/66, and the
+whole suite passes locally with nothing excluded in about **540 seconds**.
+
+The misreading is easy because vitest buffers a file's results until the file
+finishes, so a killed run shows the file's `stderr` output and no test lines at
+all — which looks exactly like a stall. I then put "do not run
+`test/guard.test.ts`, it hangs" into several delegated packets, and those workers
+excluded it from their local verification. CI ran it on every pull request, so
+nothing shipped unverified, but their evidence was weaker than it looked and one
+of them widened the claim to three more innocent files.
+
+Budget at least **ten minutes** for a local full suite and **eight** for
+`guard.test.ts` alone, and before calling anything hung, check whether the file
+simply needs longer than the bound you chose.
+
 **Judging whether a long process is alive.** I killed three healthy benchmark
 runs. Instantaneous CPU is 0 while a parent waits on a child; accumulated CPU
 (`ps -o time=`) barely moves for the same reason; the log only prints between


### PR DESCRIPTION
I reported that `test/guard.test.ts` hangs on unmodified `dev` and carried that into several delegated packets, which excluded it from their local verification. **It does not hang.**

## The measurement

| | |
|---|---|
| `test/guard.test.ts` locally | **66/66 passed, 441.57 s** |
| same file in CI | 66 tests, 147.75 s |
| full suite locally, **nothing excluded** | **65 files, 1750 passed, 1 skipped, 543.10 s, exit 0** |
| machine | load average 6.3 on 12 cores |

My watchdog bound was 480 s. The file needs ~441 s here, so runs died just short of finishing.

## Why it looked like a hang

vitest buffers a file's results until the file completes. A killed run therefore prints that file's `stderr` output — in this case the seeded false-positive corpus table — and **no test lines at all**, which is indistinguishable from a stall.

## Consequence, stated plainly

Several workers were told not to run the file and excluded it locally; one widened the claim to three more files (`inject`, `bench-exposure`, `gate-a-e2e`) that run in seconds. CI ran the file on every PR throughout, so nothing shipped unverified — but the local evidence in those reports was weaker than it appeared.

No repository defect, so no issue filed. The handoff is where inference traps belong, and this adds one.