### PR TITLE
Make install.sh Node-only, and change the README that documents it in the same commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,12 @@ jobs:
             apt-get update -qq && apt-get install -y -qq git >/dev/null
             # The checkout is owned by the runner uid, not this container user.
             git config --global --add safe.directory /w
+            git config --global --add safe.directory "*"
+            # Raw clone first, unfiltered: if the installer cannot fetch, this
+            # shows git saying why instead of leaving it to be inferred.
+            echo "--- raw clone probe ---"
+            git clone --depth 1 --branch v9.9.9 /w /tmp/probe || echo "(probe failed, see above)"
+            echo "--- installer ---"
             COMMITLORE_INSTALL_SOURCE=/w sh install.sh v9.9.9
             "$HOME/.local/bin/commitlore" --version
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,11 @@ jobs:
           src="${{ steps.stage.outputs.source }}"
           docker run --rm -v "$PWD:/w" -v "$src:/src:ro" -w /w debian:stable-slim sh -c '
             set -eu
+            # The mount is owned by the runner uid, not the container user, so
+            # git would refuse it as dubious ownership. That is an artefact of
+            # bind-mounting a local repository, not something a user installing
+            # from a URL ever meets.
+            git config --global --add safe.directory /src 2>/dev/null || true
             out=$(COMMITLORE_INSTALL_SOURCE=/src sh install.sh v9.9.9 2>&1 || true)
             printf "%s\n" "$out"
             printf "%s" "$out" | grep -qi "node" || { echo "expected the message to name Node"; exit 1; }
@@ -409,6 +414,7 @@ jobs:
           docker run --rm -v "$PWD:/w" -v "$src:/src:ro" -w /w node:22-bookworm-slim sh -c '
             set -eu
             apt-get update -qq && apt-get install -y -qq git >/dev/null
+            git config --global --add safe.directory /src
             COMMITLORE_INSTALL_SOURCE=/src sh install.sh v9.9.9
             "$HOME/.local/bin/commitlore" --version
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,21 +340,24 @@ jobs:
       # it does instead is clone a pinned tag and write a thin wrapper, so the
       # source under test is a local repository with a tag on it. Nothing here
       # reaches github.com, and nothing here builds a binary.
-      - name: Stage a tagged source repository for install.sh to clone
-        id: stage
+      # The checkout itself is the source. An earlier revision cloned it to a
+      # separate directory and bind-mounted that read-only into the containers,
+      # which made git report only "correct access rights and the repository
+      # exists" -- a mount and ownership problem standing in for the thing under
+      # test. One repository, mounted read-write where the container already
+      # mounts it, removes that whole class of noise.
+      - name: Tag the checkout so install.sh has a pinned version to clone
         run: |
           set -euo pipefail
-          src="$RUNNER_TEMP/source"
-          git clone --quiet . "$src"
-          git -C "$src" -c user.name=ci -c user.email=ci@example.invalid tag v9.9.9
-          echo "source=$src" >> "$GITHUB_OUTPUT"
+          git -c user.name=ci -c user.email=ci@example.invalid tag -f v9.9.9
+          git tag --list v9.9.9
 
       - name: Fresh install, then upgrade over it
         run: |
           set -euo pipefail
           export HOME="$RUNNER_TEMP/home"
           mkdir -p "$HOME"
-          export COMMITLORE_INSTALL_SOURCE="${{ steps.stage.outputs.source }}"
+          export COMMITLORE_INSTALL_SOURCE="$GITHUB_WORKSPACE"
 
           sh install.sh v9.9.9
           wrapper="$HOME/.local/bin/commitlore"
@@ -393,15 +396,9 @@ jobs:
       - name: Bare debian names the missing prerequisite and installs nothing
         run: |
           set -euo pipefail
-          src="${{ steps.stage.outputs.source }}"
-          docker run --rm -v "$PWD:/w" -v "$src:/src:ro" -w /w debian:stable-slim sh -c '
+          docker run --rm -v "$PWD:/w" -w /w debian:stable-slim sh -c '
             set -eu
-            # The mount is owned by the runner uid, not the container user, so
-            # git would refuse it as dubious ownership. That is an artefact of
-            # bind-mounting a local repository, not something a user installing
-            # from a URL ever meets.
-            git config --global --add safe.directory /src 2>/dev/null || true
-            out=$(COMMITLORE_INSTALL_SOURCE=/src sh install.sh v9.9.9 2>&1 || true)
+            out=$(COMMITLORE_INSTALL_SOURCE=/w sh install.sh v9.9.9 2>&1 || true)
             printf "%s\n" "$out"
             printf "%s" "$out" | grep -qi "node" || { echo "expected the message to name Node"; exit 1; }
             test ! -e "$HOME/.local/bin/commitlore" || { echo "something was installed"; exit 1; }
@@ -410,11 +407,11 @@ jobs:
       - name: The same image succeeds once Node and Git are present
         run: |
           set -euo pipefail
-          src="${{ steps.stage.outputs.source }}"
-          docker run --rm -v "$PWD:/w" -v "$src:/src:ro" -w /w node:22-bookworm-slim sh -c '
+          docker run --rm -v "$PWD:/w" -w /w node:22-bookworm-slim sh -c '
             set -eu
             apt-get update -qq && apt-get install -y -qq git >/dev/null
-            git config --global --add safe.directory /src
-            COMMITLORE_INSTALL_SOURCE=/src sh install.sh v9.9.9
+            # The checkout is owned by the runner uid, not this container user.
+            git config --global --add safe.directory /w
+            COMMITLORE_INSTALL_SOURCE=/w sh install.sh v9.9.9
             "$HOME/.local/bin/commitlore" --version
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,265 +326,89 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm run build:binary
 
-      # Stage a release the exact shape release.yml publishes — same
-      # asset-naming convention (`commitlore-<version>-<target>.tar.gz`), same
-      # `sha256sum *.tar.gz > SHA256SUMS` invocation (compare
-      # .github/workflows/release.yml's `build`/`publish` jobs) — just not
-      # fetched from github.com. A second, corrupted copy exists only to
-      # prove the checksum check rejects a bad download: flipped bytes in the
-      # archive, SHA256SUMS left pointing at the original (now wrong) hash.
-      - name: Stage a release layout for install.sh to fetch
+      # install.sh no longer downloads a release asset (ADR-0026), so there is
+      # no staged tarball, no SHA256SUMS and no corrupted copy to reject. What
+      # it does instead is clone a pinned tag and write a thin wrapper, so the
+      # source under test is a local repository with a tag on it. Nothing here
+      # reaches github.com, and nothing here builds a binary.
+      - name: Stage a tagged source repository for install.sh to clone
         id: stage
         run: |
           set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
-          target="x86_64-unknown-linux-gnu"  # ubuntu-latest's own arch -- matches the build:binary output above
-          asset="commitlore-${version}-${target}.tar.gz"
+          src="$RUNNER_TEMP/source"
+          git clone --quiet . "$src"
+          git -C "$src" -c user.name=ci -c user.email=ci@example.invalid tag v9.9.9
+          echo "source=$src" >> "$GITHUB_OUTPUT"
 
-          good="$RUNNER_TEMP/staged-good"
-          bin_stage="$RUNNER_TEMP/staged-bin"
-          mkdir -p "$good" "$bin_stage"
-          cp dist/commitlore "$bin_stage/commitlore"
-          chmod +x "$bin_stage/commitlore"
-          tar -czf "$good/$asset" -C "$bin_stage" commitlore
-          ( cd "$good" && sha256sum "$asset" > SHA256SUMS )
-
-          corrupt="$RUNNER_TEMP/staged-corrupt"
-          mkdir -p "$corrupt"
-          cp "$good/$asset" "$good/SHA256SUMS" "$corrupt/"
-          # Overwrite 16 bytes well inside the archive with fixed, non-matching
-          # content. SHA256SUMS in $corrupt is untouched -- still the hash of
-          # the *original* bytes -- so this is deliberately a mismatch, not a
-          # coincidence.
-          dd if=/dev/zero of="$corrupt/$asset" bs=1 seek=1000 count=16 conv=notrunc status=none
-
-          echo "asset=$asset" >> "$GITHUB_OUTPUT"
-          echo "good_dir=$good" >> "$GITHUB_OUTPUT"
-          echo "corrupt_dir=$corrupt" >> "$GITHUB_OUTPUT"
-
-      - name: Serve the staged releases over HTTP
+      - name: Fresh install, then upgrade over it
         run: |
           set -euo pipefail
-          python3 -m http.server 8199 --directory "${{ steps.stage.outputs.good_dir }}" --bind 127.0.0.1 &
-          python3 -m http.server 8198 --directory "${{ steps.stage.outputs.corrupt_dir }}" --bind 127.0.0.1 &
-          for port in 8199 8198; do
-            up=""
-            for _ in $(seq 1 20); do
-              if curl -sf "http://127.0.0.1:$port/SHA256SUMS" >/dev/null 2>&1; then up=1; break; fi
-              sleep 0.5
-            done
-            [ -n "$up" ] || { echo "::error::staging HTTP server on :$port never came up"; exit 1; }
+          export HOME="$RUNNER_TEMP/home"
+          mkdir -p "$HOME"
+          export COMMITLORE_INSTALL_SOURCE="${{ steps.stage.outputs.source }}"
+
+          sh install.sh v9.9.9
+          wrapper="$HOME/.local/bin/commitlore"
+          test -x "$wrapper"
+          grep -qF '# commitlore:wrapper:v1' "$wrapper"
+          test -f "$HOME/.local/share/commitlore/v9.9.9/dist/commitlore.mjs"
+          "$wrapper" --version
+
+          # The wrapper is replaced by rename, and a second run is an upgrade
+          # rather than a refusal. An in-place overwrite of a file that may be
+          # executing is the defect that forced a same-day patch release.
+          sh install.sh v9.9.9
+          "$wrapper" --version
+
+          # No shell profile is written. Printing the PATH line is the whole of
+          # what this script does about PATH.
+          for rc in .bashrc .zshrc .profile .bash_profile; do
+            test ! -e "$HOME/$rc" || { echo "::error::install.sh wrote $rc"; exit 1; }
           done
 
