### PR TITLE
Aim the containment clauses at the check that measurement shows is load-bearing

### DIFF
--- a/docs/tickets/F14-distribution.md
+++ b/docs/tickets/F14-distribution.md
@@ -353,6 +353,13 @@ a recorded target that is neither a script nor a recognised wrapper is refused. 
 absent at `8b0c9fa`, where no Windows job exists and the classification knows only a bare
 binary name.
 
+**The question is narrower than it looks.** Measured on macOS at `7b23e71`, a wrapper install
+records the `.mjs` bundle inside the checkout — not the wrapper, and not an executable — so
+there is no `.exe` to classify and the compiled-binary arm is not involved. What is unknown is
+whether Windows `init` records the same shape and whether the stub's root resolution agrees
+under Windows path semantics. The macOS baseline to compare against, including both attacks
+refused with the tampered program run zero times, is on #283.
+
 **Minimum GREEN** — the attacks pass on `windows-latest` for the wrapper path, in a required
 job, in this ticket's own PR. Only then may any document call Windows supported.
 
@@ -387,8 +394,14 @@ first, so there is never a window with neither.
 **Forbidden scope**
 
 - **do not delete #71's containment check along with the binary arm.** Requirement 28: the
-  property must hold for the wrapper case after this ticket. A diff that removes
-  `matchesRunningBinary` without a wrapper equivalent is the failure mode
+  property must hold for the wrapper case after this ticket. **Measured at `7b23e71`, the check
+  to protect is the script arm's install-root resolution, not `matchesRunningBinary`:**
+  `commitlore init` through the wrapper records `commitlore.bin` as the `.mjs` bundle inside the
+  checkout, so a wrapper install never reaches the compiled-binary arm. Both of #71's attacks
+  were executed against that install — a target outside the root, and an arbitrary executable —
+  and each was refused with a named message, exit 0, and the tampered program run zero times.
+  Building a "wrapper equivalent" of the binary arm would be work with nothing behind it, while
+  the check that actually holds the property went unnamed and unguarded. Evidence is on #284
 - do not change the version, the tag procedure, or the release gate's other checks
 - do not remove the plugin path's Node resolution in `scripts/commitlore-run.sh` — only the
   compiled-binary probe ahead of it


### PR DESCRIPTION
Docs only. One file.

## What was measured

Executed against the shipped installer at `dev`, in a scratch `HOME`:

```
commitlore.bin     …/.local/share/commitlore/v0.4.1/dist/commitlore.mjs
commitlore.root    …/.local/share/commitlore/v0.4.1
```

`commitlore init` through the wrapper records **the `.mjs` bundle inside the checkout** — not the wrapper, and not an executable. The recorded target is a script, so the compiled-binary arm is never reached on a wrapper install.

#71's two attacks, then run against that install with no `commitlore` on `PATH`:

| Attack | Result |
|---|---|
| target outside the install root | refused, named message, exit **0**, tampered script run **0 times** |
| target is an arbitrary executable (`/usr/bin/true`) | same |
| legitimate target | `shape ok · references ok`, commit lands |

## Why the clauses were wrong

**T-1125** forbade removing `matchesRunningBinary` "without a wrapper equivalent". Measured, a wrapper install never reaches it. Building that equivalent would be work with nothing behind it — while the check that actually holds the property, the **script arm's install-root resolution**, went unnamed and therefore unguarded. The clause now names it.

**T-1124** narrows: it is not whether `.exe` classification works, because there is no `.exe` to classify. It is whether Windows `init` records the same shape and whether the stub's root resolution agrees under Windows path semantics — a smaller, sharper question, with the macOS baseline recorded to compare against.

## Deliberately not concluded

**This does not make Windows containment safe.** The measurement is macOS only, which is the entire reason T-1124 exists, and inferring a platform from another is the specific error ADR-0023 recorded and ADR-0026 inherited. The ticket says so.

A ticket read at implementation time is the contract, which is why this lands in the ticket rather than staying as an issue comment (recorded on #283 and #284 as well).