### PR TITLE
Author Gate B: acceptance matrix, three ADRs, two PRDs, ten atomic tickets

### DIFF
--- a/docs/GATE-B-ACCEPTANCE.md
+++ b/docs/GATE-B-ACCEPTANCE.md
@@ -1,0 +1,78 @@
+# Gate B acceptance matrix
+
+Authority for which ticket closes which Gate B commitment. Same role for M6 that
+[`GATE-A-ACCEPTANCE.md`](GATE-A-ACCEPTANCE.md) has for M5.
+
+Gate A's matrix had to be reconstructed from citations, and five of its eight rows were
+wrong on the first attempt because a citation is not a definition. This file is written
+**before** any Gate B ticket exists, so every row below has a source that predates it:
+the M6 milestone description, an issue closed with its finding recorded, an active
+ruled-out record, or a Gate A row that was explicitly deferred here. Each row names that
+source. No row is reconstructed.
+
+## Scope of Gate B
+
+Exactly two sets, and nothing else:
+
+1. The four areas the M6 milestone description names — Windows/musl builds, package
+   managers, update/uninstall, a compatibility matrix.
+2. The two items `PRD-F9-unified-capture.md`'s "Non-goals" defers to Gate B: guard
+   integration into the capture pipeline, and the user-editable policy file.
+
+**One attribution to get right.** Of those two, only the policy file is an
+acceptance-matrix row (`P1-5`, cited as explicitly Gate B in ADR-0021 §7). Guard
+integration into the capture pipeline is a non-goal that stands on its own; PRD-F9 says so
+in the same bullet, and adds that it "is not acceptance-matrix row `P0-8`". `P0-8` is the
+unified `commitlore_before_change` tool and was **closed in Gate A by T-1024 (#219)**.
+
+This file's first draft cited `P0-8` for row `B-6` anyway. That is precisely the failure
+`GATE-A-ACCEPTANCE.md` documents — three of its rows had a subject reconstructed from
+where a label was cited — and it was caught here by reading the merged Gate A matrix
+rather than a stale local checkout. The corrected citation is recorded rather than quietly
+replaced, because the check is the point.
+
+## Rows
+
+| Row | Asserts | Source authority | Closing ticket(s) | Decided by |
+|---|---|---|---|---|
+| B-1 | Windows is either shipped with #71's containment verified **on Windows**, or still absent — never shipped with the property unverified | [#95](https://github.com/MongLong0214/commitlore/issues/95) (closed, with the order of work recorded); [ADR-0023](adr/ADR-0023-windows-requires-containment-parity.md) | T-1101, T-1102, T-1103, T-1104 | `windows-latest` CI job running #71's two containment attacks exits 0; release matrix contains `windows-latest` only after it does |
+| B-2 | musl has a **recorded decision with its evidence**, not an absence | active ruled-out record on `install.sh`/`release.yml` ("a release.yml/build-matrix change … DO NOT: no Docker in the release build matrix"); [ADR-0024](adr/ADR-0024-musl-target-gated-on-feasibility.md) | T-1105 | A committed spike result answering "can a musl-linked SEA be built in the release matrix without Docker" with a measurement and a recommendation. **A "no" closes this row.** |
+| B-3 | One package-manager channel exists and is a verified pointer to a published release — no second build, no hand-edited digest | M6 description ("package managers"); [ADR-0025](adr/ADR-0025-package-manager-as-verified-pointer.md), reconciled against [ADR-0011](adr/ADR-0011-plugin-first-distribution.md)'s rejection of a second channel | T-1106 | Regenerating the manifest from the current release produces a byte-identical file (CI diff), and one install through the channel succeeds on a machine that did not build it |
+| B-4 | A single authoritative compatibility matrix exists, and a test fails if it disagrees with `install.sh`'s target mapping or the release build matrix | M6 description ("compatibility matrix") | T-1107 | `npx vitest run test/compatibility-matrix.test.ts` fails when a target is added to `release.yml` without a matrix row |
+| B-5 | What `install.sh` writes can be removed by a command — the binary and the agent MCP entries it added — and it never removes what it did not write | M6 description ("update/uninstall"); measured absence at `e2b5725`: `hooks uninstall` and `inject uninstall-claude-hook` undo per-repository state only | T-1108 | A test installs, uninstalls, and asserts both that the written entries are gone and that a pre-existing unrelated entry in the same config survived |
+| B-6 | Guard participates in the capture pipeline as an advisory that **cannot block a capture or a commit** | `PRD-F9-unified-capture.md` "Non-goals" — a standalone deferral, explicitly **not** row `P0-8` (that row is `commitlore_before_change`, closed by T-1024 #219); [ADR-0020](adr/ADR-0020-guard-is-an-experimental-advisory.md); `bench/GUARD-CANNOT-BLOCK.md` | T-1109 | A test asserts a guard match at any score changes no exit code and no pending phase — it only adds an advisory field |
+| B-7 (row `P1-5`) | The user-editable policy file ships, and the pending-transaction format absorbs it **without a breaking change** | `P1-5`, cited as explicitly Gate B in [ADR-0021](adr/ADR-0021-capture-pending-transaction.md) §"P1-5" and `PRD-F9` "Non-goals". ADR-0021 already fixes the migration: the policy identity hash input changes from `sha256(hardcoded-defaults-json)` to `sha256(policy-file-contents)` | T-1110 | A pending file written by the pre-policy code path is still consumable after the policy file ships; the identity hash changes and the format version does not |
+
+## What this gate does not claim
+
+Stated here so no row is read as more than it is.
+
+- **B-2 can pass with no musl asset.** Its pass condition is a decision, which is a
+  weaker promise than a build. ADR-0024 says so, and this table repeats it because a
+  matrix row is where the overclaim would happen.
+- **B-1 can pass with Windows still unsupported.** If the containment attacks fail on
+  Windows for a reason outside `.exe` classification, the gate stops at T-1103 and the
+  finding becomes its own issue. "Executed, and Windows is still not ready" is a pass for
+  the safety property and a failure only for the asset.
+- **B-3 adds one channel, not a packaging strategy.** No Windows package manifest is in
+  scope, because no Windows asset exists to point at.
+- **B-6 does not make guard accurate.** ADR-0020's measured precision 44.8% / recall
+  22.0% is unchanged by integrating it. This row is about where an advisory appears, not
+  about what it is worth.
+- **Nothing here measures adoption.** The milestone is named Universal Adoption; every
+  row above is a capability or a decision. No row claims a user count, and none should be
+  added that does without an interval.
+
+## Execution constraints
+
+- **T-1101 → T-1102 → T-1103 → T-1104 is a chain, not a wave.** ADR-0023 makes the order
+  binding; T-1104 is a release-matrix edit that must be last.
+- **T-1104 and T-1106 must not merge in the same wave.** Both change what a release
+  publishes or points at; sequencing them keeps a broken manifest from being attributed
+  to a matrix change.
+- **T-1109 and T-1110 both touch the capture pipeline.** T-1110 changes the policy
+  identity hash input, which T-1109's advisory field is written alongside. T-1109 merges
+  first, or T-1110 carries its field forward.
+- Every ticket that changes `src/` must rebuild and commit `dist/`; CI compares them.
+- `README.md`'s Windows and musl statements may not be softened by any ticket before its
+  row's asset actually exists.

--- a/docs/adr/ADR-0023-windows-requires-containment-parity.md
+++ b/docs/adr/ADR-0023-windows-requires-containment-parity.md
@@ -1,0 +1,105 @@
+# ADR-0023: Windows ships only after #71's containment is verified on Windows
+
+- Status: Accepted (2026-07-31)
+- Milestone: M6 · Universal Adoption (Gate B)
+- Extends: [ADR-0015](ADR-0015-single-executable-binary.md) (single-executable binary)
+- Closes acceptance row: `B-1` in [`../GATE-B-ACCEPTANCE.md`](../GATE-B-ACCEPTANCE.md)
+
+## Context
+
+Windows is excluded from the release matrix. [#95](https://github.com/MongLong0214/commitlore/issues/95)
+recorded why, from a real `windows-latest` run rather than an assumption, and found
+**two** independent problems.
+
+1. **The build dies before SEA is reached.** `resolve(new URL('..', import.meta.url).pathname)`
+   doubles the drive letter (`D:\D:\a\commitlore\...`).
+2. **The installed hook would silently bypass #71's containment.** `classifyBinTarget`
+   (`src/core/hook-target.ts:63`) recognises a binary only as `basename(path) === 'commitlore'`,
+   and the `commit-msg` stub's allowlist glob (`src/hooks/commit-msg.ts:98`) is
+   `*.mjs|*.js|*/commitlore|commitlore`. Neither knows `commitlore.exe`. On Windows the
+   real binary would therefore not classify as a binary, and the install-root containment
+   that stops `commitlore.bin` from pointing at an arbitrary executable would not apply
+   to it.
+
+Two facts measured at `e2b5725` while writing this ADR, both sharper than what #95
+recorded:
+
+- the `.pathname` pattern is in **four** scripts — `scripts/adoption-range.mjs:21`,
+  `scripts/build-binary.mjs:62`, `scripts/check-test-files-ran.mjs:21`,
+  `scripts/check-engines.mjs:21` — not the two #95 names.
+- `scripts/check-release-version.mjs:37` already uses
+  `resolve(fileURLToPath(new URL('..', import.meta.url)))`. The correct pattern is
+  already in the repository, so this is an inconsistency to converge, not a technique
+  to discover.
+
+The distinction that matters for a gate: problem 1 is a defect, and a broken build is
+loud. Problem 2 is a **security property that would be quietly false on a platform we
+shipped to**. #71's containment was verified twice — on macOS. A property verified on
+one platform is not a property of the product.
+
+## Decision
+
+**Windows enters the release matrix last, and only after #71's two containment attacks
+have been executed on Windows and passed there.** Inference from macOS does not
+substitute.
+
+The order in #95 becomes binding, one ticket per step, in this sequence:
+
+1. Converge all four `.pathname` sites onto `fileURLToPath`, matching
+   `check-release-version.mjs`.
+2. Teach `classifyBinTarget` and the `commit-msg` stub allowlist about `.exe`, with the
+   extension recognised explicitly rather than by loosening the match.
+3. Execute #71's two containment attacks in CI **on `windows-latest`** and require them
+   to pass there.
+4. Only then add `windows-latest` to the release build matrix.
+
+Steps 1–3 are independently verifiable and mergeable. Step 4 is a matrix edit that
+depends on all three.
+
+Until step 4 lands, **a missing Windows asset stays the correct outcome**, and
+`README.md`'s existing statement that Windows is unsupported stays accurate. That
+sentence may not be softened by any ticket before step 4.
+
+## Ruled-out
+
+- **Fix the path bug and ship Windows, then fix containment** | ships a platform on
+  which #71 is open. The order exists because the second problem is the reason the
+  first one cannot be fixed alone. This is the specific sequencing #95 warned against.
+- **Broaden `classifyBinTarget` to accept any basename starting with `commitlore`** |
+  turns an exact-name allowlist into a prefix match, so `commitlore-evil` would classify
+  as the binary. The containment property depends on the match being exact; add the one
+  extension the platform requires, not a pattern.
+- **Verify containment on Windows by reasoning from the macOS result** | the property is
+  about how a shell stub and a path classifier behave against a specific filesystem and
+  executable model. That is exactly what differs. #95 states the requirement as
+  "verified there, not inferred from macOS", and this ADR does not weaken it.
+- **Add `windows-latest` to the matrix with `continue-on-error`** | a green release run
+  with a silently absent asset is worse than a missing asset, because the release then
+  claims a platform it did not produce. Assets are checksum-listed; a partial matrix
+  makes `SHA256SUMS` a document about what happened to succeed.
+- **Drop Windows from Gate B entirely** | the M6 description names it. The gate may
+  conclude that Windows is not ready, but it must reach that conclusion from executed
+  steps, not by removing the row.
+
+## Consequences
+
+- Gate B carries four Windows tickets, not one, and three of them produce no Windows
+  asset. The visible deliverable arrives only at the end.
+- The `.pathname` convergence touches build and check scripts that run on every CI job,
+  so it is verified by the existing CI passing, not only by a new unit test.
+- CI acquires a `windows-latest` job before the release matrix does. That job's purpose
+  is the containment attacks; it is not a full test-suite port and does not claim to be.
+- If the containment attacks fail on Windows for a reason that is not the `.exe`
+  classification, Gate B stops at step 3 and the finding becomes its own issue. The gate
+  is allowed to end with "Windows is still unsupported, and here is the executed
+  evidence" — that is a pass for this ADR, and a failure only for the row that wanted
+  the asset.
+
+## Falsification
+
+This ADR is wrong if any of the following is true:
+
+- a Windows asset is published while `classifyBinTarget` still matches only the bare
+  name, or while #71's attacks have never run on `windows-latest`
+- `README.md` stops stating Windows is unsupported before step 4 lands
+- the containment attacks are marked non-blocking in CI

--- a/docs/adr/ADR-0024-musl-target-gated-on-feasibility.md
+++ b/docs/adr/ADR-0024-musl-target-gated-on-feasibility.md
@@ -1,0 +1,99 @@
+# ADR-0024: a musl target is gated on a feasibility spike, not assumed
+
+- Status: Accepted (2026-07-31)
+- Milestone: M6 · Universal Adoption (Gate B)
+- Extends: [ADR-0015](ADR-0015-single-executable-binary.md) (single-executable binary)
+- Closes acceptance row: `B-2` in [`../GATE-B-ACCEPTANCE.md`](../GATE-B-ACCEPTANCE.md)
+
+## Context
+
+The published Linux targets are `<arch>-unknown-linux-gnu`: a Node single-executable
+binary dynamically linked against glibc's loader. A musl-libc host — Alpine being the
+common case — has no `/lib/ld-linux-*.so.*` to load it, and the kernel's refusal to exec
+surfaces as a bare `not found`.
+
+**That part is already handled, and this ADR does not reopen it.** `install.sh` executes
+the freshly extracted binary before copying it anywhere and, on failure, dies with a
+named, attributed message that says musl is the likely cause and points at
+install-from-source. The failure is clear; what is absent is an asset.
+
+Two recorded constraints bound anything further, both from the record on
+`install.sh`/`.github/workflows/release.yml`:
+
+- publishing a `-musl` target was ruled out **as an installer or CI-verification fix** —
+  "a release.yml/build-matrix change … orthogonal to making the existing failure clear
+  instead of a raw crash". That rejection is about *justification*, not about the target
+  itself. A musl target needs its own grounds, and Gate B is where it can have them.
+- the same record states **no Docker in the release build matrix**.
+
+Those two together are why this cannot be a plain implementation ticket. The honest
+question is not "should we ship musl" but "**can** a musl-linked Node SEA be produced
+under the constraint we have already accepted". A Node SEA embeds the Node binary
+itself; a musl-linked one requires a musl-linked Node, and GitHub-hosted runners are
+glibc. The candidate routes — an unofficial musl Node build, a static link, a
+cross-toolchain, or a non-Docker container step — differ in whether the resulting
+binary is one this project is willing to publish, sign for and checksum, not merely in
+difficulty.
+
+## Decision
+
+**Gate B does not commit to a musl asset. It commits to deciding the question with
+evidence.**
+
+1. A spike ticket produces a recorded answer to one question: can a musl-linked
+   single-executable binary be built in the release matrix without Docker, and is its
+   provenance one this project can stand behind? The deliverable is a measurement and a
+   recommendation, not a target.
+2. The spike is allowed to conclude **no**. A recorded "no, for this reason" closes the
+   row. An unrecorded "not done" does not.
+3. Independent of the spike, and not blocked by it, the compatibility matrix
+   (`B-4`) states musl's status as a first-class row rather than leaving it only in a
+   README bullet, and the existing clear failure in `install.sh` stays exactly as it is.
+4. If the spike concludes yes, publishing the target is a **separate ticket in a later
+   wave**, with its own build, checksum and release-matrix change. This ADR does not
+   pre-approve it.
+
+## Ruled-out
+
+- **Publish a `-musl` target now and treat it as the Alpine install fix** | still
+  rejected, on the recorded grounds: it is a build-matrix change, and the installer gap
+  it was offered against is already closed by a clear attributed failure. Nothing found
+  since changes that.
+- **Add a Docker build step to the release matrix to get a musl toolchain** | the
+  recorded constraint says no Docker in the release build matrix. If the spike finds
+  Docker is the only viable route, the correct outcome is a recorded "no" plus that
+  finding — not a silent exception to a constraint that was written down.
+- **Detect musl before download by probing for `/lib/ld-musl-*.so.1`** | already ruled
+  out and still wrong: executing the checksum-verified binary catches *any* reason it
+  cannot run here, not the one signature this repository happens to know.
+- **Declare musl out of scope and delete the row** | the M6 description names musl
+  builds. Removing the row would make the gate silent about the platform rather than
+  decided about it.
+- **Ship an unofficial third-party musl Node build without recording its provenance** |
+  the product claim is verifiability. An asset whose base runtime came from an
+  unattributed download cannot be defended, and its checksum would prove only that we
+  published what we downloaded.
+
+## Consequences
+
+- Gate B may end with no musl asset and still pass this row. The pass condition is a
+  recorded decision with its evidence, which is a different and weaker promise than an
+  asset — stated here so it is not read as one.
+- The spike's negative result, if that is the outcome, becomes the citable reason for
+  every future "why not Alpine" question. That is the durable value even in the no case.
+- `install.sh` is untouched by this ADR. Its musl behaviour is the current correct
+  behaviour, and a spike result of "no" leaves it correct.
+- The compatibility matrix row for musl must distinguish **unsupported** from
+  **unknown**. After the spike it is unsupported-with-a-reason; before, it is
+  unsupported-and-undecided. Those are not the same claim.
+
+## Falsification
+
+This ADR is wrong if any of the following is true:
+
+- a `-musl` asset is published without a recorded feasibility result behind it
+- the row is closed with no recorded answer — "we did not get to it" is not a decision
+- a Docker step enters the release build matrix without the constraint that forbids it
+  being explicitly revisited and superseded
+- `install.sh`'s musl failure message is weakened or removed on the grounds that an
+  asset is coming

--- a/docs/adr/ADR-0025-package-manager-as-verified-pointer.md
+++ b/docs/adr/ADR-0025-package-manager-as-verified-pointer.md
@@ -1,0 +1,100 @@
+# ADR-0025: a package manager may be a verified pointer to a release, never a second channel
+
+- Status: Accepted (2026-07-31)
+- Milestone: M6 · Universal Adoption (Gate B)
+- Extends: [ADR-0011](ADR-0011-plugin-first-distribution.md) (registry-free git distribution),
+  [ADR-0015](ADR-0015-single-executable-binary.md) (single-executable binary)
+- Closes acceptance row: `B-3` in [`../GATE-B-ACCEPTANCE.md`](../GATE-B-ACCEPTANCE.md)
+
+## Context
+
+M6 names package managers. ADR-0011 ruled out **"keep npm alongside the plugin"**, on
+the grounds that "two channels split versions and preserve the OTP ritual for every
+release". Taken at face value that rejection forbids the whole row, so this ADR has to
+say precisely which part of it still binds and why the remainder does not.
+
+ADR-0011 gave three reasons against npm. They do not survive equally.
+
+| ADR-0011's reason | Applies to a git-hosted tap? |
+|---|---|
+| The owner acquires a release ritual — accounts, tokens, an OTP that actually blocked the first attempt | **No.** A tap is a file in a git repository. No account, no token, no OTP. |
+| Users inherit an ecosystem bias — `npm install -g` inside a Python or Go repository | **No.** A system package manager is not tied to the repository's language. |
+| It is disconnected from the agent ecosystem — no agent discovers tools in a registry | **Still true**, and it is why this is not a first-class surface. Nothing about this ADR changes the fact that MCP and the plugin are how agents find CommitLore. |
+
+What does still bind is the first half of the sentence: **two channels split versions.**
+That is the failure to prevent, and it is preventable by construction. A formula that
+carries its own build splits versions. A formula that carries the tag, the asset URL and
+the checksum that the release already published cannot — it resolves to the identical
+bytes or it fails.
+
+ADR-0015 established the shape for exactly this situation once already: the binary is
+"an additional, uncommitted, reproducible build artifact rather than a second registry or
+a replacement channel." A package manifest is the same kind of thing one level up.
+
+## Decision
+
+**A package-manager manifest is permitted only as a verified pointer to an existing
+tagged release.** Four properties, all of them mechanical:
+
+1. **No second build.** The manifest downloads a published release asset. It never
+   compiles, never bundles, never produces bytes of its own.
+2. **Version from the tag.** The version in the manifest is the release tag. It is not
+   written by hand and not maintained on a separate cadence.
+3. **Checksum from `SHA256SUMS`.** The digest in the manifest is the one the release
+   published. A mismatch is an install failure, not a warning.
+4. **Generated, never hand-edited.** The manifest is produced from the release by a
+   script that CI can re-run, so drift between the manifest and the release is a
+   detectable diff rather than a discovery months later.
+
+**Homebrew is the one channel Gate B adds**, as a tap, covering macOS and Linuxbrew.
+`git clone` remains canonical and `install.sh` remains the one-liner; the tap is a third
+way to reach the same asset, listed after them.
+
+**No Windows package manager in Gate B.** Scoop or WinGet would package an asset that
+does not exist, and [ADR-0023](ADR-0023-windows-requires-containment-parity.md) forbids
+that asset until #71's containment is verified on Windows. The rule above is written to
+be reusable so that a Scoop manifest is a later ticket, not a later argument.
+
+## Ruled-out
+
+- **Publish to npm after all, now that the binary exists** | the OTP ritual and the
+  ecosystem bias are both unchanged, and ADR-0011's rejection was not conditional on the
+  binary. Nothing in Gate B is evidence against it.
+- **A formula that builds from source** | reintroduces a toolchain requirement at install
+  time, which ADR-0011 rejected for the clone path, and produces bytes no release
+  published — the exact version split this ADR exists to prevent.
+- **Hand-maintain the formula and bump it during the release checklist** | one more
+  manual step in a release procedure that already caught a version-pin defect. A
+  hand-edited digest is also a digest nobody can recompute from the release.
+- **Submit to `homebrew-core` instead of running a tap** | core submission adds an
+  external review cadence between a tag and its availability, so the two would visibly
+  diverge, and it imposes notability and maintenance requirements this project has no
+  reason to take on to make one command work.
+- **Add Scoop or WinGet in the same wave for symmetry** | there is no Windows asset to
+  point at. A manifest for a missing asset is a broken install that reports itself as a
+  supported platform.
+- **Treat the tap as the recommended install path** | agents do not discover tools
+  through a system package manager, which is ADR-0011's surviving reason. The tap serves
+  a human setting up a machine; it does not lead.
+
+## Consequences
+
+- The release surface grows by one generated file and one script. Because the script is
+  re-runnable, CI can assert that the checked-in manifest equals the one regenerated
+  from the current release — the same drift check `dist/` already has.
+- A tap is a second repository or a second directory to host. Whichever it is, it is
+  public, and it contains no secrets: a URL and a digest.
+- The first release after this lands must be verified by an actual install through the
+  tap, on a machine that did not build it. A formula that was never installed is a claim.
+- If the tap ever needs to diverge from the published asset for any reason, that is the
+  signal this ADR was wrong, not a reason to allow one exception.
+
+## Falsification
+
+This ADR is wrong if any of the following is true:
+
+- a manifest compiles or bundles anything
+- a manifest's version or digest is edited by hand, or cannot be regenerated from the
+  release it names
+- a package-manager channel is presented ahead of `git clone` or `install.sh`
+- a Windows package manifest ships before a Windows release asset exists

--- a/docs/prd/PRD-F12-universal-adoption.md
+++ b/docs/prd/PRD-F12-universal-adoption.md
@@ -1,0 +1,116 @@
+# PRD F12 — Universal adoption (platform reach, packaging, lifecycle, matrix)
+
+- Milestone: M6 · ADR: 0023 (Windows containment parity), 0024 (musl gated on a spike),
+  0025 (package manager as verified pointer)
+- Acceptance rows: `B-1`, `B-2`, `B-3`, `B-4`, `B-5` in
+  [`../GATE-B-ACCEPTANCE.md`](../GATE-B-ACCEPTANCE.md)
+
+## Goal
+
+A person on a machine this project has never run on can install CommitLore, learn from
+the product itself whether their platform is supported, and remove everything the
+installer put there — without reading the source.
+
+Four surfaces deliver this: the platform set, one package-manager channel, a lifecycle
+inverse, and a compatibility matrix that a test keeps honest.
+
+## Non-goals
+
+- Any change to `install.sh`'s existing musl failure, which is already a clear attributed
+  message and is the correct behaviour whether or not a musl asset ever ships.
+- npm, or any registry account (ADR-0011; ADR-0025 restates why the rejection stands).
+- A Windows package manifest (ADR-0025 — there is no asset to point at).
+- A full Windows port of the test suite. The Windows CI job exists for #71's containment
+  attacks, not for parity.
+- Softening the README's Windows or musl statements. They stay until the corresponding
+  asset exists.
+- Anything that measures or claims adoption. The milestone is named for the goal, not for
+  a metric this gate produces.
+
+## User stories
+
+- As someone on Alpine, I run the install one-liner, get a message that names musl as the
+  cause and points somewhere useful, and can find musl's status in one table rather than
+  inferring it from a failure.
+- As someone on macOS who already uses Homebrew, I install with one `brew` command and can
+  verify that what I got is the same asset the release published.
+- As someone evaluating CommitLore who decided against it, I run one command and the
+  binary and every agent config entry the installer added are gone — and the MCP server I
+  had configured for something else is still there.
+- As a maintainer, I add a target to the release matrix and a test fails until the
+  compatibility matrix mentions it.
+
+## Requirements
+
+### Platform reach — Windows (B-1)
+
+1. Every `REPO_ROOT`-style path resolution derives a filesystem path with
+   `fileURLToPath`, never `URL.pathname`. Four sites at `e2b5725` —
+   `scripts/adoption-range.mjs`, `scripts/build-binary.mjs`,
+   `scripts/check-test-files-ran.mjs`, `scripts/check-engines.mjs` — converge on the
+   pattern `scripts/check-release-version.mjs` already uses.
+2. `classifyBinTarget` recognises a Windows executable by the exact extension `.exe`
+   appended to the exact name, never by a prefix or a loosened match.
+3. The `commit-msg` stub's allowlist recognises the same set as `classifyBinTarget`, and a
+   test asserts the two agree rather than asserting each separately.
+4. #71's two containment attacks execute on `windows-latest` in CI and are required, not
+   `continue-on-error`.
+5. `windows-latest` enters the release build matrix only after requirement 4 passes. If it
+   does not pass, the gate records why and Windows stays absent.
+
+### Platform reach — musl (B-2)
+
+6. A spike answers one question with evidence: can a musl-linked single-executable binary
+   be produced in the release build matrix without Docker, and is its provenance
+   defensible? The output is a committed document with what was attempted, what was
+   measured, and a recommendation.
+7. The spike states what it could not determine. A route not attempted is recorded as not
+   attempted, never as impossible.
+8. No musl asset is published by this PRD. If the recommendation is yes, publishing is a
+   separate later ticket.
+
+### Package channel (B-3)
+
+9. A Homebrew formula is **generated** from a published release: version from the tag, URL
+   from the asset, digest from the release's `SHA256SUMS`.
+10. The generator is re-runnable, and CI fails if regenerating produces a diff against the
+    committed manifest — the same drift protection `dist/` has.
+11. The formula performs no build step of any kind.
+12. One real install through the channel is executed on a machine that did not build the
+    asset, and the installed binary's `--version` is checked against the tag.
+13. The channel is documented after `git clone` and `install.sh`, never ahead of them.
+
+### Lifecycle (B-5)
+
+14. A single command removes what `install.sh` wrote: the installed binary, and the agent
+    MCP configuration entries the installer added.
+15. It never removes an entry it did not write. An unrelated MCP server in the same config
+    file survives, and the file's other contents are preserved byte-for-byte apart from
+    the removed entry.
+16. It reports, per agent, what was removed, what was left and why — the same
+    wired/skipped/not-found shape `install.sh` already reports.
+17. It is idempotent: a second run removes nothing, reports nothing removed, and exits 0.
+18. It refuses to remove a binary at the target path that does not identify itself as
+    CommitLore, by the same test `install.sh` uses before overwriting one.
+19. Per-repository state is out of its scope: `hooks uninstall` and
+    `inject uninstall-claude-hook` already own that, and this command points at them
+    rather than duplicating them.
+
+### Compatibility matrix (B-4)
+
+20. One document is the authority for platform support, with a row per target and an
+    explicit status. `unsupported` and `undecided` are distinct statuses and may not be
+    collapsed.
+21. A test fails if the matrix disagrees with the release build matrix in either
+    direction — a published target with no row, or a row claiming a target the release
+    does not build.
+22. A test fails if the matrix disagrees with the architecture and OS mapping in
+    `install.sh`.
+23. Each unsupported row cites the issue or record that explains it, so the matrix carries
+    reasons rather than only verdicts.
+
+## Verification
+
+Every requirement above is decided by a command, not by review. Requirement 12 is the one
+exception in kind: it is a real-usage check on a machine that did not build the artifact,
+and it is not satisfied by a passing test suite.

--- a/docs/prd/PRD-F13-capture-advisory-and-policy.md
+++ b/docs/prd/PRD-F13-capture-advisory-and-policy.md
@@ -1,0 +1,107 @@
+# PRD F13 — Capture advisory and policy resolution (the two items Gate A deferred)
+
+- Milestone: M6 · ADR: 0020 (guard is an experimental advisory), 0021 (capture pending
+  transaction), 0006 (push injection)
+- Acceptance rows: `B-6`, `B-7` in [`../GATE-B-ACCEPTANCE.md`](../GATE-B-ACCEPTANCE.md)
+
+## Authority, and one attribution this document must not get wrong
+
+The two items here were deferred to Gate B by `PRD-F9-unified-capture.md`'s "Non-goals",
+and they are deferred on **different** grounds:
+
+- **Guard integration into the capture pipeline** is a non-goal that stands on its own.
+  PRD-F9 states, in the same bullet, that it "is not acceptance-matrix row `P0-8`: that
+  row is the unified `commitlore_before_change` query tool, which is a different subject."
+  `P0-8` was closed in Gate A by T-1024 (#219). **Nothing in this document closes `P0-8`.**
+- **The user-editable policy file** *is* acceptance-matrix row `P1-5`, cited as explicitly
+  Gate B in ADR-0021 §7 and in PRD-F9's "Non-goals".
+
+The distinction is recorded here because an earlier session attributed capture-pipeline
+guard integration to `P0-8`, and `GATE-A-ACCEPTANCE.md` had to correct three rows whose
+subject had been reconstructed from where a label was cited. Repeating that attribution
+would recreate a row that does not exist.
+
+## Goal
+
+Close the two deferred items without weakening either property Gate A established: guard
+is an advisory that cannot block, and the pending transaction's format does not break.
+
+## Non-goals
+
+- Improving guard's accuracy. ADR-0020's measured precision 44.8% / recall 22.0% is the
+  number this PRD works with, not a number it moves.
+- Letting guard block anything — a capture, a stage, a commit, or a push (ADR-0020,
+  ADR-0006, `bench/GUARD-CANNOT-BLOCK.md`).
+- Any change to the `commitlore_before_change` tool T-1024 shipped. That is a closed row.
+- A policy schema beyond the three keys that already exist in the hardcoded defaults.
+  Adding a fourth key is a later decision, not part of shipping the file.
+- Changing the pending format version. ADR-0021 already fixed the migration so that no
+  version bump is needed; producing one would falsify that ADR.
+- Any model call, any network call.
+
+## User stories
+
+- As an agent capturing a decision, I see that the approach I described matches a
+  previously ruled-out alternative, in the same output I already read — and my capture
+  still completes, because the match is information, not a gate.
+- As a user who wants one record per commit but two on this repository, I edit one file
+  rather than rebuilding the tool.
+- As a user who upgrades between staging a capture and committing it, the hook tells me
+  the policy changed underneath, exactly as it already does for the hardcoded defaults.
+
+## Requirements
+
+### Guard as a capture advisory (B-6)
+
+1. When a capture is prepared, guard runs against the drafted record's own text and the
+   paths the staged diff touches, and its matches are attached to the pending record as an
+   advisory field.
+2. The advisory field is additive. No existing field changes meaning, and a pending record
+   written without it stays readable.
+3. A guard match at **any** score leaves the exit code, the `phase`, and every gate
+   decision identical to a run with no match. A test asserts this by running the same
+   capture with the guard match forced on and off and comparing everything except the
+   advisory field.
+4. The advisory carries guard's measured precision and recall wherever it is displayed, in
+   the same form ADR-0020 requires of every other guard surface. An empty advisory is
+   never rendered as "no ruled-out alternative applies".
+5. Guard failing — for any reason, including a missing index — degrades the advisory to a
+   recorded "could not check, and why". It never fails the capture.
+6. The advisory states what it could not see, reusing the closed gap vocabulary T-1024
+   already fixed (`history-unavailable`, `shallow-history`, `notes-unfetched`) rather than
+   inventing a second one.
+
+### User-editable policy file (B-7, row `P1-5`)
+
+7. **Before the policy input changes, the three duplicated definitions of it are
+   consolidated into one.** At `e2b5725`, `computePolicyIdentityHash` and its defaults
+   object exist independently in `src/core/capture-prepare.ts`,
+   `src/core/capture-stage.ts` and `src/hooks/prepare-commit-msg.ts` — under two different
+   constant names — and agree only because the three object literals happen to list the
+   same keys in the same order, which is what `JSON.stringify` hashes. A test asserts the
+   three call sites resolve to one implementation.
+8. The policy file is optional. With no file present, resolution produces exactly today's
+   hardcoded defaults and exactly today's identity hash, so an existing pending record
+   remains valid.
+9. With a file present, the identity hash input becomes the file's contents, per
+   ADR-0021: `sha256(policy-file-contents)` replaces `sha256(hardcoded-defaults-json)`.
+   The pending record's `version` stays `1`.
+10. An invalid policy file is a named, actionable error that leaves the previous behaviour
+    in place. It is never silently ignored, and it never falls back to defaults without
+    saying so — a silent fallback would make the identity hash lie about which policy ran.
+11. The file is read from one location, resolved the same way in the CLI and in the hook.
+    A repository-local file and a user-global file may not both apply in the same run
+    without a stated precedence, and that precedence is asserted by a test.
+12. The policy file is untrusted input. It may set only the declared keys, and a key it
+    does not declare is rejected rather than merged. It may not influence any path
+    resolution, any command execution, or anything that touches Git history.
+13. The stage-to-commit mismatch behaviour already implemented for a defaults change
+    applies unchanged when the change came from the file: the hook detects a differing
+    identity hash and reports it.
+
+## Verification
+
+Requirement 3 is the load-bearing one and is verified by differential test, not by
+inspection: the same capture, guard forced to match and forced not to match, everything
+but the advisory field identical. Requirement 7 is verified by a test that would fail if a
+fourth copy of the policy definition were introduced.

--- a/docs/tickets/F12-universal-adoption.md
+++ b/docs/tickets/F12-universal-adoption.md
@@ -1,0 +1,769 @@
+# F12 tickets — Universal adoption: platform reach, packaging, lifecycle, matrix (M6)
+
+> PRD: [PRD-F12-universal-adoption.md](../prd/PRD-F12-universal-adoption.md)
+> ADR: [0023](../adr/ADR-0023-windows-requires-containment-parity.md) (Windows containment
+> parity), [0024](../adr/ADR-0024-musl-target-gated-on-feasibility.md) (musl gated on a
+> spike), [0025](../adr/ADR-0025-package-manager-as-verified-pointer.md) (package manager
+> as verified pointer)
+> Acceptance: [`../GATE-B-ACCEPTANCE.md`](../GATE-B-ACCEPTANCE.md) rows `B-1`…`B-5`
+> Baseline head: `e2b5725`. Full suite there: **65 files, 1,750 passed, 1 skipped.**
+
+**Every ticket below is bound to `e2b5725`.** Line numbers and the "fails before"
+justification are stale the moment another ticket in this file merges. The
+**Evidence invalidation** block of each ticket says what to re-derive.
+
+**Chain, not a wave**: `T-1101 → T-1102 → T-1103 → T-1104` is strictly ordered by
+ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each other.
+`T-1108` is independent. `T-1104` and `T-1106` must not merge in the same wave
+(`GATE-B-ACCEPTANCE.md` "Execution constraints").
+
+---
+
+## T-1101 Converge the four `.pathname` path resolutions onto `fileURLToPath` (S) — B-1 step 1
+
+**Owns**
+
+- `scripts/adoption-range.mjs` — line 21 at `e2b5725`
+- `scripts/build-binary.mjs` — line 62 at `e2b5725`
+- `scripts/check-test-files-ran.mjs` — line 21 at `e2b5725`
+- `scripts/check-engines.mjs` — line 21 at `e2b5725`
+- `test/scripts-path-resolution.test.ts` (new)
+
+**Depends on**
+
+- ADR-0023 accepted (nothing else)
+
+**Forbidden scope**
+
+- Do not touch `src/` or `dist/` — this ticket changes no shipped code
+- Do not touch `scripts/check-release-version.mjs`: line 37 already uses the target
+  pattern and is the reference, not a subject
+- Do not touch `.github/workflows/release.yml` or any matrix
+- Do not touch `classifyBinTarget` or any hook file (that is T-1102)
+- Do not add a Windows CI job (that is T-1103)
+
+**RED test**
+
+- File: `test/scripts-path-resolution.test.ts` (new)
+- Assertion: every tracked file under `scripts/` that derives a filesystem path from
+  `import.meta.url` uses `fileURLToPath`, and **no** tracked file matches
+  `new URL(…, import.meta.url).pathname`.
+- Fails at `e2b5725` because four files match the forbidden pattern. The test is a
+  repository-wide invariant, so it also fails if a fifth is added later.
+
+**Minimum GREEN**
+
+- Each of the four sites becomes `resolve(fileURLToPath(new URL('..', import.meta.url)))`,
+  with `fileURLToPath` imported from `node:url`, matching
+  `scripts/check-release-version.mjs:37` exactly.
+- No other change in those files.
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| No script derives a path via `.pathname` | `expect(offenders).toEqual([])` | PRD-F12 req 1; ADR-0023 §Decision 1 |
+| All four converge on the existing reference pattern | per-file `expect(src).toContain('fileURLToPath')` | ADR-0023 §Context (the pattern is already in-repo) |
+| The invariant holds for files added later | test globs `scripts/**`, not a fixed list | ADR-0023 §Consequences |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/scripts-path-resolution.test.ts` | pass |
+| full | `npx vitest run` | 66 files, 1,750+ passed, 1 skipped |
+| release | `npx tsc --noEmit && npx tsc --noEmit -p bench/tsconfig.json` | both exit 0 |
+| manual | `node scripts/check-engines.mjs && node scripts/check-test-files-ran.mjs` | both exit 0 — these scripts run in CI and must still work |
+| manual | `npm run build:binary` | still produces a binary (the file changed is its own entry path resolution) |
+| LIVE_NA | Windows behaviour is not verified by this ticket; it removes the crash cause, and T-1103 is where a Windows runner executes anything | — |
+
+**Evidence invalidation**
+
+- Bound to `e2b5725`. Re-derive the four line numbers with
+  `grep -rn "new URL(" scripts` before editing; if any site has already been converged,
+  drop it from **Owns** rather than re-editing.
+
+**Stop / escalate**
+
+- If a script needs the URL rather than a path for a legitimate reason, stop: the
+  invariant is about filesystem paths and the test must exempt it explicitly, with the
+  reason in the test.
+- If `npm run build:binary` fails after the change, stop — the fix is wrong, not the build.
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | If `fileURLToPath` cannot resolve, the script throws as before; no silent fallback to `.pathname` |
+| wrong-target | A diff touching `src/`, `dist/` or `check-release-version.mjs` is wrong |
+| ambiguity | The target pattern is quoted from a real line in the repository |
+| partial state | Four independent one-line edits; a partial application still leaves the test red, never green with a gap |
+| privacy | Path resolution only; no user data |
+| prompt injection | No external input |
+
+**Completion evidence**
+
+- `git diff --stat` shows exactly four scripts plus one new test
+- Focused test passes; full suite passes; both `tsc` exit 0
+- `node scripts/check-engines.mjs` exits 0
+
+---
+
+## T-1102 Recognise `commitlore.exe`, and bind the two allowlists together (M) — B-1 step 2
+
+**Owns**
+
+- `src/core/hook-target.ts` — `classifyBinTarget` (line 61–63 at `e2b5725`)
+- `src/hooks/commit-msg.ts` — the stub allowlist glob (line 98 at `e2b5725`:
+  `*.mjs|*.js|*/commitlore|commitlore)`)
+- `test/hook-target.test.ts` — extend the existing `classifyBinTarget` describe (line 21)
+- `dist/` — rebuild required (CI byte-compares `dist/` to `src/`)
+
+**Depends on**
+
+- T-1101 (merged) — ADR-0023 makes the order binding
+- ADR-0023 accepted
+
+**Forbidden scope**
+
+- **No prefix or fuzzy matching.** `basename(path) === 'commitlore'` becomes an exact
+  membership test over an explicit set; it must not become `startsWith`
+- Do not add any extension other than `.exe`
+- Do not touch `.github/workflows/*` (T-1103, T-1104)
+- Do not touch `README*` — Windows stays documented as unsupported until T-1104
+- Do not change `commitlore.root` containment logic itself, only what counts as the binary
+
+**RED test**
+
+- File: `test/hook-target.test.ts`
+- Assertions, all three failing at `e2b5725`:
+  1. `classifyBinTarget('/x/commitlore.exe') === 'binary'` — currently `null`
+  2. `classifyBinTarget('/x/commitlore-evil') === null` — passes today and must keep
+     passing; it is the regression guard against a prefix match
+  3. the stub allowlist string and `classifyBinTarget` accept the **same** set: for each
+     of a fixed candidate list, the glob's verdict equals the function's verdict —
+     currently disagrees on `commitlore.exe`
+
+**Minimum GREEN**
+
+- `classifyBinTarget` recognises exactly `commitlore` and `commitlore.exe`
+- The stub glob becomes `*.mjs|*.js|*/commitlore|commitlore|*/commitlore.exe|commitlore.exe`
+- The agreement assertion is a test, not a comment: one exported constant is the single
+  source of the accepted basenames, and both the function and the generated stub derive
+  from it
+- `npm run build` run and `dist/` committed
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| `.exe` classifies as binary | `expect(classifyBinTarget('/x/commitlore.exe')).toBe('binary')` | PRD-F12 req 2 |
+| No prefix match | `expect(classifyBinTarget('/x/commitlore-evil')).toBeNull()` | ADR-0023 §Ruled-out item 2 |
+| Function and stub agree | table-driven equality over a candidate list | PRD-F12 req 3 |
+| Existing behaviour intact | the pre-existing `agrees with hasAllowedBinExtension` test (line 49) still passes | ADR-0023 §Falsification |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/hook-target.test.ts test/hooks.test.ts` | pass |
+| full | `npx vitest run` | 66 files, 1,750+ passed, 1 skipped |
+| release | `npm run build && git diff --exit-code dist/` | build committed, no drift |
+| release | `npx tsc --noEmit` | exit 0 |
+| manual | `node dist/commitlore.mjs hooks status` | no crash, unchanged output shape |
+| LIVE_NA | Containment is **not** proven on Windows by this ticket. That is T-1103, and ADR-0023 forbids inferring it here | — |
+
+**Evidence invalidation**
+
+- Bound to `e2b5725`. If `hook-target.ts` or the stub changed since, re-read both before
+  editing and re-derive line 63 / line 98.
+- If T-1101 has not merged, this ticket is out of order — stop.
+
+**Stop / escalate**
+
+- If making the two allowlists share one source requires changing what the stub does at
+  runtime (beyond the accepted-name set), stop: that is containment logic, not this ticket
+- If any existing containment test flips from pass to fail, stop and report — that is the
+  property #71 established
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | An unrecognised basename stays `null`, i.e. not-a-binary, which is the safe verdict |
+| wrong-target | A diff that loosens the match to a prefix is the failure mode this ticket exists to avoid |
+| ambiguity | Accepted set is enumerated, never pattern-inferred |
+| partial state | If only one of the two allowlists changes, the agreement test fails — that is why it exists |
+| privacy | No user data |
+| prompt injection | The stub is generated from a constant, not from input |
+
+**Completion evidence**
+
+- `git diff src/core/hook-target.ts src/hooks/commit-msg.ts` shows the enumerated set
+- `git diff --exit-code dist/` clean after `npm run build`
+- Focused and full suites pass; `tsc --noEmit` exits 0
+
+---
+
+## T-1103 Execute #71's containment attacks on `windows-latest` in CI (M) — B-1 step 3
+
+**Owns**
+
+- `.github/workflows/ci.yml` — one new job (`windows-containment`), added after the
+  existing `binary` job (line 200 at `e2b5725`)
+- `test/ci-windows-containment.test.ts` (new) — asserts the workflow's shape
+
+**Depends on**
+
+- T-1101 and T-1102, both merged. Without T-1102 the job asserts a property that is
+  known false; without T-1101 the runner cannot get that far
+
+**Forbidden scope**
+
+- Do not add `windows-latest` to `.github/workflows/release.yml` (that is T-1104)
+- Do not port the full suite to Windows; this job runs the containment tests only
+- Do not mark the job `continue-on-error` or make it non-required — explicitly forbidden
+  by ADR-0023 §Ruled-out and §Falsification
+- Do not touch `src/`
+
+**RED test**
+
+- File: `test/ci-windows-containment.test.ts` (new)
+- Assertion: `ci.yml` contains a job with `runs-on: windows-latest` that executes
+  `test/hook-target.test.ts` and `test/hooks.test.ts`, and that the job declares no
+  `continue-on-error: true`.
+- Fails at `e2b5725` because `ci.yml` has no Windows job at all (jobs are `check`,
+  `git-matrix`, `binary`, `install-script`).
+
+**Minimum GREEN**
+
+- The job checks out, installs Node at the repository's floor, and runs
+  `npx vitest run test/hook-target.test.ts test/hooks.test.ts` on `windows-latest`
+- The job is required: no `continue-on-error`, no `if:` that can skip it on a normal PR
+- **The real verification is the run itself**, not the shape test: the job must pass on a
+  real `windows-latest` runner in this ticket's own PR
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| A Windows job exists and runs the containment tests | workflow-shape test | PRD-F12 req 4 |
+| The job cannot be skipped or soft-failed | `expect(job).not.toHaveProperty('continue-on-error')` | ADR-0023 §Ruled-out item 4 |
+| Containment actually holds on Windows | the job's own green result on this PR | ADR-0023 §Decision 3 — this is the row's real evidence |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/ci-windows-containment.test.ts` | pass |
+| full | `npx vitest run` | 67 files, 1,750+ passed, 1 skipped |
+| release | `npx tsc --noEmit` | exit 0 |
+| LIVE | `gh pr checks <pr>` on this ticket's PR | `windows-containment` reports **success** on a real `windows-latest` runner |
+
+**Evidence invalidation**
+
+- The shape test asserts against `ci.yml` as parsed, not against line numbers; a
+  reordering of jobs does not invalidate it. A rename of either test file does.
+- If either containment test file is split or renamed by another ticket, update the job
+  and the assertion together.
+
+**Stop / escalate**
+
+- **If the job fails on Windows for any reason other than `.exe` classification, stop.**
+  Do not weaken the job, do not add `continue-on-error`, do not skip the failing
+  assertion. Record the failure as its own issue. ADR-0023 §Consequences explicitly
+  permits Gate B to end here with Windows still unsupported.
+- If Windows runner minutes or availability block the run, that is a blocker to surface,
+  not a reason to merge the workflow unverified
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | A job that cannot run is a red check, never a skipped one |
+| wrong-target | A diff touching `release.yml` belongs to T-1104 |
+| ambiguity | The two test files are named explicitly |
+| timeout | Windows runners are slower; give the job an explicit `timeout-minutes` rather than relying on the default |
+| partial state | The job either runs both files or the shape test fails |
+| privacy | CI logs contain no user data; no secrets are needed by this job |
+| prompt injection | None — no external input |
+
+**Completion evidence**
+
+- `gh pr checks` on this ticket's PR shows `windows-containment` **success**
+- The shape test passes; full suite passes
+- The PR description quotes the Windows job's result, not a local run
+
+---
+
+## T-1104 Add `windows-latest` to the release build matrix (S) — B-1 step 4
+
+**Owns**
+
+- `.github/workflows/release.yml` — the build matrix `include:` list (lines 79–93 at
+  `e2b5725`)
+- `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md` — the Windows bullet in
+  Known limitations (line 283 in `README.md` at `e2b5725`)
+- `docs/COMPATIBILITY.md` — the Windows row (created by T-1107)
+- `install.sh` — the OS mapping (line 52–53 at `e2b5725`), only if a Windows asset is
+  actually published
+
+**Depends on**
+
+- **T-1103 green on a real `windows-latest` runner.** This is the whole of ADR-0023
+- T-1107 (compatibility matrix exists to hold the row)
+
+**Forbidden scope**
+
+- Do not merge in the same wave as T-1106 (`GATE-B-ACCEPTANCE.md` execution constraint)
+- Do not use `continue-on-error` or `fail-fast: false` as a way to publish a partial
+  asset set
+- Do not soften the README bullet before the matrix change lands in the same commit
+- Do not change the checksum or publish steps' logic
+
+**RED test**
+
+- File: `test/readme.test.ts` (extend) and `test/compatibility-matrix.test.ts` (from
+  T-1107)
+- Assertion: the release matrix contains a Windows target **and** no README states Windows
+  is unsupported **and** the compatibility matrix Windows row reads supported — all three
+  as one conjunction, so the state cannot be half-applied.
+- Fails at `e2b5725` on all three.
+
+**Minimum GREEN**
+
+- `windows-latest` with target `x86_64-pc-windows-msvc` in the matrix
+- The four README bullets removed together in one commit with the matrix change
+- The compatibility matrix Windows row flipped in the same commit
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| Matrix contains the Windows target | parse `release.yml`, expect the target present | PRD-F12 req 5 |
+| No README claims Windows unsupported | all four files asserted together | ADR-0023 §Falsification item 2 |
+| Matrix row and release agree | T-1107's sync test | `B-4` |
+| No soft-fail | `expect(job).not.toHaveProperty('continue-on-error')` | ADR-0023 §Ruled-out item 4 |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/readme.test.ts test/compatibility-matrix.test.ts` | pass |
+| full | `npx vitest run` | all files pass |
+| release | `node scripts/check-readme-numbers.mjs` | exit 0 — the `BENCH:BEGIN`/`END` block is byte-checked and must not be touched |
+| LIVE | the next release run after merge | 5 build jobs succeed; `SHA256SUMS` lists a Windows asset; the asset's checksum verifies |
+
+**Evidence invalidation**
+
+- The README line number moves whenever T-1014/T-1015-class section work lands. Re-derive
+  by content (`grep -n "Windows is unsupported" README*.md`), never by line.
+- If T-1103's Windows job was ever made non-required, this ticket's dependency is not
+  satisfied regardless of what the workflow file says.
+
+**Stop / escalate**
+
+- If the Windows build produces an asset that cannot be executed on Windows, stop and
+  revert the matrix change; a listed asset that does not run is worse than no asset
+- If the release run's Windows job fails after merge, treat it as a release blocker and
+  cut the target back out rather than shipping a partial `SHA256SUMS`
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | If the Windows job fails, the release fails; no partial publish |
+| wrong-target | Only the matrix and the platform statements change; no packaging manifest |
+| ambiguity | Target triple written explicitly |
+| partial state | The conjunctive RED test is what prevents a half-flipped claim |
+| privacy | None |
+| prompt injection | None |
+
+**Completion evidence**
+
+- A release run with 5 successful build jobs and a Windows entry in `SHA256SUMS`
+- The Windows asset downloaded on a machine that did not build it, checksum verified,
+  `--version` correct
+- All four READMEs and the compatibility matrix agree with the matrix
+
+---
+
+## T-1105 musl feasibility spike: answer the question, record the answer (M) — B-2
+
+**Owns**
+
+- `docs/spikes/SPIKE-musl-feasibility.md` (new; creates `docs/spikes/`)
+- `test/spike-musl.test.ts` (new) — asserts the document's required sections exist
+
+**Depends on**
+
+- ADR-0024 accepted. Independent of the Windows chain
+
+**Forbidden scope**
+
+- **Publish no asset.** No change to `.github/workflows/release.yml`
+- **Add no Docker step to the release build matrix** — the recorded constraint. If Docker
+  turns out to be the only route, that is a finding, not a licence
+- Do not touch `install.sh`. Its musl failure is already correct and ADR-0024 keeps it
+- Do not touch `README*` musl bullets
+- Do not weaken the existing ruled-out record; a musl target still may not be justified as
+  an installer or CI-verification fix
+
+**RED test**
+
+- File: `test/spike-musl.test.ts` (new)
+- Assertion: `docs/spikes/SPIKE-musl-feasibility.md` exists and contains all of: a route
+  table with an outcome per route, a `## Recommendation` section, and a
+  `## What this could not determine` section.
+- Fails at `e2b5725` because neither the file nor the directory exists.
+
+**Minimum GREEN**
+
+- The document records, per attempted route (unofficial musl Node build, static link,
+  cross-toolchain, non-Docker container step): what was attempted, what was observed, and
+  whether the resulting provenance is defensible
+- A recommendation: yes, no, or yes-conditional — with the condition named
+- An explicit list of routes **not** attempted, marked as not attempted rather than
+  impossible (PRD-F13-style honesty applied here: a check states what it could not see)
+- **A "no" recommendation closes this row.** That is written into the document so the
+  result is not later read as an unfinished task
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| The document exists with a route table | section-presence test | PRD-F12 req 6 |
+| A recommendation is present | `expect(doc).toMatch(/^## Recommendation/m)` | ADR-0024 §Decision 1 |
+| Undetermined routes are declared | `expect(doc).toMatch(/^## What this could not determine/m)` | PRD-F12 req 7 |
+| No asset was published | `git diff` touches no workflow file | ADR-0024 §Decision 3, §Falsification |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/spike-musl.test.ts` | pass |
+| full | `npx vitest run` | all files pass |
+| manual | `git diff --name-only origin/dev...HEAD` | contains no `.github/workflows/*` path |
+| LIVE | whatever the spike actually runs | recorded verbatim in the document, including failures |
+
+**Evidence invalidation**
+
+- The spike's measurements are bound to the Node version at the time. Record the exact
+  Node version and runner image; a later Node release does not retroactively change the
+  answer but does bound it.
+
+**Stop / escalate**
+
+- If a route requires publishing an artifact built from an unattributed third-party
+  runtime, stop: ADR-0024 rules it out and the spike should record it as ruled out
+- If the answer is yes, **stop before publishing**. Publishing is a separate ticket
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | No route working means the recommendation is no; no fallback that ships something |
+| wrong-target | A diff touching `install.sh` or `release.yml` is out of scope |
+| ambiguity | "Feasible" is defined as: builds in the matrix, without Docker, with defensible provenance — all three |
+| timeout | Each route gets a stated time box, and a timed-out route is recorded as not determined |
+| privacy | No user data |
+| prompt injection | Third-party build instructions are read as data; nothing is executed without being read first |
+
+**Completion evidence**
+
+- The committed document with the route table, recommendation and undetermined list
+- `git diff --name-only` proving no workflow or installer change
+- The focused test passing
+
+---
+
+## T-1106 Generate a Homebrew formula from the published release, with a drift check (M) — B-3
+
+**Owns**
+
+- `scripts/gen-brew-formula.mjs` (new)
+- `Formula/commitlore.rb` (new)
+- `.github/workflows/ci.yml` — one drift step inside the existing `check` job (line 12)
+- `test/brew-formula.test.ts` (new)
+- `README.md` + the three translations — one install line placed **after** `git clone`
+  and `install.sh`
+
+**Depends on**
+
+- ADR-0025 accepted. Independent of the Windows chain
+- Must not merge in the same wave as T-1104
+
+**Forbidden scope**
+
+- **No build step in the formula.** It downloads a published asset, nothing else
+- No hand-written version or digest: both come from the release
+- No `homebrew-core` submission (ADR-0025 §Ruled-out)
+- No Scoop or WinGet manifest — there is no Windows asset until T-1104
+- Do not present the tap ahead of `git clone` or `install.sh`
+- Do not touch the `BENCH:BEGIN`/`BENCH:END` block
+
+**RED test**
+
+- File: `test/brew-formula.test.ts` (new)
+- Assertion: regenerating the formula from the current release produces a file
+  byte-identical to `Formula/commitlore.rb`, and the formula contains no build directive.
+- Fails at `e2b5725` because neither the generator nor the formula exists.
+
+**Minimum GREEN**
+
+- `scripts/gen-brew-formula.mjs` reads the release tag, asset URL and the digest from the
+  release's `SHA256SUMS`, and writes `Formula/commitlore.rb` deterministically
+- CI regenerates and fails on any diff — the same protection `dist/` has
+- The formula's install step copies the extracted binary; it compiles nothing
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| Formula is regenerable byte-for-byte | `expect(generated).toBe(committed)` | PRD-F12 req 10; ADR-0025 §Decision 4 |
+| Version equals the tag | assert the formula's version against `package.json`/tag | ADR-0025 §Decision 2 |
+| Digest equals the published one | assert against `SHA256SUMS` | ADR-0025 §Decision 3 |
+| No build directive | `expect(formula).not.toMatch(/system "make"|def install.*build/s)` | ADR-0025 §Decision 1, §Falsification |
+| Channel is listed last | README assertion on ordering | ADR-0025 §Decision, §Falsification |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/brew-formula.test.ts test/readme.test.ts` | pass |
+| full | `npx vitest run` | all files pass |
+| release | `node scripts/gen-brew-formula.mjs && git diff --exit-code Formula/` | no drift |
+| release | `node scripts/check-readme-numbers.mjs` | exit 0 |
+| **LIVE (required)** | `brew install` through the tap **on a machine that did not build the asset**, then `commitlore --version` | installs; version equals the tag. PRD-F12 req 12 — a passing suite does not satisfy this |
+
+**Evidence invalidation**
+
+- The formula is bound to a specific release tag. After any release, regenerate; a stale
+  digest is a broken install, and the CI drift check is what catches it.
+- If the asset naming scheme changes, the generator changes with it in the same commit.
+
+**Stop / escalate**
+
+- If the tap cannot resolve the digest without an authenticated API call, stop: ADR-0025
+  requires the digest to come from the published `SHA256SUMS`, which is unauthenticated
+- If the real install fails, do not merge on the strength of the passing tests
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | A digest mismatch fails the install; it is never a warning |
+| wrong-target | A diff adding a Windows manifest is out of scope |
+| ambiguity | "Verified pointer" is defined by ADR-0025's four mechanical properties |
+| timeout | Generation is local and fast; the live install is the slow step and is manual |
+| partial state | A committed formula that does not match the generator is a red CI check |
+| privacy | The formula contains a URL and a digest; nothing else |
+| prompt injection | The release name is read from the release, not from user input, and is not interpolated into a shell command |
+
+**Completion evidence**
+
+- `node scripts/gen-brew-formula.mjs && git diff --exit-code Formula/` clean
+- CI drift step green
+- A transcript of a real `brew install` on a machine that did not build the asset, with
+  `--version` matching the tag
+
+---
+
+## T-1107 One compatibility matrix, kept honest by a test (M) — B-4
+
+**Owns**
+
+- `docs/COMPATIBILITY.md` (new)
+- `test/compatibility-matrix.test.ts` (new)
+- `README.md` + three translations — one pointer line in Known limitations
+
+**Depends on**
+
+- Nothing. Independent of every other ticket, and T-1104 depends on it
+
+**Forbidden scope**
+
+- Do not remove the existing Windows/musl README bullets — the matrix is an addition, and
+  those bullets stay until their assets exist
+- Do not change `install.sh`
+- Do not claim a target the release does not build
+- Do not collapse `unsupported` and `undecided` into one status
+
+**RED test**
+
+- File: `test/compatibility-matrix.test.ts` (new)
+- Assertions, all failing at `e2b5725` (the document does not exist):
+  1. every target in `release.yml`'s matrix has a row with status `supported`
+  2. every row not in `release.yml` has status `unsupported` or `undecided` **and** cites
+     an issue or record
+  3. the OS and architecture set in `install.sh` (lines 52–63) matches the matrix's
+     supported rows
+
+**Minimum GREEN**
+
+- `docs/COMPATIBILITY.md` with one row per target: OS, architecture, libc, status,
+  reason/citation
+- Rows for the four published targets as `supported`; Windows citing #95 and ADR-0023;
+  musl citing #99, the ruled-out record and ADR-0024 — as `undecided` until T-1105
+  answers, then `unsupported` with a reason
+- The three assertions above implemented against the real files, not fixtures
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| Published target with no row fails | add-a-target simulation in the test | PRD-F12 req 21 |
+| Row claiming an unbuilt target fails | inverse direction asserted | PRD-F12 req 21 |
+| `install.sh` mapping agrees | parse the `case` arms | PRD-F12 req 22 |
+| Unsupported rows carry reasons | regex for an issue or record reference per row | PRD-F12 req 23 |
+| `unsupported` ≠ `undecided` | both statuses present and distinct in the schema | ADR-0024 §Consequences |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/compatibility-matrix.test.ts` | pass |
+| full | `npx vitest run` | all files pass |
+| manual | add a fake target to a copy of `release.yml` and re-run the focused test | it fails — proving the test bites |
+| LIVE_NA | No network, no platform execution; this ticket asserts agreement between files | — |
+
+**Evidence invalidation**
+
+- Bound to `release.yml`'s matrix at `e2b5725` (4 targets) and `install.sh` lines 52–63.
+  The test reads both at runtime, so a matrix change invalidates the **document**, not the
+  test — which is the intent.
+
+**Stop / escalate**
+
+- If `install.sh`'s mapping and the release matrix already disagree at `e2b5725`, stop and
+  report: that is a pre-existing defect and this ticket must not paper over it by writing
+  a matrix that matches only one of them
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | A target with no row fails the build rather than defaulting to supported |
+| wrong-target | No change to installer logic or workflows |
+| ambiguity | Status vocabulary is a closed set: `supported`, `unsupported`, `undecided` |
+| partial state | One document; a row is either complete with a citation or the test fails |
+| privacy | None |
+| prompt injection | The matrix is repository-authored, not user input |
+
+**Completion evidence**
+
+- `docs/COMPATIBILITY.md` committed with citations on every non-supported row
+- The focused test demonstrated failing on an injected fake target, then passing
+- Full suite green
+
+---
+
+## T-1108 `commitlore uninstall`: remove what `install.sh` wrote, and nothing else (L) — B-5
+
+**Owns**
+
+- `src/commands/uninstall.ts` (new)
+- `src/core/agent-configs.ts` (new) — the single source of the agent config paths
+- `src/cli.ts` — one `register` line (imports at lines 17–35 at `e2b5725`)
+- `test/uninstall.test.ts` (new)
+- `test/agent-configs.test.ts` (new) — asserts agreement with `install.sh`
+- `dist/` — rebuild required
+
+**Depends on**
+
+- Nothing. Independent of every other ticket in this file
+
+**Forbidden scope**
+
+- Do not duplicate per-repository uninstall: `commitlore hooks uninstall` and
+  `commitlore inject uninstall-claude-hook` already own that and this command points at
+  them (PRD-F12 req 19)
+- Do not remove any config entry the installer did not write
+- Do not reformat or rewrite a config file beyond removing the entry
+- Do not touch `install.sh`'s behaviour in this ticket; only read its paths
+- Do not delete a binary at the target path that does not identify itself as CommitLore
+
+**RED test**
+
+- File: `test/uninstall.test.ts` (new)
+- Assertion: given a temporary HOME with (a) an agent config containing both a
+  `commitlore` MCP entry and an unrelated MCP entry, and (b) a fake CommitLore binary at
+  the install path, `uninstall` removes the binary and the `commitlore` entry, and the
+  unrelated entry plus every other key survives byte-for-byte.
+- Fails at `e2b5725` because no `uninstall` command exists — `grep -rn "uninstall" src`
+  finds only per-repository hook removal.
+- Second RED file: `test/agent-configs.test.ts` asserts every config path in `install.sh`
+  (`wire_claude_code`, `wire_codex`, `wire_gemini`, `wire_cursor`, `wire_windsurf`,
+  `wire_opencode`, and the generic `wire_mcp_servers_json` callers — lines 282–410 at
+  `e2b5725`) has an entry in `src/core/agent-configs.ts`. Fails because `src/` currently
+  contains **no** agent config knowledge at all (`grep -rln "mcp_servers" src` is empty).
+
+**Minimum GREEN**
+
+- `src/core/agent-configs.ts` exports one table: agent name, config path, config format
+- `test/agent-configs.test.ts` parses `install.sh` and asserts the two agree in both
+  directions — this is the lesson from the triplicated policy hash: two sources of the
+  same truth diverge silently
+- `commitlore uninstall` removes the installed binary (only if it self-identifies) and the
+  `commitlore` entry from each config in the table
+- Reports per agent: removed / left / not found, with a reason — the shape `install.sh`
+  already uses
+- Idempotent: a second run removes nothing and exits 0
+- `--dry-run` prints the plan and changes nothing
+- `npm run build` run and `dist/` committed
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| Written entries removed | entry absent after run | PRD-F12 req 14 |
+| Unrelated entry survives | deep-equality on the rest of the config | PRD-F12 req 15 |
+| Per-agent report | assert the three outcome categories | PRD-F12 req 16 |
+| Idempotent | second run: nothing removed, exit 0 | PRD-F12 req 17 |
+| Refuses a foreign binary | fake non-CommitLore binary is left in place, named reason | PRD-F12 req 18 |
+| Per-repository state untouched | hook files still present after run | PRD-F12 req 19 |
+| Config path table matches `install.sh` | bidirectional agreement test | the triplication lesson; PRD-F13 req 7 rationale |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/uninstall.test.ts test/agent-configs.test.ts` | pass |
+| full | `npx vitest run` | all files pass |
+| release | `npm run build && git diff --exit-code dist/` | no drift |
+| release | `npx tsc --noEmit` | exit 0 |
+| manual | `node dist/commitlore.mjs uninstall --dry-run` in a scratch HOME | prints a plan, changes nothing |
+| **LIVE (required)** | real `install.sh` → `uninstall` cycle in a scratch HOME, with an unrelated MCP entry present beforehand | binary and entry gone; unrelated entry intact |
+
+**Evidence invalidation**
+
+- Bound to `install.sh` lines 282–410 at `e2b5725`. If a `wire_*` function is added or a
+  path changes, the agreement test fails by design — that is the mechanism, not a
+  breakage.
+
+**Stop / escalate**
+
+- If removing an entry cannot be done without rewriting the whole config file (a format
+  with no safe partial edit), stop and report: silently reformatting a user's config is
+  worse than declining, and declining with a reason is an acceptable outcome for that
+  agent
+- If a config file is not parseable, leave it untouched and report it — never rewrite on a
+  guess
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | Anything not recognised as installer-written is left alone |
+| wrong-target | A foreign binary at the install path is never deleted |
+| ambiguity | The config table is explicit; no globbing for config files |
+| timeout | Local filesystem only |
+| partial state | Per-agent operations are independent and reported individually; one failure does not abort the rest, and none is reported as done unless it was |
+| privacy | Config files may contain tokens for other servers. The command reads them to remove one entry and **must not echo any other entry's contents** into its report |
+| prompt injection | Config contents are data; no value from a config is executed |
+
+**Completion evidence**
+
+- Focused and full suites pass; `tsc --noEmit` exits 0; `dist/` has no drift
+- A transcript of the real install-then-uninstall cycle showing the unrelated entry intact
+- The bidirectional `install.sh` agreement test passing

--- a/docs/tickets/F13-capture-advisory-and-policy.md
+++ b/docs/tickets/F13-capture-advisory-and-policy.md
@@ -1,0 +1,285 @@
+# F13 tickets — Capture advisory and policy resolution (M6)
+
+> PRD: [PRD-F13-capture-advisory-and-policy.md](../prd/PRD-F13-capture-advisory-and-policy.md)
+> ADR: [0020](../adr/ADR-0020-guard-is-an-experimental-advisory.md) (guard is an
+> experimental advisory), [0021](../adr/ADR-0021-capture-pending-transaction.md) (capture
+> pending transaction), [0006](../adr/ADR-0006-push-injection.md) (push injection)
+> Acceptance: [`../GATE-B-ACCEPTANCE.md`](../GATE-B-ACCEPTANCE.md) rows `B-6`, `B-7`
+> Baseline head: `e2b5725`. Full suite there: **65 files, 1,750 passed, 1 skipped.**
+
+**Attribution warning.** T-1109 closes `B-6`, whose authority is
+`PRD-F9-unified-capture.md`'s standalone "Non-goals" bullet. It does **not** close
+acceptance row `P0-8` — that row is the unified `commitlore_before_change` tool and was
+closed in Gate A by T-1024 (#219). PRD-F9 states the distinction itself. Do not re-label
+this ticket with `P0-8`.
+
+**Merge ordering**: T-1109 merges before T-1110, or T-1110 carries T-1109's advisory field
+forward. Both touch the capture pipeline (`GATE-B-ACCEPTANCE.md` "Execution constraints").
+
+---
+
+## T-1109 Guard as a capture advisory that cannot block (M) — B-6
+
+**Owns**
+
+- `src/core/pending.ts` — `PendingRecord` (interface at line 18 at `e2b5725`): one new
+  optional field
+- `src/core/capture-prepare.ts` — `prepareCaptureContext` (line 60): populate the field
+- `src/commands/capture.ts` — render the advisory in human and `--json` output
+- `test/capture-guard-advisory.test.ts` (new)
+- `dist/` — rebuild required
+
+**Depends on**
+
+- ADR-0020 accepted (already). Nothing else in this file
+
+**Forbidden scope**
+
+- **Guard must not change any exit code, any `phase` transition, or any gate decision.**
+  This is the whole row; a diff that lets a match affect control flow is the failure
+- Do not change guard's scoring, threshold, weights, or `DEFAULT_THRESHOLD`
+- Do not change `PendingRecord.version` — it stays `1` (ADR-0021; a bump would falsify it)
+- Do not make any existing field optional or change its meaning
+- Do not touch `src/core/capture-stage.ts`, `src/core/capture-verify.ts`, or
+  `src/hooks/prepare-commit-msg.ts`
+- Do not touch the `commitlore_before_change` tool or `src/mcp/server.ts` — T-1024 shipped
+  that and `P0-8` is closed
+- Do not emit raw `GuardMatch` objects — see the trust-grading safety row below
+- Do not add a policy key, a config option, or a way to turn the advisory into a gate
+
+**RED test**
+
+- File: `test/capture-guard-advisory.test.ts` (new)
+- Assertions, all failing at `e2b5725` (no advisory field exists):
+  1. a prepared pending record for a draft whose text revives a recorded ruled-out
+     alternative carries an advisory with at least one match
+  2. **differential**: the same capture run with the match forced on and forced off
+     produces identical `phase`, identical exit code, and pending records that are equal
+     on every field except the advisory
+  3. a pending record written without the field is still read successfully by
+     `readPending`
+  4. when guard cannot complete (`GuardResult.history === 'unavailable'` or
+     `notes === 'unfetched'`), the advisory records the gap and the capture still succeeds
+
+**Minimum GREEN**
+
+- `PendingRecord` gains one optional field:
+  `guard_advisory?: { matches: RenderedGuardMatch[]; gaps: GuardGap[]; disclosure: string } | null`
+- `gaps` is the **same closed, ordered set T-1024 fixed**: `history-unavailable`,
+  `shallow-history`, `notes-unfetched`. No new vocabulary
+- `matches` are produced by `renderGuardMatch` (`src/core/guard.ts:140`), never raw
+  `GuardMatch`
+- `disclosure` carries ADR-0020's measured figures with the same wording every other guard
+  surface uses; an empty `matches` array is never rendered as "nothing applies"
+- Guard is invoked with the draft record text as `proposal` and the staged diff's paths as
+  `paths`; any thrown error is caught and becomes a gap, never a failure
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| Advisory is attached on prepare | match present for a reviving draft | PRD-F13 req 1 |
+| Field is additive | pre-field record still readable | PRD-F13 req 2 |
+| **Cannot block** | differential equality except the advisory | PRD-F13 req 3; `bench/GUARD-CANNOT-BLOCK.md`; ADR-0006 |
+| Disclosure present | advisory contains precision 44.8% and recall 22.0% | PRD-F13 req 4; ADR-0020 |
+| Guard failure degrades | forced guard throw ⇒ gap recorded, capture succeeds | PRD-F13 req 5 |
+| Caveats travel | `GuardResult.incomplete` maps into `gaps` | PRD-F13 req 6; T-1024's closed set |
+| Trust grading preserved | a `blocked`-trust record's content is withheld in the advisory | ADR-0006; SPEC §7 |
+| Format version unchanged | `expect(record.version).toBe(1)` | ADR-0021 |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/capture-guard-advisory.test.ts test/capture.test.ts test/pending.test.ts` | pass |
+| full | `npx vitest run` | 66 files, 1,750+ passed, 1 skipped |
+| release | `npm run build && git diff --exit-code dist/` | no drift |
+| release | `npx tsc --noEmit && npx tsc --noEmit -p bench/tsconfig.json` | both exit 0 |
+| manual | `node dist/commitlore.mjs capture --transcript … prepare` in a scratch repo carrying a ruled-out record | advisory printed; exit code identical to a run with no match |
+| LIVE_NA | No model, no network. Guard is local and reads git | — |
+
+**Evidence invalidation**
+
+- Bound to `e2b5725`: `PendingRecord` at `src/core/pending.ts:18`,
+  `prepareCaptureContext` at `src/core/capture-prepare.ts:60`, `renderGuardMatch` at
+  `src/core/guard.ts:140`. Re-read all three before editing
+- If T-1110 merges first, `policy_identity_hash`'s input has changed; the differential
+  test must then force the same policy on both arms or it will compare two policies
+
+**Stop / escalate**
+
+- If attaching the advisory requires guard to run before the pending file exists in a way
+  that changes phase ordering, stop: the phase machine is ADR-0021's and is not this
+  ticket's to reshape
+- If the differential test cannot be written because guard's result is not injectable,
+  stop and report — an untestable "cannot block" claim is exactly what ADR-0020 forbids
+  asserting
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | Guard failing yields a recorded gap and a successful capture; it never blocks and never silently reports "clean" |
+| wrong-target | A diff touching stage, verify, the hook, or `src/mcp/server.ts` is out of scope |
+| ambiguity | The gap vocabulary is T-1024's closed set, reused verbatim |
+| timeout | Guard is bounded by the index; on `--no-index` it is slower. Reuse the existing guard invocation path rather than adding a second one |
+| partial state | The field is written in the same file write as the rest of prepare; there is no separate persistence step |
+| privacy | Advisory content comes from the repository's own records, and the draft text is already in the pending file |
+| **prompt injection** | Advisory text reaches a model. `renderGuardMatch` is mandatory: it is what withholds `blocked`-trust content, and emitting raw matches would route untrusted trailer text to a model as if it were trusted |
+
+**Completion evidence**
+
+- The differential test passing, quoted in the PR: same phase, same exit code, one field
+  differing
+- Focused and full suites green; both `tsc` exit 0; `dist/` no drift
+- A `--json` sample showing the advisory with its disclosure, and an empty-match case that
+  does not read as a clean bill
+
+---
+
+## T-1110 User-editable policy file, after consolidating the triplicated policy identity (L) — B-7, row `P1-5`
+
+**Owns**
+
+- `src/core/capture-policy.ts` (new) — the single definition of the policy defaults and
+  `computePolicyIdentityHash`
+- `src/core/capture-prepare.ts` — remove the local copy (`HARDCODED_DEFAULTS` and
+  `computePolicyIdentityHash`, lines 24–30 at `e2b5725`) and import
+- `src/core/capture-stage.ts` — remove the local copy (lines 30–36 at `e2b5725`) and
+  import
+- `src/hooks/prepare-commit-msg.ts` — remove the local copy (`CAPTURE_POLICY_DEFAULTS` and
+  `computePolicyIdentityHash`, lines 129–135 at `e2b5725`) and import
+- `test/capture-policy.test.ts` (new)
+- `dist/` — rebuild required
+
+**Depends on**
+
+- ADR-0021 accepted (already), which **already fixes the migration**: the identity hash
+  input changes from `sha256(hardcoded-defaults-json)` to `sha256(policy-file-contents)`
+  and the pending format needs no breaking change
+- T-1109 merged, or this ticket carries its advisory field forward
+
+**Precondition — the triplication is removed first, in this ticket, before the input
+changes**
+
+Measured at `e2b5725`: `computePolicyIdentityHash` and its defaults object exist
+**three** times, independently —
+
+| file | line | constant name |
+|---|---|---|
+| `src/core/capture-prepare.ts` | 24 | `HARDCODED_DEFAULTS` |
+| `src/core/capture-stage.ts` | 30 | `HARDCODED_DEFAULTS` |
+| `src/hooks/prepare-commit-msg.ts` | 129 | `CAPTURE_POLICY_DEFAULTS` |
+
+All three hash `JSON.stringify(<literal>)`, so they agree **only** because the three
+object literals happen to list the same three keys in the same order — `JSON.stringify`
+serialises in insertion order. Nothing tests that they agree. Changing the hash input in
+three places, one of which is named differently, is how a stage-versus-consume comparison
+starts silently disagreeing: the hook would compute a different hash from the one
+`prepare` wrote and report a policy change that never happened.
+
+Consolidation is therefore step 1 of this ticket, with its own test, and it must be a
+**no-op on the hash value** — the same hex digest before and after.
+
+**Forbidden scope**
+
+- Do not change `PendingRecord.version` (ADR-0021; a bump falsifies it)
+- Do not add a policy key beyond the three that exist (`mode`,
+  `max_records_per_commit`, `require_verified_evidence`) — PRD-F13 non-goals
+- Do not let the policy file influence path resolution, command execution, or anything
+  touching Git history
+- Do not let a missing or invalid file silently fall back to defaults
+- Do not change guard's threshold or any guard behaviour through policy
+- Do not touch `src/core/pending-gc.ts` or the GC retention window
+
+**RED test**
+
+- File: `test/capture-policy.test.ts` (new)
+- Assertions:
+  1. **consolidation is a no-op**: the identity hash for the default policy equals the
+     digest produced at `e2b5725`, pinned in the test — fails if consolidation changes key
+     order or content
+  2. exactly one definition exists: no file other than `src/core/capture-policy.ts`
+     defines `computePolicyIdentityHash` or a defaults object with those three keys —
+     fails at `e2b5725`, where three do
+  3. with no policy file, resolution equals today's defaults and today's hash — a pending
+     record written before this ticket is still consumable
+  4. with a policy file, the hash equals `sha256(file-contents)` and
+     `record.version === 1`
+  5. an invalid policy file produces a named error and leaves prior behaviour in place —
+     it is never silently ignored
+  6. an undeclared key is rejected, not merged
+  7. repository-local and user-global files have an asserted precedence
+
+**Minimum GREEN**
+
+- `src/core/capture-policy.ts` exports the defaults, `resolvePolicy(cwd)` and
+  `computePolicyIdentityHash(policy)`; all three former sites import it
+- With no file: identical behaviour and identical digest to `e2b5725`
+- With a file: `sha256(file-contents)` per ADR-0021, format version unchanged
+- Invalid file: named, actionable error; previous behaviour retained; the identity hash
+  never claims a policy that did not run
+- Precedence between repository-local and user-global stated in the code and asserted in
+  the test
+- `npm run build` run and `dist/` committed
+
+**AC ↔ test**
+
+| AC | Test assertion | Traces to |
+|---|---|---|
+| One definition only | repository scan finds a single definition | PRD-F13 req 7 |
+| Consolidation changes no digest | pinned digest equality | PRD-F13 req 8; ADR-0021 |
+| Absent file ⇒ today's behaviour | old pending record still consumable | PRD-F13 req 8 |
+| Present file ⇒ file-contents hash | hash equality; `version === 1` | PRD-F13 req 9; ADR-0021 |
+| Invalid file is loud | named error, no silent default | PRD-F13 req 10 |
+| One resolution path, stated precedence | CLI and hook agree in the test | PRD-F13 req 11 |
+| Undeclared key rejected | rejection asserted | PRD-F13 req 12 |
+| Stage-to-commit mismatch still detected | differing hash reported by the hook | PRD-F13 req 13 |
+
+**Commands**
+
+| scope | command | expected |
+|---|---|---|
+| focused | `npx vitest run test/capture-policy.test.ts test/capture.test.ts test/prepare-commit-msg.test.ts test/post-commit-capture.test.ts` | pass |
+| full | `npx vitest run` | 67 files, 1,750+ passed, 1 skipped |
+| release | `npm run build && git diff --exit-code dist/` | no drift |
+| release | `npx tsc --noEmit && npx tsc --noEmit -p bench/tsconfig.json` | both exit 0 |
+| manual | prepare a capture on the old code, upgrade, then consume | the hook's existing policy-change path behaves as it does today |
+| LIVE_NA | No model, no network | — |
+
+**Evidence invalidation**
+
+- Bound to `e2b5725`: three sites at `capture-prepare.ts:24`, `capture-stage.ts:30`,
+  `prepare-commit-msg.ts:129`. Re-derive with
+  `grep -rn "computePolicyIdentityHash" src` before editing — if a fourth copy has
+  appeared, the consolidation test is what should have caught it
+- The pinned digest in assertion 1 is the value at `e2b5725`. It may only change in a
+  commit that deliberately changes the default policy, and such a commit must say so
+
+**Stop / escalate**
+
+- If consolidation changes the digest, **stop**: every pending file in flight on any
+  machine would report a false policy change. Find the ordering or content difference first
+- If a policy key would need to influence anything outside capture, stop — that is a new
+  decision and needs an ADR, not a ticket
+- If repository-local and user-global cannot be given an unambiguous precedence, ship only
+  one location; ambiguous precedence is worse than a missing feature
+
+**Safety checks**
+
+| check | response |
+|---|---|
+| fail-closed | An unreadable or invalid policy leaves the previous, stricter behaviour in place and says so |
+| wrong-target | A diff that bumps `version` or adds a fourth policy key is out of scope |
+| ambiguity | The key set is closed; unknown keys are rejected rather than merged |
+| timeout | One small file read per invocation; the hook path must not gain a second read |
+| partial state | Consolidation and the input change are separable commits inside one PR; the pinned-digest test guards the boundary between them |
+| privacy | The policy file is the user's own content and is never echoed beyond the named error |
+| **prompt injection** | The policy file is untrusted input. It may set only declared keys with validated values, never a path, a command, or free text that reaches a model |
+
+**Completion evidence**
+
+- `grep -rn "computePolicyIdentityHash" src` shows exactly one definition and three imports
+- The pinned-digest test proving consolidation was a no-op
+- Focused and full suites green; both `tsc` exit 0; `dist/` no drift
+- A demonstrated old-pending-record consumption after the change

--- a/docs/tickets/TICKETS.md
+++ b/docs/tickets/TICKETS.md
@@ -16,12 +16,20 @@
 | [F9-unified-capture.md](F9-unified-capture.md) | T-1001 ~ T-1009, T-1018, T-1019, T-1023 (12) | M5 | #193–#201, #213, #215, #216 |
 | [F10-first-run-experience.md](F10-first-run-experience.md) | T-1010 ~ T-1016 (7) | M5 | #202–#207, #212 |
 | [F11-guard-classification.md](F11-guard-classification.md) | T-1020 ~ T-1022, T-1024 (4) | M5 | #208–#210, #219 |
+| [F12-universal-adoption.md](F12-universal-adoption.md) | T-1101 ~ T-1108 (8) | M6 | new×8 |
+| [F13-capture-advisory-and-policy.md](F13-capture-advisory-and-policy.md) | T-1109 ~ T-1110 (2) | M6 | new×2 |
 
-Total: 27 v0.1.0 tickets · 7 Backlog (#28–#34, items cut from scope in ADR-0001) · 25 M5 Gate A tickets (T-1001 ~ T-1031; T-1019 and T-1023 are independent audit findings recorded in `docs/GATE-A-ACCEPTANCE.md` and close no acceptance-matrix row; T-1024 is ticketed to close row P0-8 and is defined in `F11-guard-classification.md`)
+Total: 27 v0.1.0 tickets · 7 Backlog (#28–#34, items cut from scope in ADR-0001) · 25 M5 Gate A tickets (T-1001 ~ T-1031; T-1019 and T-1023 are independent audit findings recorded in `docs/GATE-A-ACCEPTANCE.md` and close no acceptance-matrix row; T-1024 is ticketed to close row P0-8 and is defined in `F11-guard-classification.md`) · 10 M6 Gate B tickets (T-1101 ~ T-1110)
 
 `docs/GATE-A-ACCEPTANCE.md` is the authority for which ticket closes which
 acceptance-matrix row (`P0-1`…`P0-8`, `P1-5`) and for the `src/mcp/server.ts`
 merge-sequencing constraint across T-1007/T-1008/T-1009/T-1020.
+
+`docs/GATE-B-ACCEPTANCE.md` is the same authority for M6 (`B-1`…`B-7`), and carries Gate
+B's execution constraints: the `T-1101 → T-1102 → T-1103 → T-1104` Windows chain is
+strictly ordered by ADR-0023, T-1104 and T-1106 may not merge in the same wave, and T-1109
+merges before T-1110. **T-1109 closes `B-6`, not `P0-8`** — `P0-8` is
+`commitlore_before_change` and T-1024 already closed it.
 
 ## Dependency overview (critical path)
 


### PR DESCRIPTION
Closes #263.

Documents only. No `src/`, no `dist/`, no version, no workflow change.

## What lands

| file | role |
|---|---|
| `docs/GATE-B-ACCEPTANCE.md` | one row per Gate B commitment (`B-1`…`B-7`), each with a source that predates it and the command that decides it |
| `docs/adr/ADR-0023-windows-requires-containment-parity.md` | Windows ships only after #71's containment is verified **on Windows** |
| `docs/adr/ADR-0024-musl-target-gated-on-feasibility.md` | musl is gated on a feasibility spike; a recorded "no" closes the row |
| `docs/adr/ADR-0025-package-manager-as-verified-pointer.md` | a package manifest is a verified pointer to a published release, never a second channel |
| `docs/prd/PRD-F12-universal-adoption.md` | 23 numbered requirements — platform reach, packaging, lifecycle, matrix |
| `docs/prd/PRD-F13-capture-advisory-and-policy.md` | 13 numbered requirements — capture advisory, policy file |
| `docs/tickets/F12-universal-adoption.md` | T-1101 … T-1108 |
| `docs/tickets/F13-capture-advisory-and-policy.md` | T-1109, T-1110 |
| `docs/tickets/TICKETS.md` | index rows and Gate B execution constraints |

## Scope boundary

The four areas the M6 description names — Windows/musl builds, package managers,
update/uninstall, a compatibility matrix — plus the two items `PRD-F9`'s non-goals defer to
Gate B. Nothing else.

## A wrong row, caught before it shipped

The first draft of `B-6` cited acceptance row `P0-8` for the capture guard advisory. That
is wrong: `P0-8` is the unified `commitlore_before_change` tool and T-1024 (#219) closed it
in Gate A. `PRD-F9` records the guard deferral as a **standalone** non-goal and, in the
same bullet, warns against this exact conflation.

The cause was reading `GATE-A-ACCEPTANCE.md` from a local checkout that was **81 commits
behind `origin/dev`** and therefore served the pre-alignment table — the same
verify-against-the-wrong-artifact failure the roadmap's rule 5 names. Re-read at
`origin/dev`, corrected, and the correction is recorded in the file rather than quietly
replaced.

## Two measurements that sharpened the tickets

- The doubled-drive-letter pattern `new URL('..', import.meta.url).pathname` is in **four**
  scripts (`adoption-range`, `build-binary`, `check-test-files-ran`, `check-engines`), not
  the two #95 names — and `check-release-version.mjs` already uses the correct
  `fileURLToPath`. T-1101 is convergence on an in-repo pattern.
- `computePolicyIdentityHash` and its defaults object exist **three** times
  (`capture-prepare.ts:24`, `capture-stage.ts:30`, `prepare-commit-msg.ts:129`), under two
  different constant names, agreeing only because three object literals list the same keys
  in the same order — which is what `JSON.stringify` hashes, and nothing tests it.
  Consolidating them is a bound precondition of T-1110 and must not change the digest.

## Ticket discipline

Every ticket carries: exact file and symbol ownership with line numbers at `e2b5725`,
forbidden scope, a RED test with why it fails at that head, minimum GREEN, an AC-to-test
table tracing each row to a PRD requirement or ADR clause, focused/full/release/manual
command tables, stale-evidence invalidation, stop-and-escalate conditions, a safety-check
table, and completion evidence.

Two tickets carry a **required live check** that a passing suite does not satisfy: T-1106
(real `brew install` on a machine that did not build the asset) and T-1108 (real
install-then-uninstall cycle with an unrelated MCP entry present).

## Verification

- internal link resolution across all nine documents: no missing target
- `commitlore validate` on the commit message: `shape ok · references ok`
- no `src/`, `dist/`, workflow or version path in the diff

## Next

One issue per ticket, 1:1, on milestone M6 — after this lands, per #263's completion
condition.