-      # install.sh's documented, default command has no override -- it hits
-      # github.com directly. "Download from a release if one exists" means
-      # checking first and using it when so, rather than assuming either way.
-      # As of #99 it does not: v0.1.0 was published with zero attached
-      # assets (`gh release view v0.1.0` -- `assets: []`), which is exactly
-      # what this check finds on its own (SHA256SUMS 404s). Every assertion
-      # below therefore runs against the staged layout above; this step also
-      # means that changes the day a real release actually carries assets,
-      # with no edit to this workflow required.
-      - name: Does the latest real release publish this target's asset?
-        id: real
+      - name: The script carries no asset, checksum or target triple
         run: |
           set -euo pipefail
-          url="https://github.com/${{ github.repository }}/releases/latest/download/SHA256SUMS"
-          code="$(curl -s -o /dev/null -w '%{http_code}' -L "$url")"
-          if [ "$code" = "200" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::latest release publishes SHA256SUMS -- the real-path step below will run against github.com"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::latest release has no SHA256SUMS asset (HTTP $code) -- install.sh's documented one-liner cannot be exercised against a real release right now; every assertion in this job uses the staged release from the previous step instead"
-          fi
+          for forbidden in SHA256SUMS '.tar.gz' 'tar -xzf' unknown-linux-gnu apple-darwin; do
+            if grep -qF "$forbidden" install.sh; then
+              echo "::error::install.sh still mentions $forbidden"
+              exit 1
+            fi
+          done
 
-      # === debian:stable-slim ==================================================
-
-      # Nothing preinstalled. Neither curl nor wget ships on this image by
-      # default -- confirmed by removing both from consideration entirely,
-      # not by reading the Dockerfile. fetch()'s own command -v checks should
-      # catch this and die with a named, actionable message instead of a raw
-      # "curl: not found" from the shell.
-      - name: "debian: nothing preinstalled -- the dependency check fires cleanly"
+      # A bare image is the point: the prerequisites are genuinely absent, so
+      # the named failure is the thing being asserted rather than routed around.
+      # Adding them afterwards is the same progression the previous version of
+      # this job used for curl -- assert the clean failure first, then the
+      # success once the requirement is satisfied.
+      - name: Bare debian names the missing prerequisite and installs nothing
         run: |
           set -euo pipefail
-          out="$(docker run --rm --network host \
-            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8199" \
-            -e HOME=/root \
-            -v "$PWD/install.sh:/install.sh:ro" \
-            debian:stable-slim sh /install.sh 2>&1)" && rc=0 || rc=$?
-          echo "$out"
-          test "$rc" -eq 2 || { echo "::error::expected exit 2 (download failed), got $rc"; exit 1; }
-          echo "$out" | grep -qF "neither curl nor wget is available to download the release" || {
-            echo "::error::expected the curl/wget-missing message, got something else"; exit 1;
-          }
+          src="${{ steps.stage.outputs.source }}"
+          docker run --rm -v "$PWD:/w" -v "$src:/src:ro" -w /w debian:stable-slim sh -c '
+            set -eu
+            out=$(COMMITLORE_INSTALL_SOURCE=/src sh install.sh v9.9.9 2>&1 || true)
+            printf "%s\n" "$out"
+            printf "%s" "$out" | grep -qi "node" || { echo "expected the message to name Node"; exit 1; }
+            test ! -e "$HOME/.local/bin/commitlore" || { echo "something was installed"; exit 1; }
+          '
 
-      # curl is the one thing this image is missing that install.sh hard
-      # requires (sha256sum and tar both ship by default on Debian). Adding
-      # it here is not "pre-installing dependencies to make the test pass" --
-      # it is the second half of the same test: the step above already
-      # proved the bare-machine failure is clean and named; this step proves
-      # the success path actually works once that one gap is filled, which
-      # #99's item 4 (binary runs, --version, agent detection with none
-      # installed) needs a working download to even reach.
-      - name: "debian: add curl, then the full install + agent-detection path succeeds"
+      - name: The same image succeeds once Node and Git are present
         run: |
           set -euo pipefail
