### PR TITLE
Give every F14 region one owner, and close the README truth window

### DIFF
--- a/docs/GATE-B-ACCEPTANCE.md
+++ b/docs/GATE-B-ACCEPTANCE.md
@@ -17,10 +17,13 @@ repository asks for a binary.
    integration into the capture pipeline, and the user-editable policy file. Both survive
    the reversal untouched — neither has anything to do with distribution.
 2. Distribution work is **re-planned from ADR-0026**: plugin-first for Claude Code,
-   Node-only `install.sh` / `install.ps1` elsewhere. Its rows are added here by the revised
-   PRD and its atomic tickets, each separately approved. **This file does not pre-empt them
-   with placeholder rows** — an acceptance row with no approved ticket is exactly the
-   dangling authority Gate A's matrix was written to stop.
+   Node-only `install.sh` / `install.ps1` elsewhere, specified by
+   [`PRD-F14`](prd/PRD-F14-distribution.md) and broken into six atomic tickets in
+   [`docs/tickets/F14-distribution.md`](tickets/F14-distribution.md). A row lands here **as
+   its ticket becomes approval-ready**, never before — an acceptance row with no approved
+   ticket is exactly the dangling authority Gate A's matrix was written to stop. `B-8` below is
+   the first, added when T-1120 was corrected to a single owner per region; `T-1121`…`T-1125`
+   have no row yet.
 
 ## Rows
 
