### PR TITLE
Bind the uninstall contract to a measured inventory

### DIFF
--- a/docs/tickets/F14-distribution.md
+++ b/docs/tickets/F14-distribution.md
@@ -293,6 +293,29 @@ source of the agent config paths); `src/cli.ts` (one `register` line);
 
 **Depends on** — T-1120 and T-1121 merged: the command removes what they wrote.
 
+**Measured inventory** (shipped installer, scratch `HOME`, at `6e1d46d`) — the contract is bound
+to these numbers rather than to a description:
+
+| Owner | Artefact | Count |
+|---|---|---|
+| **this ticket** | wrapper `~/.local/bin/commitlore` | 1 file |
+| **this ticket** | checkout `~/.local/share/commitlore/<tag>/` | 1206 files |
+| **this ticket** | agent MCP entries — `.codex/config.toml`, `.gemini/settings.json`, `.cursor/mcp.json`, `.config/opencode/opencode.json` | 4 configs |
+| **Claude Code** | `~/.claude/plugins/cache/**` | 6948 files, of which 4527 are `node_modules` |
+| **Claude Code** | `~/.claude.json` | written by the `claude` CLI |
+
+The plugin cache is a full copy of the repository with its dependencies, keyed by plugin
+version. It is why this ticket names the plugin uninstall step instead of performing it: a
+command that removed 6948 files it did not write would be doing Claude Code's job badly.
+
+**The entry shape to match** is `{"command": "<wrapper path>", "args": ["mcp"]}` — the value is
+the wrapper, not `node` and not the bundle. Recognition matches that shape. Matching any entry
+whose command merely contains `commitlore` would also match an unrelated server a user happened
+to name that way, which is the "never remove an entry the installer did not write" rule failing
+in the one case nobody would notice. Two of the four configs pre-existed and were merged into,
+and an unrelated entry with its token plus an unrelated top-level key both survived — so the
+byte-for-byte survival requirement below is measured, not hoped for.
+
 **Forbidden scope**
 
 - do not reach into Claude Code plugin state — name the plugin uninstall step and stop


### PR DESCRIPTION
Docs only. One file.

## Measured, in a scratch `HOME`, against the shipped installer

| Owner | Artefact | Count |
|---|---|---|
| **T-1123** | wrapper `~/.local/bin/commitlore` | **1** |
| **T-1123** | checkout `~/.local/share/commitlore/<tag>/` | **1206** |
| **T-1123** | agent MCP entries (codex, gemini, cursor, opencode) | **4** |
| **Claude Code** | `~/.claude/plugins/cache/**` | **6948**, of which **4527** are `node_modules` |
| **Claude Code** | `~/.claude.json` | written by the `claude` CLI |

The two paths differ by three orders of magnitude, which is the whole reason the ticket separates them. A command that removed 6948 files it did not write would be doing Claude Code's job badly — so the ticket names the plugin uninstall step rather than performing it.

## The entry shape is now fixed

The installer writes `{"command": "<wrapper path>", "args": ["mcp"]}` — the value is the **wrapper**, not `node` and not the bundle. Recognition matches that shape.

Matching any entry whose command merely *contains* `commitlore` would also match an unrelated server a user happened to name that way: the never-remove-what-you-did-not-write rule failing in the one case nobody would notice.

## Byte-for-byte survival is measured, not hoped for

Two of the four configs pre-existed and were merged into. Afterwards:

```
gemini servers: ['my-other-server', 'commitlore']
unrelated token preserved: keep-me
unrelated top-level key kept: True
cursor servers: ['cursor-thing', 'commitlore']
```

**Not established:** the same inventory on Windows, since `install.ps1` has not shipped.