-          expected_version="$(node -p "require('./package.json').version")"
-          docker run --rm --network host \
-            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8199" \
-            -e HOME=/root \
-            -e EXPECTED_VERSION="$expected_version" \
-            -v "$PWD/install.sh:/install.sh:ro" \
-            debian:stable-slim sh -c '
-              set -eu
-              apt-get update -qq
-              apt-get install -y -qq curl
-              echo "=== install.sh ==="
-              sh /install.sh
-              echo "=== post-install assertions ==="
-              [ -x /root/.local/bin/commitlore ] || { echo "binary was not installed"; exit 1; }
-              v="$(/root/.local/bin/commitlore --version)"
-              [ "$v" = "$EXPECTED_VERSION" ] || { echo "unexpected --version output: $v (expected $EXPECTED_VERSION)"; exit 1; }
-              if command -v commitlore >/dev/null 2>&1; then
-                v_by_name="$(commitlore --version)"
-                [ "$v_by_name" = "$EXPECTED_VERSION" ] || { echo "unexpected by-name --version output: $v_by_name (expected $EXPECTED_VERSION)"; exit 1; }
-                echo "commitlore-ci: commitlore is invokable by name"
-              else
-                echo "commitlore-ci: commitlore is not on PATH"
-              fi
-              # None of the six clients this script knows about exist in this
-              # container. All six must be reported absent, none "wired", and
-              # -- the part a clean summary line alone does not prove -- no
-              # config file may exist at any path install.sh would have
-              # written to.
-              for p in /root/.claude /root/.codex/config.toml /root/.gemini/settings.json \
-                       /root/.cursor/mcp.json /root/.codeium/windsurf/mcp_config.json \
-                       /root/.config/opencode/opencode.json; do
-                [ ! -e "$p" ] || { echo "a config was written for an agent that is not installed: $p"; exit 1; }
-              done
-            ' 2>&1 | tee "$RUNNER_TEMP/debian-success.log"
-          grep -qF "Not detected on this machine: Claude Code, Codex, Gemini CLI, Cursor, Windsurf, opencode" \
-            "$RUNNER_TEMP/debian-success.log" || {
-            echo "::error::the six-agent-absent summary line is missing or changed"; exit 1;
-          }
-          if ! grep -qF "commitlore-ci: commitlore is invokable by name" "$RUNNER_TEMP/debian-success.log"; then
-            grep -qF "commitlore-install: note: /root/.local/bin is not on PATH." \
-              "$RUNNER_TEMP/debian-success.log" || {
-              echo "::error::install.sh neither made commitlore invokable by name nor explained its missing PATH entry"; exit 1;
-            }
-            grep -qF "commitlore-install: add this line to /root/.profile:" \
-              "$RUNNER_TEMP/debian-success.log" || {
-              echo "::error::install.sh did not name the shell file to update"; exit 1;
-            }
-            grep -qF 'commitlore-install:   export PATH="/root/.local/bin:$PATH"' \
-              "$RUNNER_TEMP/debian-success.log" || {
-              echo "::error::install.sh did not print the exact PATH export line"; exit 1;
-            }
-            note_line="$(grep -nF "commitlore-install: note: /root/.local/bin is not on PATH." "$RUNNER_TEMP/debian-success.log" | cut -d: -f1)"
-            next_line="$(grep -nF "commitlore-install: Next: cd into a repository and run 'commitlore init'" "$RUNNER_TEMP/debian-success.log" | cut -d: -f1)"
-            [ -n "$note_line" ] && [ -n "$next_line" ] && [ "$note_line" -lt "$next_line" ] || {
-              echo "::error::PATH guidance must be printed before the Next instruction"; exit 1;
-            }
-          fi
-
-      # === alpine:latest -- busybox sh, not bash. The real portability test. ==
-
-      # Nothing preinstalled here either, and nothing needs to be: busybox
-      # ships wget, sha256sum, and tar by default, so the download and
-      # checksum-verify steps run with no setup at all. What actually breaks
-      # is the binary itself -- the published target is
-      # `<arch>-unknown-linux-gnu` (glibc), and Alpine is musl. Before #99's
-      # fix, install.sh copied the unusable binary into place, printed
-      # "installed to ...", and then crashed on its own "$dest" --version
-      # sanity check with a bare `not found` (busybox's rendering of "no
-      # dynamic interpreter") and exit 127 -- not one of the four exit codes
-      # this script documents for itself. The fix executes the freshly
-      # extracted binary *before* installing it anywhere and `die`s with a
-      # named, attributed message if it cannot run.
-      - name: "alpine: nothing preinstalled -- the musl/glibc mismatch is refused cleanly"
-        run: |
-          set -euo pipefail
-          out="$(docker run --rm --network host \
-            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8199" \
-            -e HOME=/root \
-            -v "$PWD/install.sh:/install.sh:ro" \
-            alpine:latest sh /install.sh 2>&1)" && rc=0 || rc=$?
-          echo "$out"
-          test "$rc" -eq 1 || { echo "::error::expected exit 1 (unsupported platform), got $rc"; exit 1; }
-          echo "$out" | grep -qF "does not run on this machine" || {
-            echo "::error::expected the musl/glibc diagnostic, got something else"; exit 1;
-          }
-          echo "$out" | grep -qF "nothing was installed" || {
-            echo "::error::expected the nothing-was-installed reassurance"; exit 1;
-          }
-          docker run --rm --network host -e HOME=/root debian:stable-slim \
-            test ! -e /root/.local/bin/commitlore
-
-      # Checksum verification is the one guarantee this script exists to make
-      # (see install.sh's own header comment) -- a check that has never been
-      # seen to reject anything is not a checksum check. Run against both
-      # images: debian with curl added (glibc, the common case) and bare
-      # alpine (busybox's own sha256sum applet, reached before the musl
-      # binary-execution guard above ever runs -- checksum verification
-      # happens first). Both must refuse the corrupted asset the same way.
-      - name: "checksum corruption is rejected on both images -- nothing is installed"
-        run: |
-          set -euo pipefail
-
-          out_debian="$(docker run --rm --network host \
-            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8198" \
-            -e HOME=/root \
-            -v "$PWD/install.sh:/install.sh:ro" \
-            debian:stable-slim sh -c '
-              set -eu
-              apt-get update -qq
-              apt-get install -y -qq curl
-              sh /install.sh
-            ' 2>&1)" && rc_debian=0 || rc_debian=$?
-          echo "$out_debian"
-          test "$rc_debian" -eq 3 || { echo "::error::debian: expected exit 3 (checksum mismatch), got $rc_debian"; exit 1; }
-          echo "$out_debian" | grep -qF "checksum mismatch for" || { echo "::error::debian: expected the checksum-mismatch message"; exit 1; }
-          echo "$out_debian" | grep -qF "Nothing was installed" || { echo "::error::debian: expected the nothing-was-installed reassurance"; exit 1; }
-
-          out_alpine="$(docker run --rm --network host \
-            -e COMMITLORE_INSTALL_BASE_URL="http://127.0.0.1:8198" \
-            -e HOME=/root \
-            -v "$PWD/install.sh:/install.sh:ro" \
-            alpine:latest sh /install.sh 2>&1)" && rc_alpine=0 || rc_alpine=$?
-          echo "$out_alpine"
-          test "$rc_alpine" -eq 3 || { echo "::error::alpine: expected exit 3 (checksum mismatch), got $rc_alpine"; exit 1; }
-          echo "$out_alpine" | grep -qF "checksum mismatch for" || { echo "::error::alpine: expected the checksum-mismatch message"; exit 1; }
-
-      # === the real path, once it exists ======================================
-
-      # Skipped entirely today (see the "Does the latest real release
-      # publish..." step -- v0.1.0 has no assets). The day a real release
-      # does carry an asset for this target, this step starts running
-      # automatically and must pass: the actual documented one-liner,
-      # against the actual GitHub release, with no override at all.
-      - name: "real release path (only runs once a release actually publishes assets)"
-        if: steps.real.outputs.available == 'true'
-        run: |
-          set -euo pipefail
-          out="$(docker run --rm --network host \
-            -e HOME=/root \
-            -v "$PWD/install.sh:/install.sh:ro" \
-            debian:stable-slim sh -c '
-              set -eu
-              apt-get update -qq
-              apt-get install -y -qq curl
-              sh /install.sh
-              /root/.local/bin/commitlore --version
-            ' 2>&1)" && rc=0 || rc=$?
-          echo "$out"
-          test "$rc" -eq 0 || { echo "::error::the real, documented install command failed against the actual GitHub release"; exit 1; }
+          src="${{ steps.stage.outputs.source }}"
+          docker run --rm -v "$PWD:/w" -v "$src:/src:ro" -w /w node:22-bookworm-slim sh -c '
+            set -eu
+            apt-get update -qq && apt-get install -y -qq git >/dev/null
+            COMMITLORE_INSTALL_SOURCE=/src sh install.sh v9.9.9
+            "$HOME/.local/bin/commitlore" --version
+          '

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@
 /plugin install commitlore@commitlore
 ```
 
-プラグイン経路の前提条件: Node.js 22+ と Git。
+どちらの経路も前提条件は Node.js 22+ と Git です。スクリプトは何かを書き込む前に両方を確認します。
 
 **その他のコーディングエージェント** — CLI をインストールします:
 
@@ -110,18 +110,16 @@ commitlore context .
 <details>
 <summary>インストールを確認または固定したいですか？</summary>
 
-この一行は利便性のためです。レビュー済みまたは固定されたインストールが必要なら、まず `install.sh` をダウンロードして確認するか、リポジトリを clone するか、リリース資産を手動でダウンロードして `SHA256SUMS` を検証してください。スクリプトはダウンロードするバイナリのチェックサムを検証しますが、すでに `sh` に渡したスクリプト自体を認証するものではありません。
+この一行は利便性のためです。レビュー済みまたは固定されたインストールが必要なら、まず `install.sh` をダウンロードして確認するか、リポジトリを clone してください。スクリプトは固定タグのソースチェックアウトと、`node <checkout>/dist/commitlore.mjs` を実行する薄い wrapper だけをインストールします — コンパイル済み成果物のダウンロードもビルド手順もないため、マシンに置かれるのは読めるソースです。
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
 curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
 sh install.sh v0.4.1
 
-# または release binary を自分で検証してから展開します。
-version=0.4.1; target=aarch64-apple-darwin
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
-grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
+# あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
+git clone --depth 1 --branch v0.4.1 https://github.com/MongLong0214/commitlore
+node commitlore/dist/commitlore.mjs --version
 ```
 
 </details>

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
 /plugin install commitlore@commitlore
 ```
 
-플러그인 경로의 전제 조건: Node.js 22+ 와 Git.
+두 경로 모두의 전제 조건: Node.js 22+ 와 Git. 스크립트는 무엇이든 쓰기 전에 둘을 확인한다.
 
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
@@ -110,18 +110,16 @@ commitlore context .
 <details>
 <summary>설치 내용을 살펴보거나 버전을 고정하고 싶나요?</summary>
 
-한 줄 명령은 편의를 위한 것이다. 검토하거나 고정한 설치가 필요하면 먼저 `install.sh`를 내려받아 살펴보거나, 저장소를 clone하거나, 릴리스 자산을 직접 내려받아 `SHA256SUMS`를 검증한다. 스크립트는 내려받는 바이너리의 체크섬을 검증하지만, 이미 `sh`로 전달한 스크립트를 인증하지는 않는다.
+한 줄 명령은 편의를 위한 것이다. 검토하거나 고정한 설치가 필요하면 먼저 `install.sh`를 내려받아 살펴보거나, 저장소를 clone한다. 스크립트는 고정된 태그의 소스 체크아웃과 `node <checkout>/dist/commitlore.mjs`를 실행하는 얇은 wrapper만 설치한다 — 컴파일된 산출물을 내려받지 않고 빌드 단계도 없으므로, 기계에 놓이는 것은 읽을 수 있는 소스다.
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
 curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
 sh install.sh v0.4.1
 
-# 또는 릴리스 바이너리를 직접 검증한 뒤 압축을 푼다.
-version=0.4.1; target=aarch64-apple-darwin
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
-grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
+# 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
+git clone --depth 1 --branch v0.4.1 https://github.com/MongLong0214/commitlore
+node commitlore/dist/commitlore.mjs --version
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install once. Your coding agent can record the decisions worth carrying forward,
 /plugin install commitlore@commitlore
 ```
 
-Prerequisites for the plugin path: Node.js 22+ and Git.
+Prerequisites for either path: Node.js 22+ and Git. The script checks both before it writes anything.
 
 **Any other coding agent** — install the CLI:
 
@@ -110,18 +110,16 @@ Then keep working through your coding agent. When a change contains decision con
 <details>
 <summary>Prefer to inspect or pin the installation?</summary>
 
-The one-liner is for convenience. For a reviewed or pinned install, download and inspect `install.sh` first, clone the repository, or manually download a release asset and verify its `SHA256SUMS`. The script checksum-verifies the binary it downloads; it does not authenticate the script already piped to `sh`.
+The one-liner is for convenience. For a reviewed or pinned install, download and inspect `install.sh` first, or clone the repository. The script installs a pinned source checkout and a thin wrapper that runs `node <checkout>/dist/commitlore.mjs` — it downloads no compiled artifact and runs no build step, so what it puts on your machine is the source you can read.
 
 ```bash
 # Pin and inspect the installer before executing it.
 curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
 sh install.sh v0.4.1
 
-# Or verify the release binary yourself before extracting it.
-version=0.4.1; target=aarch64-apple-darwin
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
-grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
+# Or skip the script entirely: the checkout it makes is one you can make yourself.
+git clone --depth 1 --branch v0.4.1 https://github.com/MongLong0214/commitlore
+node commitlore/dist/commitlore.mjs --version
 ```
 
 </details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@
 /plugin install commitlore@commitlore
 ```
 
-插件路径的前置条件: Node.js 22+ 与 Git。
+两条路径的前置条件都是 Node.js 22+ 与 Git。脚本在写入任何内容之前会检查这两项。
 
 **其他编程代理** — 安装 CLI:
 
@@ -110,18 +110,16 @@ commitlore context .
 <details>
 <summary>想检查或固定安装版本？</summary>
 
-这一行命令是为了方便。若需要经过审阅或固定版本的安装，请先下载并检查 `install.sh`，或 clone 仓库，或手动下载发布资产并验证其 `SHA256SUMS`。脚本会校验下载二进制文件的校验和；它不会认证已经通过管道交给 `sh` 的脚本本身。
+这一行命令是为了方便。若需要经过审阅或固定版本的安装，请先下载并检查 `install.sh`，或 clone 仓库。脚本只安装一个固定标签的源码检出，以及一个运行 `node <checkout>/dist/commitlore.mjs` 的薄 wrapper —— 它不下载任何编译产物，也没有构建步骤，因此放到机器上的就是你能阅读的源码。
 
 ```bash
 # 固定版本并检查 installer 后再执行。
 curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
 sh install.sh v0.4.1
 
