### PR TITLE
Say where the commitlore command comes from, since the plugin does not carry it

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,6 +43,8 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 /plugin install commitlore@commitlore
 ```
 
+プラグインが持つのはここまでで、MCP サーバー、編集前フック、スキルです。`commitlore` を `PATH` に置くことはないので、以下の `commitlore …` コマンドは `install.sh` / `install.ps1` から来るものであり、そのインストールも必要です。
+
 どちらの経路も前提条件は Node.js 22+ と Git です。スクリプトは何かを書き込む前に両方を確認します。
 
 **その他のコーディングエージェント** — CLI をインストールします:

--- a/README.ko.md
+++ b/README.ko.md
@@ -43,6 +43,8 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 /plugin install commitlore@commitlore
 ```
 
+플러그인이 담는 것은 여기까지다: MCP 서버, 편집 전 훅, 스킬. `commitlore`를 `PATH`에 올리지는 않으므로, 아래의 `commitlore …` 명령은 `install.sh` / `install.ps1`에서 오고 그 설치까지 필요하다.
+
 두 경로 모두의 전제 조건: Node.js 22+ 와 Git. 스크립트는 무엇이든 쓰기 전에 둘을 확인한다.
 
 **그 밖의 코딩 에이전트** — CLI를 설치한다:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Install once. Your coding agent can record the decisions worth carrying forward,
 /plugin install commitlore@commitlore
 ```
 
+That is the whole plugin: the MCP server, the pre-edit hook and the skills. It puts no `commitlore` on `PATH`, so the `commitlore …` commands below come from `install.sh` / `install.ps1` and need that install as well.
+
 Prerequisites for either path: Node.js 22+ and Git. The script checks both before it writes anything.
 
 **Any other coding agent** — install the CLI:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,6 +42,8 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 /plugin install commitlore@commitlore
 ```
 
+插件所含仅此而已：MCP 服务器、编辑前钩子与技能。它不会把 `commitlore` 放到 `PATH` 上，因此下面的 `commitlore …` 命令来自 `install.sh` / `install.ps1`，还需要那一步安装。
+
 两条路径的前置条件都是 Node.js 22+ 与 Git。脚本在写入任何内容之前会检查这两项。
 
 **其他编程代理** — 安装 CLI:

--- a/skills/commitlore-setup/SKILL.md
+++ b/skills/commitlore-setup/SKILL.md
@@ -5,6 +5,11 @@ description: Use when a git repository needs CommitLore wired up for the first t
 
 # CommitLore setup
 
+Every command below is the `commitlore` CLI, which arrives with `install.sh` /
+`install.ps1`. The Claude Code plugin ships the MCP server, the pre-edit hook
+and these skills, and puts nothing on `PATH` — where `commitlore` is not found,
+`node <plugin-checkout>/dist/commitlore.mjs` takes the same arguments.
+
 **Shortcut for a repository that just needs wiring up, nothing broken to diagnose:**
 `commitlore init` runs steps 2-4 below (`hooks install`, `index --rebuild`, then
 `doctor --fix` as a final check) in one command, reports what it did and what it


### PR DESCRIPTION
Closes #353

The README leads with the plugin and then tells the reader to run `commitlore init`
and `commitlore context .`. Nothing between those two points puts a `commitlore`
anywhere, so for a plugin-only user both commands exit 127.

Verified before changing anything:

- `package.json` is `"private": true` with no `bin`.
- `.claude-plugin/plugin.json` declares metadata only — no executable, no commands.
- The plugin's payload is `.mcp.json`, `hooks/hooks.json`, `skills/` and `dist/`.
- The MCP server exposes seven tools (`before_change`, `guard`, `prepare_capture`,
  `query`, `stage_capture`, `stale`, `verify_capture`) — there is no `init` route.
- `scripts/commitlore-bootstrap.sh` is referenced by nothing in the tree.

The documentation route, not the bootstrap route. Nothing in the product is wrong:
the plugin does what its own section claims, the pre-edit hook resolves the bundle
through `CLAUDE_PLUGIN_ROOT` without needing `PATH`, and `docs/COMPATIBILITY.md`
already separates what each path *requires* from what it *checks* and already
records that the plugin path enforces nothing. The README never inherited that
care. Wiring the orphaned bootstrap would re-arm the supply-chain hole that was
just closed, and a `bin` entry would name an install path a private package cannot
offer.

## Changes

- `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md` — one sentence
  after the plugin install block, in each file's own language and register: the
  plugin holds the MCP server, the pre-edit hook and the skills, puts no
  `commitlore` on `PATH`, and the `commitlore …` commands below come from
  `install.sh` / `install.ps1`.
- `skills/commitlore-setup/SKILL.md` — names the CLI's origin before the first
  command, with `node <plugin-checkout>/dist/commitlore.mjs` as the fallback the
  hook itself uses. This skill ships with the plugin, so its reader is by
  construction the one least likely to have the CLI.

The `BENCH:BEGIN`/`BENCH:END` block, the guard precision/recall figures and their
placement in Known limitations are untouched, and no new number was introduced.

## Verification

```
npx vitest run test/readme.test.ts test/readme-order.test.ts test/readme-numbers.test.ts \
  test/compatibility-matrix.test.ts test/install-script.test.ts test/manifest.test.ts
  → 6 files, 116 tests passed

npx vitest run test/readme-positioning.test.ts test/doctor.test.ts
  → 2 files, 59 tests passed

node scripts/check-readme-numbers.mjs
  → exit 0, measured-results block byte-identical (39 lines, 2262 bytes)
```
