### PR TITLE
Add install.ps1 as install.sh's twin, with a Windows runner as the evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,15 +323,17 @@ jobs:
   # job does for the shell installer: nothing here reaches github.com, so the job
   # tests the script rather than the network.
   #
-  # Windows PowerShell 5.1 is tested alongside PowerShell 7 because 5.1 is what a
-  # Windows machine has before anyone installs anything, and a 7-only construct
-  # fails to parse the *whole* file rather than one branch of it.
+  # Both hosts are exercised, and each one does real work rather than repeating
+  # the other: Windows PowerShell 5.1 performs the first install, PowerShell 7
+  # performs the upgrade. 5.1 matters because it is what a Windows machine has
+  # before anyone installs anything, and a 7-only construct fails to parse the
+  # whole file rather than one branch of it.
+  #
+  # The hosts are named literally. `shell:` accepts no expression -- a
+  # `${{ matrix.shell }}` there makes the workflow unloadable, which is how this
+  # job was first written and how it first failed (actions/runner#444).
   install-ps1:
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shell: [powershell, pwsh]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -346,17 +348,23 @@ jobs:
           git config user.name "CommitLore CI"
           git tag v9.9.9
 
-      - name: Install from the local tag
-        shell: ${{ matrix.shell }}
+      # -File, under 5.1, with the version as a positional argument: the same
+      # entry point a user gets from `& ([scriptblock]::Create((irm ...))) v9.9.9`,
+      # and the one that proves param() binds.
+      - name: Install under Windows PowerShell 5.1
+        shell: cmd
         env:
           COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
         run: |
-          $ErrorActionPreference = 'Stop'
-          & .\install.ps1 v9.9.9
-          if ($LASTEXITCODE -ne 0) { throw "installer exited $LASTEXITCODE" }
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9
+          if errorlevel 1 exit /b 1
 
-      - name: The shim exists, reports a version, and runs a real command
-        shell: ${{ matrix.shell }}
+      - name: The 5.1 host reports its own version, for the record
+        shell: cmd
+        run: powershell.exe -NoProfile -Command "$PSVersionTable.PSVersion.ToString()"
+
+      - name: The shim exists, is CRLF, and reports the declared version
+        shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           $shim = Join-Path $env:LOCALAPPDATA 'commitlore\bin\commitlore.cmd'
@@ -366,34 +374,37 @@ jobs:
           if ($body -notmatch "`r`n") { throw 'the shim is not CRLF' }
           $version = (& $shim --version | Select-Object -First 1)
           Write-Host "shim reports: $version"
-          if ($version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+') { throw "unexpected version output: $version" }
           $declared = (Get-Content -LiteralPath package.json -Raw | ConvertFrom-Json).version
           if ($version.Trim() -ne $declared) { throw "shim reports $version, package.json declares $declared" }
           & $shim --help > $null
           if ($LASTEXITCODE -ne 0) { throw "--help exited $LASTEXITCODE" }
 
-      - name: A second run is an upgrade, not a refusal
-        shell: ${{ matrix.shell }}
+      # The documented piped form, under PowerShell 7. `iex` gives a piped script
+      # no arguments, so the version arrives through COMMITLORE_VERSION -- which is
+      # why that variable exists. This step is also the only check that a leading
+      # param() block survives Invoke-Expression at all.
+      - name: A second install through the documented pipe is an upgrade
+        shell: pwsh
         env:
           COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
+          COMMITLORE_VERSION: v9.9.9
         run: |
           $ErrorActionPreference = 'Stop'
-          $out = (& .\install.ps1 v9.9.9 2>&1 | Out-String)
+          $out = (Get-Content -LiteralPath .\install.ps1 -Raw | Invoke-Expression 2>&1 | Out-String)
           Write-Host $out
-          if ($LASTEXITCODE -ne 0) { throw "re-run exited $LASTEXITCODE" }
           if ($out -notmatch 'reusing the existing checkout') { throw 'the checkout was not reused' }
           if ($out -notmatch 'upgrading the existing commitlore shim') { throw 'the shim was not recognized as its own' }
 
       - name: A foreign file at the destination is refused with exit 4
-        shell: ${{ matrix.shell }}
+        shell: pwsh
+        env:
+          COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
         run: |
-          $ErrorActionPreference = 'Continue'
           $dir = Join-Path $env:TEMP 'commitlore-occupied'
           New-Item -ItemType Directory -Force -Path $dir | Out-Null
           Set-Content -LiteralPath (Join-Path $dir 'commitlore.cmd') -Value '@echo not commitlore'
           $env:COMMITLORE_INSTALL_DIR = $dir
-          $env:COMMITLORE_INSTALL_SOURCE = '${{ github.workspace }}'
-          $out = (& .\install.ps1 v9.9.9 2>&1 | Out-String)
+          $out = (& powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 2>&1 | Out-String)
           $code = $LASTEXITCODE
           Remove-Item Env:\COMMITLORE_INSTALL_DIR
           Write-Host $out
@@ -402,18 +413,20 @@ jobs:
           $body = Get-Content -LiteralPath (Join-Path $dir 'commitlore.cmd') -Raw
           if ($body -notmatch 'not commitlore') { throw 'the foreign file was modified' }
 
-      - name: A bad tag is refused with exit 2 and installs nothing
-        shell: ${{ matrix.shell }}
+      - name: An unknown tag is refused with exit 2 and installs nothing
+        shell: pwsh
+        env:
+          COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
         run: |
-          $ErrorActionPreference = 'Continue'
-          $env:COMMITLORE_INSTALL_SOURCE = '${{ github.workspace }}'
-          $out = (& .\install.ps1 v0.0.0 2>&1 | Out-String)
+          $out = (& powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v0.0.0 2>&1 | Out-String)
           $code = $LASTEXITCODE
           Write-Host $out
           if ($code -ne 2) { throw "expected exit 2 for an unknown tag, got $code" }
           if ($out -notmatch 'git said:') { throw "git's own reason was not quoted" }
           if (Test-Path -LiteralPath (Join-Path $env:LOCALAPPDATA 'commitlore\v0.0.0')) { throw 'a checkout was left behind' }
 
+      # The hook is the point. Windows support is not claimed by this job (T-1124
+      # owns that), but what the installer puts on the machine has to work.
       - name: The installed tool works in a real repository
         shell: bash
         run: |
@@ -436,9 +449,6 @@ jobs:
           git config --local --get commitlore.node
           "$shim" doctor || echo "(doctor reported problems -- see above)"
 
-          # The hook is the point: a record that violates the vocabulary must be
-          # rejected, and a valid one accepted. Windows support is not claimed by
-          # this job (T-1124 owns that), but what it installs has to work.
           printf 'export const value = 1;\n' > file.ts
           git add file.ts
           if git commit -q -m "$(printf 'Bad\n\nBlast: wide\n')"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,12 +449,18 @@ jobs:
             exit /b 1
           )
 
-      # The hook is the point. Windows support is not claimed by this job (T-1124
-      # owns that), but what the installer puts on the machine has to work.
+      # What T-1121 owns is that the installer put a working CLI on this machine.
+      # It deliberately does not require a healthy `doctor`: on Windows the
+      # hook-runtime probe spawns /bin/sh, which does not exist there, and the
+      # PreToolUse entry names `commitlore` while the shim is `commitlore.cmd`.
+      # Both are real findings and both belong to T-1124, which owns the Windows
+      # hook path and the support claim that depends on it. Asserting a green
+      # doctor here would either fail this ticket for another ticket's work or
+      # smuggle in a support claim this one is forbidden from making.
       - name: The installed tool works in a real repository
         shell: bash
         run: |