-# 或自行验证 release binary 后再解压。
-version=0.4.1; target=aarch64-apple-darwin
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/commitlore-$version-$target.tar.gz"
-curl -fsSLO "https://github.com/MongLong0214/commitlore/releases/download/v$version/SHA256SUMS"
-grep "commitlore-$version-$target.tar.gz" SHA256SUMS | shasum -a 256 -c - # Linux: sha256sum -c -
+# 或者完全不用脚本：它创建的检出，你自己也能创建。
+git clone --depth 1 --branch v0.4.1 https://github.com/MongLong0214/commitlore
+node commitlore/dist/commitlore.mjs --version
 ```
 
 </details>

--- a/install.sh
+++ b/install.sh
@@ -1,38 +1,47 @@
 #!/bin/sh
-# Installs a prebuilt commitlore release binary.
+# Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/dev/install.sh | sh -s v0.2.0
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh -s v0.4.1
 #
-# This is a *second* install path, not the canonical one — `git clone` plus
-# either a Node runtime or `npm run build:binary` (see the README, ADR-0011,
-# ADR-0015) remains that. What this script adds is a way to get a working
-# binary with no Node, no build step, and no clone at all: it downloads the
-# release asset matching this machine's OS/arch and the matching
-# `SHA256SUMS` from the same GitHub release, verifies the asset's checksum
-# *before* anything is installed, and only then puts the binary in place.
+# **Claude Code users do not need this script.** The repository is itself a
+# plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP
+# server, the pre-edit context hook and the skills. That path is first in the
+# README and this one is second.
 #
-# A script that skips that verification step is worse than no script at all
-# — it teaches whoever runs it that piping a URL to `sh` is safe by itself,
-# which is exactly the habit this project's own trust model (README §"Trust
-# is routing, not a badge") argues against. Piping to a shell should never be
-# the *only* documented install path either — the READMEs also carry the
-# manual curl + verify steps this script automates, unabbreviated.
+# What this installs: a pinned source checkout in the user's data directory,
+# and a thin wrapper on PATH that runs `node <checkout>/dist/commitlore.mjs`.
+# `dist/` is committed (ADR-0011), so there is no build step and no
+# dependency install. **No compiled executable, no platform asset, no
+# checksum of a downloaded tarball** -- ADR-0026 removed all of that from the
+# product, and a script that reintroduced it would contradict the release it
+# came from.
 #
-# Exit codes: 1 = unsupported platform or bad usage, 2 = download failed,
-# 3 = checksum did not match (nothing was installed), 4 = install target
-# already occupied by something this script did not put there.
+# Prerequisites are Node.js 22+ (ADR-0010) and Git, and they are checked
+# before anything is written rather than assumed.
 #
-# A second phase runs after the binary is in place (see "detect and wire
-# coding agents" below): it looks for which coding agents are on this
-# machine and registers commitlore's MCP server — the plugin, for Claude
-# Code — with each one it finds. That phase never fails the script: an agent
-# config it cannot verify from that agent's own docs, or cannot merge
-# safely, is reported and skipped, never guessed at.
+# Exit codes: 1 = missing or too-old prerequisite, or bad usage (nothing was
+# written), 2 = the source could not be fetched, 4 = the install target is
+# occupied by something this script did not put there.
+#
+# Post-install verification never decides the exit code. An install that
+# succeeded is not retroactively failed by a check that could not run: that
+# was a real defect once, where the installer's own `--version` was killed by
+# a signal and its exit code became the script's.
+#
+# This script never edits a shell profile. If the wrapper's directory is not
+# on PATH it prints the line to add, which is the whole of what it does about
+# it.
+#
+# A second phase runs after the wrapper is in place (see "detect and wire
+# coding agents" below): it looks for which coding agents are on this machine
+# and registers commitlore's MCP server with each one it finds. That phase
+# never fails the script.
 set -eu
 
 REPO="MongLong0214/commitlore"
-RAW_VERSION="${1:-${COMMITLORE_INSTALL_VERSION:-latest}}"
+SOURCE_URL="${COMMITLORE_INSTALL_SOURCE:-https://github.com/$REPO.git}"
+NODE_MAJOR_MIN=22
 
 log() { printf 'commitlore-install: %s\n' "$1"; }
 die() {
@@ -40,125 +49,87 @@ die() {
   exit "${2:-1}"
 }
 
-# --- 1. platform detection -> target triple -----------------------------
+# --- 1. prerequisites, before anything is written ---------------------------
 #
-# The Rust ecosystem's target-triple convention (`<arch>-<vendor>-<os>`) is
-# what release.yml names assets with, precisely so a script like this one
-# has one string to build instead of a table of special cases per OS.
-os_raw="$(uname -s)"
-arch_raw="$(uname -m)"
+# Both are hard requirements rather than conveniences: the wrapper runs the
+# bundle with node, and the checkout is a git clone. A missing one is named,
+# with what to do about it, and nothing is installed.
 
-case "$os_raw" in
-  Darwin) os=apple-darwin ;;
-  Linux) os=unknown-linux-gnu ;;
-  *)
-    die "unsupported OS \"$os_raw\" — only macOS and Linux release binaries are published (no Windows asset yet: the SEA build and the commit-msg hook shim are not verified there, see ADR-0015). Install from source instead: https://github.com/$REPO#install-from-source" 1
-    ;;
+node_bin="$(command -v node 2>/dev/null || true)"
+[ -n "$node_bin" ] || die "Node.js $NODE_MAJOR_MIN or newer is required and no \"node\" was found on PATH. Install Node.js $NODE_MAJOR_MIN+ (https://nodejs.org), then run this again. Nothing was installed." 1
+
+node_version="$("$node_bin" --version 2>/dev/null || true)"
+case "$node_version" in
+  v[0-9]*) ;;
+  *) die "\"$node_bin --version\" did not report a version (got: \"$node_version\"), so the Node.js major version cannot be checked. Nothing was installed." 1 ;;
 esac
-
-case "$arch_raw" in
-  arm64 | aarch64) arch=aarch64 ;;
-  x86_64 | amd64) arch=x86_64 ;;
-  *)
-    die "unsupported architecture \"$arch_raw\" — published binaries are aarch64 and x86_64 only. Install from source instead: https://github.com/$REPO#install-from-source" 1
-    ;;
-esac
-
-target="${arch}-${os}"
-
-# --- 2. resolve the release + build download URLs -----------------------
-#
-# `releases/latest/download/<asset>` and `releases/download/<tag>/<asset>`
-# both redirect straight to the asset without an API call — no token, no
-# rate limit, the same pattern GitHub's own docs use for install scripts.
-if [ -n "${COMMITLORE_INSTALL_BASE_URL:-}" ]; then
-  # Escape hatch for a mirror, or for testing this script against a locally
-  # built binary and a hand-made SHA256SUMS — never needed for the documented
-  # install command.
-  base_url="$COMMITLORE_INSTALL_BASE_URL"
-  log "using COMMITLORE_INSTALL_BASE_URL override: $base_url"
-elif [ "$RAW_VERSION" = "latest" ]; then
-  release_path="latest/download"
-  log "resolving the latest release for $target"
-  base_url="https://github.com/$REPO/releases/$release_path"
-else
-  case "$RAW_VERSION" in
-    v*) tag="$RAW_VERSION" ;;
-    *) tag="v$RAW_VERSION" ;;
-  esac
-  release_path="download/$tag"
-  log "installing $tag for $target"
-  base_url="https://github.com/$REPO/releases/$release_path"
+node_major="$(printf '%s' "$node_version" | sed 's/^v//' | cut -d. -f1)"
+if [ "$node_major" -lt "$NODE_MAJOR_MIN" ]; then
+  die "Node.js $NODE_MAJOR_MIN or newer is required; this machine has $node_version. Upgrade Node.js, then run this again. Nothing was installed." 1
 fi
-# The version segment of the asset name is only known once "latest" is
-# resolved, and this script never calls the API to resolve it — it downloads
-# the fixed-name SHA256SUMS first (every release has exactly one, at a fixed
-# URL) and reads the real asset name for this target back out of that,
-# instead of guessing the version and hoping GitHub's redirect saves it.
-sums_url="$base_url/SHA256SUMS"
 
-fetch() {
-  # $1 = url, $2 = output path
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$1" -o "$2"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q "$1" -O "$2"
-  else
-    die "neither curl nor wget is available to download the release" 2
-  fi
-}
+# Run it rather than only look for it: a git that cannot execute is as useless
+# here as a missing one, and this is the check that catches both.
+git --version >/dev/null 2>&1 || die "Git is required, and \"git --version\" did not run. Install Git (or repair the installation), then run this again. Nothing was installed." 1
 
+# --- 2. resolve the version to install -------------------------------------
+#
+# A tag, never a branch. Passing one explicitly is the reviewable path; with
+# none, the newest semver tag is resolved with `git ls-remote`, which needs no
+# API token and no rate limit. The default must not resolve to a branch --
+# installing a moving target is what pinning exists to prevent.
+
+version="${1:-}"
+if [ -n "$version" ]; then
+  case "$version" in
+    v[0-9]*) ;;
+    [0-9]*) version="v$version" ;;
+    *) die "\"$version\" is not a version tag. Pass a tag such as v0.4.1, or pass nothing to install the newest one." 1 ;;
+  esac
+else
+  version="$(git ls-remote --tags --refs "$SOURCE_URL" 2>/dev/null \
+    | awk '{print $2}' | sed 's#refs/tags/##' \
+    | grep '^v[0-9]' \
+    | sort -t. -k1,1V -k2,2n -k3,3n \
+    | tail -n 1 || true)"
+  [ -n "$version" ] || die "no version tag could be resolved from $SOURCE_URL. Pass one explicitly, for example: sh install.sh v0.4.1" 2
+fi
+
+log "installing $version"
+
+# Scratch space for the wiring phase's write-temp-then-rename config merges.
+# Created here, removed on exit, exactly as the previous script did.
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-sums_file="$work/SHA256SUMS"
-fetch "$sums_url" "$sums_file" || die "could not download $sums_url (bad version, or no release published yet)" 2
+# --- 3. fetch the pinned checkout ------------------------------------------
+#
+# Into the user's data directory, keyed by tag, so an upgrade adds a checkout
+# beside the old one instead of mutating it. Cloned to a temporary name and
+# renamed, so a failed clone never leaves a half-checkout that looks installed.
 
-asset_line="$(grep -- "-${target}\.tar\.gz\$" "$sums_file" || true)"
-[ -n "$asset_line" ] || die "SHA256SUMS at $sums_url lists no asset for $target" 2
-asset_name="$(printf '%s\n' "$asset_line" | awk '{print $2}' | sed 's/^\*//')"
+data_root="${XDG_DATA_HOME:-$HOME/.local/share}/commitlore"
+checkout="$data_root/$version"
 
-asset_url="$base_url/$asset_name"
-asset_file="$work/$asset_name"
-log "downloading $asset_name"
-fetch "$asset_url" "$asset_file" || die "could not download $asset_url" 2
-
-# --- 3. verify the checksum before installing anything -------------------
-expected="$(printf '%s\n' "$asset_line" | awk '{print $1}')"
-if command -v sha256sum >/dev/null 2>&1; then
-  actual="$(cd "$work" && sha256sum "$asset_name" | awk '{print $1}')"
-elif command -v shasum >/dev/null 2>&1; then
-  actual="$(cd "$work" && shasum -a 256 "$asset_name" | awk '{print $1}')"
+if [ -d "$checkout/dist" ]; then
+  log "reusing the existing checkout at $checkout"
 else
-  die "neither sha256sum nor shasum is available to verify the download — refusing to install an unverified binary" 3
+  mkdir -p "$data_root"
+  checkout_tmp="$data_root/.$version.incoming.$$"
+  rm -rf "$checkout_tmp"
+  cleanup_checkout_tmp() { rm -rf "$checkout_tmp"; }
+  trap cleanup_checkout_tmp EXIT
+  git clone --quiet --depth 1 --branch "$version" "$SOURCE_URL" "$checkout_tmp" 2>/dev/null \
+    || die "could not fetch $version from $SOURCE_URL. Check the tag name and your network. Nothing was installed." 2
+  [ -f "$checkout_tmp/dist/commitlore.mjs" ] \
+    || die "$version does not carry dist/commitlore.mjs, so there is nothing to run. Nothing was installed." 2
+  rm -rf "$checkout"
+  mv "$checkout_tmp" "$checkout"
+  trap - EXIT
+  log "checked out $version into $checkout"
 fi
 
-if [ "$expected" != "$actual" ]; then
-  die "checksum mismatch for $asset_name
-  expected: $expected
-  got:      $actual
-  Nothing was installed. Do not re-run against the same cache; re-download fresh, and if it mismatches again, report it — the release may be corrupted." 3
-fi
-log "checksum verified ($actual)"
-
-# --- 4. install ------------------------------------------------------------
-tar -xzf "$asset_file" -C "$work" commitlore
-chmod +x "$work/commitlore"
-
-# The checksum proves the bytes are the ones the release published — it says
-# nothing about whether this machine can *run* them. The published target is
-# `<arch>-unknown-linux-gnu`: built against glibc, dynamically linked against
-# glibc's loader. A musl-libc host (Alpine and its `#!/bin/sh` -> busybox ash
-# are the common case; there is no `-musl` asset for this target) has no
-# `/lib/ld-linux-*.so.*` for that binary to run against, and the kernel's
-# refusal to exec it surfaces as a bare "not found" from the shell — which
-# reads exactly like a typo in this script, not a platform gap. Executing the
-# freshly extracted binary here, before it is copied anywhere, turns that
-# into the same clear, attributed failure every other unsupported-platform
-# case in this script already gives.
-if ! "$work/commitlore" --version >/dev/null 2>&1; then
-  die "the downloaded binary for $target does not run on this machine (nothing was installed). This usually means a musl-libc host such as Alpine — only glibc (\"-gnu\") Linux binaries are published, and Alpine's dynamic linker cannot load them. Install from source instead: https://github.com/$REPO#install-from-source" 1
-fi
+# --- 4. install the wrapper ------------------------------------------------
 
 if [ -n "${COMMITLORE_INSTALL_DIR:-}" ]; then
   dest_dir="$COMMITLORE_INSTALL_DIR"
