### PR TITLE
Pin the plugin hook runner's fail-open branch with a test

### DIFF
--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -257,4 +257,41 @@ describe("plugin manifest: hooks/hooks.json's command resolves and produces outp
     expect(parsed.hookSpecificOutput.hookEventName).toBe('PreToolUse');
     expect(parsed.hookSpecificOutput.additionalContext).toContain('r-manifestprobe');
   });
+
+  // The runner's own first rule: fail open, always. A PreToolUse hook that
+  // exits non-zero can stop the edit, and the worst acceptable outcome is that
+  // the agent proceeds without records — exactly where it was before the plugin
+  // existed. Its third rule is no stdout on failure, because stdout garbage
+  // would corrupt the payload the agent reads.
+  //
+  // `test/inject.test.ts` covers the CLI's own fail-open branches (unparseable
+  // payload, missing file_path, path outside the repository). The branch below
+  // is the runner script's: it could not find a CLI to exec at all. That one had
+  // no test, and it is the one whose regression would block edits rather than
+  // merely lose context.
+  it('exits 0 with no stdout when it cannot resolve a CLI at all', () => {
+    const unresolvable = tempDir('no-cli');
+    const payload = JSON.stringify({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: join(unresolvable, 'anything.ts') },
+    });
+
+    const run = spawnSync('/bin/bash', [clonePath('scripts/commitlore-run.sh'), 'inject', '--hook-input'], {
+      encoding: 'utf8',
+      cwd: unresolvable,
+      input: payload,
+      // A PATH with a shell but deliberately no node, and a plugin root holding
+      // neither the bundle nor a binary: every branch of resolve() must miss.
+      env: {
+        PATH: '/usr/bin:/bin',
+        HOME: process.env['HOME'] ?? '',
+        CLAUDE_PLUGIN_ROOT: unresolvable,
+      },
+    });
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toBe('');
+    expect(run.stderr).toContain('no context was injected');
+  });
 });


### PR DESCRIPTION
Real-usage verification of the plugin path — now the first install UX the README documents — showed the runner behaves correctly. Nothing asserted it.

## The uncovered branch

`scripts/commitlore-run.sh` states two rules for the hot path: **fail open, always**, because a PreToolUse hook that exits non-zero can stop the edit; and **no stdout on failure**, because stdout garbage would corrupt the payload the agent reads.

`test/inject.test.ts` covers the CLI's own fail-open branches — unparseable payload, missing `file_path`, a path outside the repository. The branch with no test was the runner script's own: **it could not find a CLI to exec at all.** That is the one whose regression blocks edits rather than merely losing context, which makes it the worst one to leave uncovered.

## The test

Runs the real script from a clean clone with a `PATH` that has a shell and deliberately no node, and a plugin root holding neither the bundle nor a binary, so every branch of `resolve()` misses. Asserts exit 0, empty stdout, and a named reason on stderr.

## Seen failing first — and why that took a committed mutation

A working-tree edit could not demonstrate it: this suite deliberately runs against a **clean clone of HEAD**, not the checkout, which is the whole point of the suite. So the mutation had to be committed:

```
resolution-failure branch changed to exit 1

AssertionError: expected 1 to be +0
Tests  1 failed | 17 skipped (18)
```

The probe worktree and branch were discarded immediately.

## Verification

18 tests in the manifest suite pass with the new one included; `tsc --noEmit` exits 0. No `src/` or `dist/` change.

## What else this turn's real-usage pass checked, and found sound

- the plugin hook injects `Limit`, `Ruled-out`, `Warn` and the record id for a path that has records, exit 0
- outside a git repository the hook exits 0 with empty stdout and a named reason
- squash survival: after a real `git merge --squash`, records were invisible from the squash commit; `commitlore squash-preserve <range> --target <sha>` carried both onto it, and `ruled-out`/`limits` then read them back attributed to the squash commit

No defect in any of those, so nothing else changes here.