### PR TITLE
Say the worktrees are gone, because they are now

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -268,9 +268,11 @@ is non-null.
 
 ## State at handoff
 
-Nothing is in flight: no open pull request, no open issue. Worktrees under
-`~/projects/wt/` were **not** cleaned up this session and there are many —
-check them before assigning work, and remove the ones whose branches merged.
+Nothing is in flight: no open pull request, no open issue, and `git worktree list`
+shows the main checkout only. Thirty-six worktrees accumulated during the session
+and were removed after checking each for uncommitted files and confirming its
+branch had merged; the 42 stale `/private/tmp` records from earlier sessions are
+gone too.
 
 ```
 dev 0.4.1, green            main carries v0.4.1


### PR DESCRIPTION
The state block merged in #261 said worktrees were **not** cleaned up and there were many. True when written, false ten minutes later — I then removed all thirty-six after checking each for uncommitted files and confirming its branch had merged, and the 42 stale `/private/tmp` records from earlier sessions with them.

`git worktree list` now shows the main checkout only.

Correcting it in the same session rather than leaving exactly the staleness #261 existed to fix. Third correction to this file today, which is itself evidence that a hand-maintained state block goes stale faster than anyone updates it.