@@ -169,45 +140,52 @@ else
 fi
 dest="$dest_dir/commitlore"
 
-# Refuse to silently clobber a file this script did not put there. A prior
-# commitlore install (from this script, `hooks install`'s own binary
-# resolution, or a manual copy) is a legitimate upgrade target — but exit 0
-# alone does not prove that: plenty of unrelated executables exit 0 and print
-# *something* for an unrecognized `--version` flag. The output has to look
-# like ours — a bare semver, nothing else — before this overwrites anything.
+WRAPPER_MARKER="# commitlore:wrapper:v1"
+
+# Refuse to clobber a file this script did not put there. A previous wrapper
+# carries the marker; a previous binary install prints a bare semver. Anything
+# else is somebody else's file and is left exactly where it is.
 if [ -e "$dest" ]; then
-  existing_version="$("$dest" --version 2>/dev/null || true)"
-  case "$existing_version" in
-    [0-9]*.[0-9]*.[0-9]*)
-      log "upgrading existing install at $dest ($existing_version -> $(cd "$work" && ./commitlore --version))"
-      ;;
-    *)
-      die "$dest already exists and does not look like a commitlore binary (got: \"$existing_version\") — refusing to overwrite it. Remove it first, or set COMMITLORE_INSTALL_DIR to install elsewhere." 4
-      ;;
-  esac
+  if grep -qF "$WRAPPER_MARKER" "$dest" 2>/dev/null; then
+    log "upgrading the existing commitlore wrapper at $dest"
+  else
+    existing_version="$("$dest" --version 2>/dev/null || true)"
+    case "$existing_version" in
+      [0-9]*.[0-9]*.[0-9]*)
+        log "replacing a previous commitlore install at $dest ($existing_version -> $version)"
+        ;;
+      *)
+        die "$dest already exists and is not a commitlore wrapper (got: \"$existing_version\") -- refusing to overwrite it. Remove it first, or set COMMITLORE_INSTALL_DIR to install elsewhere." 4
+        ;;
+    esac
+  fi
 fi
 
 mkdir -p "$dest_dir"
-# Write beside the destination and rename, rather than `cp` over it. An
-# in-place overwrite leaves the destination inode holding new bytes, and this
-# file already uses write-temp-then-rename for config merges below. Rename is
-# atomic, so a reader either sees the old binary or the new one and never a
-# half-written 100 MB executable.
+# Write beside the destination and rename. An in-place overwrite of a file that
+# may be executing is the defect that forced a same-day patch release; rename is
+# atomic, so a reader sees either the old wrapper or the new one.
 dest_tmp="$dest.commitlore-install.$$"
 cleanup_dest_tmp() { rm -f "$dest_tmp"; }
 trap cleanup_dest_tmp EXIT
-cp "$work/commitlore" "$dest_tmp"
+cat >"$dest_tmp" <<WRAPPER
+#!/bin/sh
+$WRAPPER_MARKER
+# Installed by install.sh. Edits are lost on reinstall.
+NODE="$node_bin"
+[ -x "\$NODE" ] || NODE=node
+exec "\$NODE" "$checkout/dist/commitlore.mjs" "\$@"
+WRAPPER
 chmod +x "$dest_tmp"
 mv "$dest_tmp" "$dest"
 trap - EXIT
 
 log "installed to $dest"
 
-# The install is already complete. A verification that cannot run says so; it
-# does not retroactively fail an install that succeeded. On macOS the first
-# exec of a freshly written large binary has been observed being killed by a
-# signal (see #256) while the second succeeds, so a single failure is retried
-# before it is reported.
+# The install is complete by this point. Verification reports; it does not
+# decide. A single failure is retried once before it is reported, and a
+# reported failure still exits 0 -- an install that succeeded must not be
+# failed by a check that could not run.
 if ! installed_version=$("$dest" --version 2>/dev/null); then
   sleep 1
   installed_version=$("$dest" --version 2>/dev/null) || installed_version=""
@@ -215,8 +193,8 @@ fi
 if [ -n "$installed_version" ]; then
   printf '%s\n' "$installed_version"
 else
-  log "installed, but could not run \"$dest --version\" in this shell to confirm it."
-  log "the binary is in place; verify it yourself with: $dest --version"
+  log "installed, but unverified: \"$dest --version\" did not run in this shell."
+  log "the wrapper is in place; verify it yourself with: $dest --version"
 fi
 
 path_file="$HOME/.profile"
@@ -226,6 +204,8 @@ case "${SHELL:-}" in
 esac
 path_export="export PATH=\"$dest_dir:\$PATH\""
 
+# Printed, never written. Rewriting a shell profile from a piped installer is
+# ruled out on this file: it is what makes people distrust curl-to-shell.
 case ":$PATH:" in
   *":$dest_dir:"*) ;;
   *)
@@ -238,17 +218,17 @@ esac
 # --- 5. detect and wire coding agents --------------------------------------
 #
 # Everything below is additive and best-effort: it never touches the exit
