### PR TITLE
Bind the ten Gate B issue numbers into the tickets

### DIFF
--- a/docs/tickets/F12-universal-adoption.md
+++ b/docs/tickets/F12-universal-adoption.md
@@ -19,7 +19,7 @@ ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each 
 
 ---
 
-## T-1101 Converge the four `.pathname` path resolutions onto `fileURLToPath` (S) — B-1 step 1
+## T-1101 Converge the four `.pathname` path resolutions onto `fileURLToPath` (S) — #265 · B-1 step 1
 
 **Owns**
 
@@ -109,7 +109,7 @@ ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each 
 
 ---
 
-## T-1102 Recognise `commitlore.exe`, and bind the two allowlists together (M) — B-1 step 2
+## T-1102 Recognise `commitlore.exe`, and bind the two allowlists together (M) — #266 · B-1 step 2
 
 **Owns**
 
@@ -205,7 +205,7 @@ ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each 
 
 ---
 
-## T-1103 Execute #71's containment attacks on `windows-latest` in CI (M) — B-1 step 3
+## T-1103 Execute #71's containment attacks on `windows-latest` in CI (M) — #267 · B-1 step 3
 
 **Owns**
 
@@ -296,7 +296,7 @@ ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each 
 
 ---
 
-## T-1104 Add `windows-latest` to the release build matrix (S) — B-1 step 4
+## T-1104 Add `windows-latest` to the release build matrix (S) — #268 · B-1 step 4
 
 **Owns**
 
@@ -388,7 +388,7 @@ ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each 
 
 ---
 
-## T-1105 musl feasibility spike: answer the question, record the answer (M) — B-2
+## T-1105 musl feasibility spike: answer the question, record the answer (M) — #269 · B-2
 
 **Owns**
 
@@ -477,7 +477,7 @@ ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each 
 
 ---
 
-## T-1106 Generate a Homebrew formula from the published release, with a drift check (M) — B-3
+## T-1106 Generate a Homebrew formula from the published release, with a drift check (M) — #270 · B-3
 
 **Owns**
 
@@ -569,7 +569,7 @@ ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each 
 
 ---
 
-## T-1107 One compatibility matrix, kept honest by a test (M) — B-4
+## T-1107 One compatibility matrix, kept honest by a test (M) — #271 · B-4
 
 **Owns**
 
@@ -658,7 +658,7 @@ ADR-0023. `T-1105`, `T-1106`, `T-1107` are independent of the chain and of each 
 
 ---
 
-## T-1108 `commitlore uninstall`: remove what `install.sh` wrote, and nothing else (L) — B-5
+## T-1108 `commitlore uninstall`: remove what `install.sh` wrote, and nothing else (L) — #272 · B-5
 
 **Owns**
 

--- a/docs/tickets/F13-capture-advisory-and-policy.md
+++ b/docs/tickets/F13-capture-advisory-and-policy.md
@@ -18,7 +18,7 @@ forward. Both touch the capture pipeline (`GATE-B-ACCEPTANCE.md` "Execution cons
 
 ---
 
-## T-1109 Guard as a capture advisory that cannot block (M) — B-6
+## T-1109 Guard as a capture advisory that cannot block (M) — #273 · B-6
 
 **Owns**
 
@@ -137,7 +137,7 @@ forward. Both touch the capture pipeline (`GATE-B-ACCEPTANCE.md` "Execution cons
 
 ---
 
-## T-1110 User-editable policy file, after consolidating the triplicated policy identity (L) — B-7, row `P1-5`
+## T-1110 User-editable policy file, after consolidating the triplicated policy identity (L) — #274 · B-7, row `P1-5`
 
 **Owns**
 

--- a/docs/tickets/TICKETS.md
+++ b/docs/tickets/TICKETS.md
@@ -16,8 +16,8 @@
 | [F9-unified-capture.md](F9-unified-capture.md) | T-1001 ~ T-1009, T-1018, T-1019, T-1023 (12) | M5 | #193–#201, #213, #215, #216 |
 | [F10-first-run-experience.md](F10-first-run-experience.md) | T-1010 ~ T-1016 (7) | M5 | #202–#207, #212 |
 | [F11-guard-classification.md](F11-guard-classification.md) | T-1020 ~ T-1022, T-1024 (4) | M5 | #208–#210, #219 |
-| [F12-universal-adoption.md](F12-universal-adoption.md) | T-1101 ~ T-1108 (8) | M6 | new×8 |
-| [F13-capture-advisory-and-policy.md](F13-capture-advisory-and-policy.md) | T-1109 ~ T-1110 (2) | M6 | new×2 |
+| [F12-universal-adoption.md](F12-universal-adoption.md) | T-1101 ~ T-1108 (8) | M6 | #265–#272 |
+| [F13-capture-advisory-and-policy.md](F13-capture-advisory-and-policy.md) | T-1109 ~ T-1110 (2) | M6 | #273–#274 |
 
 Total: 27 v0.1.0 tickets · 7 Backlog (#28–#34, items cut from scope in ADR-0001) · 25 M5 Gate A tickets (T-1001 ~ T-1031; T-1019 and T-1023 are independent audit findings recorded in `docs/GATE-A-ACCEPTANCE.md` and close no acceptance-matrix row; T-1024 is ticketed to close row P0-8 and is defined in `F11-guard-classification.md`) · 10 M6 Gate B tickets (T-1101 ~ T-1110)
 


### PR DESCRIPTION
Ticket sections T-1101 … T-1110 now name their tracking issues (#265–#274), and `TICKETS.md` carries the ranges instead of a placeholder.

Headings only. No requirement, acceptance criterion, dependency or forbidden-scope clause changes.