### PR TITLE
Resolve the newest tag without sort -V, which would install an older release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,11 +87,22 @@ if [ -n "$version" ]; then
     *) die "\"$version\" is not a version tag. Pass a tag such as v0.4.1, or pass nothing to install the newest one." 1 ;;
   esac
 else
+  # Newest release tag, compared numerically without `sort -V`. That flag is a
+  # GNU/BSD extension and this script is POSIX sh: where it is missing the major
+  # field compares lexically, which puts v9 above v10 and installs an older
+  # release while reporting success. Zero-padding the three numbers turns a plain
+  # lexical `sort` into a numeric one, which needs no extension at all.
+  #
+  # Only `vMAJOR.MINOR.PATCH` is considered. A pre-release tag would otherwise tie
+  # with its release on the padded numbers and then win the tie-break by being
+  # the longer string, which is backwards.
   version="$(git ls-remote --tags --refs "$SOURCE_URL" 2>/dev/null \
     | awk '{print $2}' | sed 's#refs/tags/##' \
-    | grep '^v[0-9]' \
-    | sort -t. -k1,1V -k2,2n -k3,3n \
-    | tail -n 1 || true)"
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | awk -F. '{ maj = $1; sub(/^v/, "", maj); printf "%010d %010d %010d %s\n", maj + 0, $2 + 0, $3 + 0, $0 }' \
+    | sort \
+    | tail -n 1 \
+    | awk '{ print $4 }' || true)"
   [ -n "$version" ] || die "no version tag could be resolved from $SOURCE_URL. Pass one explicitly, for example: sh install.sh v0.4.1" 2
 fi
 

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -240,6 +240,51 @@ describe('T-1120 upgrade and verification', () => {
   });
 });
 
+describe('#298 tag auto-resolution needs no sort extension', () => {
+  /**
+   * `sort -V` is not POSIX, and this file is POSIX `sh`. Where it is absent the
+   * major field compares lexically, which puts v9 above v10 — the installer
+   * would log success while installing an older release. Today's tags are all
+   * v0.x so both orderings agree, which is exactly why this needs a test rather
+   * than a reading.
+   */
+  it('the script resolves versions without depending on sort -V', () => {
+    // Invocations, not prose: the comment beside the fix names the flag on
+    // purpose, and a test that forbade the word would delete the explanation.
+    const code = readFileSync(INSTALLER, 'utf8')
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('#'));
+    for (const line of code) {
+      expect(line, `no sort invocation may use -V: ${line}`).not.toMatch(/\bsort\b[^|]*-V/);
+      expect(line).not.toMatch(/-k1,1V/);
+    }
+  });
+
+  it('resolves the newest tag when a double-digit major exists', () => {
+    const repo = join(tempDir('majors'), 'commitlore');
+    mkdirSync(join(repo, 'dist'), { recursive: true });
+    writeFileSync(join(repo, 'dist', 'commitlore.mjs'), "console.log('10.0.0');\n");
+    execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: repo });
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '--quiet', '-m', 'src']);
+    for (const tag of ['v1.0.0', 'v2.5.0', 'v9.9.9', 'v10.0.0']) git(repo, ['tag', tag]);
+
+    const home = tempDir('majors-home');
+    const run = spawnSync('/bin/sh', [INSTALLER], {
+      encoding: 'utf8',
+      env: {
+        PATH: stubPath({ node: 'current' }),
+        HOME: home,
+        COMMITLORE_INSTALL_SOURCE: repo,
+      },
+    });
+    expect(run.status).toBe(0);
+    // The newest is v10.0.0, not v9.9.9.
+    expect(`${run.stdout}${run.stderr}`).toContain('installing v10.0.0');
+    expect(readdirSync(join(home, '.local', 'share', 'commitlore'))).toContain('v10.0.0');
+  });
+});
+
 describe('T-1120 the README describes the installer that ships beside it (req 29)', () => {
   const bodies = (): Record<string, string> =>
     Object.fromEntries(READMES.map((f) => [f, readFileSync(join(REPO_ROOT, f), 'utf8')]));


### PR DESCRIPTION
Closes #298. Found by running the **default install path** — no version argument — against the real remote, which no test and neither CI container step had done: all of them pass an explicit tag.

## The defect

`sort -V` is a GNU/BSD extension and `install.sh` is POSIX `sh`. Where the flag is absent the major field compares lexically:

```
as shipped (-k1,1V)   picks: v10.2.0
lexical major         picks: v9.9.9     <- older release, reported as success
```

Nothing would say the newest release had been skipped. **Latent, not live** — every tag today is `v0.x`, so both orderings pick `v0.4.1`; it becomes live at v10 and it fails silently, which is the combination worth fixing before it can happen.

## The fix

Zero-pad the three numbers so a plain lexical `sort` is numeric, needing no extension. Only `vMAJOR.MINOR.PATCH` is resolved now — a pre-release would otherwise tie on the padded numbers and win the tie-break by being the longer string, which is backwards.

## RED, and proof it bites

```
→ expected '#!/bin/sh…' not to match /-k1,1V/          ← before the fix
✓ resolves the newest tag when a double-digit major exists

with -V put back into the pipeline:
→ no sort invocation may use -V:     | sort -V \
```

The invariant checks **invocations, not prose** — the comment beside the fix names the flag on purpose, and a test forbidding the word would delete the explanation.

## Verification

| check | result |
|---|---|
| ordering, exercised directly | `v1.0.0 v2.5.0 v9.9.9 v10.0.0 v10.2.0 v10.2.0-rc1` → **v10.2.0** |
| behavioural | source tagged through `v10.0.0` installs **v10.0.0** |
| real remote | still resolves `v0.4.1` and installs it, exit 0 |
| focused | install-script + readme — 42 passed |
| full | 68 files, **1795 passed**, 1 skipped |
| shell | `sh -n` exit 0 |

**Not established:** whether `busybox sort` supports `-V`. The local container daemon was not running, so the fix removes the dependency rather than proving which shells lack it.

Scope: `install.sh` tag resolution and `test/install-script.test.ts`. No README, no workflow, no other ticket's region.