-# codes above (1-4 stay reserved for phase 1 — the binary is already
+# codes above (1-4 stay reserved for phase 1 -- the binary is already
 # installed and working by the time this runs), and every agent it wires is
 # detect-then-act, in the same order every time:
 #
 #   1. Is the agent actually on this machine? An agent that is not found is
-#      left alone completely — no config is created "for later".
+#      left alone completely -- no config is created "for later".
 #   2. Does its config already mention commitlore? If so, this is a re-run:
 #      report it and change nothing (the whole install is safe to run
 #      again this way, same as phase 1's upgrade path above).
 #   3. Otherwise, either create the config fresh, or merge into the existing
-#      one with `jq` (only if `jq` is actually present — this script does
+#      one with `jq` (only if `jq` is actually present -- this script does
 #      not install it), or, failing both, report exactly what to add by
 #      hand rather than risk the rest of the file.
 #
@@ -260,11 +240,11 @@ esac
 #
 # Every other client here documents the same MCP shape
 # (`{"mcpServers":{"<name>":{"command":...,"args":[...]}}}`) at the path
-# named next to its has_/wire_ pair below — verified against each agent's
+# named next to its has_/wire_ pair below -- verified against each agent's
 # own docs, not assumed from one client's format working for another.
 # opencode is the one exception to *that*: its config key is `mcp`, not
 # `mcpServers`, and its `command` is an argv array rather than
-# command+args — see its own comment below.
+# command+args -- see its own comment below.
 
 log ""
 log "Detecting coding agents..."
@@ -277,7 +257,7 @@ skipped_log="$work/skipped.log"
 record_wired() { printf '%s\n' "$1" >>"$wired_log"; }
 record_skipped() { printf '%s: %s\n' "$1" "$2" >>"$skipped_log"; }
 
-# `mcpServers: { name: { command, args } }` — Gemini CLI, Cursor, and
+# `mcpServers: { name: { command, args } }` -- Gemini CLI, Cursor, and
 # Windsurf all document this exact shape.
 wire_mcp_servers_json() {
   agent="$1"
@@ -305,7 +285,7 @@ EOF
   fi
 
   if grep -q '"commitlore"' "$config_path" 2>/dev/null; then
-    record_skipped "$agent" "$config_path already mentions commitlore — left unchanged"
+    record_skipped "$agent" "$config_path already mentions commitlore -- left unchanged"
     return
   fi
 
@@ -317,7 +297,7 @@ EOF
       record_wired "$agent: added the commitlore MCP server into the existing $config_path"
     else
       rm -f "$merge_tmp"
-      record_skipped "$agent" "$config_path exists but jq could not parse it as JSON (or the merge could not be written) — left untouched. Add manually: {\"mcpServers\":{\"commitlore\":{\"command\":\"$dest\",\"args\":[\"mcp\"]}}}"
+      record_skipped "$agent" "$config_path exists but jq could not parse it as JSON (or the merge could not be written) -- left untouched. Add manually: {\"mcpServers\":{\"commitlore\":{\"command\":\"$dest\",\"args\":[\"mcp\"]}}}"
     fi
     return
   fi
@@ -325,29 +305,29 @@ EOF
   record_skipped "$agent" "$config_path already exists and jq is not installed, so it cannot be merged without risking its other entries. Add manually: {\"mcpServers\":{\"commitlore\":{\"command\":\"$dest\",\"args\":[\"mcp\"]}}}"
 }
 
-# Claude Code — https://code.claude.com/docs/en/discover-plugins#install-plugins
+# Claude Code -- https://code.claude.com/docs/en/discover-plugins#install-plugins
 has_claude_code() { command -v claude >/dev/null 2>&1; }
 wire_claude_code() {
   installed_plugins="$(claude plugin list 2>/dev/null || true)"
   case "$installed_plugins" in
     *commitlore*)
-      record_skipped "claude-code" "the commitlore plugin is already installed — left unchanged"
+      record_skipped "claude-code" "the commitlore plugin is already installed -- left unchanged"
       return
       ;;
   esac
 
   if ! claude plugin marketplace add "$REPO" >/dev/null 2>&1; then
-    record_skipped "claude-code" "could not add the $REPO marketplace (offline, or already added under a different state) — run manually: claude plugin marketplace add $REPO"
+    record_skipped "claude-code" "could not add the $REPO marketplace (offline, or already added under a different state) -- run manually: claude plugin marketplace add $REPO"
     return
   fi
   if claude plugin install commitlore@commitlore --scope user >/dev/null 2>&1; then
     record_wired "claude-code: installed the commitlore plugin (marketplace: commitlore, scope: user)"
   else
-    record_skipped "claude-code" "marketplace added, but plugin install failed — run manually: claude plugin install commitlore@commitlore"
+    record_skipped "claude-code" "marketplace added, but plugin install failed -- run manually: claude plugin install commitlore@commitlore"
   fi
 }
 
