### PR TITLE
Add one authoritative compatibility matrix, kept honest by a test

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -290,6 +290,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - cryptographic author verification、repository-wide record coverage、symbol anchor、interactive record builder は未実装です: [#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
 - M4 は guard の効果を検証していません。row に `guard_exposure` がないため treatment exposure を検証できません: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
 - Guard（ruled-out alternative matching）は実験的参考情報です: precision 44.8%（95% Wilson CI 32.7%–57.5%）、recall 22.0%、417-decision corpus 基準（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空の guard 結果は、提案がすべての ruled-out alternative を回避したという保証ではありません — recall 22% では、見逃しが一般的です。
+- 完全なプラットフォーム互換性マトリクス: [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md)。
 
 ## コントリビュート
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -290,6 +290,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - 암호학적 작성자 검증, 저장소 전체 record coverage, symbol anchor, interactive record builder는 아직 구현되지 않았다: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
 - M4는 guard 효과를 시험하지 못했다. row에 `guard_exposure`가 없어 treatment exposure를 검증할 수 없다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
 - Guard(ruled-out alternative matching)는 실험적 참고 자료이다: precision 44.8%(95% Wilson CI 32.7%–57.5%), recall 22.0%, 417-decision corpus 기준([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). 빈 guard 결과는 제안이 모든 ruled-out alternative를 피했다는 보장이 아니다 — recall 22%에서 누락이 일반적이다.
+- 전체 플랫폼 호환성 매트릭스: [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md).
 
 ## 기여하기
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - Cryptographic author verification, repository-wide record coverage, symbol anchors, and an interactive record builder are not implemented yet: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
 - M4 did not test a guard effect: its rows have no `guard_exposure`, so treatment exposure is unverifiable ([#122](https://github.com/MongLong0214/commitlore/issues/122)).
 - Guard (ruled-out alternative matching) is an experimental advisory: precision 44.8% (95% Wilson CI 32.7%–57.5%), recall 22.0% on the 417-decision corpus ([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). An empty guard result does not guarantee a proposal avoids all ruled-out alternatives — at 22% recall, a miss is the common case.
+- Full platform compatibility matrix: [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md).
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -290,6 +290,7 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 - 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
 - M4 没有检验 guard 效果：row 没有 `guard_exposure`，因而无法验证 treatment exposure（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
 - Guard（ruled-out alternative matching）是实验性参考信息：precision 44.8%（95% Wilson CI 32.7%–57.5%），recall 22.0%，基于 417-decision corpus（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空的 guard 结果不保证提案避开了所有 ruled-out alternative——在 recall 22% 下，遗漏才是常态。
+- 完整平台兼容性矩阵：[`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md)。
 
 ## 贡献
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,18 @@
+# Compatibility matrix
+
+One row per platform target. Authority for what is published: `.github/workflows/release.yml`.
+Authority for what the installer accepts: `install.sh`.
+
+Status vocabulary (closed set):
+- **supported** — a release asset is published and the installer resolves it.
+- **unsupported** — a recorded decision exists explaining why no asset is published.
+- **undecided** — an open question is blocking a decision; a spike or investigation is in progress.
+
+| OS | Architecture | libc | Target | Status | Reason / citation |
+|---|---|---|---|---|---|
+| macOS | aarch64 (Apple Silicon) | system | aarch64-apple-darwin | supported | Published in release matrix |
+| macOS | x86_64 (Intel) | system | x86_64-apple-darwin | supported | Published in release matrix |
+| Linux | x86_64 | glibc | x86_64-unknown-linux-gnu | supported | Published in release matrix |
+| Linux | aarch64 | glibc | aarch64-unknown-linux-gnu | supported | Published in release matrix |
+| Windows | x86_64 | msvc | x86_64-pc-windows-msvc | unsupported | [#95](https://github.com/MongLong0214/commitlore/issues/95), [ADR-0023](adr/ADR-0023-windows-requires-containment-parity.md) |
+| Linux | x86_64 | musl | x86_64-unknown-linux-musl | undecided | [#99](https://github.com/MongLong0214/commitlore/issues/99), [ADR-0024](adr/ADR-0024-musl-target-gated-on-feasibility.md) |

--- a/test/compatibility-matrix.test.ts
+++ b/test/compatibility-matrix.test.ts
@@ -1,0 +1,199 @@
+/**
+ * T-1107 (#271): Compatibility matrix kept honest by a test.
+ *
+ * Three directions:
+ * 1. Every target in release.yml's matrix has a matrix row with status `supported`.
+ * 2. Every row NOT in release.yml has status `unsupported` or `undecided` AND cites
+ *    an issue number or a record id.
+ * 3. The OS and architecture set accepted by install.sh matches the supported rows.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+
+// --- Parsers ---
+
+/** Extract targets from release.yml build matrix */
+function parseReleaseTargets(): string[] {
+  const content = fs.readFileSync(
+    path.join(REPO_ROOT, '.github/workflows/release.yml'),
+    'utf8',
+  );
+  const targets: string[] = [];
+  // Match `target: <value>` lines inside the matrix include block
+  const lines = content.split('\n');
+  let inMatrix = false;
+  for (const line of lines) {
+    if (/^\s+matrix:/.test(line)) inMatrix = true;
+    if (inMatrix && /^\s+target:\s+/.test(line)) {
+      const match = line.match(/target:\s+(.+)/);
+      if (match) targets.push(match[1].trim());
+    }
+    // Stop after the matrix block (when we hit `runs-on:` at job level)
+    if (inMatrix && /^\s{4}runs-on:/.test(line)) break;
+  }
+  return targets;
+}
+
+/** Parse the compatibility matrix document */
+interface MatrixRow {
+  os: string;
+  arch: string;
+  libc: string;
+  target: string;
+  status: 'supported' | 'unsupported' | 'undecided';
+  reason: string;
+}
+
+function parseCompatibilityMatrix(): MatrixRow[] {
+  const filePath = path.join(REPO_ROOT, 'docs/COMPATIBILITY.md');
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+
+  const rows: MatrixRow[] = [];
+  // Find the table (header row starts with |)
+  let headerFound = false;
+  let separatorPassed = false;
+
+  for (const line of lines) {
+    if (!headerFound && /^\|\s*OS\s*\|/i.test(line)) {
+      headerFound = true;
+      continue;
+    }
+    if (headerFound && !separatorPassed && /^\|[-\s|]+\|$/.test(line)) {
+      separatorPassed = true;
+      continue;
+    }
+    if (headerFound && separatorPassed) {
+      if (!line.startsWith('|')) break; // End of table
+      const cells = line
+        .split('|')
+        .slice(1, -1)
+        .map((c) => c.trim());
+      if (cells.length >= 6) {
+        const status = cells[4] as MatrixRow['status'];
+        rows.push({
+          os: cells[0],
+          arch: cells[1],
+          libc: cells[2],
+          target: cells[3],
+          status,
+          reason: cells[5],
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+/** Parse install.sh to extract the supported OS/arch combinations */
+function parseInstallerTargets(): string[] {
+  const content = fs.readFileSync(path.join(REPO_ROOT, 'install.sh'), 'utf8');
+
+  // Extract OS mapping: case values → target OS component
+  const osMap: Record<string, string> = {};
+  const osBlock = content.match(
+    /case "\$os_raw" in\n([\s\S]*?)\nesac/,
+  );
+  if (osBlock) {
+    const osLines = osBlock[1].split('\n');
+    for (const line of osLines) {
+      const m = line.match(/^\s*(\S+)\)\s*os=(\S+)\s*;;/);
+      if (m) osMap[m[1]] = m[2];
+    }
+  }
+
+  // Extract arch mapping: case values → target arch component
+  const archMap: Record<string, string> = {};
+  const archBlock = content.match(
+    /case "\$arch_raw" in\n([\s\S]*?)\nesac/,
+  );
+  if (archBlock) {
+    const archLines = archBlock[1].split('\n');
+    for (const line of archLines) {
+      const m = line.match(/^\s*([^)]+)\)\s*arch=(\S+)\s*;;/);
+      if (m) {
+        // Normalise: take only the canonical arch name (first in pipe-separated)
+        archMap[m[2]] = m[2];
+      }
+    }
+  }
+
+  // Build the cross product of unique OS × unique arch → target triples
+  const osValues = [...new Set(Object.values(osMap))];
+  const archValues = [...new Set(Object.values(archMap))];
+
+  const targets: string[] = [];
+  for (const arch of archValues) {
+    for (const os of osValues) {
+      targets.push(`${arch}-${os}`);
+    }
+  }
+  return targets.sort();
+}
+
+// --- Tests ---
+
+describe('Compatibility matrix (T-1107)', () => {
+  const releaseTargets = parseReleaseTargets();
+  const matrixRows = parseCompatibilityMatrix();
+  const installerTargets = parseInstallerTargets();
+
+  it('release.yml targets are parseable and non-empty', () => {
+    expect(releaseTargets.length).toBeGreaterThan(0);
+  });
+
+  it('every release target has a matrix row with status supported', () => {
+    for (const target of releaseTargets) {
+      const row = matrixRows.find((r) => r.target === target);
+      expect(row, `missing matrix row for release target: ${target}`).toBeDefined();
+      expect(
+        row!.status,
+        `matrix row for ${target} should be "supported", got "${row!.status}"`,
+      ).toBe('supported');
+    }
+  });
+
+  it('every non-release row has status unsupported or undecided with a citation', () => {
+    const nonReleaseRows = matrixRows.filter(
+      (r) => !releaseTargets.includes(r.target),
+    );
+    for (const row of nonReleaseRows) {
+      expect(
+        ['unsupported', 'undecided'],
+        `row ${row.target} has invalid status "${row.status}"`,
+      ).toContain(row.status);
+      // Must cite an issue number (#NNN) or a record id (r-XXXX)
+      const hasCitation = /#\d+/.test(row.reason) || /r-[a-z0-9]{4,}/.test(row.reason);
+      expect(
+        hasCitation,
+        `row ${row.target} (status: ${row.status}) must cite an issue or record id in reason: "${row.reason}"`,
+      ).toBe(true);
+    }
+  });
+
+  it('install.sh OS/arch mapping matches the supported matrix rows', () => {
+    const supportedTargets = matrixRows
+      .filter((r) => r.status === 'supported')
+      .map((r) => r.target)
+      .sort();
+
+    expect(
+      installerTargets,
+      `install.sh produces targets ${JSON.stringify(installerTargets)} but matrix supported rows are ${JSON.stringify(supportedTargets)}`,
+    ).toEqual(supportedTargets);
+  });
+
+  it('status vocabulary is exactly supported, unsupported, or undecided', () => {
+    const validStatuses = new Set(['supported', 'unsupported', 'undecided']);
+    for (const row of matrixRows) {
+      expect(
+        validStatuses.has(row.status),
+        `row ${row.target} has invalid status "${row.status}"`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #271. Acceptance row `B-4`.

`docs/COMPATIBILITY.md` is now the single authority for platform support: one row per target with OS, architecture, libc, status and a citation.

The status vocabulary is a closed set, and `unsupported` and `undecided` are deliberately distinct — the difference is whether a recorded reason exists. Windows is `unsupported` citing #95 and ADR-0023. musl is `undecided` citing #99 and ADR-0024, because a spike is deciding it.

`test/compatibility-matrix.test.ts` fails in three directions: a published target with no row, a row claiming a target the release does not build, and a mismatch against `install.sh`'s OS and architecture mapping. It also pins the status vocabulary.

The existing README Windows and musl bullets are untouched; each README gains one pointer line to the matrix. The `BENCH` block is unchanged.