### PR TITLE
Stop calling musl unsupported, because the reason for it was removed

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -295,7 +295,6 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 ## 既知の制限事項
 
 - Windows は未対応です: [#95](https://github.com/MongLong0214/commitlore/issues/95)。
-- Alpine および他の musl Linux host は未対応です: [#99](https://github.com/MongLong0214/commitlore/issues/99)。
 - cryptographic author verification、repository-wide record coverage、symbol anchor、interactive record builder は未実装です: [#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
 - M4 は guard の効果を検証していません。row に `guard_exposure` がないため treatment exposure を検証できません: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
 - Guard（ruled-out alternative matching）は実験的参考情報です: precision 44.8%（95% Wilson CI 32.7%–57.5%）、recall 22.0%、417-decision corpus 基準（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空の guard 結果は、提案がすべての ruled-out alternative を回避したという保証ではありません — recall 22% では、見逃しが一般的です。

--- a/README.ko.md
+++ b/README.ko.md
@@ -295,7 +295,6 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 ## 알려진 제한 사항
 
 - Windows는 지원하지 않는다: [#95](https://github.com/MongLong0214/commitlore/issues/95).
-- Alpine 및 다른 musl Linux host는 지원하지 않는다: [#99](https://github.com/MongLong0214/commitlore/issues/99).
 - 암호학적 작성자 검증, 저장소 전체 record coverage, symbol anchor, interactive record builder는 아직 구현되지 않았다: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
 - M4는 guard 효과를 시험하지 못했다. row에 `guard_exposure`가 없어 treatment exposure를 검증할 수 없다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
 - Guard(ruled-out alternative matching)는 실험적 참고 자료이다: precision 44.8%(95% Wilson CI 32.7%–57.5%), recall 22.0%, 417-decision corpus 기준([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). 빈 guard 결과는 제안이 모든 ruled-out alternative를 피했다는 보장이 아니다 — recall 22%에서 누락이 일반적이다.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,6 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 ## Known limitations
 
 - Windows is unsupported: [#95](https://github.com/MongLong0214/commitlore/issues/95).
-- Alpine and other musl Linux hosts are unsupported: [#99](https://github.com/MongLong0214/commitlore/issues/99).
 - Cryptographic author verification, repository-wide record coverage, symbol anchors, and an interactive record builder are not implemented yet: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
 - M4 did not test a guard effect: its rows have no `guard_exposure`, so treatment exposure is unverifiable ([#122](https://github.com/MongLong0214/commitlore/issues/122)).
 - Guard (ruled-out alternative matching) is an experimental advisory: precision 44.8% (95% Wilson CI 32.7%–57.5%), recall 22.0% on the 417-decision corpus ([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). An empty guard result does not guarantee a proposal avoids all ruled-out alternatives — at 22% recall, a miss is the common case.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -295,7 +295,6 @@ node ~/.commitlore/dist/commitlore.mjs context src/auth
 ## 已知限制
 
 - 不支持 Windows：[#95](https://github.com/MongLong0214/commitlore/issues/95)。
-- 不支持 Alpine 与其他 musl Linux host：[#99](https://github.com/MongLong0214/commitlore/issues/99)。
 - 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
 - M4 没有检验 guard 效果：row 没有 `guard_exposure`，因而无法验证 treatment exposure（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
 - Guard（ruled-out alternative matching）是实验性参考信息：precision 44.8%（95% Wilson CI 32.7%–57.5%），recall 22.0%，基于 417-decision corpus（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空的 guard 结果不保证提案避开了所有 ruled-out alternative——在 recall 22% 下，遗漏才是常态。

--- a/docs/tickets/F14-distribution.md
+++ b/docs/tickets/F14-distribution.md
@@ -33,7 +33,9 @@
 **No implementation code until this PRD and the individual ticket are both approved.**
 
 **Order.** `T-1120 → T-1121` (shared contract) → `T-1124` (Windows containment) ; `T-1122`
-and `T-1123` follow both installers ; `T-1125` (remove the compiled-binary code) is last, so
+and `T-1123` follow both installers ; `T-1126` precedes `T-1122`, because a README that calls a
+host unsupported must stop saying so before a document says otherwise ; `T-1125`
+(remove the compiled-binary code) is last, so
 there is never a window with neither install path.
 
 ## Ownership map — one owner per region
@@ -55,6 +57,7 @@ not have to reconstruct it:
 | `commitlore uninstall` | **T-1123** | — |
 | Windows containment for the wrapper path | **T-1124** | — |
 | Residual compiled-binary and release references left after T-1120 | **T-1125** | T-1120 |
+| The Known-limitations host-status bullets in all four READMEs | **T-1126** | T-1122, T-1125 |
 
 `.github/workflows/ci.yml` is the one file with more than one owner, and deliberately so: the
 four tickets own four **different jobs** in it. A filename-level scan cannot see that, so the
@@ -499,3 +502,58 @@ not a removal ticket.
 
 **Completion evidence** — the invariant test passing, the containment test green on both sides
 of the change, a release run with no platform asset, and the plugin path exercised end to end.
+
+---
+
+## T-1126 Retire the Known-limitations claims that measurement has overtaken (S) — #323 · PRD-F14 req 26
+
+**Owns** — the **host-status bullets** in the `Known limitations` section of `README.md` and the
+three translations, and nothing else in those files
+
+**Why this exists as its own ticket.** The ownership map gave the stale distribution bullets to
+T-1125, which merged without removing them, and T-1122 may add a pointer line to a README and
+nothing else. Neither ticket can now touch the bullet, so a third owner is allocated rather than
+widening either one. Reassignment, not a new claim: the row above moves these four regions off
+T-1125.
+
+**Depends on** — nothing. This ticket only **removes** a statement, so it is safe in any order,
+and it is sequenced *before* T-1122 for exactly that reason: deleting a false claim leaves an
+absence, while merging T-1122 first would leave four languages contradicting the document they
+point at.
+
+**The claim, and what overtook it** — each README carries:
+
+> `- Alpine and other musl Linux hosts are unsupported: #99.`
+
+Its reason was that only glibc-linked binaries were published. ADR-0026 removed compiled
+artifacts, and neither installer contains a platform, architecture or libc check of any kind.
+Executed on `alpine:3.21` against a clone at a pinned tag, on `aarch64` and again on `x86_64`:
+the checkout lands, the wrapper carries its marker, `--version` reports the packaged version and
+`validate` refuses an invalid record. Bare Alpine with no Node names the missing prerequisite and
+installs nothing. The bullet is false for Alpine 3.21 and its stated reason describes nothing.
+
+**Forbidden scope**
+
+- **do not replace it with a support claim.** T-1122 owns the compatibility statement; a second
+  summary in the README is the duplication the ownership map exists to prevent. This ticket
+  deletes and stops
+- do not touch the Windows bullet beside it. It remains true, `test/readme.test.ts` uses its
+  exact wording as a mutation oracle, and T-1124 owns that claim
+- do not touch the shell-install region, the pinned-asset block, or `BENCH:BEGIN`/`BENCH:END`
+- do not touch `docs/COMPATIBILITY.md` or `test/compatibility-matrix.test.ts`
+
+**RED test** — none is added. The removal is asserted by what must keep passing: the
+Known-limitations slice in `test/readme.test.ts` still finds the guard precision and recall
+figures in all four files, `test/readme-order.test.ts` still resolves its six anchors, and
+`node scripts/check-readme-numbers.mjs` exits 0. A bullet deletion that breaks any of those
+took a region it does not own.
+
+**Minimum GREEN** — the bullet is gone from all four languages in one commit, and the three
+checks above still pass.
+
+**Stop / escalate** — if any check fails, stop rather than adjusting it: this ticket owns four
+bullets, not the tests that read the section around them.
+
+**Completion evidence** — the four-file diff, the focused run of `test/readme.test.ts`,
+`test/readme-order.test.ts` and `test/readme-numbers.test.ts`, and `check-readme-numbers.mjs`
+at 0.


### PR DESCRIPTION
Closes #323. Allocates **T-1126** and executes it in the same commit.

## The claim, and what overtook it

All four READMEs say:

> `- Alpine and other musl Linux hosts are unsupported: #99.`

The reason #99 gave was that only glibc-linked binaries were published. ADR-0026 removed compiled artifacts from the product, and neither `install.sh` nor `install.ps1` contains a platform, architecture or libc check of any kind — a repository-wide search for `uname`, an arch mapping, or a musl/glibc probe finds nothing in either script.

Absence of a gate is not evidence that anything works, so it was executed:

```
alpine:3.21 · /lib/ld-musl-aarch64.so.1 · aarch64 · node v22.23.2 · git 2.47.3
  checked out into ~/.local/share/commitlore/<tag>
  wrapper installed, carrying its `# commitlore:wrapper:v1` marker
  commitlore --version -> 0.4.1 ; validate refuses an invalid record

alpine:3.21 · /lib/ld-musl-x86_64.so.1 · x86_64 · node v22.23.2
  installs and runs, --version -> 0.4.1
```

Bare Alpine with no Node names the missing prerequisite and installs nothing — the same contract the glibc images hold to.

## Deleted, not rewritten

T-1122 owns the compatibility statement. A second summary in a README is the duplication the ownership map exists to prevent, so this removes the false claim and stops. What replaces it arrives with `docs/COMPATIBILITY.md` (#322), which records Alpine 3.21 as `supported` and musl **as a class** as `undecided` — one image is not a family.

The Windows bullet beside it is untouched: it is still true, `test/readme.test.ts` uses its exact wording as a mutation oracle, and T-1124 owns that claim.

## Why a third ticket, and why before #322

The ownership map gave these regions to T-1125, which merged without removing them. T-1122 may add a pointer line to a README and nothing else. **Neither ticket can touch the bullet**, so the regions are reassigned to a new owner rather than widening either — the amendment to `docs/tickets/F14-distribution.md` is in this commit.

Sequencing is deliberate. Deleting a false statement leaves an **absence**; merging #322 first would leave four languages contradicting the file they point at, and two ordinary merges are not transactional — that window has no upper bound. This is the only ordering in which no revision of the repository asserts both.

## Verification

No RED test is added: this ticket removes a statement, and what asserts the removal is what must keep passing.

- `test/readme.test.ts`, `test/readme-order.test.ts`, `test/readme-numbers.test.ts`, `test/install-script.test.ts` — **61 passed**
- `node scripts/check-readme-numbers.mjs` — exit 0
- No `src/`, no `dist/`, no test changes; the diff is four deletions plus the ticket allocation

A check breaking here would mean a region was taken that was not allocated, which is the stop condition.
