### PR TITLE
Write the 0.5.0 notes before tagging

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@
 
 Nothing yet.
 
+## 0.5.0 — 2026-08-01
+
+Windows works, and this is the release that can say so from a run rather than
+from an argument.
+
+### Upgrade reasons
+
+- **On Windows, `git commit` in a repository with the hook installed did not
+  return.** It did not refuse and it did not succeed — it hung, and the shell it
+  spawned kept running after the commit was killed. Two defects in one chain: the
+  install root is recorded by Node as a win32 path and read by the hook under Git
+  for Windows' shell, where `pwd -P` answers in POSIX form, so the containment
+  comparison matched **nothing** — an attacker's path and the installer's own
+  bundle alike — and control fell through to a directory walk that could not
+  terminate at a drive root. Both are fixed; both sides of the comparison are now
+  resolved before they are compared, and the walk stops when stripping a
+  component stops making progress (#321).
+- **If you installed the hook before this release, installing this release does
+  not repair it.** The hook is written into `.git/hooks/commit-msg` when it is
+  installed, so an existing repository keeps the old one. Run `commitlore hooks
+  install` in each affected repository — it is not a commit, so it still works
+  where commits are blocked. `commitlore doctor` reports such a repository as
+  `outdated`.
+- **Windows is supported.** Not because a PowerShell installer exists — that
+  shipped in 0.4.1 and made Windows *reachable*, which is a different claim — but
+  because #71's install-root containment is now established there by execution:
+  in a required job on `windows-latest`, a real commit through the recorded
+  install is accepted, an invalid record refused, and both containment attacks
+  execute and refuse with the tampered program run zero times (#283).
+- **`commitlore uninstall` removes what the installers wrote, and nothing else.**
+  The wrapper, the pinned checkout, and one MCP entry per agent config. An entry
+  is matched on its shape and on the wrapper it points at, never on the key it
+  sits under — a server you named `commitlore` yourself, or the other install's
+  entry on a machine carrying two, is left alone. Per-repository state and the
+  Claude Code plugin are named rather than touched (#272).
+- **`docs/COMPATIBILITY.md` states which hosts are supported and what each
+  install path checks**, and a test compares every row to the file that provides
+  what it claims (#271). It also separates *required* from *checked*: the plugin
+  path enforces nothing, so a machine without Node gets a hook that fails open
+  rather than a message naming what is missing.
+- **Alpine and other musl Linux hosts are no longer described as unsupported.**
+  The reason was that only glibc-linked binaries were published; there are no
+  binaries. Executed in `alpine:3.21` on `aarch64` and `x86_64`: the install
+  lands and the tool runs. Alpine 3.21 is supported; musl as a class is recorded
+  as undecided, because one image is not a family (#323).
+
+### What this release does not claim
+
+Windows `supported` means the containment property was established there by
+execution. It does not mean Windows has the same mileage behind it as macOS and
+Linux, and it does not reach a repository whose hook predates this release.
+
+`commitlore uninstall` does not remove the Claude Code plugin cache — thousands
+of files it did not write, keyed by plugin version. It names the step instead.
+
 ## 0.4.1 — 2026-07-31
 
 ### Upgrade reasons

--- a/README.ja.md
+++ b/README.ja.md
@@ -34,7 +34,7 @@
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh | sh
 ```
 
 どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
@@ -115,11 +115,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
-sh install.sh v0.4.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh
+sh install.sh v0.5.0
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v0.4.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.5.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -34,7 +34,7 @@
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh | sh
 ```
 
 어떤 host를 지원하는지, 각 설치 경로가 무엇을 요구하는지: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
@@ -115,11 +115,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
-sh install.sh v0.4.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh
+sh install.sh v0.5.0
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v0.4.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.5.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Prerequisites for either path: Node.js 22+ and Git. The script checks both befor
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh | sh
 ```
 
 Which hosts are supported, and what each install path requires: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
@@ -115,11 +115,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
-sh install.sh v0.4.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh
+sh install.sh v0.5.0
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v0.4.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.5.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,7 +34,7 @@
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh | sh
 ```
 
 支持哪些 host，以及各条安装路径需要什么：[docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
@@ -115,11 +115,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh
-sh install.sh v0.4.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh
+sh install.sh v0.5.0
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v0.4.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.5.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Git commit trailers as institutional memory for AI coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump and release notes for **0.5.0**. Targets `dev`.

**This PR does not release anything.** The two acts that do are the owner's:

1. `dev` → `main` — every previous tag sits on `main`, and `main` is the default branch
2. pushing `v0.5.0` — `.github/workflows/release.yml` says it plainly: *"Cutting a release is an owner action, not something CI can decide to do… Pushing the tag **is** the approval; this workflow has no separate one to give."*

## Why minor

A new command ships (`commitlore uninstall`), a platform moves from *reachable* to *supported*, and a defect that stopped Windows users committing at all is fixed. None of that fits a patch number; none of it breaks an existing install.

## The line a Windows user cannot reach any other way

> **If you installed the hook before this release, installing this release does not repair it.**

The stub is written into `.git/hooks/commit-msg` at install time, so an existing repository keeps the old one — and keeps hanging. `commitlore hooks install` repairs it, and it works where commits are blocked **because it is not a commit**. `commitlore doctor` reports such a repository as `outdated`.

Somebody in that state cannot read a changelog from inside the tool, which is why the sentence is plain and near the top of the entry.

## What the notes decline to claim

Two words are easy to over-read, so the entry bounds them:

- **`supported` for Windows** means #71's install-root containment was established there by execution, in a required job, with a working install in front of it. It does not mean Windows carries the mileage macOS and Linux do, and it does not reach a repository whose hook predates this release.
- **`uninstall`** removes what the installers wrote. That excludes the Claude Code plugin cache — thousands of files it did not write, keyed by plugin version. It names the step instead.

## What moves

| File | Change |
|---|---|
| `package.json`, `.claude-plugin/plugin.json` | `0.4.1` → `0.5.0` |
| `README.md` + 3 translations | 4 version pins each |
| `CHANGELOG.md` | the 0.5.0 entry |

`dist/` does **not** move: the CLI reads its version from `package.json` at run time rather than having it built in, so the release gate's three-way check compares the tag against a number that exists in one place.

## Verification

- `node scripts/check-release-version.mjs v0.5.0` — tag, `package.json` and `commitlore --version` all `0.5.0`
- `node scripts/check-readme-numbers.mjs` — exit 0
- `npm run typecheck` clean; `npm run build` leaves `dist/` unchanged
- Full suite — **78 files, 1914 passed, 1 skipped**

## Contents

Gate B (M6) closed in #330. This release carries what closed it: #282, #271, #272, #283, #321, #323.