-# Codex CLI — TOML, one [mcp_servers.<name>] table per server.
+# Codex CLI -- TOML, one [mcp_servers.<name>] table per server.
 # https://developers.openai.com/codex/mcp
 has_codex() { command -v codex >/dev/null 2>&1 || [ -d "$HOME/.codex" ]; }
 wire_codex() {
@@ -356,7 +336,7 @@ wire_codex() {
   mkdir -p "$config_dir" 2>/dev/null || { record_skipped "codex" "could not create $config_dir"; return; }
 
   if [ -f "$config_path" ] && grep -q '^\[mcp_servers\.commitlore\]' "$config_path" 2>/dev/null; then
-    record_skipped "codex" "$config_path already has a [mcp_servers.commitlore] block — left unchanged"
+    record_skipped "codex" "$config_path already has a [mcp_servers.commitlore] block -- left unchanged"
     return
   fi
 
@@ -377,22 +357,22 @@ wire_codex() {
   fi
 }
 
-# Gemini CLI — same mcpServers shape as Claude Desktop.
+# Gemini CLI -- same mcpServers shape as Claude Desktop.
 # https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html
 has_gemini() { command -v gemini >/dev/null 2>&1 || [ -d "$HOME/.gemini" ]; }
 wire_gemini() { wire_mcp_servers_json "gemini-cli" "$HOME/.gemini/settings.json"; }
 
-# Cursor — global config (community-documented; Cursor has no single
+# Cursor -- global config (community-documented; Cursor has no single
 # canonical MCP-config reference page at the time of writing).
 has_cursor() { command -v cursor >/dev/null 2>&1 || [ -d "$HOME/.cursor" ] || [ -d "/Applications/Cursor.app" ]; }
 wire_cursor() { wire_mcp_servers_json "cursor" "$HOME/.cursor/mcp.json"; }
 
-# Windsurf — same mcpServers shape, under Codeium's config directory.
+# Windsurf -- same mcpServers shape, under Codeium's config directory.
 # https://docs.windsurf.com/windsurf/cascade/mcp
 has_windsurf() { command -v windsurf >/dev/null 2>&1 || [ -d "$HOME/.codeium/windsurf" ] || [ -d "/Applications/Windsurf.app" ]; }
 wire_windsurf() { wire_mcp_servers_json "windsurf" "$HOME/.codeium/windsurf/mcp_config.json"; }
 
-# opencode — different shape from the rest: the key is `mcp`, not
+# opencode -- different shape from the rest: the key is `mcp`, not
 # `mcpServers`, and `command` is an argv array alongside a `type`/`enabled`
 # pair. https://opencode.ai/docs/mcp-servers/ (config path: https://opencode.ai/docs/config/)
 has_opencode() { command -v opencode >/dev/null 2>&1 || [ -d "$HOME/.config/opencode" ]; }
@@ -423,7 +403,7 @@ EOF
   fi
 
   if grep -q '"commitlore"' "$config_path" 2>/dev/null; then
-    record_skipped "opencode" "$config_path already mentions commitlore — left unchanged"
+    record_skipped "opencode" "$config_path already mentions commitlore -- left unchanged"
     return
   fi
 
@@ -435,7 +415,7 @@ EOF
       record_wired "opencode: added the commitlore MCP server into the existing $config_path"
     else
       rm -f "$merge_tmp"
-      record_skipped "opencode" "$config_path exists but jq could not parse it as JSON (or the merge could not be written) — left untouched. Add manually under \"mcp\": {\"commitlore\":{\"type\":\"local\",\"command\":[\"$dest\",\"mcp\"],\"enabled\":true}}"
+      record_skipped "opencode" "$config_path exists but jq could not parse it as JSON (or the merge could not be written) -- left untouched. Add manually under \"mcp\": {\"commitlore\":{\"type\":\"local\",\"command\":[\"$dest\",\"mcp\"],\"enabled\":true}}"
     fi
     return
   fi
@@ -480,4 +460,4 @@ if [ -n "$not_found" ]; then
 fi
 log ""
 log "Next: cd into a repository and run 'commitlore init' to install its git hook and index."
-log "(install.sh never runs init for you — it only installs the tool and wires agents, never touches a repository's .git.)"
+log "(install.sh never runs init for you -- it only installs the tool and wires agents, never touches a repository's .git.)"

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,12 @@ else
   # cause is something else, which is most of the time.
   clone_log="$(mktemp)"
   if ! git clone --quiet --depth 1 --branch "$version" "$SOURCE_URL" "$checkout_tmp" 2>"$clone_log"; then
-    clone_reason="$(tail -n 3 "$clone_log" | tr '\n' ' ' | sed 's/  */ /g')"
+    # git puts the useful line first ("does not appear to be a git repository",
+    # "could not read Username", "dubious ownership") and the generic advice
+    # last, so the first fatal: line is what a reader needs. Falling back to the
+    # whole log keeps the case where there is no fatal: at all.
+    clone_reason="$(grep -m1 '^fatal:' "$clone_log" 2>/dev/null || true)"
+    [ -n "$clone_reason" ] || clone_reason="$(tr '\n' ' ' <"$clone_log" | sed 's/  */ /g')"
     rm -f "$clone_log"
     die "could not fetch $version from $SOURCE_URL. git said: ${clone_reason:-nothing}. Nothing was installed." 2
   fi

--- a/install.sh
+++ b/install.sh
@@ -119,8 +119,16 @@ else
   rm -rf "$checkout_tmp"
   cleanup_checkout_tmp() { rm -rf "$checkout_tmp"; }
   trap cleanup_checkout_tmp EXIT
-  git clone --quiet --depth 1 --branch "$version" "$SOURCE_URL" "$checkout_tmp" 2>/dev/null \
-    || die "could not fetch $version from $SOURCE_URL. Check the tag name and your network. Nothing was installed." 2
+  # Keep git's own reason. Swallowing it and printing a guess ("check the tag
+  # name and your network") sends a user looking in the wrong place whenever the
+  # cause is something else, which is most of the time.
+  clone_log="$(mktemp)"
+  if ! git clone --quiet --depth 1 --branch "$version" "$SOURCE_URL" "$checkout_tmp" 2>"$clone_log"; then
+    clone_reason="$(tail -n 3 "$clone_log" | tr '\n' ' ' | sed 's/  */ /g')"
+    rm -f "$clone_log"
+    die "could not fetch $version from $SOURCE_URL. git said: ${clone_reason:-nothing}. Nothing was installed." 2
+  fi
+  rm -f "$clone_log"
   [ -f "$checkout_tmp/dist/commitlore.mjs" ] \
     || die "$version does not carry dist/commitlore.mjs, so there is nothing to run. Nothing was installed." 2
   rm -rf "$checkout"

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -1,0 +1,277 @@
+/**
+ * T-1120 (#281) — `install.sh` is a Node-only installer, and the README
+ * describes the installer that ships beside it.
+ *
+ * Acceptance row `B-8`. PRD-F14 requirements 4–15 and 29.
+ *
+ * The script is exercised for real, not inspected: each case runs it with a
+ * controlled `PATH`, a scratch `HOME`, and a local source repository, because
+ * three of these requirements exist only because this project already shipped
+ * the defect they forbid —
+ *
+ *   - req 9: the wrapper is installed by atomic rename. An in-place overwrite of
+ *     a file that may be executing forced a same-day patch release.
+ *   - req 10: post-install verification never decides the exit code. That was
+ *     the other half of the same defect: the install had succeeded and the
+ *     script reported failure with exit 137.
+ *   - req 11: the installer never edits a shell profile. An active ruled-out
+ *     record on this file rejects it.
+ */
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const INSTALLER = join(REPO_ROOT, 'install.sh');
+const READMES = ['README.md', 'README.ko.md', 'README.ja.md', 'README.zh-CN.md'];
+
+const scratch: string[] = [];
+const tempDir = (label: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), `commitlore-t1120-${label}-`));
+  scratch.push(dir);
+  return dir;
+};
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A local repository the installer can clone a tag from — no network. */
+let sourceRepo: string;
+/** A source whose bundle exits non-zero — a real broken release, not a test hook. */
+let brokenRepo: string;
+const TAG = 'v9.9.9';
+
+const git = (cwd: string, args: string[]): void => {
+  execFileSync('git', ['-c', 'user.name=T', '-c', 'user.email=t@e.invalid', ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+};
+
+beforeAll(() => {
+  sourceRepo = join(tempDir('source'), 'commitlore');
+  mkdirSync(join(sourceRepo, 'dist'), { recursive: true });
+  // A stand-in bundle: prints a version, which is all the installer's own
+  // verification step asks of it.
+  writeFileSync(
+    join(sourceRepo, 'dist', 'commitlore.mjs'),
+    "#!/usr/bin/env node\nconsole.log('9.9.9');\n",
+  );
+  writeFileSync(join(sourceRepo, 'package.json'), JSON.stringify({ name: 'commitlore', version: '9.9.9' }));
+  execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: sourceRepo });
+  git(sourceRepo, ['add', '-A']);
+  git(sourceRepo, ['commit', '--quiet', '-m', 'source']);
+  git(sourceRepo, ['tag', TAG]);
+
+  brokenRepo = join(tempDir('broken'), 'commitlore');
+  mkdirSync(join(brokenRepo, 'dist'), { recursive: true });
+  writeFileSync(join(brokenRepo, 'dist', 'commitlore.mjs'), "process.exit(3);\n");
+  execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: brokenRepo });
+  git(brokenRepo, ['add', '-A']);
+  git(brokenRepo, ['commit', '--quiet', '-m', 'broken bundle']);
+  git(brokenRepo, ['tag', TAG]);
+});
+
+/** A PATH holding a shell and the tools the case wants, and nothing else. */
+const stubPath = (opts: { node?: 'current' | 'old' | 'absent'; git?: boolean }): string => {
+  const bin = tempDir('bin');
+  if (opts.node === 'current') {
+    writeFileSync(join(bin, 'node'), `#!/bin/sh\nexec ${process.execPath} "$@"\n`);
+    chmodSync(join(bin, 'node'), 0o755);
+  } else if (opts.node === 'old') {
+    writeFileSync(join(bin, 'node'), '#!/bin/sh\nif [ "$1" = "--version" ]; then echo v20.11.0; exit 0; fi\nexit 0\n');
+    chmodSync(join(bin, 'node'), 0o755);
+  }
+  const realGit = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+  if (opts.git === false) {
+    // A git that cannot run. Hiding /usr/bin/git is not possible without also
+    // hiding the coreutils the script needs, and a broken git is the same
+    // failure from the installer's point of view.
+    writeFileSync(join(bin, 'git'), '#!/bin/sh\nexit 127\n');
+  } else {
+    writeFileSync(join(bin, 'git'), `#!/bin/sh\nexec ${realGit} "$@"\n`);
+  }
+  chmodSync(join(bin, 'git'), 0o755);
+  return `${bin}:/usr/bin:/bin`;
+};
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  home: string;
+  wrapper: string;
+  dataDir: string;
+}
+
+const runInstaller = (opts: {
+  node?: 'current' | 'old' | 'absent';
+  git?: boolean;
+  home?: string;
+  extraEnv?: Record<string, string>;
+  args?: string[];
+}): RunResult => {
+  const home = opts.home ?? tempDir('home');
+  const run = spawnSync('/bin/sh', [INSTALLER, ...(opts.args ?? [TAG])], {
+    encoding: 'utf8',
+    env: {
+      PATH: stubPath({ node: opts.node ?? 'current', git: opts.git }),
+      HOME: home,
+      COMMITLORE_INSTALL_SOURCE: sourceRepo,
+      ...(opts.extraEnv ?? {}),
+    },
+  });
+  return {
+    status: run.status,
+    stdout: run.stdout ?? '',
+    stderr: run.stderr ?? '',
+    home,
+    wrapper: join(home, '.local', 'bin', 'commitlore'),
+    dataDir: join(home, '.local', 'share', 'commitlore'),
+  };
+};
+
+describe('T-1120 prerequisites are checked before anything is written', () => {
+  it('names Node and the required major version when node is absent, and writes nothing', () => {
+    const r = runInstaller({ node: 'absent' });
+    expect(r.status).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/[Nn]ode/);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/22/);
+    expect(existsSync(r.wrapper)).toBe(false);
+    expect(existsSync(r.dataDir)).toBe(false);
+  });
+
+  it('names the version it found when node is older than 22', () => {
+    const r = runInstaller({ node: 'old' });
+    expect(r.status).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/20\./);
+    expect(existsSync(r.wrapper)).toBe(false);
+  });
+
+  it('names Git when git is absent', () => {
+    const r = runInstaller({ git: false });
+    expect(r.status).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/[Gg]it/);
+    expect(existsSync(r.wrapper)).toBe(false);
+  });
+});
+
+describe('T-1120 a successful install produces a checkout and a thin wrapper', () => {
+  it('writes the wrapper on PATH and the checkout under the data directory', () => {
+    const r = runInstaller({});
+    expect(r.status).toBe(0);
+    expect(existsSync(r.wrapper)).toBe(true);
+    const body = readFileSync(r.wrapper, 'utf8');
+    // A thin wrapper: it resolves a node and execs the bundle, and does nothing
+    // else. No install logic, no version check, no network.
+    expect(body).toMatch(/^NODE=.*node"?$/m);
+    expect(body).toMatch(/exec "\$NODE"/);
+    expect(body).toContain('dist/commitlore.mjs');
+    expect(body.split('\n').filter((l) => l.trim() && !l.startsWith('#')).length).toBeLessThan(6);
+    const checkouts = readdirSync(r.dataDir);
+    expect(checkouts).toContain(TAG);
+    expect(existsSync(join(r.dataDir, TAG, 'dist', 'commitlore.mjs'))).toBe(true);
+    // And the wrapper actually runs.
+    const version = spawnSync('/bin/sh', [r.wrapper, '--version'], {
+      encoding: 'utf8',
+      env: { PATH: stubPath({ node: 'current' }), HOME: r.home },
+    });
+    expect(version.stdout.trim()).toBe('9.9.9');
+  });
+
+  it('carries no asset download, checksum or target triple anywhere in the script', () => {
+    const body = readFileSync(INSTALLER, 'utf8');
+    for (const forbidden of ['SHA256SUMS', '.tar.gz', 'tar -xzf', 'unknown-linux-gnu', 'apple-darwin']) {
+      expect(body, `install.sh must not mention ${forbidden}`).not.toContain(forbidden);
+    }
+  });
+
+  it('never edits a shell profile, and prints the PATH line instead', () => {
+    const r = runInstaller({});
+    for (const rc of ['.bashrc', '.zshrc', '.profile', '.bash_profile']) {
+      expect(existsSync(join(r.home, rc)), `${rc} must not be created`).toBe(false);
+    }
+  });
+});
+
+describe('T-1120 upgrade and verification', () => {
+  it('replaces a running wrapper by rename and exits 0', () => {
+    const home = tempDir('upgrade');
+    expect(runInstaller({ home }).status).toBe(0);
+    const wrapper = join(home, '.local', 'bin', 'commitlore');
+    // Second run over the same target: an in-place overwrite of a file that may
+    // be executing is the defect req 9 forbids, so the replacement is a rename.
+    // The wrapper must be whole and working afterwards, and must still point at
+    // the same checkout — byte equality is not the property, because the
+    // resolved node path legitimately differs between environments.
+    const again = runInstaller({ home });
+    expect(again.status).toBe(0);
+    expect(existsSync(wrapper)).toBe(true);
+    const after = readFileSync(wrapper, 'utf8');
+    expect(after).toContain('# commitlore:wrapper:v1');
+    expect(after).toContain(join(home, '.local', 'share', 'commitlore', TAG, 'dist', 'commitlore.mjs'));
+    expect(`${again.stdout}${again.stderr}`).toMatch(/upgrading the existing commitlore wrapper/);
+  });
+
+  it('refuses a foreign file at the wrapper path instead of overwriting it', () => {
+    const home = tempDir('foreign');
+    mkdirSync(join(home, '.local', 'bin'), { recursive: true });
+    const wrapper = join(home, '.local', 'bin', 'commitlore');
+    writeFileSync(wrapper, '#!/bin/sh\necho not commitlore\n');
+    chmodSync(wrapper, 0o755);
+    const r = runInstaller({ home });
+    expect(r.status).not.toBe(0);
+    expect(readFileSync(wrapper, 'utf8')).toContain('not commitlore');
+    expect(`${r.stdout}${r.stderr}`).toMatch(/refus|already exists|not .*commitlore/i);
+  });
+
+  it('still exits 0 when post-install verification cannot complete', () => {
+    // req 10: verification may report, never decide. Forced by making the
+    // bundle unusable at the moment the installer checks it.
+    const r = runInstaller({ extraEnv: { COMMITLORE_INSTALL_SOURCE: brokenRepo } });
+    expect(r.status).toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/unverified/i);
+    expect(existsSync(r.wrapper)).toBe(true);
+  });
+});
+
+describe('T-1120 the README describes the installer that ships beside it (req 29)', () => {
+  const bodies = (): Record<string, string> =>
+    Object.fromEntries(READMES.map((f) => [f, readFileSync(join(REPO_ROOT, f), 'utf8')]));
+
+  it('no README shell-install region mentions an asset, a checksum list or a target triple', () => {
+    for (const [file, body] of Object.entries(bodies())) {
+      for (const forbidden of ['SHA256SUMS', '.tar.gz', 'aarch64-apple-darwin', 'releases/download']) {
+        expect(body, `${file} must not mention ${forbidden}`).not.toContain(forbidden);
+      }
+    }
+  });
+
+  it('every README states the Node and Git prerequisites for the script path', () => {
+    for (const [file, body] of Object.entries(bodies())) {
+      expect(body, `${file} must state the Node floor`).toMatch(/Node\.js 22\+|Node 22\+|Node\.js 22/);
+      expect(body, `${file} must name Git`).toMatch(/Git/);
+    }
+  });
+
+  it('the plugin-first block above it is unchanged, in all four files', () => {
+    for (const [file, body] of Object.entries(bodies())) {
+      expect(body, `${file} must still lead with the plugin commands`).toContain(
+        '/plugin marketplace add MongLong0214/commitlore',
+      );
+      expect(body).toContain('/plugin install commitlore@commitlore');
+    }
+  });
+
+  it('all four change together — the set is asserted, not one file', () => {
+    const b = bodies();
+    expect(Object.keys(b)).toHaveLength(4);
+    const mentionsAsset = Object.entries(b).filter(([, body]) => body.includes('SHA256SUMS'));
+    expect(mentionsAsset.map(([f]) => f)).toEqual([]);
+  });
+});

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -50,12 +50,15 @@ describe('README install one-liner and version pin', () => {
         expect(pinMatch).not.toBeNull();
         expect(pinMatch![1]).toBe(PACKAGE_VERSION);
 
-        // Also check the version= assignment line
-        const versionAssign = lines.find((l) => /^version=\d+\.\d+\.\d+/.test(l));
-        expect(versionAssign).toBeDefined();
-        const assignMatch = versionAssign!.match(/version=(\d+\.\d+\.\d+)/);
-        expect(assignMatch).not.toBeNull();
-        expect(assignMatch![1]).toBe(PACKAGE_VERSION);
+        // T-1120: the `version=<semver>; target=<triple>` line this used to assert
+        // belonged to the release-asset download example, and ADR-0026 removed
+        // compiled artifacts from the product. The pinned example is now a source
+        // checkout, so that is what carries the pin.
+        const clonePin = lines.find((l) => l.includes('git clone') && l.includes('--branch v'));
+        expect(clonePin).toBeDefined();
+        const cloneMatch = clonePin!.match(/--branch v(\d+\.\d+\.\d+)/);
+        expect(cloneMatch).not.toBeNull();
+        expect(cloneMatch![1]).toBe(PACKAGE_VERSION);
 
         // Also check the pinned curl download URL
         const pinnedCurl = lines.find(


### PR DESCRIPTION
Closes #281. Acceptance row `B-8`. PRD-F14 requirements 4–15 and 29.

| binding | value |
|---|---|
| Gate | T-1120 approved at docs head `f149ff9e` (that correction merged as #294 at `be4b5eb2`) |
| Exact head | `14deeb4` |
| Scope | `install.sh`, four README shell-install regions, `test/install-script.test.ts`, `test/readme.test.ts`, `ci.yml` `install-script` job — nothing else |
| Not touched | `src/`, `dist/`, `install.ps1`, `COMPATIBILITY.md`, the release matrix, the binary code, the `BENCH` block, the plugin-first block |

## What changed

`install.sh` checks **Node 22+ and Git before writing anything**, clones a **pinned tag** into `${XDG_DATA_HOME:-$HOME/.local/share}/commitlore/<tag>`, and puts a **thin wrapper** on `PATH` that execs node against the committed bundle. No compile step, no downloaded tarball, no checksum of one, no target triple anywhere in the file.

**The README changes in this same commit**, which is the ticket rather than a convenience. The shipped script downloaded an asset and the README said so, truthfully. Rewriting the README earlier makes it false immediately; later leaves it false in between. One commit is the only arrangement in which it is never wrong, and the eighth RED assertion checks the four language files **as a set** so the state cannot be half-applied.

## Guard raised this, correctly, and the answer is recorded

`commitlore guard` flagged the README rewrite against `r-gateb3rev`, which ruled it out because *"the shipped installer still downloads a platform asset, so the rewrite would describe behaviour the code does not have."* This change alters both together — the condition that reason names — so the rejection is **satisfied, not revived**. That reasoning is in the commit record rather than only here.

## RED first

```
Tests  8 failed | 5 passed (13)
  → expected 'commitlore-install: installing…' to match /[Nn]ode/
  → install.sh must not mention SHA256SUMS
  → README.md must not mention SHA256SUMS
  → expected [ 'README.md', 'README.ko.md', …(2) ] to deeply equal []
```

## Three findings from doing the work

1. **A non-ASCII ellipsis inside a `log` string terminated `/bin/sh` silently.** The file parsed clean under `sh -n`, then exited 1 with no output at all — before its first log line. `install.sh` is ASCII-only now, and a `Warn:` trailer records it.
2. **The preserved agent-wiring region referenced a scratch directory the deleted download region created.** Under `set -u` that aborted the wiring phase *after a successful install* — the one phase that must never fail the script.
3. **One README assertion asserted a line belonging to the deleted asset example** (`version=<semver>; target=<triple>`). It now pins the source-checkout example, which is what the pinned example is.

## Verification at this head

| scope | result |
|---|---|
| focused | `install-script` + `readme` — **40 passed** |
| full | **68 files, 1793 passed, 1 skipped** |
| types | `tsc --noEmit` exit 0 |
| shell | `sh -n install.sh` exit 0 |
| byte check | `check-readme-numbers.mjs` exit 0, `BENCH` block untouched |
| forbidden strings | `SHA256SUMS`, `.tar.gz`, `releases/download`, target triples — **0 across `install.sh` and all four READMEs** |

### Live, in a scratch `HOME`

```
1. fresh install      → checked out v9.9.9, installed wrapper, printed 0.4.1; wrapper runs
2. upgrade            → "upgrading the existing commitlore wrapper", exit 0
3. broken bundle      → exit 0, "installed, but unverified: … did not run in this shell"
4. no node            → names Node and the required major, installs nothing
   git that cannot run → names Git, installs nothing
```

## Self-review

- **fail-closed** — a missing or too-old prerequisite installs nothing and names which one.
- **wrong-target** — a file at the wrapper path that is neither a commitlore wrapper nor a previous commitlore binary is refused with exit 4 and left byte-identical; asserted.
- **partial-state** — the checkout is cloned to a temporary name and renamed, so a failed clone never leaves something that looks installed; the wrapper is written beside the target and renamed.
- **privacy** — no config value is echoed; the wiring region is unchanged and already carried that property.
- **not verified here** — the bare-debian container steps run in CI and were not executed locally; no Windows path is touched or claimed.

The CI `install-script` job no longer stages a fake asset release. It clones a tagged local source, asserts fresh install and upgrade, asserts no shell profile is written, greps the script for the forbidden strings, and keeps the previous job's progression shape on a bare image: **assert the named failure first, then success once the prerequisite is present.**