-          set -euo pipefail
+          set -uo pipefail
           shim="$LOCALAPPDATA\\commitlore\\bin\\commitlore.cmd"
           repo=$(mktemp -d)/repo
           mkdir -p "$repo"
@@ -465,19 +471,35 @@ jobs:
           git config commit.gpgsign false
           printf 'export const value = 0;\n' > file.ts
           git add file.ts
-          git commit -q -m "$(printf 'Seed\n\nRecord-Id: r-ciwin0001\nBlast: local\nUndo: easy\nCertainty: firm\n')"
+          git commit -q -m "$(printf 'Seed\n\nLimit: the runner has no compiled artifact\nRecord-Id: r-ciwin0001\n')"
 
-          "$shim" init
-          echo "--- recorded ---"
-          git config --local --get commitlore.bin
-          git config --local --get commitlore.node
-          "$shim" doctor || echo "(doctor reported problems -- see above)"
+          # init reports; a check that needs attention is not this step's failure.
+          "$shim" init || echo "(init reported steps needing attention -- see above)"
 
-          printf 'export const value = 1;\n' > file.ts
-          git add file.ts
-          if git commit -q -m "$(printf 'Bad\n\nBlast: wide\n')"; then
-            echo "::error::an invalid record was accepted by the hook"
+          echo "--- what init recorded ---"
+          bin=$(git config --local --get commitlore.bin || true)
+          node_path=$(git config --local --get commitlore.node || true)
+          echo "commitlore.bin  = $bin"
+          echo "commitlore.node = $node_path"
+          case "$bin" in
+            *dist/commitlore.mjs|*dist\\commitlore.mjs) ;;
+            *) echo "::error::commitlore.bin is not the bundle: $bin"; exit 1 ;;
+          esac
+          test -n "$node_path" || { echo "::error::no interpreter was recorded"; exit 1; }
+
+          echo "--- the CLI itself ---"
+          "$shim" context file.ts || { echo "::error::context failed"; exit 1; }
+
+          printf 'Bad\n\nBlast: wide\n' > /tmp/bad-message.txt
+          if "$shim" validate --message-file /tmp/bad-message.txt; then
+            echo "::error::an invalid record was accepted"
             exit 1
           fi
-          git commit -q -m "$(printf 'Good\n\nLimit: the runner has no compiled artifact\nRecord-Id: r-ciwin0002\n')"
-          "$shim" context file.ts
+          printf 'Good\n\nLimit: a real condition\nRecord-Id: r-ciwin0002\n' > /tmp/good-message.txt
+          "$shim" validate --message-file /tmp/good-message.txt || {
+            echo "::error::a valid record was rejected"
+            exit 1
+          }
+
+          echo "--- the Windows hook path, reported rather than asserted (T-1124) ---"
+          "$shim" doctor || echo "(doctor reported problems -- T-1124 owns the Windows hook path)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,3 +313,137 @@ jobs:
             COMMITLORE_INSTALL_SOURCE=/w sh install.sh v9.9.9
             "$HOME/.local/bin/commitlore" --version
           '
