### PR TITLE
One compatibility statement, and a test that compares it to the files it describes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -37,6 +37,7 @@
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
 ```
 
+どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
 
 ## 実際に動かす
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -37,6 +37,7 @@
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
 ```
 
+어떤 host를 지원하는지, 각 설치 경로가 무엇을 요구하는지: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
 
 ## 실제로 보기
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Prerequisites for either path: Node.js 22+ and Git. The script checks both befor
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
 ```
 
+Which hosts are supported, and what each install path requires: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
 
 ## See it work
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,6 +37,7 @@
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
 ```
 
+支持哪些 host，以及各条安装路径需要什么：[docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
 
 ## 看它实际运行
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,80 @@
+# Compatibility
+
+The authoritative statement of which hosts CommitLore supports and what each
+install path requires. Where a README and this document disagree, this document
+is correct — and `test/compatibility-matrix.test.ts` compares every table below
+to the files that provide what it claims, so a row that drifts fails rather than
+misleads.
+
+There is no compiled artifact anywhere in the product ([ADR-0026](adr/ADR-0026-node-only-distribution.md)),
+and neither install script contains a platform, architecture or libc check —
+there is no platform-specific artifact to choose between.
+
+## Install paths
+
+| Path | Command | Who it is for |
+|---|---|---|
+| Plugin | `/plugin marketplace add MongLong0214/commitlore`, then `/plugin install commitlore@commitlore` | Claude Code users on macOS, Linux and Windows |
+| Shell script | `install.sh` | everyone else on macOS and Linux |
+| PowerShell script | `install.ps1` | Windows — see the host table below |
+
+## Hosts
+
+| Host | Status | Established by |
+|---|---|---|
+| macOS | supported | the conformance suite runs on `macos-latest` (`git-matrix` in CI). The install path itself is exercised on Linux only, so this row rests on the suite rather than on an executed macOS install |
+| Linux, glibc | supported | the `install-script` job in CI: `install.sh` in `debian:stable-slim` with no prerequisites present, then in `node:22-bookworm-slim` with them |
+| Linux, musl (Alpine 3.21) | supported | `install.sh` executed in `alpine:3.21` on `aarch64` and on `x86_64`, against a clone at a pinned tag. Supersedes the `unsupported` claim in [#99](https://github.com/MongLong0214/commitlore/issues/99), whose reason was that only glibc-linked binaries were published — there are no binaries now |
+| Linux, musl (other distributions) | undecided | the reason #99 gave no longer describes anything, and no other musl distribution has been run. Neither a promise nor a warning would be honest |
+| Windows | unsupported | [#71](https://github.com/MongLong0214/commitlore/issues/71)'s install-root containment has not been established there and the `commit-msg` hook does not return: [#95](https://github.com/MongLong0214/commitlore/issues/95), [#321](https://github.com/MongLong0214/commitlore/issues/321), T-1124 ([#283](https://github.com/MongLong0214/commitlore/issues/283)). `install.ps1` makes Windows reachable, which is a different claim |
+
+### The three words
+
+- **supported** — an install path reaches the host and the result was executed there.
+- **unsupported** — a property the product depends on is known to be missing or broken there.
+- **undecided** — the host has **not been measured**. Nobody has run it, so there is neither a
+  result to promise nor a defect to warn about. It is not a gentler `unsupported`.
+
+Reachability is not support. A script that runs on a host says nothing about
+whether the properties the product depends on hold there, and the two are kept
+apart on purpose.
+
+## Prerequisites
+
+Two columns, because **required** and **checked** are not the same claim. Only
+the two install scripts check anything. The plugin path *enforces nothing*: its
+pre-edit hook runs `scripts/commitlore-run.sh`, which resolves a CLI — the
+installed `commitlore` wrapper if one is on `PATH`, otherwise
+`node ${CLAUDE_PLUGIN_ROOT}/dist/commitlore.mjs` — and a machine that has neither
+gets a hook that fails open at exit 0 with no context injected, rather than a
+message naming what is missing. The MCP server runs the bundle directly.
+
+| Prerequisite | Required by | Checked by `install.sh` | Checked by `install.ps1` |
+|---|---|---|---|
+| Node.js ≥ 22 | plugin path, `install.sh`, `install.ps1` | yes | yes |
+| Git | plugin path, `install.sh`, `install.ps1` | yes | yes |
+| A POSIX shell (`bash`) | plugin path only | — | — |
+
+The Node floor is the one the package declares ([ADR-0010](adr/ADR-0010-node-floor.md)),
+and the table states the same number both scripts hold.
+
+The shell row is the prerequisite that is easiest to miss: `commitlore-run.sh`
+carries a `#!/bin/bash` shebang, so the plugin's pre-edit hook needs a shell that
+neither install script installs and neither one checks for. On a host without
+one the MCP server still works and the hook does not.
+
+## Plugin capabilities
+
+Each row is a claim about a committed manifest, and the assertion reads the file
+named in the middle column rather than one it assumed.
+
+| Capability | Provided by | Value |
+|---|---|---|
+| MCP server | `.mcp.json` | `node ${CLAUDE_PLUGIN_ROOT}/dist/commitlore.mjs mcp` |
+| pre-edit context hook | `hooks/hooks.json` | `PreToolUse` on `Edit\|Write\|MultiEdit\|NotebookEdit` |
+| skills | `skills/` | `commitlore-commits`, `commitlore-query`, `commitlore-setup` |
+| plugin identity | `.claude-plugin/plugin.json` | `commitlore` at the `package.json` version |
+| marketplace | `.claude-plugin/marketplace.json` | `commitlore`, `source: "./"` |
+
+The documented install command is `<plugin>@<marketplace>`, so it is derived from
+the last two rows rather than asserted on its own.

--- a/test/compatibility-matrix.test.ts
+++ b/test/compatibility-matrix.test.ts
@@ -1,0 +1,367 @@
+/**
+ * T-1122 (#271): `docs/COMPATIBILITY.md` is the one place that says which hosts
+ * CommitLore supports and what each install path checks before it writes. A
+ * statement like that goes stale silently -- the code moves, the table does not,
+ * and nothing fails -- so the document is only worth having if something checks
+ * it.
+ *
+ * Every table is compared to the files that provide what it claims, and the
+ * comparisons are written to fail on the two kinds of drift that are easy to
+ * miss:
+ *
+ * - **Deletion.** A "the table is non-empty" guard is satisfied by one surviving
+ *   row, so the whole host statement can evaporate and still pass. Each table's
+ *   row keys are asserted as an exact set instead.
+ * - **Superstring.** `toContain` on a short value passes on a narrowing: `./` is
+ *   inside `../`, and `Edit|Write` is inside `Edit|Write|MultiEdit|NotebookEdit`
+ *   -- so a matcher that silently stopped firing on two tools would pass. Cells
+ *   are compared as the rendered form, or reconstructed and compared whole.
+ *
+ * Separate from `test/manifest.test.ts`, which asserts the manifests are
+ * internally coherent in a clean clone. This file asserts a *document* against
+ * them, and the two fail for different reasons: a broken manifest fails there, a
+ * document that drifted from a working manifest fails here.
+ *
+ * Separate from `test/readme.test.ts`, which owns the READMEs' own claims. The
+ * only overlap is the pointer line each README carries to this document, and
+ * that is asserted below so the pointer and its target fail together.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const DOC_PATH = join(REPO_ROOT, 'docs/COMPATIBILITY.md');
+
+const README_FILES = ['README.md', 'README.ko.md', 'README.ja.md', 'README.zh-CN.md'] as const;
+
+/** The whole vocabulary. A fifth word is a claim nobody defined. */
+const STATUS_WORDS = ['supported', 'unsupported', 'undecided'] as const;
+type Status = (typeof STATUS_WORDS)[number];
+
+const readFile = (path: string): string => readFileSync(path, 'utf8');
+const readJson = (path: string): unknown => JSON.parse(readFile(path));
+const unticked = (cell: string): string => cell.replace(/`/g, '');
+
+interface McpManifest {
+  mcpServers?: Record<string, { command?: unknown; args?: unknown }>;
+}
+interface HooksManifest {
+  hooks?: { PreToolUse?: { matcher?: unknown; hooks?: { command?: unknown }[] }[] };
+}
+interface PluginManifest {
+  name?: unknown;
+  version?: unknown;
+}
+interface MarketplaceManifest {
+  name?: unknown;
+  plugins?: { name?: unknown; source?: unknown }[];
+}
+
+/**
+ * A GitHub-flavoured table under a given heading, as rows of trimmed cells.
+ *
+ * An escaped `\|` is parked on a sentinel before the split and restored after: a
+ * matcher like `Edit|Write|MultiEdit` has to be escaped to survive a markdown
+ * table at all, and splitting first would cut the row on the matcher's own
+ * pipes. The sentinel is printable on purpose -- a `\0` here made git classify
+ * this file as binary, which cost it its own diff in the pull request that
+ * introduced it.
+ */
+const ESCAPED_PIPE = '@@COMMITLORE_ESCAPED_PIPE@@';
+
+const tableUnder = (doc: string, heading: string): string[][] => {
+  const lines = doc.split('\n');
+  const start = lines.findIndex((l) => l.trim() === heading);
+  if (start === -1) return [];
+  const rows: string[][] = [];
+  let sawSeparator = false;
+  for (const line of lines.slice(start + 1)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('##')) break;
+    if (!trimmed.startsWith('|')) continue;
+    const cells = trimmed
+      .replaceAll('\\|', ESCAPED_PIPE)
+      .replace(/^\|/, '')
+      .replace(/\|$/, '')
+      .split('|');
+    // The separator is found rather than assumed to be the second line: an
+    // unconditional `slice(1)` drops a real data row whenever a table's
+    // alignment row is malformed, and drops it silently.
+    if (cells.every((c) => /^\s*:?-+:?\s*$/.test(c))) {
+      sawSeparator = true;
+      rows.length = 0;
+      continue;
+    }
+    if (!sawSeparator) continue;
+    rows.push(cells.map((c) => c.trim().replaceAll(ESCAPED_PIPE, '|')));
+  }
+  return rows;
+};
+
+const doc = existsSync(DOC_PATH) ? readFile(DOC_PATH) : '';
+const keysOf = (rows: string[][]): string[] => rows.map((r) => unticked(r[0]));
+
+describe('T-1122 the compatibility statement exists and is the authoritative one', () => {
+  it('docs/COMPATIBILITY.md is committed', () => {
+    expect(existsSync(DOC_PATH), 'docs/COMPATIBILITY.md must exist').toBe(true);
+  });
+
+  it.each(README_FILES)('%s points at it exactly once', (file) => {
+    const hits = readFile(join(REPO_ROOT, file)).split('docs/COMPATIBILITY.md').length - 1;
+    expect(hits, `${file} must carry exactly one pointer`).toBe(2);
+  });
+});
+
+describe('T-1122 the install paths table names paths that exist', () => {
+  const rows = (): string[][] => tableUnder(doc, '## Install paths');
+
+  it('names exactly the three paths, in the order a reader should try them', () => {
+    expect(keysOf(rows())).toEqual(['Plugin', 'Shell script', 'PowerShell script']);
+  });
+
+  it('every script it names is committed', () => {
+    for (const [path, command] of rows()) {
+      for (const script of unticked(command).match(/install\.(sh|ps1)/g) ?? []) {
+        expect(existsSync(join(REPO_ROOT, script)), `${path}: ${script} is missing`).toBe(true);
+      }
+    }
+  });
+
+  it('the plugin row derives its commands from the two manifests', () => {
+    const row = rows().find(([p]) => /plugin/i.test(p));
+    const market = readJson(join(REPO_ROOT, '.claude-plugin/marketplace.json')) as MarketplaceManifest;
+    const entry = market.plugins?.[0];
+    expect(unticked(row![1])).toContain(`/plugin install ${String(entry?.name)}@${String(market.name)}`);
+  });
+
+  it('no table outside ## Hosts carries a host status word', () => {
+    // The forbidden claim is "Windows is supported", not "Windows is supported
+    // in one particular table". Checking only ## Hosts left the document able to
+    // make it anywhere else.
+    for (const heading of ['## Install paths', '## Prerequisites', '## Plugin capabilities']) {
+      for (const row of tableUnder(doc, heading)) {
+        for (const cell of row) {
+          expect(
+            /\b(un)?supported\b/i.test(cell),
+            `${heading} states a support status in "${cell}"; only ## Hosts may`,
+          ).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+describe('T-1122 every documented plugin capability is backed by its manifest (req 2)', () => {
+  const rows = (): string[][] => tableUnder(doc, '## Plugin capabilities');
+  /** The cell, not a hardcoded path: a drifted "Provided by" must read the wrong file. */
+  const providedBy = (capability: RegExp): { path: string; value: string } => {
+    const row = rows().find(([c]) => capability.test(c));
+    expect(row, `no row matching ${capability}`).toBeDefined();
+    return { path: join(REPO_ROOT, unticked(row![1]).replace(/\/$/, '')), value: row![2] };
+  };
+
+  it('names exactly the capabilities the ticket enumerates', () => {
+    expect(keysOf(rows())).toEqual([
+      'MCP server',
+      'pre-edit context hook',
+      'skills',
+      'plugin identity',
+      'marketplace',
+    ]);
+  });
+
+  it('every row names a file that exists', () => {
+    for (const [capability, provider] of rows()) {
+      const path = unticked(provider).replace(/\/$/, '');
+      expect(existsSync(join(REPO_ROOT, path)), `${capability}: ${path} does not exist`).toBe(true);
+    }
+  });
+
+  it('the MCP server row matches .mcp.json', () => {
+    const { path, value } = providedBy(/mcp/i);
+    const server = (readJson(path) as McpManifest).mcpServers?.commitlore;
+    expect(unticked(value)).toBe([server?.command, ...((server?.args as string[]) ?? [])].join(' '));
+  });
+
+  it('the pre-edit hook row matches hooks/hooks.json exactly, not as a prefix', () => {
+    const { path, value } = providedBy(/hook/i);
+    const entry = (readJson(path) as HooksManifest).hooks?.PreToolUse?.[0];
+    // Rendered form: `Edit|Write` is a substring of the real matcher, so a
+    // narrowed manifest passed a bare toContain while the hook quietly stopped
+    // firing on MultiEdit and NotebookEdit.
+    expect(value).toBe(`\`PreToolUse\` on \`${String(entry?.matcher)}\``);
+  });
+
+  it('the skills row names exactly the committed skills', () => {
+    const { path, value } = providedBy(/skill/i);
+    const onDisk = readdirSync(path, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+    expect(value.split(',').map((s) => unticked(s).trim()).sort()).toEqual(onDisk);
+  });
+
+  it('the plugin identity row matches plugin.json at the package version', () => {
+    const { path, value } = providedBy(/identity/i);
+    const plugin = readJson(path) as PluginManifest;
+    const pkg = readJson(join(REPO_ROOT, 'package.json')) as { version?: unknown };
+    expect(plugin.version, 'plugin.json must carry the package version').toBe(pkg.version);
+    expect(value).toContain(`\`${String(plugin.name)}\``);
+  });
+
+  it('the marketplace row matches marketplace.json', () => {
+    const { path, value } = providedBy(/marketplace/i);
+    const market = readJson(path) as MarketplaceManifest;
+    const entry = market.plugins?.[0];
+    expect(value).toContain(`\`${String(entry?.name)}\``);
+    // The rendered form: `./` is a substring of `../`.
+    expect(value).toContain(`source: "${String(entry?.source)}"`);
+  });
+});
+
+describe('T-1122 the documented prerequisites are the ones the installers check (req 3)', () => {
+  const rows = (): string[][] => tableUnder(doc, '## Prerequisites');
+  const sh = (): string => readFile(join(REPO_ROOT, 'install.sh'));
+  const ps1 = (): string => readFile(join(REPO_ROOT, 'install.ps1'));
+
+  /**
+   * A row this map does not recognise is a failure rather than a skip. An
+   * earlier version returned `continue`, which let an injected
+   * `Ruby | ... | yes | yes` row pass -- the document could claim an installer
+   * checked anything at all. An assertion that silently skips what it cannot
+   * verify is not an assertion.
+   */
+  const PROBES: Record<string, { sh: RegExp; ps1: RegExp }> = {
+    node: { sh: /command -v node/, ps1: /Get-Command node/ },
+    git: { sh: /git --version/, ps1: /git\b[^\n]*--version/ },
+    shell: { sh: /.^/, ps1: /.^/ },
+  };
+
+  it('names exactly the prerequisites, with none dropped', () => {
+    expect(keysOf(rows()).map((k) => k.replace(/\s*\(.*\)$/, ''))).toEqual([
+      'Node.js ≥ 22',
+      'Git',
+      'A POSIX shell',
+    ]);
+  });
+
+  it('the Node floor in the table is the floor both installers enforce', () => {
+    const floor = sh().match(/NODE_MAJOR_MIN=(\d+)/)?.[1];
+    expect(floor, 'install.sh must declare NODE_MAJOR_MIN').toBeDefined();
+    expect(ps1(), 'install.ps1 must declare the same floor').toContain(`$NodeMajorMin = ${floor}`);
+    const row = rows().find(([n]) => /node/i.test(n));
+    expect(row![0], 'the table states a floor the installers do not enforce').toContain(floor!);
+  });
+
+  it('each yes is checked and each dash is not', () => {
+    for (const [name, , checkedBySh, checkedByPs1] of rows()) {
+      const key = Object.keys(PROBES).find((k) => new RegExp(k, 'i').test(name));
+      expect(
+        key,
+        `the document lists "${name}" as a prerequisite and this test has no probe for it, so the claim is unverifiable`,
+      ).toBeDefined();
+      // Both directions: a stale `no` is as wrong as a missing check, and only
+      // asserting `yes` caught under-delivery while ignoring over-caution.
+      expect(PROBES[key!].sh.test(sh()), `install.sh vs "${name}"`).toBe(/yes/i.test(checkedBySh));
+      expect(PROBES[key!].ps1.test(ps1()), `install.ps1 vs "${name}"`).toBe(
+        /yes/i.test(checkedByPs1),
+      );
+    }
+  });
+
+  it('the document says the plugin path checks nothing', () => {
+    expect(doc).toMatch(/plugin path/i);
+    expect(doc, 'required and checked must be kept apart').toMatch(
+      /enforces nothing|checks nothing|does not check/i,
+    );
+  });
+});
+
+describe('T-1122 the host table uses one vocabulary and claims nothing unreached', () => {
+  const rows = (): string[][] => tableUnder(doc, '## Hosts');
+  const definitions = (): string => {
+    const from = doc.indexOf('### The three words');
+    const to = doc.indexOf('\n## ', from === -1 ? 0 : from);
+    return from === -1 ? '' : doc.slice(from, to === -1 ? undefined : to);
+  };
+
+  it('no host row is missing', () => {
+    expect(keysOf(rows())).toEqual([
+      'macOS',
+      'Linux, glibc',
+      'Linux, musl (Alpine 3.21)',
+      'Linux, musl (other distributions)',
+      'Windows',
+    ]);
+  });
+
+  it('every status is one of the three words', () => {
+    for (const [host, status] of rows()) {
+      expect(STATUS_WORDS, `${host} has status "${status}"`).toContain(status as Status);
+    }
+  });
+
+  it('all three words are defined, in their own block, and unsupported is not undecided', () => {
+    const block = definitions();
+    expect(block.length, 'the document must define the vocabulary in its own section').toBeGreaterThan(0);
+    for (const word of STATUS_WORDS) {
+      expect(block, `${word} is used but never defined`).toContain(`**${word}**`);
+    }
+    const meaning = (word: Status): string =>
+      block.slice(block.indexOf(`**${word}**`)).split('\n- ')[0];
+    expect(
+      meaning('undecided'),
+      'undecided must mean unmeasured rather than being a gentler unsupported',
+    ).toMatch(/not been measured|unmeasured|nobody has run/i);
+    expect(meaning('unsupported')).not.toBe(meaning('undecided'));
+  });
+
+  it('every host row cites what established its status', () => {
+    for (const [host, , establishedBy] of rows()) {
+      expect((establishedBy ?? '').length, `${host} cites no evidence`).toBeGreaterThan(0);
+    }
+  });
+
+  it('a row is undecided only when its own evidence says nothing was run', () => {
+    // A silent downgrade is not a false claim, so nothing above catches it --
+    // but the document defines `undecided` as unmeasured, and a row citing an
+    // execution contradicts its own status word. That is checkable.
+    for (const [host, status, establishedBy] of rows()) {
+      if (status !== 'undecided') continue;
+      expect(
+        /executed|runs on|the `[\w-]+` job/i.test(establishedBy),
+        `${host} is undecided but cites an execution: "${establishedBy}"`,
+      ).toBe(false);
+    }
+  });
+
+  it('Windows is not marked supported', () => {
+    // T-1124 (#283) owns that claim, and its baseline does not pass. Reachability
+    // through install.ps1 is not the same statement.
+    const row = rows().find(([h]) => /windows/i.test(h));
+    expect(row, 'no Windows row').toBeDefined();
+    expect(row![1], 'T-1124 owns the Windows support claim').not.toBe('supported');
+    expect(row![2], 'the Windows row must cite #95 and T-1124').toMatch(/#95/);
+    expect(row![2]).toMatch(/T-1124|#283/);
+  });
+
+  it('no supported row names a host no install path reaches', () => {
+    // Derived from the install-path table rather than matched against a keyword
+    // allowlist. A list of accepted words is not a reachability check: it let
+    // `FreeBSD | supported | it feels right` through.
+    const reached = tableUnder(doc, '## Install paths')
+      .map(([, , who]) => who.toLowerCase())
+      .join(' ');
+    for (const [host, status] of rows()) {
+      if (status !== 'supported') continue;
+      const platform = unticked(host).split(/[,(]/)[0].trim().toLowerCase();
+      expect(
+        reached.includes(platform),
+        `${host} is marked supported but no install path in the table above names ${platform}`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #271 (T-1122). Adds `docs/COMPATIBILITY.md`, the test that keeps it honest, and one pointer line in each README.

Supersedes draft #277, which cannot be rebased into correctness: its Windows row cites `ADR-0023`, a document the ADR-0026 scope change removed, and its columns (`msvc`, `x86_64-pc-windows-msvc`) are compiled-binary target concepts that no longer exist in the product. The ticket's contract also asks that row to cite #95 **and T-1124**, which postdates that draft.

## The first version of this passed its own injections and was not worth trusting

Seven injected disagreements failed correctly, so it looked done. A review ran **fourteen** more and **all fourteen passed**. That is the substance of this PR, so the failures are listed rather than summarised:

| What was wrong | What it let through |
|---|---|
| "Table is non-empty" is satisfied by one row | three of five host rows deleted — the support statement evaporates |
| Every assertion hardcoded its own path, never reading the "Provided by" cell | the MCP row could name `package.json` as its source |
| `toContain` on the hook matcher | `hooks.json` narrowed to `Edit\|Write` — the hook stops firing on `MultiEdit`/`NotebookEdit` and nothing fails, because the narrowed value is a substring of the documented one |
| Only `## Hosts` was checked for the forbidden claim | `## Install paths` could say "Windows — fully supported" |
| Reachability was a keyword allowlist | `FreeBSD \| supported \| it feels right` |
| `undecided` proven distinct by free text anywhere in the document | the definition block deleted entirely |
| The checked columns asserted `yes` only | a stale `—` against an installer that does check |
| Nothing detected a silent status downgrade | `macOS` quietly moved to `undecided` while still citing an execution |

All fourteen now fail, and the unmutated document passes at **27 tests**.

The test file was also committed as **binary** — the pipe-escaping sentinel was `\0`, so git recorded `Bin 0 -> 12075 bytes` and the file that is this ticket's completion evidence had no diff in its own pull request. The sentinel is printable now and the commit was amended rather than fixed forward, so no binary blob reaches `dev`.

## Two things the document claimed that were false

- **The pre-edit hook does not run `node dist/commitlore.mjs`.** It runs `scripts/commitlore-run.sh`, which prefers an installed `commitlore` on `PATH`. That script is `#!/bin/bash`, so **the plugin path needs a POSIX shell** — a third prerequisite that neither installer checks. It is in the table now, and it bears directly on Windows.
- **macOS was justified partly by "install.sh has no platform gate to fail"** — the same absence-of-evidence argument this change explicitly rules out for musl. `install.sh` runs on macOS in no CI job (`install-script` is `runs-on: ubuntu-latest`), so the row now says what was actually measured: the conformance suite on `macos-latest`, and the install path on Linux only.

## musl was executed, not inherited

The README says Alpine and other musl hosts are unsupported because only glibc binaries are published. There are no binaries — ADR-0026 removed them — and neither installer has a platform, architecture or libc check. Absence of a gate is not evidence of working, so it was run:

```
alpine:3.21, /lib/ld-musl-aarch64.so.1, aarch64, node v22.23.2, git 2.47.3
  checked out v9.9.9 into /root/.local/share/commitlore/v9.9.9
  installed to /root/.local/bin/commitlore
  --version -> 0.4.1 ; validate refuses an invalid record

alpine:3.21, /lib/ld-musl-x86_64.so.1, x86_64, node v22.23.2
  installs and runs, --version -> 0.4.1
```

Bare Alpine with no Node was checked first: it names the missing prerequisite and installs nothing.

That covers **Alpine 3.21**, not musl as a class. So the class is `undecided` — the third status word's first real use, rather than a promise the evidence does not carry.

## Windows

`unsupported`, citing #95, **#321** and T-1124 (#283). `install.ps1` makes Windows reachable, which is a different claim. #321 carries the executed evidence: the containment comparison cannot match there, and the `commit-msg` hook does not return.

## Scope

Four READMEs get **one pointer line each and nothing else** (`@@ -39,0 +40 @@` in all four, pure insertion). Clear of the plugin-first block, the one-liner, the pinned-asset block, `BENCH:BEGIN`/`BENCH:END` and the Known-limitations slice. The pointer names no installer behaviour — the ownership map reserves that for T-1120, which already states it eight lines above.

## Reported, not fixed here

`README*` line 299 still says Alpine and other musl hosts are unsupported, which this PR's executed evidence contradicts in four languages. The ownership map assigns that bullet to T-1125 (#284), which merged without removing it. This ticket may add a pointer line and nothing else, so it is left alone and reported. **This should be sequenced before or with this merge**, rather than shipping a README that contradicts the document it points at.

## Verification

- RED: **17 failed / 5 passed** with the document absent; **27 passed** with it
- All **14** review mutations fail; unmutated control passes
- Focused: `compatibility-matrix`, `readme`, `readme-order`, `readme-numbers`, `install-script`, `manifest` — **106 passed**
- `node scripts/check-readme-numbers.mjs` — exit 0
- `npm run typecheck`, `npm run build` — clean, `dist/` unchanged
- Full suite — **76 files, 1870 passed, 1 skipped**