@@ -28,6 +31,7 @@ repository asks for a binary.
 |---|---|---|---|---|
 | B-6 | Guard participates in the capture pipeline as an advisory that **cannot block a capture or a commit** | `PRD-F9-unified-capture.md` "Non-goals" — a standalone deferral, explicitly **not** row `P0-8` (that row is `commitlore_before_change`, closed by T-1024 #219); [ADR-0020](adr/ADR-0020-guard-is-an-experimental-advisory.md); `bench/GUARD-CANNOT-BLOCK.md` | T-1109 (#273) — **shipped** | A differential test: a guard match at any score changes no exit code and no pending phase, and the two pending records differ in exactly one field |
 | B-7 (row `P1-5`) | The user-editable policy file ships, and the pending-transaction format absorbs it **without a breaking change** | `P1-5`, cited as explicitly Gate B in [ADR-0021](adr/ADR-0021-capture-pending-transaction.md) §"P1-5" and `PRD-F9` "Non-goals". ADR-0021 already fixes the migration: the policy identity hash input changes from `sha256(hardcoded-defaults-json)` to `sha256(policy-file-contents)` | T-1110 (#274) | A pending file written by the pre-policy code path is still consumable after the policy file ships; the identity hash changes and the format version does not |
+| B-8 | `install.sh` installs with **no compiled artifact** — Node ≥ 22 and Git checked before anything is written, a pinned checkout in the user's data directory, and a thin `PATH` wrapper that runs `node dist/commitlore.mjs` — and the README describes **that** installer, in the same commit | [ADR-0026](adr/ADR-0026-node-only-distribution.md); [PRD-F14](prd/PRD-F14-distribution.md) requirements 4–15 and 29 | T-1120 (#281) | Eight RED assertions in `test/install-script.test.ts` and `test/readme.test.ts`, `sh -n install.sh` at 0, `node scripts/check-readme-numbers.mjs` at 0, and a live fresh-install, upgrade-over-running-wrapper and missing-Node run. **One commit** carries the installer and all four README shell-install regions, so no revision exists in which a README describes an installer that is not beside it |
 
 ## Withdrawn rows, and why
 

--- a/docs/adr/ADR-0026-node-only-distribution.md
+++ b/docs/adr/ADR-0026-node-only-distribution.md
@@ -133,7 +133,7 @@ No code is mutated by this change. Measured at `69e5208`:
 | `scripts/commitlore-run.sh` → `resolve()` first branch | probes `$CLAUDE_PLUGIN_ROOT/dist/commitlore` before the Node bundle |
 | `src/core/hook-target.ts` → `BinKind`, `classifyBinTarget`, `matchesRunningBinary` | classifies an install target as `script` or compiled `binary` |
 | `src/hooks/commit-msg.ts` → the stub allowlist glob | accepts a bare `commitlore` executable as a hook target |
-| `README.md` and the three translations | the pinned-asset verification block and the platform limitation bullets |
+| `README.md` and the three translations | the pinned-asset verification block and the platform limitation bullets. **Owned by T-1120, not by the removal ticket**: it rewrites that region in the same commit that makes the installer Node-only, because that is the only arrangement in which the README is never wrong. The removal ticket owns only a residual reference surviving elsewhere in these files |
 
 `src/core/hook-target.ts` and `src/hooks/commit-msg.ts` are the two carrying #71's
 install-root containment. Their removal must **preserve that property for the wrapper case**

--- a/docs/prd/PRD-F14-distribution.md
+++ b/docs/prd/PRD-F14-distribution.md
@@ -41,7 +41,11 @@ Linux and Windows, with no compiled artifact anywhere in the path.
 
 ## Requirements
 
-### Plugin path — document and bind what already works (verified at `da1c733`)
+### Plugin path — document and bind what already works (verified at `8b0c9fa`)
+
+Owner: **T-1122**. Requirement 1 is **already implemented** at this base — all four READMEs
+lead with the two commands. What is missing is the assertion, so requirement 1 is satisfied by
+a test rather than by an edit, and a diff that rewrites the plugin-first block is out of scope.
 
 1. The install documentation leads with the two Claude Code commands
    (`/plugin marketplace add MongLong0214/commitlore`, then
@@ -131,7 +135,20 @@ Linux and Windows, with no compiled artifact anywhere in the path.
     `src/hooks/commit-msg.ts` are the two sites that carry it.
 29. The README's shell-install section is rewritten in the same change that makes the
     installer Node-only, never before it — otherwise the README describes behaviour the code
-    does not have.
+    does not have. **Owner: T-1120**, which owns both the installer and that region, because a
+    single commit is the only arrangement in which the README is never wrong: earlier makes it
+    false immediately, later leaves it false in between. T-1122 owns only a pointer line in
+    those files, and T-1125 owns only whatever compiled-binary or release reference survives
+    elsewhere in them — expected to be none. This requirement sits in the removal section
+    because that is where it was first written, not because T-1125 owns it.
+
+## Ownership
+
+One owner per region, so no requirement can be claimed twice. The table lives in
+[`../tickets/F14-distribution.md`](../tickets/F14-distribution.md) "Ownership map" and is
+authoritative; this PRD's requirements name their owner where it is not obvious. The first
+draft of both documents failed review because requirement 29 and T-1120's forbidden scope
+contradicted each other while T-1122 and T-1125 each also claimed the same README block.
 
 ## Verification
 

--- a/docs/tickets/F14-distribution.md
+++ b/docs/tickets/F14-distribution.md
@@ -6,13 +6,56 @@
 > Acceptance: rows are added to [`../GATE-B-ACCEPTANCE.md`](../GATE-B-ACCEPTANCE.md) **as each
 > ticket is approved**, never in advance — an acceptance row with no approved ticket is the
 > dangling authority Gate A's matrix exists to prevent.
-> Baseline head: `da1c733`. `install.sh` is 483 lines there.
+> Baseline head: `8b0c9fa`. `install.sh` is 483 lines there; its `SHA256SUMS` handling is at
+> lines 12, 76, 95, 98, 114 and 118, `uname` at 48, the extract at 145; `release.yml`'s
+> `build` job starts at 77 and `publish` at 138; `README.md` carries the shell-install
+> one-liner at line 37 and the pinned-asset block at lines 113–124.
 
 **No implementation code until this PRD and the individual ticket are both approved.**
 
 **Order.** `T-1120 → T-1121` (shared contract) → `T-1124` (Windows containment) ; `T-1122`
 and `T-1123` follow both installers ; `T-1125` (remove the compiled-binary code) is last, so
 there is never a window with neither install path.
+
+## Ownership map — one owner per region
+
+The first draft of this file failed review on a contradiction: PRD-F14 requirement 29
+requires the README's shell-install section to change **in the same change** that makes
+`install.sh` Node-only, while T-1120 forbade `README*` and deferred it to T-1122, and T-1125
+claimed the same pinned-asset block. Three tickets claimed one region and the requirement
+claimed a fourth arrangement. Ownership is now single, and stated here so a later reader does
+not have to reconstruct it:
+
+| Region | Owner | Not owned by |
+|---|---|---|
+| `install.sh` Node-only behaviour | **T-1120** | — |
+| The shell-install one-liner and the pinned-asset block in all four READMEs | **T-1120**, in the same commit as the installer change | T-1122, T-1125 |
+| `test/readme.test.ts` and `scripts/check-readme-numbers.mjs` evidence for that region | **T-1120** | — |
+| `install.ps1` | **T-1121** | — |
+| `docs/COMPATIBILITY.md`, and a pointer line that names no installer behaviour | **T-1122** | T-1120 |
+| `commitlore uninstall` | **T-1123** | — |
+| Windows containment for the wrapper path | **T-1124** | — |
+| Residual compiled-binary and release references left after T-1120 | **T-1125** | T-1120 |
+
+`.github/workflows/ci.yml` is the one file with more than one owner, and deliberately so: the
+four tickets own four **different jobs** in it. A filename-level scan cannot see that, so the
+jobs are enumerated here and a scan should treat this file as owned per job rather than per file:
+
+| Job in `ci.yml` | Owner |
+|---|---|
+| `install-script` (line 325+ at `8b0c9fa`) | T-1120 |
+| a new `windows-latest` job running `install.ps1` | T-1121 |
+| that same Windows job, extended with #71's containment attacks | T-1124, strictly after T-1121 merges |
+| `binary` (line 200+) | T-1125 |
+
+No two of those touch the same job in the same change; T-1124 follows T-1121 by the ordering
+rule above rather than editing beside it.
+
+**The README truth window is why T-1120 owns the README.** The shipped `install.sh` downloads
+and checksum-verifies a platform asset today, so the README documenting that is currently
+true. Changing the README earlier would make it false; changing it later would leave it false
+in between. Both changes landing in one commit is the only arrangement in which the README is
+never wrong, and ADR-0026 already states it that way.
 
 **Records that bind every ticket here** (active, on `install.sh`):
 
@@ -27,20 +70,34 @@ there is never a window with neither install path.
 **Owns**
 
 - `install.sh` — the asset-resolution, download, checksum and extract region (lines ~48–200
-  at `da1c733`); the wiring region (277–483) changes only where it writes the MCP command
+  at `8b0c9fa`); the wiring region (277–483) changes only where it writes the MCP command
 - `.github/workflows/ci.yml` — the `install-script` job (line 325+), which currently builds
   the binary and stages a fake release
 - `test/install-script.test.ts` (extend, or a new file if none covers the contract)
+- **`README.md` and the three translations — the shell-install region only**: the one-liner
+  (line 37 in `README.md` at `8b0c9fa`) and the pinned-asset block (lines 113–124), together
+  with their equivalents in `README.ko.md`, `README.ja.md`, `README.zh-CN.md`. All four change
+  in the same commit as the installer, for the truth-window reason in the ownership map
+- `test/readme.test.ts` — the assertions covering that region
+- `scripts/check-readme-numbers.mjs` — evidence only: it must exit 0, and the byte-checked
+  `BENCH:BEGIN`/`BENCH:END` block must be untouched
 
 **Depends on** — ADR-0026 and PRD-F14 approved. Nothing else.
 
 **Forbidden scope**
 
 - no asset download, no `SHA256SUMS` fetch, no tarball checksum, no compile step
-- do not touch `install.ps1` (T-1121), the uninstall command (T-1123), or `README*` (T-1122)
+- do not touch `install.ps1` (T-1121) or the uninstall command (T-1123)
+- **in the READMEs, touch only the shell-install region named in Owns.** The plugin-first
+  block above it is already correct and stays byte-identical; the `BENCH:BEGIN`/`BENCH:END`
+  block is byte-checked by CI and may not be edited; no compatibility statement or matrix
+  pointer is added here — that is T-1122's, and adding one would recreate the overlap this
+  ticket was corrected for
 - do not remove `scripts/build-binary.mjs`, the release matrix, or the binary code (T-1125)
 - do not edit a shell profile; do not add a second script; no bash arrays
 - do not resolve a branch — the default install must not reach `dev`
+- do not claim Windows support anywhere — Windows arrives with T-1121 and is only *supported*
+  after T-1124
 
 **RED test**
 
@@ -54,8 +111,13 @@ there is never a window with neither install path.
 6. **upgrade over a running wrapper**: the wrapper is replaced by rename, and the install exits 0
 7. **forced verification failure**: with the wrapper made unusable after installation, the
    installer still exits 0 and reports "installed but unverified"
+8. **README truth, all four languages together**: no README's shell-install region mentions
+   `SHA256SUMS`, a `.tar.gz` asset, or a target triple; each states the Node ≥ 22 and Git
+   prerequisites for the script path; and the plugin-first block above it is byte-identical to
+   the base. Asserted over all four files in one test, so the state cannot be half-applied.
 
-All fail at `da1c733`: the current script has no Node or Git check and downloads a platform asset.
+All fail at `8b0c9fa`: the current script has no Node or Git check and downloads a platform
+asset, and all four READMEs document that asset path (`README.md` line 37 and lines 113–124).
 
 **Minimum GREEN** — requirements 4–15 implemented, POSIX `sh`, one command, wrapper written to
 a temporary name in the target directory and renamed over the target, verification retried once
@@ -75,16 +137,21 @@ and never deciding the exit code.
 | No profile edit | assert no write to any rc file | req 11; active ruled-out record |
 | Upgrade repoints, refuses a foreign wrapper | test 6 plus a foreign-wrapper case | req 12 |
 | MCP command points at the wrapper | assert the written config value | req 13 |
+| README describes the installer that ships in this commit | test 8 | req 29 — the truth window; ADR-0026 §Consequences |
+| All four languages change together | test 8 asserts the set, not one file | req 29; the four-README convention |
+| The byte-checked block is untouched | `scripts/check-readme-numbers.mjs` exits 0 | ownership map — evidence only |
 
-**Commands** — focused `npx vitest run test/install-script.test.ts`; full `npx vitest run`;
-`sh -n install.sh` exits 0; `shellcheck install.sh` if available; **LIVE (required)**: a real
-install in a scratch `HOME` on a machine with Node ≥ 22 and Git, then `commitlore --version`;
-then an upgrade run over it; then the same on a container image without Node, asserting the
-named failure.
+**Commands** — focused `npx vitest run test/install-script.test.ts test/readme.test.ts`; full
+`npx vitest run`; `sh -n install.sh` exits 0; `node scripts/check-readme-numbers.mjs` exits 0;
+`shellcheck install.sh` if available; **LIVE (required)**: a real install in a scratch `HOME`
+on a machine with Node ≥ 22 and Git, then `commitlore --version`; then an upgrade run over it;
+then the same on a container image without Node, asserting the named failure.
 
-**Evidence invalidation** — line anchors are `da1c733`. Re-derive the asset region with
-`grep -n "SHA256SUMS\|tar -xzf" install.sh` before editing; if T-1125 has already removed the
-release matrix, this ticket is out of order — stop.
+**Evidence invalidation** — line anchors are `8b0c9fa`. Re-derive the asset region with
+`grep -n "SHA256SUMS\|tar -xzf" install.sh` and the README region with
+`grep -n "install.sh | sh\|SHA256SUMS" README*.md` before editing; never edit a README by line
+number, because the install section moves whenever positioning work lands. If T-1125 has
+already removed the release matrix, this ticket is out of order — stop.
 
 **Stop / escalate**
 
@@ -99,8 +166,11 @@ no other entry's contents are echoed); prompt injection (nothing from a config o
 is interpolated into a shell command unquoted); partial state (checkout completes before the
 wrapper is renamed into place, so a failed run leaves no half-installed `PATH` entry).
 
-**Completion evidence** — the seven RED tests passing; `sh -n` clean; the live fresh-install,
-upgrade, and missing-Node transcripts; a diff containing no asset or checksum logic.
+**Completion evidence** — the eight RED tests passing; `sh -n` clean;
+`node scripts/check-readme-numbers.mjs` at 0; the live fresh-install, upgrade, and missing-Node
+transcripts; a diff containing no asset or checksum logic; and **one commit** carrying both the
+installer change and all four README shell-install regions, so no revision of this branch
+exists in which a README describes an installer that is not the one beside it.
 
 ---
 
@@ -119,7 +189,7 @@ defines it.
 - do not claim Windows is supported anywhere — that is T-1124's precondition
 - do not touch `install.sh`, the uninstall command, or `README*`
 
-**RED test** — the file does not exist at `da1c733`, so every assertion fails: Node and Git
+**RED test** — the file does not exist at `8b0c9fa`, so every assertion fails: Node and Git
 checks with named messages; user-local checkout and shim paths; the shim invoking
 `node <checkout>\dist\commitlore.mjs`; no asset or compile reference; correct line endings for
 the shim type; idempotent re-run; and a `windows-latest` CI job that actually runs it.
@@ -149,7 +219,12 @@ no execution-policy change; the shim is written to a temporary name and moved in
 ## T-1122 One authoritative install and compatibility statement (M) — #271 · PRD-F14 req 1–3
 
 **Owns** — `docs/COMPATIBILITY.md` (new); `test/compatibility-matrix.test.ts` (new);
-`README.md` + the three translations (the install section and one pointer line)
+`README.md` + the three translations — **one pointer line each, and nothing else**
+
+**Contract with T-1124** — ship the Windows row present, with status `unsupported`, citing #95
+and T-1124. T-1124 then changes that one cell and nothing else. Shipping the row absent would
+force T-1124 to add a row, which is this ticket's job and would put two owners on the table's
+shape.
 
 **Depends on** — T-1120 and T-1121 merged. The document may not describe an installer that has
 not shipped; that constraint is why this ticket is not first.
@@ -157,10 +232,17 @@ not shipped; that constraint is why this ticket is not first.
 **Forbidden scope**
 
 - no build target, release matrix, `SHA256SUMS`, or platform asset in the document
-- do not touch the `BENCH:BEGIN`/`BENCH:END` block; all four READMEs change together
+- **do not touch the shell-install region of any README.** T-1120 owns the one-liner and the
+  pinned-asset block and rewrites them in the same commit as the installer. This ticket adds a
+  pointer to the compatibility document and changes nothing else in those files — a wider diff
+  here is the overlap the ownership map exists to prevent
+- do not restate any installer behaviour in prose. The document states host support and the
+  prerequisites each installer *checks*; it does not re-describe how either installs
+- do not touch the `BENCH:BEGIN`/`BENCH:END` block; the pointer line lands in all four READMEs
+  together
 - do not mark Windows `supported` — T-1124 owns that claim
 
-**RED test** — the document does not exist at `da1c733`. Assertions: every documented plugin
+**RED test** — the document does not exist at `8b0c9fa`. Assertions: every documented plugin
 capability is backed by the manifest that provides it (`.mcp.json`, `hooks/hooks.json`,
 `skills/`, both `.claude-plugin/` manifests); each installer's checked prerequisites match the
 document; no row claims a platform no install path reaches; the status vocabulary is exactly
@@ -201,7 +283,7 @@ both a `commitlore` entry and an unrelated entry: the checkout, wrapper and `com
 are removed while the unrelated entry and every other key survive byte-for-byte; a foreign
 wrapper is left with a named reason; the second run removes nothing and exits 0; `--dry-run`
 changes nothing; the report and `--json` contain no other entry's contents; and a bidirectional
-test asserts the config-path table agrees with both installers. All fail at `da1c733` — no such
+test asserts the config-path table agrees with both installers. All fail at `8b0c9fa` — no such
 command exists and `src/` holds no agent config path knowledge.
 
 **Why bidirectional** — two sources of the same truth diverge silently. This repository already
@@ -223,8 +305,15 @@ drift, and the bidirectional agreement test green.
 ## T-1124 Establish #71's containment for the wrapper path on Windows (M) — #283 · PRD-F14 req 26
 
 **Owns** — `.github/workflows/ci.yml` (extend T-1121's Windows job, or one adjacent required
-job); `test/hook-target.test.ts` (wrapper-path cases); `docs/COMPATIBILITY.md` (the Windows row,
-only if the property holds)
+job); `test/hook-target.test.ts` (wrapper-path cases)
+
+**Also changes, under the single-writer rule** — the compatibility document's Windows row
+`status` cell and its reason, and **nothing else in that file**. T-1122 owns the document and
+ships that row already present with status `unsupported`, citing #95 and this ticket, so this
+ticket has exactly one cell to change and never has to add or restructure a row. A diff here
+that adds a row, edits another row, or touches the table's shape belongs to T-1122. The path is
+deliberately not listed under **Owns**, so an ownership scan that matches on filenames still
+reports one owner per file.
 
 **Depends on** — T-1121 merged. There is no wrapper on Windows before it.
 
@@ -237,7 +326,7 @@ only if the property holds)
 **RED test** — #71's two containment attacks, executed against a **wrapper** target on
 `windows-latest`: a recorded `commitlore.bin` pointing outside the install root is refused, and
 a recorded target that is neither a script nor a recognised wrapper is refused. Both fail or are
-absent at `da1c733`, where no Windows job exists and the classification knows only a bare
+absent at `8b0c9fa`, where no Windows job exists and the classification knows only a bare
 binary name.
 
 **Minimum GREEN** — the attacks pass on `windows-latest` for the wrapper path, in a required
@@ -256,11 +345,17 @@ with the recorded reason.
 
 ## T-1125 Remove the compiled-binary code (L) — #284 · PRD-F14 req 27–29
 
-**Owns** — every site in ADR-0026's inventory: `scripts/build-binary.mjs`;
-`package.json` `build:binary`; `.github/workflows/release.yml` `build` and `publish` asset and
-`SHA256SUMS` steps; `.github/workflows/ci.yml` `binary` job; `scripts/commitlore-run.sh`'s
-compiled-binary probe; `src/core/hook-target.ts`; `src/hooks/commit-msg.ts`; the README
-pinned-asset verification block in all four languages; `dist/` rebuilt
+**Owns** — the sites in ADR-0026's inventory that remain after T-1120:
+`scripts/build-binary.mjs`; `package.json` `build:binary`;
+`.github/workflows/release.yml` `build` (from line 77 at `8b0c9fa`) and `publish` (from 138)
+asset and `SHA256SUMS` steps; `.github/workflows/ci.yml` `binary` job;
+`scripts/commitlore-run.sh`'s compiled-binary probe; `src/core/hook-target.ts`;
+`src/hooks/commit-msg.ts`; `dist/` rebuilt.
+
+**Not the README shell-install region.** T-1120 removed the one-liner's asset path and the
+pinned-asset block already. This ticket touches a README only if a *residual* compiled-binary
+or release reference survived elsewhere in it, and its RED test names which one — an empty
+README diff is the expected outcome.
 
 **Depends on** — T-1120, T-1121 and T-1122 merged. Requirement 27: the replacement must ship
 first, so there is never a window with neither.
@@ -276,7 +371,7 @@ first, so there is never a window with neither.
 
 **RED test** — a repository-wide invariant asserting no tracked file builds, downloads, or
 classifies a compiled executable: no `build:binary`, no SEA call, no `SHA256SUMS` fetch in an
-installer, no `BinKind` arm for a compiled binary. Fails at `da1c733`, where all of those exist.
+installer, no `BinKind` arm for a compiled binary. Fails at `8b0c9fa`, where all of those exist.
 Plus a containment test proving the wrapper case is still refused when it points outside the
 install root — which must pass **before and after** this ticket.
 
@@ -285,8 +380,9 @@ invariant; full suite; `npm run build` with `dist/` committed; both `tsc --noEmi
 `node scripts/check-readme-numbers.mjs` exit 0; **LIVE (required)**: the next release run
 publishes no platform asset and the plugin path still resolves and runs.
 
-**Evidence invalidation** — the inventory is bound to `69e5208` in ADR-0026 and re-anchored at
-this ticket's own head. Re-derive every line number before editing; if any site has already
+**Evidence invalidation** — the inventory is bound to `69e5208` in ADR-0026, re-anchored to
+`8b0c9fa` here, and must be re-anchored again at this ticket's own head, which is several
+merges later by construction. Re-derive every line number before editing; if any site has already
 been removed, drop it from **Owns** rather than re-editing.
 
 **Stop / escalate** — if removing the binary arm cannot preserve containment for the wrapper


### PR DESCRIPTION
Docs only. No `src/`, no `dist/`, no workflow, no version change. **No implementation code for T-1120 until it passes review as corrected.**

| binding | value |
|---|---|
| Owning issue | #281 (T-1120), gate review outcome: FAIL-AS-WRITTEN, docs-only correction authorized |
| Base | `dev@8b0c9fa42cf4e44b3e5684084230230902dda5a6` |
| Exact head | `f149ff9eb9b1a363e1286dd5583e056375157c3b` |
| Tree | `cdf1db0327f71e29ade41914aae5fa86caa75702` |
| Acceptance | `B-8` added to `docs/GATE-B-ACCEPTANCE.md` |

## The contradiction that failed review

PRD-F14 requirement 29 requires the README's shell-install section to change **in the same change** that makes `install.sh` Node-only. T-1120 forbade `README*` and deferred it to T-1122. T-1125 also claimed the same pinned-asset block. Three tickets claimed one region while the requirement asked for a fourth arrangement.

**The requirement was the one that was right**, and the reason is worth stating: the shipped installer downloads a platform asset today, so the README documenting that is *currently true*. Changing the README earlier makes it false immediately; changing it later leaves it false in between. One commit carrying both is the only arrangement in which the README is never wrong.

## Ownership after this change

| Region | Owner |
|---|---|
| `install.sh` Node-only behaviour | **T-1120** |
| The shell-install one-liner and pinned-asset block, all four languages | **T-1120**, same commit as the installer |
| `test/readme.test.ts` and `check-readme-numbers.mjs` evidence for it | **T-1120** |
| `install.ps1` | **T-1121** |
| `docs/COMPATIBILITY.md` + one pointer line per README | **T-1122** |
| `commitlore uninstall` | **T-1123** |
| Windows containment for the wrapper path | **T-1124** |
| Residual compiled-binary/release references left after T-1120 | **T-1125** |

T-1120 gains an eighth RED assertion covering the four READMEs **as a set**, so the state cannot be half-applied, and its completion evidence now requires one commit for installer + all four READMEs.

## Two more overlaps, found by running the check rather than reading

- **`docs/COMPATIBILITY.md` was owned by both T-1122 and T-1124.** T-1124 now changes one cell under a stated single-writer rule and **no longer names the path under Owns**, so a filename-level scan still reports one owner. T-1122's side is pinned: ship the Windows row present as `unsupported`, so T-1124 never has to add a row.
- **`.github/workflows/ci.yml` genuinely has four owners — one job each.** No filename scan can see that, so the four jobs are enumerated in the ownership map and the exception is written down. An exception a reader has to interpret is the kind that rots.

## Re-anchoring

All `da1c733` line assumptions moved to `8b0c9fa` (0 stale references remain). README anchors are recorded as **content greps rather than line numbers**, because the install section moves whenever positioning work lands.

## Checks run

| check | result |
|---|---|
| internal links, all four changed documents | no broken target |
| authority | every acceptance row names a ticket; every ticket names its issue and authority |
| region ownership | one owner for README shell-install, pinned-asset, `COMPATIBILITY.md`, `install.sh`, `install.ps1`, `release.yml`, `hook-target.ts`, `commit-msg.ts`, `build-binary.mjs`; `ci.yml` per job |
| requirement trace | 29 PRD requirements — **0 unclaimed, 0 claimed twice** |
| stale anchors | 0 |
| docs-only | 0 non-`docs/` paths in the diff |
| record | commit-msg hook `shape ok · references ok` |

## Self-review

- **README truth window** — closed by construction: one commit, four files, asserted as a set.
- **wrong-target** — T-1120's `Owns` mentions none of `install.ps1`, `COMPATIBILITY`, `build-binary`, `uninstall.ts`, `src/core`, `dist/`.
- **partial-state** — nine clauses bind the four-file and one-commit rules.
- **security** — T-1125's #71 containment clause is intact: a diff that removes `matchesRunningBinary` without a wrapper equivalent remains the named failure mode.
- **not verified** — no code changed and no test ran, so nothing here is evidence about installer behaviour.

## Next

Implementation of T-1120 starts only after this corrected ticket passes review.
