### PR TITLE
fix(scripts): converge .pathname path resolutions onto fileURLToPath

### DIFF
--- a/scripts/adoption-range.mjs
+++ b/scripts/adoption-range.mjs
@@ -17,8 +17,9 @@
 
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = resolve(new URL('..', import.meta.url).pathname);
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 const git = (args) =>
   execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -58,8 +58,9 @@ import { execFileSync } from 'node:child_process';
 import { chmodSync, copyFileSync, existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = resolve(new URL('..', import.meta.url).pathname);
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const DIST_DIR = join(REPO_ROOT, 'dist');
 const BUNDLE = join(DIST_DIR, 'commitlore.mjs');
 const OUTPUT = join(DIST_DIR, process.platform === 'win32' ? 'commitlore.exe' : 'commitlore');

--- a/scripts/check-engines.mjs
+++ b/scripts/check-engines.mjs
@@ -17,8 +17,9 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = resolve(new URL('..', import.meta.url).pathname);
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const NODE_MODULES = join(REPO_ROOT, 'node_modules');
 
 const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'));

--- a/scripts/check-test-files-ran.mjs
+++ b/scripts/check-test-files-ran.mjs
@@ -17,8 +17,9 @@
 
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = resolve(new URL('..', import.meta.url).pathname);
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const TEST_DIR = resolve(REPO_ROOT, 'test');
 
 const reportPath = process.argv[2];

--- a/test/scripts-path-resolution.test.ts
+++ b/test/scripts-path-resolution.test.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+
+/**
+ * Repository-wide invariant: every tracked file under scripts/ that derives a
+ * filesystem path from import.meta.url must use fileURLToPath, never .pathname.
+ *
+ * ADR-0023: .pathname doubles the drive letter on Windows (C:/C:/…). The
+ * reference pattern is scripts/check-release-version.mjs line 37.
+ */
+describe('scripts path resolution', () => {
+  const trackedFiles = execFileSync(
+    'git',
+    ['ls-files', '--', 'scripts/'],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  )
+    .trim()
+    .split('\n')
+    .filter((f) => f.length > 0);
+
+  it('no script uses new URL(…).pathname for a filesystem path', () => {
+    const offenders: string[] = [];
+    for (const rel of trackedFiles) {
+      const src = readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+      if (/new\s+URL\([^)]*,\s*import\.meta\.url\)\.pathname/.test(src)) {
+        offenders.push(rel);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  const TARGET_FILES = [
+    'scripts/adoption-range.mjs',
+    'scripts/build-binary.mjs',
+    'scripts/check-test-files-ran.mjs',
+    'scripts/check-engines.mjs',
+  ];
+
+  for (const file of TARGET_FILES) {
+    it(`${file} uses fileURLToPath`, () => {
+      const src = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+      expect(src).toContain('fileURLToPath');
+    });
+  }
+});


### PR DESCRIPTION
Converge the four scripts that derived a filesystem path via `new URL('..', import.meta.url).pathname` onto `resolve(fileURLToPath(new URL('..', import.meta.url)))`, matching the existing reference at `scripts/check-release-version.mjs:37`.

The `.pathname` accessor doubles the drive letter on Windows (`C:/C:/…`); `fileURLToPath` handles the file-URL-to-path conversion correctly on every platform.

**Changed files:**
- `scripts/adoption-range.mjs`
- `scripts/build-binary.mjs`
- `scripts/check-test-files-ran.mjs`
- `scripts/check-engines.mjs`

**Added:**
- `test/scripts-path-resolution.test.ts` — repository-wide invariant preventing the pattern from returning.

Closes #265.