### PR TITLE
Notice a file that ships but was never declared

### DIFF
--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -295,3 +295,49 @@ describe("plugin manifest: hooks/hooks.json's command resolves and produces outp
     expect(run.stderr).toContain('no context was injected');
   });
 });
+
+/**
+ * #334: distribution here is a `git clone` (ADR-0011), so whatever is in the
+ * tree ships. The suite above asserts that every *declared* file parses — and a
+ * file nobody declared is invisible to it, because it is not on the list being
+ * checked.
+ *
+ * `.serena/project.yml` reached v0.5.0 that way: a tool writes it into whatever
+ * directory it is pointed at, a `git add -A` in a worktree swept it in, and the
+ * released tree carried that worktree's name as somebody's project label.
+ *
+ * This does not assert "no unexpected files". The tree legitimately holds `src/`,
+ * `test/`, `bench/`, `spec/`, `docs/`, `dist/`, `skills/` and more, and a
+ * whitelist of everything would fail on every honest addition and teach people to
+ * widen it rather than read it. It asserts something narrower and checkable:
+ * **no tool-local state ships**. That state is keyed to the machine or the
+ * directory that produced it, so it is wrong for every clone by construction —
+ * which is what separates it from editor settings a repository may ship on
+ * purpose.
+ */
+describe('plugin manifest: a clean clone carries no tool-local state (#334)', () => {
+  /** Written by a tool into the directory it was pointed at, never by an author. */
+  const TOOL_STATE = [
+    '.serena',
+    '.idea',
+    '.history',
+    '.aider.chat.history.md',
+    '.claude/settings.local.json',
+  ] as const;
+
+  it.each(TOOL_STATE)('%s is not in the clone', (relPath) => {
+    expect(
+      existsSync(clonePath(relPath)),
+      `${relPath} is tool-local state keyed to the machine or directory that created it, ` +
+        'and a clone is the distribution — see #334',
+    ).toBe(false);
+  });
+
+  it('looks where the files would actually be', () => {
+    // An assertion that passes because it looks in the wrong place is the exact
+    // failure this suite is about, so the path construction is checked against a
+    // file that is genuinely there.
+    expect(existsSync(clonePath('package.json'))).toBe(true);
+    expect(existsSync(clonePath('.claude-plugin/plugin.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #334.

`.serena/project.yml` reached v0.5.0 — a tool's per-project config carrying `project_name: "t1124"`, the name of the worktree a `git add -A` swept it in from. Removed in #333; this is the guard.

## Why nothing caught it

The manifest suite asserts that every **declared** file parses in a clean clone:

```
.claude-plugin/plugin.json, .claude-plugin/marketplace.json,
.mcp.json, hooks/hooks.json, package.json
```

A file nobody declared is invisible to that — it is not on the list being checked. Distribution here is a `git clone` (ADR-0011), so it shipped anyway.

## What the guard does and does not assert

**Not** "no unexpected files". The tree legitimately holds `src/`, `test/`, `bench/`, `spec/`, `docs/`, `dist/`, `skills/` and more, and a whitelist of everything would fail on every honest addition and teach the next author to widen it rather than read it.

**Instead**: no *tool-local state* ships. That state is keyed to the machine or the directory that produced it, so it is wrong for every clone by construction — which is what separates it from editor settings a repository may ship on purpose. Those are not forbidden here.

The list names what has appeared or plausibly would. It does not claim to be exhaustive; a guard that pretends to catch everything is the same false comfort as one that catches nothing.

## It was proved to fail, not just to pass

A guard that passes on a clean tree proves nothing about a dirty one. So the defect was recreated — `.serena/project.yml` committed, the suite run, then reset:

```
FAIL  a clean clone carries no tool-local state (#334) > .serena is not in the clone
      .serena is tool-local state keyed to the machine or directory that
      created it, and a clone is the distribution — see #334
```

Note the clone fixture reads **HEAD**, not the index — staging the file is not enough to trip it, which is correct: only committed files ship.

A second assertion checks the path construction against files that are genuinely present, so a pass cannot come from looking in the wrong place.

## Verification

`test/manifest.test.ts` — **24 passed** on the current tree, **1 failed** on the recreated defect. `npm run typecheck` clean.