### PR TITLE
Drop the last non-POSIX grep option, and make the invariant general

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,7 +139,10 @@ else
     # "could not read Username", "dubious ownership") and the generic advice
     # last, so the first fatal: line is what a reader needs. Falling back to the
     # whole log keeps the case where there is no fatal: at all.
-    clone_reason="$(grep -m1 '^fatal:' "$clone_log" 2>/dev/null || true)"
+    # `sed -n '/re/{p;q;}'` rather than `grep -m1`: -m is a GNU/BSD extension and
+    # this script is POSIX sh. Same reason sort -V was removed from the version
+    # resolution above.
+    clone_reason="$(sed -n '/^fatal:/{p;q;}' "$clone_log" 2>/dev/null || true)"
     [ -n "$clone_reason" ] || clone_reason="$(tr '\n' ' ' <"$clone_log" | sed 's/  */ /g')"
     rm -f "$clone_log"
     die "could not fetch $version from $SOURCE_URL. git said: ${clone_reason:-nothing}. Nothing was installed." 2

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -248,6 +248,28 @@ describe('#298 tag auto-resolution needs no sort extension', () => {
    * v0.x so both orderings agree, which is exactly why this needs a test rather
    * than a reading.
    */
+  it('no grep invocation uses a non-POSIX option (#305)', () => {
+    // POSIX grep defines exactly these options. Anything else -- `-m` being the
+    // one that got in -- is an extension, and this file is declared POSIX sh.
+    // Generalised from the sort -V check because the same commit that removed
+    // that flag introduced grep -m1: a one-off assertion catches one instance,
+    // an invariant catches the next.
+    const POSIX_GREP = new Set(['E', 'F', 'c', 'e', 'f', 'i', 'l', 'n', 'q', 's', 'v', 'x']);
+    const offenders: string[] = [];
+    const code = readFileSync(INSTALLER, 'utf8')
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('#'));
+    for (const line of code) {
+      for (const match of line.matchAll(/\bgrep\s+(-[a-zA-Z0-9]+)/g)) {
+        const flags = match[1]!.slice(1).replace(/[0-9]+$/, '');
+        for (const flag of flags) {
+          if (!POSIX_GREP.has(flag)) offenders.push(`${match[1]} in: ${line.trim().slice(0, 80)}`);
+        }
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+
   it('the script resolves versions without depending on sort -V', () => {
     // Invocations, not prose: the comment beside the fix names the flag on
     // purpose, and a test that forbade the word would delete the explanation.


### PR DESCRIPTION
Closes #305. Self-inflicted, and recorded as such.

## What happened

#298 removed `sort -V` from `install.sh` because the file is declared POSIX `sh` and `-V` is a GNU/BSD extension. **The commit carrying that reasoning introduced `grep -m1` two hunks later in the same file.**

```
POSIX grep options: -E -F -c -e -f -i -l -n -q -s -v -x

install.sh:101  grep -E     POSIX
install.sh:142  grep -m1    NOT POSIX   <- introduced by 0412668
install.sh:173  grep -qF    POSIX
install.sh:311  grep -q     POSIX
```

Nothing observably breaks today — which is exactly what was true of `sort -V` until a major version reached double digits.

## The fix, and why the invariant changed shape

`sed -n '/^fatal:/{p;q;}'` does the same job in POSIX. Compared both ways on the same input:

```
old (grep -m1): fatal: repository does not exist
new (sed):      fatal: repository does not exist
no match  ->    old: ''   new: ''
```

The assertion is now an **invariant over every grep invocation**, not a check for one flag. A one-off catches one instance; the last instance arrived in the commit that removed its predecessor, so the check has to cover the option set.

## Deliberately not folded in

`mktemp -d` is not POSIX either, but it predates this work by months (`c6e1d04`, the original `install.sh`). Mixing an inherited constraint with a self-inflicted one in a single change makes neither reviewable. Recorded on the issue.

## Verification

| check | result |
|---|---|
| RED | invariant failed on `grep -m1`, then passed |
| equivalence | identical output on a multi-line input and on a no-match input |
| live | a real clone failure still quotes git's own `fatal:` line |
| shell | `sh -n` exit 0 |
| focused | install-script suite — 16 passed |
| full | 69 files, 1797 passed, 1 skipped |