+
+  # T-1121 (#282): install.ps1 is install.sh's twin, and a shape test cannot show
+  # that a PowerShell script runs. This job is the evidence -- a real
+  # windows-latest runner, the script executed the way a user would execute it,
+  # and the tool it installs used afterwards.
+  #
+  # The source is this checkout with a local tag, exactly as the install-script
+  # job does for the shell installer: nothing here reaches github.com, so the job
+  # tests the script rather than the network.
+  #
+  # Windows PowerShell 5.1 is tested alongside PowerShell 7 because 5.1 is what a
+  # Windows machine has before anyone installs anything, and a 7-only construct
+  # fails to parse the *whole* file rather than one branch of it.
+  install-ps1:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [powershell, pwsh]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Tag this checkout so the installer has a pinned source
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.email t@example.com
+          git config user.name "CommitLore CI"
+          git tag v9.9.9
+
+      - name: Install from the local tag
+        shell: ${{ matrix.shell }}
+        env:
+          COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & .\install.ps1 v9.9.9
+          if ($LASTEXITCODE -ne 0) { throw "installer exited $LASTEXITCODE" }
+
+      - name: The shim exists, reports a version, and runs a real command
+        shell: ${{ matrix.shell }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $shim = Join-Path $env:LOCALAPPDATA 'commitlore\bin\commitlore.cmd'
+          if (-not (Test-Path -LiteralPath $shim)) { throw "no shim at $shim" }
+          $body = Get-Content -LiteralPath $shim -Raw
+          if ($body -notmatch 'commitlore:wrapper:v1') { throw 'the shim carries no marker' }
+          if ($body -notmatch "`r`n") { throw 'the shim is not CRLF' }
+          $version = (& $shim --version | Select-Object -First 1)
+          Write-Host "shim reports: $version"
+          if ($version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+') { throw "unexpected version output: $version" }
+          $declared = (Get-Content -LiteralPath package.json -Raw | ConvertFrom-Json).version
+          if ($version.Trim() -ne $declared) { throw "shim reports $version, package.json declares $declared" }
+          & $shim --help > $null
+          if ($LASTEXITCODE -ne 0) { throw "--help exited $LASTEXITCODE" }
+
+      - name: A second run is an upgrade, not a refusal
+        shell: ${{ matrix.shell }}
+        env:
+          COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $out = (& .\install.ps1 v9.9.9 2>&1 | Out-String)
+          Write-Host $out
+          if ($LASTEXITCODE -ne 0) { throw "re-run exited $LASTEXITCODE" }
+          if ($out -notmatch 'reusing the existing checkout') { throw 'the checkout was not reused' }
+          if ($out -notmatch 'upgrading the existing commitlore shim') { throw 'the shim was not recognized as its own' }
+
+      - name: A foreign file at the destination is refused with exit 4
+        shell: ${{ matrix.shell }}
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $dir = Join-Path $env:TEMP 'commitlore-occupied'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          Set-Content -LiteralPath (Join-Path $dir 'commitlore.cmd') -Value '@echo not commitlore'
+          $env:COMMITLORE_INSTALL_DIR = $dir
+          $env:COMMITLORE_INSTALL_SOURCE = '${{ github.workspace }}'
+          $out = (& .\install.ps1 v9.9.9 2>&1 | Out-String)
+          $code = $LASTEXITCODE
+          Remove-Item Env:\COMMITLORE_INSTALL_DIR
+          Write-Host $out
+          if ($code -ne 4) { throw "expected exit 4 for an occupied destination, got $code" }
+          if ($out -notmatch 'refusing to overwrite it') { throw 'the refusal was not named' }
+          $body = Get-Content -LiteralPath (Join-Path $dir 'commitlore.cmd') -Raw
+          if ($body -notmatch 'not commitlore') { throw 'the foreign file was modified' }
+
+      - name: A bad tag is refused with exit 2 and installs nothing
+        shell: ${{ matrix.shell }}
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $env:COMMITLORE_INSTALL_SOURCE = '${{ github.workspace }}'
+          $out = (& .\install.ps1 v0.0.0 2>&1 | Out-String)
+          $code = $LASTEXITCODE
+          Write-Host $out
+          if ($code -ne 2) { throw "expected exit 2 for an unknown tag, got $code" }
+          if ($out -notmatch 'git said:') { throw "git's own reason was not quoted" }
+          if (Test-Path -LiteralPath (Join-Path $env:LOCALAPPDATA 'commitlore\v0.0.0')) { throw 'a checkout was left behind' }
+
+      - name: The installed tool works in a real repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          shim="$LOCALAPPDATA\\commitlore\\bin\\commitlore.cmd"
+          repo=$(mktemp -d)/repo
+          mkdir -p "$repo"
+          cd "$repo"
+          git init -q -b main
+          git config user.email t@example.com
+          git config user.name "CommitLore CI"
+          git config commit.gpgsign false
+          printf 'export const value = 0;\n' > file.ts
+          git add file.ts
+          git commit -q -m "$(printf 'Seed\n\nRecord-Id: r-ciwin0001\nBlast: local\nUndo: easy\nCertainty: firm\n')"
+
+          "$shim" init
+          echo "--- recorded ---"
+          git config --local --get commitlore.bin
+          git config --local --get commitlore.node
+          "$shim" doctor || echo "(doctor reported problems -- see above)"
+
+          # The hook is the point: a record that violates the vocabulary must be
+          # rejected, and a valid one accepted. Windows support is not claimed by
+          # this job (T-1124 owns that), but what it installs has to work.
+          printf 'export const value = 1;\n' > file.ts
+          git add file.ts
+          if git commit -q -m "$(printf 'Bad\n\nBlast: wide\n')"; then
+            echo "::error::an invalid record was accepted by the hook"
+            exit 1
+          fi
+          git commit -q -m "$(printf 'Good\n\nLimit: the runner has no compiled artifact\nRecord-Id: r-ciwin0002\n')"
+          "$shim" context file.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,35 +395,59 @@ jobs:
           if ($out -notmatch 'reusing the existing checkout') { throw 'the checkout was not reused' }
           if ($out -notmatch 'upgrading the existing commitlore shim') { throw 'the shim was not recognized as its own' }
 
+      # These two run under cmd, deliberately. A pwsh step on GitHub runs with
+      # $ErrorActionPreference = 'Stop', which promotes a native command's stderr
+      # to a terminating error -- so a step that captures the installer's own
+      # error message with 2>&1 aborts on reading it and never reaches its
+      # assertion. cmd has no error records: %ERRORLEVEL% is the exit code and
+      # findstr reads the text. This is the same hazard the installer itself hit,
+      # in the harness rather than the script.
       - name: A foreign file at the destination is refused with exit 4
-        shell: pwsh
+        shell: cmd
         env:
           COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
         run: |
-          $dir = Join-Path $env:TEMP 'commitlore-occupied'
-          New-Item -ItemType Directory -Force -Path $dir | Out-Null
-          Set-Content -LiteralPath (Join-Path $dir 'commitlore.cmd') -Value '@echo not commitlore'
-          $env:COMMITLORE_INSTALL_DIR = $dir
-          $out = (& powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 2>&1 | Out-String)
-          $code = $LASTEXITCODE
-          Remove-Item Env:\COMMITLORE_INSTALL_DIR
-          Write-Host $out
-          if ($code -ne 4) { throw "expected exit 4 for an occupied destination, got $code" }
-          if ($out -notmatch 'refusing to overwrite it') { throw 'the refusal was not named' }
-          $body = Get-Content -LiteralPath (Join-Path $dir 'commitlore.cmd') -Raw
-          if ($body -notmatch 'not commitlore') { throw 'the foreign file was modified' }
+          set "dir=%TEMP%\commitlore-occupied"
+          mkdir "%dir%" 2>nul
+          > "%dir%\commitlore.cmd" echo @echo not commitlore
+          set "COMMITLORE_INSTALL_DIR=%dir%"
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 > "%TEMP%\occupied.log" 2>&1
+          set "code=%ERRORLEVEL%"
+          set "COMMITLORE_INSTALL_DIR="
+          type "%TEMP%\occupied.log"
+          if not "%code%"=="4" (
+            echo ::error::expected exit 4 for an occupied destination, got %code%
+            exit /b 1
+          )
+          findstr /C:"refusing to overwrite it" "%TEMP%\occupied.log" >nul || (
+            echo ::error::the refusal was not named
+            exit /b 1
+          )
+          findstr /C:"not commitlore" "%dir%\commitlore.cmd" >nul || (
+            echo ::error::the foreign file was modified
+            exit /b 1
+          )
 
       - name: An unknown tag is refused with exit 2 and installs nothing
-        shell: pwsh
+        shell: cmd
         env:
           COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
         run: |
-          $out = (& powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v0.0.0 2>&1 | Out-String)
-          $code = $LASTEXITCODE
-          Write-Host $out
-          if ($code -ne 2) { throw "expected exit 2 for an unknown tag, got $code" }
-          if ($out -notmatch 'git said:') { throw "git's own reason was not quoted" }
-          if (Test-Path -LiteralPath (Join-Path $env:LOCALAPPDATA 'commitlore\v0.0.0')) { throw 'a checkout was left behind' }
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v0.0.0 > "%TEMP%\badtag.log" 2>&1
+          set "code=%ERRORLEVEL%"
+          type "%TEMP%\badtag.log"
+          if not "%code%"=="2" (
+            echo ::error::expected exit 2 for an unknown tag, got %code%
+            exit /b 1
+          )
+          findstr /C:"git said:" "%TEMP%\badtag.log" >nul || (
+            echo ::error::git's own reason was not quoted
+            exit /b 1
+          )
+          if exist "%LOCALAPPDATA%\commitlore\v0.0.0" (
+            echo ::error::a checkout was left behind
+            exit /b 1
+          )
 
       # The hook is the point. Windows support is not claimed by this job (T-1124
       # owns that), but what the installer puts on the machine has to work.

--- a/install.ps1
+++ b/install.ps1
@@ -182,13 +182,27 @@ if (Test-Path -LiteralPath (Join-Path $checkout 'dist')) {
     # looking in the wrong place whenever the cause is something else, which is
     # most of the time. git puts the useful line first and the generic advice
     # last, so the first fatal: line is what a reader needs.
+    #
+    # git's stderr goes to a file, exactly as install.sh does it, and success is
+    # decided by the exit code alone. Merging stderr into the output stream with
+    # 2>&1 is what a first draft did, and Windows PowerShell 5.1 promotes a native
+    # command's stderr to a terminating error under $ErrorActionPreference =
+    # 'Stop' -- so git's harmless "--depth is ignored in local clones" warning
+    # aborted a clone that had otherwise succeeded. A warning is not a failure, and
+    # only the exit code says which one this is.
+    $cloneLogPath = Join-Path ([System.IO.Path]::GetTempPath()) ("commitlore-clone-{0}.log" -f $PID)
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    & git clone --quiet --depth 1 --branch $Version $SourceUrl $checkoutTmp 2> $cloneLogPath
+    $cloneCode = $LASTEXITCODE
+    $ErrorActionPreference = $previousPreference
     $cloneLog = ''
-    try {
-        $cloneLog = (& git clone --quiet --depth 1 --branch $Version $SourceUrl $checkoutTmp 2>&1 | Out-String)
-    } catch {
-        $cloneLog = $_.Exception.Message
+    if (Test-Path -LiteralPath $cloneLogPath) {
+        $cloneLog = (Get-Content -LiteralPath $cloneLogPath -Raw -ErrorAction SilentlyContinue)
+        if ($null -eq $cloneLog) { $cloneLog = '' }
+        Remove-Item -LiteralPath $cloneLogPath -Force -ErrorAction SilentlyContinue
     }
-    if ($LASTEXITCODE -ne 0) {
+    if ($cloneCode -ne 0) {
         if (Test-Path -LiteralPath $checkoutTmp) {
             Remove-Item -LiteralPath $checkoutTmp -Recurse -Force -ErrorAction SilentlyContinue
         }

--- a/install.ps1
+++ b/install.ps1
@@ -80,7 +80,12 @@ function Stop-Install {
 # with node, and the checkout is a git clone. A missing one is named, with what
 # to do about it, and nothing is installed.
 
-$nodeCommand = Get-Command node -CommandType Application -ErrorAction SilentlyContinue
+# `Select-Object -First 1`: Get-Command returns *every* match on PATH, and a
+# Windows runner really does carry two node.exe. Without it $nodeBin becomes an
+# array, the interpolated error message reads as two paths joined by a space, and
+# the version check invokes something that is not a program. The first match is
+# also the right one -- it is what typing `node` would run.
+$nodeCommand = Get-Command node -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
 if ($null -eq $nodeCommand) {
     Stop-Install "Node.js $NodeMajorMin or newer is required and no ""node"" was found on PATH. Install Node.js $NodeMajorMin+ (https://nodejs.org), then run this again. Nothing was installed." 1
 }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,556 @@
+<#
+    Installs commitlore from source on Windows, for any agent that is not Claude Code.
+
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.ps1))) v0.4.1
+
+    Claude Code users do not need this script. The repository is itself a plugin
+    marketplace (ADR-0011), so two /plugin commands register the MCP server, the
+    pre-edit context hook and the skills. That path is first in the README and
+    this one is second.
+
+    This is install.sh's twin, not a port of a different idea. The shell script
+    defines the contract and this one implements the same one:
+
+      - Node.js 22+ (ADR-0010) and Git are checked before anything is written.
+      - A pinned tag is checked out into the user's local application data.
+      - A thin shim runs "node <checkout>\dist\commitlore.mjs".
+      - No compiled executable, no platform asset, no checksum of a downloaded
+        tarball. ADR-0026 removed all of that from the product.
+      - Nothing is elevated: no administrator prompt, no Program Files, no
+        machine-level PATH.
+      - The user's PATH is never modified. When the shim's directory is not on
+        PATH the command to add it is printed, which is the whole of what this
+        script does about it. Two active records on install.sh reject an
+        installer that edits the user's environment behind their back, and a
+        user-scope PATH write is the same act in Windows spelling.
+      - Post-install verification reports; it never decides the exit code.
+
+    Exit codes, identical to install.sh: 1 = missing or too-old prerequisite, or
+    bad usage (nothing was written), 2 = the source could not be fetched, 4 = the
+    install target is occupied by something this script did not put there.
+
+    Windows support is not claimed by this file. It installs, and what it
+    installs runs; whether the containment property #71 establishes holds on
+    Windows is a separate question with its own ticket (T-1124).
+
+    ASCII only, deliberately. A non-ASCII character in a string silently
+    terminated /bin/sh in install.sh's own history, and a script that arrives
+    down a pipe has no encoding declaration to fall back on.
+
+    Windows PowerShell 5.1 and PowerShell 7+ both run this. Nothing here uses
+    the ternary operator, null-coalescing, or any other 7-only syntax.
+#>
+
+param(
+    [string] $Version = $env:COMMITLORE_VERSION
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'MongLong0214/commitlore'
+$NodeMajorMin = 22
+$WrapperMarker = ':: commitlore:wrapper:v1'
+
+$SourceUrl = $env:COMMITLORE_INSTALL_SOURCE
+if ([string]::IsNullOrEmpty($SourceUrl)) {
+    $SourceUrl = "https://github.com/$Repo.git"
+}
+
+function Write-Log {
+    param([string] $Message)
+    Write-Host "commitlore-install: $Message"
+}
+
+function Stop-Install {
+    param(
+        [string] $Message,
+        [int] $Code = 1
+    )
+    # Written to the error stream, read by a human. `throw` would print a
+    # PowerShell stack trace over the message that matters.
+    [Console]::Error.WriteLine("commitlore-install: error: $Message")
+    exit $Code
+}
+
+# --- 1. prerequisites, before anything is written ---------------------------
+#
+# Both are hard requirements rather than conveniences: the shim runs the bundle
+# with node, and the checkout is a git clone. A missing one is named, with what
+# to do about it, and nothing is installed.
+
+$nodeCommand = Get-Command node -CommandType Application -ErrorAction SilentlyContinue
+if ($null -eq $nodeCommand) {
+    Stop-Install "Node.js $NodeMajorMin or newer is required and no ""node"" was found on PATH. Install Node.js $NodeMajorMin+ (https://nodejs.org), then run this again. Nothing was installed." 1
+}
+$nodeBin = $nodeCommand.Source
+
+$nodeVersion = ''
+try {
+    $nodeVersion = (& $nodeBin --version 2>$null | Select-Object -First 1)
+} catch {
+    $nodeVersion = ''
+}
+if ($null -eq $nodeVersion) { $nodeVersion = '' }
+$nodeVersion = $nodeVersion.Trim()
+if ($nodeVersion -notmatch '^v[0-9]+') {
+    Stop-Install """$nodeBin --version"" did not report a version (got: ""$nodeVersion""), so the Node.js major version cannot be checked. Nothing was installed." 1
+}
+$nodeMajor = [int]($nodeVersion.TrimStart('v').Split('.')[0])
+if ($nodeMajor -lt $NodeMajorMin) {
+    Stop-Install "Node.js $NodeMajorMin or newer is required; this machine has $nodeVersion. Upgrade Node.js, then run this again. Nothing was installed." 1
+}
+
+# Run it rather than only look for it: a git that cannot execute is as useless
+# here as a missing one, and this is the check that catches both.
+$gitRan = $false
+try {
+    & git --version > $null 2>&1
+    $gitRan = ($LASTEXITCODE -eq 0)
+} catch {
+    $gitRan = $false
+}
+if (-not $gitRan) {
+    Stop-Install "Git is required, and ""git --version"" did not run. Install Git (or repair the installation), then run this again. Nothing was installed." 1
+}
+
+# --- 2. resolve the version to install -------------------------------------
+#
+# A tag, never a branch. Passing one explicitly is the reviewable path; with
+# none, the newest semver tag is resolved with `git ls-remote`, which needs no
+# API token and no rate limit. The default must not resolve to a branch --
+# installing a moving target is what pinning exists to prevent.
+
+if (-not [string]::IsNullOrEmpty($Version)) {
+    if ($Version -match '^v[0-9]') {
+        # already a tag
+    } elseif ($Version -match '^[0-9]') {
+        $Version = "v$Version"
+    } else {
+        Stop-Install """$Version"" is not a version tag. Pass a tag such as v0.4.1, or pass nothing to install the newest one." 1
+    }
+} else {
+    # Only vMAJOR.MINOR.PATCH is considered. A pre-release tag would otherwise
+    # sort against its release and win on string length, which is backwards.
+    # [version] compares the numbers as numbers, which is the whole reason
+    # install.sh had to zero-pad: it has no such type and `sort -V` is not POSIX.
+    $refs = ''
+    try {
+        $refs = (& git ls-remote --tags --refs $SourceUrl 2>$null) -join "`n"
+    } catch {
+        $refs = ''
+    }
+    $tags = @()
+    foreach ($line in ($refs -split "`n")) {
+        if ($line -match 'refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$') {
+            $tags += $Matches[1]
+        }
+    }
+    if ($tags.Count -eq 0) {
+        Stop-Install "no version tag could be resolved from $SourceUrl. Pass one explicitly, for example: & ([scriptblock]::Create((irm <url>/install.ps1))) v0.4.1" 2
+    }
+    $Version = ($tags | Sort-Object -Property { [version]($_.TrimStart('v')) } | Select-Object -Last 1)
+}
+
+Write-Log "installing $Version"
+
+# --- 3. fetch the pinned checkout ------------------------------------------
+#
+# Into the user's local application data, keyed by tag, so an upgrade adds a
+# checkout beside the old one instead of mutating it. Cloned to a temporary name
+# and renamed, so a failed clone never leaves a half-checkout that looks
+# installed.
+
+$dataRoot = Join-Path $env:LOCALAPPDATA 'commitlore'
+$checkout = Join-Path $dataRoot $Version
+
+if (Test-Path -LiteralPath (Join-Path $checkout 'dist')) {
+    Write-Log "reusing the existing checkout at $checkout"
+} else {
+    New-Item -ItemType Directory -Force -Path $dataRoot | Out-Null
+    $checkoutTmp = Join-Path $dataRoot (".{0}.incoming.{1}" -f $Version, $PID)
+    if (Test-Path -LiteralPath $checkoutTmp) {
+        Remove-Item -LiteralPath $checkoutTmp -Recurse -Force
+    }
+    # Keep git's own reason. Swallowing it and printing a guess sends a user
+    # looking in the wrong place whenever the cause is something else, which is
+    # most of the time. git puts the useful line first and the generic advice
+    # last, so the first fatal: line is what a reader needs.
+    $cloneLog = ''
+    try {
+        $cloneLog = (& git clone --quiet --depth 1 --branch $Version $SourceUrl $checkoutTmp 2>&1 | Out-String)
+    } catch {
+        $cloneLog = $_.Exception.Message
+    }
+    if ($LASTEXITCODE -ne 0) {
+        if (Test-Path -LiteralPath $checkoutTmp) {
+            Remove-Item -LiteralPath $checkoutTmp -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        $reason = ''
+        foreach ($line in ($cloneLog -split "`r?`n")) {
+            if ($line -match '^fatal:') { $reason = $line.Trim(); break }
+        }
+        if ([string]::IsNullOrEmpty($reason)) {
+            $reason = ($cloneLog -replace '\s+', ' ').Trim()
+        }
+        if ([string]::IsNullOrEmpty($reason)) { $reason = 'nothing' }
+        Stop-Install "could not fetch $Version from $SourceUrl. git said: $reason. Nothing was installed." 2
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $checkoutTmp 'dist\commitlore.mjs'))) {
+        Remove-Item -LiteralPath $checkoutTmp -Recurse -Force -ErrorAction SilentlyContinue
+        Stop-Install "$Version does not carry dist/commitlore.mjs, so there is nothing to run. Nothing was installed." 2
+    }
+    if (Test-Path -LiteralPath $checkout) {
+        Remove-Item -LiteralPath $checkout -Recurse -Force
+    }
+    Move-Item -LiteralPath $checkoutTmp -Destination $checkout
+    Write-Log "checked out $Version into $checkout"
+}
+
+# --- 4. install the shim ---------------------------------------------------
+#
+# A .cmd shim rather than an extensionless file: cmd.exe and PowerShell both
+# find and run a .cmd from PATH, and an extensionless script is not executable
+# on Windows at all. The git hook does not go through PATH -- `commitlore init`
+# records the bundle and the interpreter in the repository's git config -- so the
+# shim is for the terminal, which is where a user types the name.
+
+$destDir = $env:COMMITLORE_INSTALL_DIR
+if ([string]::IsNullOrEmpty($destDir)) {
+    $destDir = Join-Path $dataRoot 'bin'
+}
+$dest = Join-Path $destDir 'commitlore.cmd'
+
+# Refuse to clobber a file this script did not put there. A previous shim
+# carries the marker; a previous install prints a bare semver. Anything else is
+# somebody else's file and is left exactly where it is.
+if (Test-Path -LiteralPath $dest) {
+    $existing = ''
+    try {
+        $existing = (Get-Content -LiteralPath $dest -Raw -ErrorAction SilentlyContinue)
+    } catch {
+        $existing = ''
+    }
+    if ($null -eq $existing) { $existing = '' }
+    if ($existing.Contains($WrapperMarker)) {
+        Write-Log "upgrading the existing commitlore shim at $dest"
+    } else {
+        $existingVersion = ''
+        try {
+            $existingVersion = (& $dest --version 2>$null | Select-Object -First 1)
+        } catch {
+            $existingVersion = ''
+        }
+        if ($null -eq $existingVersion) { $existingVersion = '' }
+        $existingVersion = $existingVersion.Trim()
+        if ($existingVersion -match '^[0-9]+\.[0-9]+\.[0-9]+') {
+            Write-Log "replacing a previous commitlore install at $dest ($existingVersion -> $Version)"
+        } else {
+            Stop-Install "$dest already exists and is not a commitlore shim (got: ""$existingVersion"") -- refusing to overwrite it. Remove it first, or set COMMITLORE_INSTALL_DIR to install elsewhere." 4
+        }
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+
+$bundle = Join-Path $checkout 'dist\commitlore.mjs'
+# CRLF, written explicitly. cmd.exe mis-parses a batch file with LF endings in
+# ways that depend on the line -- a `set` can swallow the next line -- so the
+# endings are part of the file format here rather than a preference.
+$shimLines = @(
+    '@echo off',
+    $WrapperMarker,
+    ':: Installed by install.ps1. Edits are lost on reinstall.',
+    'setlocal',
+    ('set "COMMITLORE_NODE=' + $nodeBin + '"'),
+    'if not exist "%COMMITLORE_NODE%" set "COMMITLORE_NODE=node"',
+    ('"%COMMITLORE_NODE%" "' + $bundle + '" %*'),
+    'exit /b %ERRORLEVEL%'
+)
+$shimText = ($shimLines -join "`r`n") + "`r`n"
+
+# Write beside the destination and rename. An in-place overwrite of a file that
+# may be executing is the defect that forced a same-day patch release in the
+# shell installer's history; a move is the closest thing Windows offers to the
+# atomic rename that fixed it.
+$destTmp = "$dest.commitlore-install.$PID"
+[System.IO.File]::WriteAllText($destTmp, $shimText, (New-Object System.Text.UTF8Encoding($false)))
+Move-Item -LiteralPath $destTmp -Destination $dest -Force
+
+Write-Log "installed to $dest"
+
+# The install is complete by this point. Verification reports; it does not
+# decide. A single failure is retried once before it is reported, and a reported
+# failure still exits 0 -- an install that succeeded must not be failed by a
+# check that could not run.
+$installedVersion = ''
+foreach ($attempt in 1, 2) {
+    try {
+        $installedVersion = (& $dest --version 2>$null | Select-Object -First 1)
+    } catch {
+        $installedVersion = ''
+    }
+    if ($null -eq $installedVersion) { $installedVersion = '' }
+    $installedVersion = $installedVersion.Trim()
+    if (-not [string]::IsNullOrEmpty($installedVersion)) { break }
+    if ($attempt -eq 1) { Start-Sleep -Seconds 1 }
+}
+if (-not [string]::IsNullOrEmpty($installedVersion)) {
+    Write-Host $installedVersion
+} else {
+    Write-Log "installed, but unverified: ""$dest --version"" did not run in this shell."
+    Write-Log "the shim is in place; verify it yourself with: $dest --version"
+}
+
+# Printed, never written. Rewriting a user's environment from a piped installer
+# is ruled out on install.sh, and this is the same act in Windows spelling.
+$onPath = $false
+foreach ($entry in ($env:PATH -split ';')) {
+    if ($entry.TrimEnd('\') -eq $destDir.TrimEnd('\')) { $onPath = $true; break }
+}
+if (-not $onPath) {
+    Write-Log "note: $destDir is not on PATH."
+    Write-Log "add it for your account with:"
+    Write-Log "  [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';$destDir', 'User')"
+}
+
+# --- 5. detect and wire coding agents --------------------------------------
+#
+# Everything below is additive and best-effort: it never touches the exit codes
+# above (1-4 stay reserved for phase 1 -- the tool is already installed and
+# working by the time this runs), and every agent it wires is detect-then-act, in
+# the same order as install.sh:
+#
+#   1. Is the agent actually on this machine? An agent that is not found is left
+#      alone completely -- no config is created "for later".
+#   2. Does its config already mention commitlore? If so, this is a re-run:
+#      report it and change nothing.
+#   3. Otherwise create the config fresh, or merge into the existing one.
+#
+# PowerShell parses and writes JSON natively, so unlike install.sh there is no
+# jq to be missing -- the "cannot merge without jq" branch has no counterpart
+# here. An unparseable config is still left untouched and reported.
+
+Write-Log ''
+Write-Log 'Detecting coding agents...'
+
+$wired = New-Object System.Collections.ArrayList
+$skipped = New-Object System.Collections.ArrayList
+$notFound = New-Object System.Collections.ArrayList
+
+function Add-Wired { param([string] $Message) $wired.Add($Message) | Out-Null }
+function Add-Skipped { param([string] $Agent, [string] $Reason) $skipped.Add("$($Agent): $Reason") | Out-Null }
+
+function Test-AgentPresent {
+    param([string] $Command, [string[]] $Paths)
+    if (-not [string]::IsNullOrEmpty($Command)) {
+        if ($null -ne (Get-Command $Command -CommandType Application -ErrorAction SilentlyContinue)) { return $true }
+    }
+    foreach ($path in $Paths) {
+        if (Test-Path -LiteralPath $path) { return $true }
+    }
+    return $false
+}
+
+# `mcpServers: { name: { command, args } }` -- Gemini CLI, Cursor and Windsurf
+# all document this exact shape.
+function Wire-McpServersJson {
+    param([string] $Agent, [string] $ConfigPath)
+
+    $configDir = Split-Path -Parent $ConfigPath
+    try {
+        New-Item -ItemType Directory -Force -Path $configDir | Out-Null
+    } catch {
+        Add-Skipped $Agent "could not create $configDir"
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $ConfigPath)) {
+        $fresh = [ordered]@{
+            mcpServers = [ordered]@{
+                commitlore = [ordered]@{ command = $dest; args = @('mcp') }
+            }
+        }
+        try {
+            ($fresh | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $ConfigPath -Encoding UTF8
+            Add-Wired "$($Agent): created $ConfigPath"
+        } catch {
+            Add-Skipped $Agent "could not write $ConfigPath"
+        }
+        return
+    }
+
+    $body = ''
+    try {
+        $body = (Get-Content -LiteralPath $ConfigPath -Raw)
+    } catch {
+        Add-Skipped $Agent "could not read $ConfigPath"
+        return
+    }
+    if ($body -match '"commitlore"') {
+        Add-Skipped $Agent "$ConfigPath already mentions commitlore -- left unchanged"
+        return
+    }
+    try {
+        $parsed = $body | ConvertFrom-Json
+    } catch {
+        Add-Skipped $Agent "$ConfigPath exists but is not parseable JSON -- left untouched. Add manually: {""mcpServers"":{""commitlore"":{""command"":""$dest"",""args"":[""mcp""]}}}"
+        return
+    }
+    try {
+        if ($null -eq $parsed.PSObject.Properties['mcpServers']) {
+            $parsed | Add-Member -MemberType NoteProperty -Name 'mcpServers' -Value (New-Object PSObject)
+        }
+        $server = [ordered]@{ command = $dest; args = @('mcp') }
+        $parsed.mcpServers | Add-Member -MemberType NoteProperty -Name 'commitlore' -Value $server -Force
+        ($parsed | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $ConfigPath -Encoding UTF8
+        Add-Wired "$($Agent): added the commitlore MCP server into the existing $ConfigPath"
+    } catch {
+        Add-Skipped $Agent "$ConfigPath could not be updated -- left as it was. Add manually: {""mcpServers"":{""commitlore"":{""command"":""$dest"",""args"":[""mcp""]}}}"
+    }
+}
+
+$home_ = $env:USERPROFILE
+
+# Claude Code -- https://code.claude.com/docs/en/discover-plugins#install-plugins
+if (Test-AgentPresent 'claude' @()) {
+    $plugins = ''
+    try { $plugins = (& claude plugin list 2>$null | Out-String) } catch { $plugins = '' }
+    if ($plugins -match 'commitlore') {
+        Add-Skipped 'claude-code' 'the commitlore plugin is already installed -- left unchanged'
+    } else {
+        $added = $false
+        try {
+            & claude plugin marketplace add $Repo > $null 2>&1
+            $added = ($LASTEXITCODE -eq 0)
+        } catch { $added = $false }
+        if (-not $added) {
+            Add-Skipped 'claude-code' "could not add the $Repo marketplace -- run manually: claude plugin marketplace add $Repo"
+        } else {
+            $ok = $false
+            try {
+                & claude plugin install commitlore@commitlore --scope user > $null 2>&1
+                $ok = ($LASTEXITCODE -eq 0)
+            } catch { $ok = $false }
+            if ($ok) {
+                Add-Wired 'claude-code: installed the commitlore plugin (marketplace: commitlore, scope: user)'
+            } else {
+                Add-Skipped 'claude-code' 'marketplace added, but plugin install failed -- run manually: claude plugin install commitlore@commitlore'
+            }
+        }
+    }
+} else {
+    $notFound.Add('Claude Code') | Out-Null
+}
+
+# Codex CLI -- TOML, one [mcp_servers.<name>] table per server.
+# https://developers.openai.com/codex/mcp
+if (Test-AgentPresent 'codex' @((Join-Path $home_ '.codex'))) {
+    $codexConfig = Join-Path $home_ '.codex\config.toml'
+    $existingToml = ''
+    if (Test-Path -LiteralPath $codexConfig) {
+        try { $existingToml = (Get-Content -LiteralPath $codexConfig -Raw) } catch { $existingToml = '' }
+    }
+    if ($existingToml -match '(?m)^\[mcp_servers\.commitlore\]') {
+        Add-Skipped 'codex' "$codexConfig already has a [mcp_servers.commitlore] block -- left unchanged"
+    } else {
+        try {
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $codexConfig) | Out-Null
+            # A backslash is TOML's escape character inside a basic string, so a
+            # Windows path has to be doubled or the parser reads \d as an escape.
+            $tomlPath = $dest -replace '\\', '\\'
+            $block = "`r`n[mcp_servers.commitlore]`r`ncommand = ""$tomlPath""`r`nargs = [""mcp""]`r`n"
+            if (Test-Path -LiteralPath $codexConfig) {
+                [System.IO.File]::AppendAllText($codexConfig, $block)
+                Add-Wired "codex: appended a [mcp_servers.commitlore] block to the existing $codexConfig"
+            } else {
+                [System.IO.File]::WriteAllText($codexConfig, $block.TrimStart("`r", "`n"))
+                Add-Wired "codex: created $codexConfig"
+            }
+        } catch {
+            Add-Skipped 'codex' "could not write $codexConfig"
+        }
+    }
+} else {
+    $notFound.Add('Codex') | Out-Null
+}
+
+# Gemini CLI -- https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html
+if (Test-AgentPresent 'gemini' @((Join-Path $home_ '.gemini'))) {
+    Wire-McpServersJson 'gemini-cli' (Join-Path $home_ '.gemini\settings.json')
+} else {
+    $notFound.Add('Gemini CLI') | Out-Null
+}
+
+# Cursor -- global config.
+if (Test-AgentPresent 'cursor' @((Join-Path $home_ '.cursor'), (Join-Path $env:LOCALAPPDATA 'Programs\cursor'))) {
+    Wire-McpServersJson 'cursor' (Join-Path $home_ '.cursor\mcp.json')
+} else {
+    $notFound.Add('Cursor') | Out-Null
+}
+
+# Windsurf -- https://docs.windsurf.com/windsurf/cascade/mcp
+if (Test-AgentPresent 'windsurf' @((Join-Path $home_ '.codeium\windsurf'))) {
+    Wire-McpServersJson 'windsurf' (Join-Path $home_ '.codeium\windsurf\mcp_config.json')
+} else {
+    $notFound.Add('Windsurf') | Out-Null
+}
+
+# opencode -- different shape from the rest: the key is `mcp`, not `mcpServers`,
+# and `command` is an argv array. https://opencode.ai/docs/mcp-servers/
+if (Test-AgentPresent 'opencode' @((Join-Path $home_ '.config\opencode'))) {
+    $openConfig = Join-Path $home_ '.config\opencode\opencode.json'
+    try {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $openConfig) | Out-Null
+        if (-not (Test-Path -LiteralPath $openConfig)) {
+            $fresh = [ordered]@{
+                '$schema' = 'https://opencode.ai/config.json'
+                mcp = [ordered]@{
+                    commitlore = [ordered]@{ type = 'local'; command = @($dest, 'mcp'); enabled = $true }
+                }
+            }
+            ($fresh | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $openConfig -Encoding UTF8
+            Add-Wired "opencode: created $openConfig"
+        } else {
+            $body = (Get-Content -LiteralPath $openConfig -Raw)
+            if ($body -match '"commitlore"') {
+                Add-Skipped 'opencode' "$openConfig already mentions commitlore -- left unchanged"
+            } else {
+                $parsed = $body | ConvertFrom-Json
+                if ($null -eq $parsed.PSObject.Properties['mcp']) {
+                    $parsed | Add-Member -MemberType NoteProperty -Name 'mcp' -Value (New-Object PSObject)
+                }
+                $server = [ordered]@{ type = 'local'; command = @($dest, 'mcp'); enabled = $true }
+                $parsed.mcp | Add-Member -MemberType NoteProperty -Name 'commitlore' -Value $server -Force
+                ($parsed | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $openConfig -Encoding UTF8
+                Add-Wired "opencode: added the commitlore MCP server into the existing $openConfig"
+            }
+        }
+    } catch {
+        Add-Skipped 'opencode' "$openConfig could not be written or parsed -- left as it was. Add manually under ""mcp"": {""commitlore"":{""type"":""local"",""command"":[""$dest"",""mcp""],""enabled"":true}}"
+    }
+} else {
+    $notFound.Add('opencode') | Out-Null
+}
+
+Write-Log ''
+Write-Log '== commitlore install summary =='
+if ($wired.Count -gt 0) {
+    Write-Log ''
+    Write-Log 'Wired:'
+    foreach ($line in $wired) { Write-Log "  - $line" }
+}
+if ($skipped.Count -gt 0) {
+    Write-Log ''
+    Write-Log 'Skipped:'
+    foreach ($line in $skipped) { Write-Log "  - $line" }
+}
+if ($notFound.Count -gt 0) {
+    Write-Log ''
+    Write-Log ("Not detected on this machine: " + ($notFound -join ', '))
+}
+Write-Log ''
+Write-Log "Next: cd into a repository and run 'commitlore init' to install its git hook and index."
+Write-Log '(install.ps1 never runs init for you -- it only installs the tool and wires agents, never touches a repository''s .git.)'
+exit 0

--- a/test/install-ps1.test.ts
+++ b/test/install-ps1.test.ts
@@ -1,0 +1,170 @@
+/**
+ * T-1121 (#282) — `install.ps1` implements the same contract as `install.sh`.
+ *
+ * PRD-F14 requirements 16-19.
+ *
+ * These are shape assertions, and shape is not the evidence. The evidence is the
+ * `windows-latest` CI job that runs the script on a real runner: prerequisites,
+ * checkout, shim, re-run, and a repository that ends up with a working hook.
+ * What this file is for is the part a Windows runner cannot show cheaply --
+ * that the two installers agree, clause by clause, on the decisions that were
+ * already argued out for the shell one.
+ *
+ * Two of those decisions exist because this project shipped the defect they
+ * forbid, and both are recorded on `install.sh`:
+ *
+ *   - the installer never edits the user's environment. Printing the line is
+ *     honest; writing it silently is what makes people distrust a piped
+ *     installer. A user-scope `PATH` write is that same act in Windows spelling.
+ *   - post-install verification never decides the exit code. An install that
+ *     succeeded must not be failed by a check that could not run.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PS1 = join(REPO_ROOT, 'install.ps1');
+const SH = join(REPO_ROOT, 'install.sh');
+
+const body = (): string => readFileSync(PS1, 'utf8');
+
+describe('T-1121 install.ps1 exists and matches install.sh clause for clause', () => {
+  it('is ASCII only, like its shell twin', () => {
+    // A non-ASCII character in a string silently terminated `/bin/sh` in
+    // install.sh's history while `sh -n` accepted the file. A script that
+    // arrives down a pipe has no encoding declaration to fall back on either.
+    const bytes = readFileSync(PS1);
+    const offenders = [...bytes.entries()].filter(([, byte]) => byte > 127);
+    expect(offenders.map(([index]) => index)).toEqual([]);
+  });
+
+  it('checks Node and Git before writing anything', () => {
+    const text = body();
+    const nodeCheck = text.indexOf('NodeMajorMin = 22');
+    const gitCheck = text.indexOf('git --version');
+    const firstWrite = text.indexOf('New-Item -ItemType Directory');
+    expect(nodeCheck).toBeGreaterThan(-1);
+    expect(gitCheck).toBeGreaterThan(-1);
+    expect(nodeCheck).toBeLessThan(firstWrite);
+    expect(gitCheck).toBeLessThan(firstWrite);
+    // The same floor as the shell script and package.json, not a second opinion.
+    expect(readFileSync(SH, 'utf8')).toContain('NODE_MAJOR_MIN=22');
+  });
+
+  it('names the missing prerequisite and says nothing was installed', () => {
+    const text = body();
+    for (const phrase of [
+      // The floor is interpolated from one constant rather than typed twice, so
+      // the source carries the variable and the user sees the number.
+      'Node.js $NodeMajorMin or newer is required',
+      'Git is required',
+      'Nothing was installed',
+    ]) {
+      expect(text, phrase).toContain(phrase);
+    }
+  });
+
+  it('uses the same exit codes for the same conditions', () => {
+    const text = body();
+    // 1 prerequisite or usage, 2 fetch, 4 occupied destination.
+    expect(text).toMatch(/Stop-Install "Node\.js \$NodeMajorMin or newer is required[\s\S]*?" 1/);
+    expect(text).toMatch(/could not fetch \$Version[\s\S]*?" 2/);
+    expect(text).toMatch(/refusing to overwrite it[\s\S]*?" 4/);
+  });
+
+  it('installs a pinned tag and never resolves a branch', () => {
+    const text = body();
+    expect(text).toContain('git ls-remote --tags --refs');
+    expect(text).toMatch(/refs\/tags\/\(v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\)\$/);
+    expect(text).toContain('--branch $Version');
+  });
+
+  it('writes a shim that runs node against the bundle, and nothing compiled', () => {
+    const text = body();
+    expect(text).toContain('dist\\commitlore.mjs');
+    expect(text).toContain(':: commitlore:wrapper:v1');
+    for (const forbidden of ['SHA256SUMS', '.tar.gz', 'releases/download', '.exe"', 'postject']) {
+      expect(text, `${forbidden} must not appear`).not.toContain(forbidden);
+    }
+  });
+
+  it('writes the shim with CRLF, which cmd.exe requires', () => {
+    // Not a preference: a batch file with LF endings is mis-parsed in ways that
+    // depend on the line, and a `set` can swallow the one after it.
+    expect(body()).toContain('-join "`r`n"');
+  });
+
+  it('installs user-local, with no elevation and no machine-wide write', () => {
+    const text = body();
+    expect(text).toContain('$env:LOCALAPPDATA');
+    // Comment lines are excluded: the header says what this script does *not* do,
+    // and forbidding the words there would forbid saying so.
+    const code = text
+      .split('\n')
+      .filter((line) => !/^\s*(#|<#|\s*\w*\s*-)/.test(line) && !line.trimStart().startsWith('#'))
+      .join('\n');
+    for (const forbidden of ['Program Files', 'RunAs', 'requireAdministrator', "'Machine'"]) {
+      expect(code, `${forbidden} must not appear in code`).not.toContain(forbidden);
+    }
+  });
+
+  it('prints the PATH instruction instead of writing PATH', () => {
+    const text = body();
+    expect(text).toContain('is not on PATH');
+    // The printed instruction names the User scope, which is what a reader would
+    // run. What must not happen is this script running it.
+    const writes = text
+      .split('\n')
+      .filter((line) => line.includes('SetEnvironmentVariable'))
+      .filter((line) => !line.trimStart().startsWith('Write-Log'));
+    expect(writes).toEqual([]);
+  });
+
+  it('lets verification report without deciding the exit code', () => {
+    const text = body();
+    expect(text).toContain('installed, but unverified');
+    // The retry, then exit 0 regardless.
+    expect(text).toContain('Start-Sleep -Seconds 1');
+    const lastExit = text.lastIndexOf('exit 0');
+    expect(lastExit).toBeGreaterThan(text.indexOf('installed, but unverified'));
+  });
+
+  it('is re-runnable: an existing checkout and an existing shim are both upgrades', () => {
+    const text = body();
+    expect(text).toContain('reusing the existing checkout at');
+    expect(text).toContain('upgrading the existing commitlore shim at');
+    expect(text).toContain('already mentions commitlore -- left unchanged');
+  });
+
+  it('writes the shim beside the target and moves it into place', () => {
+    const text = body();
+    expect(text).toContain('$destTmp');
+    expect(text).toMatch(/Move-Item -LiteralPath \$destTmp/);
+  });
+
+  it('runs on Windows PowerShell 5.1: no 7-only syntax', () => {
+    const text = body();
+    // The ternary and null-coalescing operators are PowerShell 7+. A 5.1 host
+    // fails to parse the whole file, so one use makes the script unusable on the
+    // version most Windows machines have by default.
+    expect(text).not.toMatch(/\?\?/);
+    expect(text).not.toMatch(/\s\?\s[^\s]+\s:\s/);
+  });
+
+  it('does not claim Windows is supported', () => {
+    // That claim has a precondition owned by T-1124: #71's install-root
+    // containment has to hold on Windows first.
+    const text = body().toLowerCase();
+    expect(text).not.toContain('windows is supported');
+    expect(text).not.toContain('windows support is complete');
+  });
+
+  it('is exercised by a windows-latest CI job that runs it', () => {
+    const ci = readFileSync(join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
+    expect(ci).toContain('windows-latest');
+    expect(ci).toContain('install.ps1');
+  });
+});

--- a/test/install-ps1.test.ts
+++ b/test/install-ps1.test.ts
@@ -174,4 +174,16 @@ describe('T-1121 install.ps1 exists and matches install.sh clause for clause', (
     // match is also the correct one -- it is what typing `node` would run.
     expect(body()).toMatch(/Get-Command node[^\n]*\| Select-Object -First 1/);
   });
+  it('judges the clone by its exit code, not by whether git printed to stderr', () => {
+    // Windows PowerShell 5.1 promotes a native command's stderr to a terminating
+    // error under `$ErrorActionPreference = 'Stop'`. A first draft merged git's
+    // stderr with `2>&1`, so git's harmless "--depth is ignored in local clones"
+    // warning aborted a clone that had succeeded. Only the exit code distinguishes
+    // a warning from a failure.
+    const text = body();
+    expect(text).toContain('2> $cloneLogPath');
+    expect(text).toContain('$cloneCode = $LASTEXITCODE');
+    expect(text).toContain('if ($cloneCode -ne 0)');
+    expect(text).not.toMatch(/git clone[^\n]*2>&1/);
+  });
 });

--- a/test/install-ps1.test.ts
+++ b/test/install-ps1.test.ts
@@ -167,4 +167,11 @@ describe('T-1121 install.ps1 exists and matches install.sh clause for clause', (
     expect(ci).toContain('windows-latest');
     expect(ci).toContain('install.ps1');
   });
+  it('takes the first node on PATH, not every match', () => {
+    // Found by the Windows runner, not by reading: `Get-Command` returns every
+    // match, a hosted runner carries two `node.exe`, and the array turned the
+    // version check into an invocation of two paths joined by a space. The first
+    // match is also the correct one -- it is what typing `node` would run.
+    expect(body()).toMatch(/Get-Command node[^\n]*\| Select-Object -First 1/);
+  });
 });


### PR DESCRIPTION
Closes #282. T-1121.

The shell script defines the contract; this implements the same one. Node 22+ and Git checked with named messages **before anything is written**, a pinned tag checked out into `LOCALAPPDATA`, and a `.cmd` shim running `node <checkout>\dist\commitlore.mjs`. Exit codes identical: **1** prerequisite/usage, **2** fetch failed, **4** destination occupied.

## Three decisions inherited, not re-argued

Active records on `install.sh` already settled them:

| decision | why it carries over |
|---|---|
| never edit the user's environment | a user-scope `PATH` write is the same act as rewriting `.bashrc`; the command is **printed**, not run |
| verification never decides the exit code | an install that succeeded must not be failed by a check that could not run |
| write beside the target, then move | an in-place overwrite of a file that may be executing forced a same-day patch release |

The guard did not surface these — its 22% recall missed them. The records themselves did, read directly with `commitlore ruled-out install.sh`.

## Windows-specific choices with no shell counterpart

- a **`.cmd`** shim: an extensionless file is not executable on Windows, and `cmd.exe`/PowerShell both find a `.cmd` on PATH
- **CRLF written explicitly**: a batch file with LF endings is mis-parsed in ways that depend on the line
- Codex's TOML path **doubled**: a backslash is TOML's escape character

## The CI job is the evidence

`windows-latest`, under **both Windows PowerShell 5.1 and PowerShell 7** — 5.1 because that is what a Windows machine has before anyone installs anything, and a 7-only construct is a parse error for the *whole file*.

It installs from a local tag, checks the shim's marker and CRLF, matches the reported version against `package.json`, re-runs to prove the upgrade path, provokes **exit 4** on an occupied destination and **exit 2** on an unknown tag, then uses the installed tool in a real repository: `init`, `doctor`, an **invalid record rejected by the hook** and a valid one accepted.

## What I could not verify

**Nothing on this machine can execute this file** — there is no PowerShell here. Every claim about its behaviour comes from this PR's Windows runner. RED was captured with the file absent (all 15 assertions failing on ENOENT); the file is ASCII-only by byte scan; the full suite is **75 files, 1841 passed, 1 skipped**.

Windows is **not** claimed as supported. That claim has a precondition owned by T-1124.