### PR TITLE
Cut the fourth restatement of the hero and name the payoff once

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -30,8 +30,6 @@ CommitLore はその工学的判断を Git に保存し、次の編集の前に*
 
 Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 
-**AI 支援コードベースのための Git-native 意思決定権威。** CommitLore は、どの決定がまだ有効でどの決定が覆されたかを Git 内で直接追跡します。コーディングエージェントがパスを問い合わせると、現在有効な決定だけが返されます。
-
 ホスト型メモリサービスも、ベンダー固有のチャット履歴もありません。リポジトリが所有し、共に移動する、レビュー可能な意思決定コンテキストだけです。
 
 一度インストールします。コーディングエージェントは引き継ぐ価値のある意思決定を記録でき、CommitLore はそれを検証して Git に保存します。
@@ -54,6 +52,8 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/inst
 ```
 
 どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
+
+**前のエージェントが得た判断を、次のエージェントに渡しましょう。**
 
 ## 実際に動かす
 
@@ -141,7 +141,7 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
-## 違いを見る
+## コードは残った。決定は残らなかった。
 
 *同じ悪い案を二度レビューしない。*
 
@@ -225,7 +225,6 @@ other
 
 類似検索は関連する決定を見つけられます。CommitLore はさらに、その決定が今も有効か、
 置き換えられたか、期限切れかを知っていて — 最初のものだけを示します。
-  ともに決定を受け取る。
 
 ## 違い
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -30,8 +30,6 @@ CommitLore는 그 엔지니어링 판단을 Git에 보존하고, 다음 편집 �
 
 Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 
-**AI 보조 코드베이스를 위한 Git-native 결정 권위.** CommitLore는 어떤 결정이 아직 유효하고 어떤 결정이 뒤집혔는지를 Git에서 직접 추적한다. 코딩 에이전트가 경로를 조회하면 현재 유효한 결정만 보인다.
-
 호스팅 메모리 서비스도, 벤더 전용 채팅 기록도 없다. 저장소가 소유하고 함께 이동하는, 검토 가능한 결정 맥락만 있다.
 
 한 번 설치한다. 코딩 에이전트가 계속 가져갈 가치가 있는 결정을 기록할 수 있고, CommitLore는 이를 검증해 Git에 보존한다.
@@ -54,6 +52,8 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/inst
 ```
 
 어떤 host를 지원하는지, 각 설치 경로가 무엇을 요구하는지: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
+
+**지난 에이전트가 얻어낸 판단을, 다음 에이전트에게 물려주세요.**
 
 ## 실제로 보기
 
@@ -141,7 +141,7 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
-## 차이
+## 코드는 남았다. 결정은 남지 않았다.
 
 *같은 나쁜 아이디어를 다시 리뷰하지 않는다.*
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ superseded or expired does not reach the agent as if it still stood.
 
 Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 
-**Git-native decision authority for AI-assisted codebases.** CommitLore tracks which decisions are still in force and which have been reversed—directly in Git—so a coding agent sees only current decisions when it queries a path.
-
 No hosted memory service. No vendor-specific chat history. Just reviewable decision context, owned by and portable with the repository.
 
 Install once. Your coding agent can record the decisions worth carrying forward, while CommitLore validates and preserves them in Git.
@@ -55,6 +53,8 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/inst
 ```
 
 Which hosts are supported, and what each install path requires: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
+
+**Give your next agent the judgment your last one earned.**
 
 ## See it work
 
@@ -142,7 +142,7 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
-## See the difference
+## The code survived. The decision didn't.
 
 *Stop re-reviewing the same bad idea.*
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,8 +29,6 @@ CommitLore 把这份工程判断保存在 Git 中，并在下一次编辑前只�
 
 Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 
-**面向 AI 辅助代码库的 Git-native 决策权威。** CommitLore 在 Git 中直接追踪哪些决策仍然有效、哪些已被推翻。编程代理查询路径时，只能看到当前有效的决策。
-
 没有托管记忆服务，也没有特定供应商的聊天历史。只有由仓库拥有并随仓库流转、可供审查的决策上下文。
 
 安装一次。你的编程代理可以记录值得延续的决策，而 CommitLore 会验证它们并将其保存在 Git 中。
@@ -53,6 +51,8 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.5.1/inst
 ```
 
 支持哪些 host，以及各条安装路径需要什么：[docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
+
+**把上一个代理挣得的判断，交给下一个代理。**
 
 ## 看它实际运行
 
@@ -140,7 +140,7 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
-## 看看差别
+## 代码留了下来，决定没有。
 
 *不再重复评审同一个坏主意。*
 


### PR DESCRIPTION
An external positioning review of the v0.5.0 README argued that the hero should sell engineering-judgment inheritance rather than a review-convenience feature. That hero was already applied. What the review surfaced that was **not** applied is the redundancy it left behind, and the missing ask.

### Changed

1. **Deleted the fourth restatement.** `**Git-native decision authority for AI-assisted codebases.** …` restated the mechanism paragraph directly above it. Three consecutive paragraphs claimed the same thing. In `README.ko.md` the leftover was also 해라체 against a 존댓말 hero.
2. **Added the ask** — one line closing the install block: *Give your next agent the judgment your last one earned.*
3. **Renamed the scene section** from "See the difference" to "The code survived. The decision didn't." — the heading now states the loss the scene is about. *Stop re-reviewing the same bad idea* stays as the caption, which is where the review says it belongs.

All three applied to `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`.

### Audited, no change needed

The review's list of copy the product cannot honestly make — "never let agents make the same mistake twice", "eliminate architectural regressions", "save tokens and review time", "the memory your AI never forgets" — none appear. Guard precision 44.8% / recall 22.0% remain disclosed with their Wilson CI in Known limitations.

### Verified

- `readme`, `readme-order`, `readme-numbers`, `readme-positioning`, `compatibility-matrix` — 83 tests pass
- `scripts/check-readme-numbers.mjs` exit 0, BENCH block byte-identical (39 lines, 2262 bytes)
- The four `readme-positioning` authority assertions still resolve — through the hero image alt text, not the deleted paragraph
