### PR TITLE
Write the 0.5.1 notes before tagging

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 Nothing yet.
 
+## 0.5.1 — 2026-08-01
+
+### Upgrade reasons
+
+- **On a repository with no records, the index invented them, and `context` fed
+  them to the agent.** Any RFC-822-shaped `key: value` line was ingested as a
+  trailer — conventional-commit prefixes (`ax:`, `fix:`, `docs:`), a Homebrew
+  digest (`sha256:`), arbitrary body fields. One report had 106 rows on a
+  repository with zero records. `context` is wired into the pre-edit hook, so
+  what an agent received before editing was a commit subject presented as a
+  recorded decision, and `doctor` called that state healthy while `stale` — which
+  reads git — correctly reported nothing. A block carrying no key from the
+  protocol's vocabulary is not a record now, and the two commands agree (#335).
+- **`harvest-verify` says the draft is not a draft before asking for a
+  transcript.** A draft that was prose rather than the contract's JSON object
+  came back as `missing --transcript`, which sent the reader after a file they
+  did not need for a draft that was never going to parse. The draft is checked
+  first (#329).
+- A tool's local config, `.serena/`, was committed into 0.5.0 by a `git add -A`
+  and shipped carrying the name of the worktree it came from. Removed, ignored,
+  and a test now notices a file that ships but was never declared (#334).
+
+### What this release does not change
+
+`Verified:` is protocol vocabulary. A release note that happens to use it as a
+field is indistinguishable from a record that uses it for what it means, so a
+block containing one is still a record. Guessing from surrounding context is how
+a tool starts discarding records somebody wrote on purpose.
+
+Nothing here changes the Windows repair path from 0.5.0: a repository whose hook
+was installed before that release still needs `commitlore hooks install` re-run.
+
 ## 0.5.0 — 2026-08-01
 
 Windows works, and this is the release that can say so from a run rather than

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,7 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/install.sh | sh
 ```
 
 どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh
-sh install.sh v0.5.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/install.sh
+sh install.sh v0.5.1
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v0.5.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.5.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -48,7 +48,7 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/install.sh | sh
 ```
 
 어떤 host를 지원하는지, 각 설치 경로가 무엇을 요구하는지: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh
-sh install.sh v0.5.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/install.sh
+sh install.sh v0.5.1
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v0.5.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.5.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Prerequisites for either path: Node.js 22+ and Git. The script checks both befor
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/install.sh | sh
 ```
 
 Which hosts are supported, and what each install path requires: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
@@ -130,11 +130,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh
-sh install.sh v0.5.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/install.sh
+sh install.sh v0.5.1
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v0.5.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.5.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/install.sh | sh
 ```
 
 支持哪些 host，以及各条安装路径需要什么：[docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
@@ -128,11 +128,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.0/install.sh
-sh install.sh v0.5.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/install.sh
+sh install.sh v0.5.1
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v0.5.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.5.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump and release notes for **0.5.1**. Targets `dev`.

**This PR does not release anything.** `release.yml` triggers on a pushed `v*` tag and nothing else.

## Why patch

No new command, nothing breaking. One defect that changed what an agent was handed, and two corrections beside it.

## The one that matters

On a repository with **no records**, the index accepted any RFC-822-shaped `key: value` line as a trailer — conventional-commit prefixes, a Homebrew digest, arbitrary body fields. One report had **106 rows where git had nothing**.

`context` is wired into the pre-edit hook, so a commit subject reached an agent as a recorded decision, while `doctor` called the state healthy and `stale` — which reads git — correctly reported zero. Two commands in one tool disagreeing about whether the repository had any records.

That is the product's own claim inverted. It does not wait for the next minor (#335).

## Also in

- `harvest-verify` reports an unparseable draft before asking for a transcript (#329)
- `.serena/`, a tool config a `git add -A` swept into 0.5.0, removed — with a guard so an undeclared file cannot ship unnoticed (#334)
- README no longer says Windows is unsupported while the compatibility document says it is, and a test now catches that class of contradiction (#339)

## Deliberately unchanged, and the notes say so

`Verified:` is protocol vocabulary. A release note using it as a field is indistinguishable from a record using it for what it means, and guessing from surrounding context is how a tool starts discarding records somebody wrote on purpose.

The Windows repair path from 0.5.0 is **restated, not assumed inherited**: a repository whose hook predates 0.5.0 still needs `commitlore hooks install` re-run. A new release invites "this one fixes everything".

## Verification

- `check-release-version.mjs v0.5.1` — tag, `package.json`, `commitlore --version` all `0.5.1`
- `check-readme-numbers.mjs` — exit 0
- Full suite — **78 files, 1931 passed, 1 skipped**