### PR TITLE
Move the README's reference manual into docs/ and link to it

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -79,21 +79,13 @@ warnings
   r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
 ```
 
-<details>
-<summary>正確な PreToolUse hook path を再現する</summary>
-
-```bash
-printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
-  | node dist/commitlore.mjs inject --hook-input --budget 5000
-```
-
-</details>
+この `PreToolUse` hook path をそのまま再現する方法と、その他すべてのコマンドは [docs/cli.md](docs/cli.md) にあります。
 
 ## 検索はレコードを見つけられる。パス範囲は覆された意思決定を除外する。
 
 レコードを一つ取り逃がせば、モデルはコンテキストを失います。すでに覆された意思決定を渡せば、正しさを損ないます。この[検索測定](bench/retrieval/result.md)では、ノイズが 0 件から 10,000 件までのすべてのサイズで、BM25、embedding top-k、hybrid RRF、パスフィルター付き embedding がそれぞれ廃止済みのレコードを一つ返しました。lifecycle を伴う CommitLore のパス範囲は古いレコードをゼロにし、現在の二つのレコード (2/2) を返しました。
 
-再現率は補助的な結果です。検索はおおむねどちらでも同じレコードを見つけますが、どの意思決定がまだ有効かを知るルートは一つだけです。廃止済みのレコードがない #166 のコーパスでは、embedding 検索はパス範囲と同じ 2/2 でした。意思決定が覆されたときに違いが現れます。これはまさにこの製品が存在するケースです。
+再現率は補助的な結果です。検索はおおむねどちらでも同じレコードを見つけますが、どの意思決定がまだ有効かを知るルートは一つだけです。意思決定が覆されたときに違いが現れます。これはまさにこの製品が存在するケースです。
 
 別の #167 の露出実行も重要です。10,002 件のうちモデルに届いたレコードは 2 件だけでした。
 
@@ -103,18 +95,11 @@ printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
 | top-k 語彙検索 | 2 | 1/2 | 190 |
 | CommitLore パス範囲 | 2 | 2/2 | 335 |
 
-これは固定した 2 レコードの出力予算における露出と再現率の測定であり、トークンコスト、請求コスト、正確さ、エージェントの振る舞いを測るものではありません。これは一つのコーパス、一つのクエリ、一つの固定された embedding モデルによる結果です。
-
-検証フックとローカル index を使う各リポジトリで、続けて `commitlore init` を実行します。installer は対応するコーディングエージェントを検出し、安全に可能な場所でローカル MCP server を登録します。
-
-## init の後に起きること
-
-- 普段どおりコミットします。ほとんどのコミットには record がありません。
-- record がある場合、commit-msg hook が検証します。record を作成することはありません。
-- エージェントは MCP で意思決定コンテキストを照会するか、`PreToolUse` hook から受け取ります。
-- path を変更する前に、active limit、ruled-out alternative、warning、verification gap を確認します。
+これは固定した 2 レコードの出力予算における露出と再現率の測定であり、トークンコスト、請求コスト、正確さ、エージェントの振る舞いを測るものではありません。これは一つのコーパス、一つのクエリ、一つの固定された embedding モデルによる結果です。再現率が並ぶ地点と、ほかに何が測定され何が測定されていないかは [docs/evidence.md](docs/evidence.md) にあります。
 
 ## リポジトリで試す
+
+検証フックとローカル index を使う各リポジトリで、続けて `commitlore init` を実行します。installer は対応するコーディングエージェントを検出し、安全に可能な場所でローカル MCP server を登録します。
 
 ```bash
 cd your-repository
@@ -122,7 +107,14 @@ commitlore init
 commitlore context .
 ```
 
-その後もコーディングエージェントと作業を続けます。変更に diff が保存できない意思決定コンテキストがあるときは、エージェントに CommitLore record をコミットへ含めるよう頼んでください。
+そのあとは:
+
+- 普段どおりコミットします。ほとんどのコミットには record がありません。
+- record がある場合、commit-msg hook が検証します。record を作成することはありません。
+- エージェントは MCP で意思決定コンテキストを照会するか、`PreToolUse` hook から受け取ります。
+- path を変更する前に、active limit、ruled-out alternative、warning、verification gap を確認します。
+
+コーディングエージェントとの作業を続けます。変更に diff が保存できない意思決定コンテキストがあるときは、エージェントに CommitLore record をコミットへ含めるよう頼んでください。
 
 <details>
 <summary>インストールを確認または固定したいですか？</summary>
@@ -185,33 +177,19 @@ Ruled-out
 ## 実際のリポジトリでの見え方
 
 コミット約768個の Swift MCP サーバーのフィールドレポートより、インストール翌日。
-エンジニアは CommitLore を入れる前にコードベースの全数調査を終えており、その調査が
-印を付けたファイルを作業していた。
-
-```
-$ commitlore context Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
-context for … — 0 limits, 0 ruled-out, 0 warnings, 2 other in 2 records
-
-other
-  -  01ff2705  [claim]  ax: eliminate clear-win coordinate actuations (8 sites)
-                        with live-verified AX paths
-```
+ファイルパスを一つ指定しただけで、エンジニアが存在を知らなかったマージ済み PR が現れ、
+残っていたコードの意味が変わった。
 
 > **そのコミットの存在を知らなかった。** 2週間前にマージされた PR で、これらのサイトの
 > うち8か所を既に削除し、それぞれを accessibility-native な等価物に置き換えていた —
 > すべて fail-closed で実機検証済み。
 >
-> これは私の全数調査を組み替えた。残っているサイトを問題**そのもの**として扱っていたが、
-> 違った。出荷済みの削除キャンペーンの**残余**だ — 意図的な削除の試みを生き延びたもの。
-> まったく別の工学的問題であり、別のリスク評価だ。
->
 > どれもチャット履歴にはなかった。リポジトリにあり、ファイルパスを指定して得た。
 
 代替手段は2週間分のマージ済み PR を読むことだった。エージェントが自発的にやることでは
-なく、人が編集のたびにやることでもない。
-
-同じレポートの導入コスト: コマンド1つ、コミット768個のインデックスに7.4秒。履歴も作業
-ツリーも触らない。
+なく、人が編集のたびにやることでもない。同じレポートの導入コスト: コマンド1つ、コミット
+768個のインデックスに7.4秒。履歴も作業ツリーも触らない。コンソール出力とレポート全文は
+[docs/evidence.md](docs/evidence.md) にあります。
 
 **ホスト型のチャット履歴製品が提供できない3つの性質**、そして権威をサービスではなく Git に
 置いた理由:
@@ -250,38 +228,15 @@ other
 
 すべてのコミットに trailer を手書きする必要はありません。ほとんどのコミットには record がないべきです。外部制約、除外した代案、warning、verification gap のように、diff だけでは復元できない意思決定にだけ record を追加します。
 
-### コーディングエージェント経由
-
 エージェントには、普段どおりコミットし、diff では説明できない意思決定コンテキストだけを残すよう頼みます。
 
 > この変更をコミットしてください。diff で重要な制約、除外した代案、warning、または verification gap を復元できない場合にだけ、CommitLore record を追加してください。
 
-ほとんどのコミットには、やはり record は不要です。エージェント向けの指針は `skills/commitlore-commits/` にあり、commit hook はエージェントが追加した record を検証します。
-
-### 高度な経路: harvest
-
-`commitlore harvest` は session transcript と staged diff から prompt contract を作り、`commitlore harvest-verify` はそれに対する draft を検証します。これらは draft を支援しますが、自動でコミットしません。interactive record builder は未実装です。
-
-### 手書き
-
-逃げ道として、人は通常の Git trailer を手書きできます。commit-msg hook はすでにある record を検証するだけで、record を発明したり黙って追加したりしません。
-
-## 最小の record
-
-record は小さくできます。失われるものだけを入れてください。
-
-```text
-Fix expired-token refresh
-
-Ruled-out: Extend token TTL to 24h | security policy violation
-Warn: Do not narrow the 4xx handler without verifying upstream behavior
-```
-
-ほとんどの record に protocol field のすべては不要です。意思決定が必要とするときは、identity、lifecycle、risk、provenance、verification field を使えます。
+エージェント向けの指針は `skills/commitlore-commits/` にあり、commit-msg hook はエージェントが追加した record を検証するだけで、record を発明したり黙って追加したりしません。`harvest` の経路、`capture` トランザクション、そして人が trailer を手書きする逃げ道は、いずれも [docs/capture.md](docs/capture.md) にあります。
 
 ## 完全な record
 
-この例は conformance fixture でもあります。Git trailer parser は、すべての翻訳 README で下の code block を同じように読みます。
+record はこれよりずっと小さくできますし、ほとんどは数個の field で足ります。この例が語彙のすべてを使うのは、conformance fixture でもあるからです — Git trailer parser は、すべての翻訳 README で下の code block を同じように読みます。
 
 ```text
 Prevent silent session drops during long-running operations
@@ -322,13 +277,7 @@ CommitLore-Version: 2.0.0
 | `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
 | `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
 
-path の履歴は `commitlore context <path>` で読み、Git を直接使うこともできます。
-
-```bash
-git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
-```
-
-text search ではなく Git trailer parser を使います。本文の `Key:` は trailer とは限りません。
+path の履歴は `commitlore context <path>` で読みます。より小さな例と、Git だけで record を読む方法は [docs/protocol.md](docs/protocol.md) に、規範的な定義は [SPEC §3](spec/SPEC.md) にあります。
 
 ## リポジトリが証明すること
 
@@ -343,13 +292,7 @@ text search ではなく Git trailer parser を使います。本文の `Key:` �
 
 112 回の実験は記録されましたが、M4 には run ごとの `guard_exposure` 記録がありません。treatment があったか検証できないため、agent behavior の主張を検証も支持も反証もしていません。上記のより狭い製品上の主張は独立して検証可能な動作に基づきます。クリーンなデータセットと撤回については [M4 verdict](bench/VERDICT-M4.md) を読んでください。
 
-### レイテンシ、コスト、損益分岐
-
-100,000 コミットではインデックス付き `context` の p50 は 496 ms、CommitLore 自身の `--no-index` フォールバックは 86,673 ms です。この内部フォールバックの差は 1k で 4.8×、10k で 36×、100k で 175×へと大きくなります（[完全な決定論的実行](https://github.com/MongLong0214/commitlore/blob/2fade893f25917fce1ffb497aab96b1eb271a185/bench/results/deterministic-20260729T032652Z.md)）。これは規模に対する形であり、製品と代替手段の比較結果ではありません。
-
-guard が一回実行されるコストは、注入される context と測定した hook overhead です。commit-msg は p50 185.85 ms、injection hook は p50 102.40 ms です（[deterministic measurements](bench/results/deterministic-20260727T174801Z.md)）。
-
-損益分岐の数値を再び示すには、プロバイダー報告のターンごとのトークン使用量台帳と、リポジトリがすでに却下した代案に費やした作業の観測済みコストが必要です。
+何が測定されたか — 検索、露出、レイテンシと規模、hook overhead — そして何が測定されていないか — 損益分岐、そしてエージェントの振る舞いへの効果 — は [docs/evidence.md](docs/evidence.md) にまとめてあります。
 
 <details>
 <summary>完全な benchmark record（112 回の実験）</summary>
@@ -396,16 +339,6 @@ guard が一回実行されるコストは、注入される context と測定�
 
 </details>
 
-## source からインストール
-
-source distribution を確認または実行するには次を使います。
-
-```bash
-git clone https://github.com/MongLong0214/commitlore ~/.commitlore
-node ~/.commitlore/dist/commitlore.mjs init
-node ~/.commitlore/dist/commitlore.mjs context src/auth
-```
-
 ## アンインストール
 
 ```bash
@@ -414,10 +347,18 @@ commitlore uninstall
 
 `install.sh` または `install.ps1` が書いたものを削除します — wrapper、固定された
 checkout、そして各 agent config に追加した MCP エントリ。自分が書いていないものは
-削除せず、残すものを明示します: リポジトリごとの hook（`commit-msg`・
-`prepare-commit-msg`・`post-commit` の三つとも `commitlore hooks uninstall` が外します）、agent hook（`commitlore inject uninstall-claude-hook`）、Claude Code
-plugin（`/plugin uninstall commitlore@commitlore`）。`--dry-run` は何も変更せずに
-報告します。
+削除せず、残すものを明示します: リポジトリごとの hook、agent hook、Claude Code
+plugin。`--dry-run` は何も変更せずに報告します。それぞれを何が外すか、そして source
+チェックアウトから実行する方法は [docs/install.md](docs/install.md) にあります。
+
+## ドキュメント
+
+- [docs/install.md](docs/install.md) — インストール経路、各経路が書くもの、取り消し方
+- [docs/cli.md](docs/cli.md) — すべてのコマンドとフラグ
+- [docs/capture.md](docs/capture.md) — record が書かれるまで
+- [docs/protocol.md](docs/protocol.md) — record の形式と、Git だけで読む方法
+- [docs/evidence.md](docs/evidence.md) — 何が測定され、何が測定されていないか
+- [spec/SPEC.md](spec/SPEC.md) — 規範プロトコル
 
 ## 既知の制限事項
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -79,21 +79,13 @@ warnings
   r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
 ```
 
-<details>
-<summary>정확한 PreToolUse hook path 재현하기</summary>
-
-```bash
-printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
-  | node dist/commitlore.mjs inject --hook-input --budget 5000
-```
-
-</details>
+이 PreToolUse hook path를 그대로 재현하는 방법과 나머지 모든 명령은 [docs/cli.md](docs/cli.md)에 있다.
 
 ## 검색은 레코드를 찾을 수 있습니다. 경로 범위는 뒤집힌 결정을 걸러냅니다.
 
 레코드 하나를 놓치면 모델은 맥락을 잃습니다. 이미 뒤집힌 결정을 건네면 정확성을 잃습니다. 이 [검색 측정](bench/retrieval/result.md)에서 방해 레코드가 0개부터 10,000개까지인 모든 크기에서 BM25, 임베딩 top-k, 하이브리드 RRF, 경로 필터를 적용한 임베딩은 각각 대체되어 폐기된 레코드 하나를 반환했습니다. 수명 주기를 적용한 CommitLore 경로 범위는 오래된 레코드를 0개 반환하고 현재 레코드 둘(2/2)을 모두 반환했습니다.
 
-재현율은 보조 결과입니다. 검색은 대체로 어느 쪽이든 같은 레코드를 찾지만, 현재 유효한 결정을 아는 경로는 하나뿐입니다. 대체되어 폐기된 레코드가 없던 #166의 코퍼스에서는 임베딩 검색이 경로 범위와 같은 2/2를 기록했습니다. 결정이 뒤집혔을 때 차이가 나타나며, 바로 이 경우를 위해 이 제품이 존재합니다.
+재현율은 보조 결과입니다. 검색은 대체로 어느 쪽이든 같은 레코드를 찾지만, 현재 유효한 결정을 아는 경로는 하나뿐입니다. 결정이 뒤집혔을 때 차이가 나타나며, 바로 이 경우를 위해 이 제품이 존재합니다.
 
 별도의 #167 노출 실행도 중요합니다. 10,002개 레코드 중 모델에 닿은 것은 2개뿐입니다.
 
@@ -103,18 +95,11 @@ printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
 | top-k 어휘 검색 | 2 | 1/2 | 190 |
 | CommitLore 경로 범위 | 2 | 2/2 | 335 |
 
-이는 고정된 두 레코드 출력 예산에서 노출과 재현율을 측정한 것이며, 토큰 비용, 청구 비용, 정확도 또는 에이전트 행동을 측정하지 않습니다. 코퍼스 하나, 쿼리 하나, 고정된 임베딩 모델 하나의 결과입니다.
-
-검증 훅과 로컬 인덱스를 쓸 각 저장소에서 이어서 `commitlore init`을 실행한다. 설치기는 지원되는 코딩 에이전트를 감지하고, 안전하게 가능한 곳에 로컬 MCP 서버를 등록한다.
-
-## init 뒤에 일어나는 일
-
-- 평소처럼 커밋한다. 대부분의 커밋에는 record가 없다.
-- record가 있으면 commit-msg hook이 검증한다. record를 만들지는 않는다.
-- 에이전트는 MCP로 결정 맥락을 조회하거나 `PreToolUse` hook으로 받는다.
-- path를 바꾸기 전에 active limit, ruled-out alternative, warning, verification gap을 본다.
+이는 고정된 두 레코드 출력 예산에서 노출과 재현율을 측정한 것이며, 토큰 비용, 청구 비용, 정확도 또는 에이전트 행동을 측정하지 않습니다. 코퍼스 하나, 쿼리 하나, 고정된 임베딩 모델 하나의 결과입니다. 재현율이 동률인 지점과 그 밖에 무엇이 측정됐고 무엇이 측정되지 않았는지는 [docs/evidence.md](docs/evidence.md)에 있습니다.
 
 ## 저장소에서 사용해 보기
+
+검증 훅과 로컬 인덱스를 쓸 각 저장소에서 이어서 `commitlore init`을 실행한다. 설치기는 지원되는 코딩 에이전트를 감지하고, 안전하게 가능한 곳에 로컬 MCP 서버를 등록한다.
 
 ```bash
 cd your-repository
@@ -122,7 +107,14 @@ commitlore init
 commitlore context .
 ```
 
-그다음에도 코딩 에이전트와 계속 작업한다. 변경에 diff가 보존할 수 없는 결정 맥락이 있으면, 에이전트에게 커밋에 CommitLore record를 넣어 달라고 요청한다.
+그다음에는:
+
+- 평소처럼 커밋한다. 대부분의 커밋에는 record가 없다.
+- record가 있으면 commit-msg hook이 검증한다. record를 만들지는 않는다.
+- 에이전트는 MCP로 결정 맥락을 조회하거나 `PreToolUse` hook으로 받는다.
+- path를 바꾸기 전에 active limit, ruled-out alternative, warning, verification gap을 본다.
+
+코딩 에이전트와 계속 작업한다. 변경에 diff가 보존할 수 없는 결정 맥락이 있으면, 에이전트에게 커밋에 CommitLore record를 넣어 달라고 요청한다.
 
 <details>
 <summary>설치 내용을 살펴보거나 버전을 고정하고 싶나요?</summary>
@@ -184,32 +176,18 @@ record는 `[directive]`로 렌더된다.
 
 ## 실제 저장소에서는 이렇게 보인다
 
-커밋 약 768개인 Swift MCP 서버의 필드리포트에서, 설치 다음 날. 엔지니어는 CommitLore를
-설치하기 전에 이미 코드베이스 전수 조사를 마쳤고, 그 조사가 표시한 파일들을 작업 중이었다.
-
-```
-$ commitlore context Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
-context for … — 0 limits, 0 ruled-out, 0 warnings, 2 other in 2 records
-
-other
-  -  01ff2705  [claim]  ax: eliminate clear-win coordinate actuations (8 sites)
-                        with live-verified AX paths
-```
+커밋 약 768개인 Swift MCP 서버의 필드리포트에서, 설치 다음 날. 파일 경로 하나를 댔더니
+엔지니어가 존재조차 몰랐던 merge된 PR이 나왔고, 남아 있던 코드의 의미가 달라졌다.
 
 > **그 커밋이 있는 줄 몰랐다.** 2주 전 merge된 PR이고, 이미 이 사이트 여덟 곳을 제거하고
 > 각각을 accessibility-native 등가물로 교체했다 — 전부 fail-closed에 실기기 검증까지.
 >
-> 이건 내 전수 조사를 재배치했다. 나는 남아 있는 사이트들을 문제 **자체**로 다루고
-> 있었다. 아니었다. 그건 이미 출시된 제거 캠페인의 **잔여물**이다 — 의도적인 제거 시도를
-> 견디고 살아남은 것들. 완전히 다른 공학 문제이고 다른 리스크 평가다.
->
 > 이 중 어느 것도 채팅 기록에 없었다. 저장소에 있었고, 나는 파일 경로를 대서 얻었다.
 
 대안은 2주치 merge된 PR을 읽는 것이었다. 에이전트가 자발적으로 하는 일이 아니고, 사람이
-매 편집 전에 하는 일도 아니다.
-
-같은 리포트의 도입 비용: 명령 하나, 그리고 커밋 768개 인덱싱에 7.4초. 히스토리도 작업
-트리도 건드리지 않는다.
+매 편집 전에 하는 일도 아니다. 같은 리포트의 도입 비용: 명령 하나, 그리고 커밋 768개
+인덱싱에 7.4초. 히스토리도 작업 트리도 건드리지 않는다. 콘솔 출력과 리포트 전문은
+[docs/evidence.md](docs/evidence.md)에 있다.
 
 **호스팅형 채팅 기록 제품이 줄 수 없는 세 가지**, 그리고 권위를 서비스가 아니라 Git에 둔 이유:
 
@@ -247,38 +225,15 @@ other
 
 모든 커밋에 trailer를 손으로 쓸 필요는 없다. 대부분의 커밋에는 record가 없어야 한다. 외부 제약, 제외한 대안, 경고, 검증 공백처럼 diff만으로 복구할 수 없는 결정에만 record를 추가한다.
 
-### 코딩 에이전트를 통해
-
 에이전트에게 평소대로 커밋하고 diff로 설명할 수 없는 결정 맥락만 보존하도록 요청한다.
 
 > 이 변경을 커밋해. diff로 중요한 제약, 제외한 대안, 경고 또는 검증 공백을 복구할 수 없을 때만 CommitLore record를 추가해.
 
-대부분의 커밋에는 여전히 record가 없어야 한다. 에이전트 지침은 `skills/commitlore-commits/`에 있고, commit hook은 에이전트가 추가한 record를 검증한다.
-
-### 고급 경로: harvest
-
-`commitlore harvest`는 session transcript와 staged diff에서 prompt contract를 만들고, `commitlore harvest-verify`는 그에 맞는 draft를 검증한다. 둘은 draft를 돕지만 자동 커밋하지 않는다. interactive record builder는 구현되지 않았다.
-
-### 직접 작성
-
-탈출구로 사람이 평범한 Git trailer를 직접 쓸 수 있다. commit-msg hook은 이미 있는 record를 검증할 뿐이며, record를 발명하거나 조용히 추가하지 않는다.
-
-## 최소 record
-
-record는 작을 수 있다. 그렇지 않으면 잃게 될 맥락만 넣는다.
-
-```text
-Fix expired-token refresh
-
-Ruled-out: Extend token TTL to 24h | security policy violation
-Warn: Do not narrow the 4xx handler without verifying upstream behavior
-```
-
-대부분의 record에는 모든 protocol field가 필요하지 않다. 결정에 필요할 때 identity, lifecycle, risk, provenance, verification field를 사용할 수 있다.
+에이전트 지침은 `skills/commitlore-commits/`에 있고, commit-msg hook은 에이전트가 추가한 record를 검증할 뿐 record를 발명하거나 조용히 추가하지 않는다. `harvest` 경로, `capture` 트랜잭션, 그리고 사람이 trailer를 직접 쓰는 탈출구는 모두 [docs/capture.md](docs/capture.md)에 있다.
 
 ## 완전한 record
 
-이 예시는 conformance fixture이기도 하다. Git trailer parser는 모든 번역 README에서 아래 code block을 동일하게 읽는다.
+record는 이보다 훨씬 작을 수 있고, 대부분은 몇 개 field면 충분하다. 이 예시가 어휘 전체를 쓰는 이유는 conformance fixture이기도 하기 때문이다 — Git trailer parser는 모든 번역 README에서 아래 code block을 동일하게 읽는다.
 
 ```text
 Prevent silent session drops during long-running operations
@@ -319,13 +274,7 @@ CommitLore-Version: 2.0.0
 | `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
 | `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
 
-경로의 이력을 `commitlore context <path>`로 읽거나 Git을 직접 쓴다.
-
-```bash
-git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
-```
-
-텍스트 검색 대신 Git trailer parser를 쓴다. 본문에 있는 `Key:`는 trailer가 아닐 수 있다.
+경로의 이력은 `commitlore context <path>`로 읽는다. 더 작은 예시와 Git만으로 record를 읽는 방법은 [docs/protocol.md](docs/protocol.md)에, 규범적 정의는 [SPEC §3](spec/SPEC.md)에 있다.
 
 ## 저장소가 증명하는 것
 
@@ -340,13 +289,7 @@ git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
 
 112회 실험은 기록됐지만 M4에는 run별 `guard_exposure` 기록이 없다. treatment가 있었는지 검증할 수 없으므로 agent behavior 주장을 시험하거나 뒷받침하거나 반박하지 못한다. 위의 더 좁은 제품 주장은 독립적으로 검증 가능한 동작에 근거한다. 깨끗한 데이터셋과 철회 내용은 [M4 verdict](bench/VERDICT-M4.md)에서 읽을 수 있다.
 
-### 지연 시간, 비용과 손익분기점
-
-100,000개 커밋에서 색인된 `context`의 p50은 496 ms이고 CommitLore 자체의 `--no-index` 대체 경로는 86,673 ms다. 이 내부 대체 경로 간격은 1k에서 4.8×, 10k에서 36×, 100k에서 175×로 커진다([전체 결정론적 실행](https://github.com/MongLong0214/commitlore/blob/2fade893f25917fce1ffb497aab96b1eb271a185/bench/results/deterministic-20260729T032652Z.md)). 이는 확장 양상이며 제품과 대안을 비교한 결과가 아니다.
-
-guard가 한 번 실행될 때 드는 비용은 주입된 context와 측정된 hook 오버헤드다. commit-msg는 p50 185.85 ms, injection hook은 p50 102.40 ms다([deterministic measurements](bench/results/deterministic-20260727T174801Z.md)).
-
-손익분기 수치를 다시 제시하려면 제공업체가 보고한 턴별 토큰 사용량 원장과 저장소가 이미 배제한 대안에 쓴 작업의 관측된 비용이 필요하다.
+무엇이 측정됐는지 — 검색, 노출, 지연 시간과 확장, hook 오버헤드 — 그리고 무엇이 측정되지 않았는지 — 손익분기, 그리고 에이전트 행동에 대한 효과 — 는 [docs/evidence.md](docs/evidence.md)에 정리돼 있다.
 
 <details>
 <summary>전체 benchmark 기록 (112회 실험)</summary>
@@ -393,16 +336,6 @@ guard가 한 번 실행될 때 드는 비용은 주입된 context와 측정된 h
 
 </details>
 
-## 소스에서 설치
-
-소스 배포를 살펴보거나 실행하려면 다음을 쓴다.
-
-```bash
-git clone https://github.com/MongLong0214/commitlore ~/.commitlore
-node ~/.commitlore/dist/commitlore.mjs init
-node ~/.commitlore/dist/commitlore.mjs context src/auth
-```
-
 ## 제거
 
 ```bash
@@ -411,11 +344,18 @@ commitlore uninstall
 
 `install.sh` 또는 `install.ps1`이 쓴 것을 제거한다 — wrapper, 고정된 checkout,
 그리고 각 agent config에 추가한 MCP 항목. 자신이 쓰지 않은 것은 제거하지 않으며,
-남기는 것을 명시한다: 저장소별 hook — `commit-msg`, `prepare-commit-msg`,
-`post-commit` 세 개 모두 `commitlore hooks uninstall`이 제거한다 —, agent
-hook(`commitlore inject uninstall-claude-hook`), Claude Code
-plugin(`/plugin uninstall commitlore@commitlore`). `--dry-run`은 아무것도 바꾸지
-않고 보고만 한다.
+남기는 것을 명시한다: 저장소별 hook, agent hook, Claude Code plugin.
+`--dry-run`은 아무것도 바꾸지 않고 보고만 한다. 각각을 무엇이 제거하는지, 그리고
+소스 체크아웃에서 실행하는 방법은 [docs/install.md](docs/install.md)에 있다.
+
+## 문서
+
+- [docs/install.md](docs/install.md) — 설치 경로, 각 경로가 쓰는 것, 되돌리는 방법
+- [docs/cli.md](docs/cli.md) — 모든 명령과 플래그
+- [docs/capture.md](docs/capture.md) — record가 쓰이는 과정
+- [docs/protocol.md](docs/protocol.md) — record 형식과 Git만으로 읽는 방법
+- [docs/evidence.md](docs/evidence.md) — 무엇이 측정됐고 무엇이 아닌지
+- [spec/SPEC.md](spec/SPEC.md) — 규범 프로토콜
 
 ## 알려진 제한 사항
 

--- a/README.md
+++ b/README.md
@@ -80,21 +80,13 @@ warnings
   r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
 ```
 
-<details>
-<summary>Reproduce the exact PreToolUse hook path</summary>
-
-```bash
-printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
-  | node dist/commitlore.mjs inject --hook-input --budget 5000
-```
-
-</details>
+Reproducing that exact `PreToolUse` hook path, and every other command: [docs/cli.md](docs/cli.md).
 
 ## Retrieval can find records. Path scope keeps reversed decisions out.
 
 Missing a record costs the model context. Handing it a decision that was already reversed costs it correctness. In this [retrieval measurement](bench/retrieval/result.md), at every size from 0 to 10,000 distractors, BM25, embedding top-k, hybrid RRF, and embedding with a path filter each returned one superseded record. CommitLore path scope with lifecycle returned zero stale records and both current records (2/2).
 
-Recall is the supporting result: retrieval finds broadly the same records either way, but only one route knows which are still current. On #166's corpus with no superseded records, embedding retrieval matched path scope at 2/2. The advantage appears when decisions have been reversed—the case this product exists for.
+Recall is the supporting result: retrieval finds broadly the same records either way, but only one route knows which are still current. The advantage appears when decisions have been reversed—the case this product exists for.
 
 The separate #167 exposure run still matters: only 2 of 10,002 records reached the model.
 
@@ -104,18 +96,11 @@ The separate #167 exposure run still matters: only 2 of 10,002 records reached t
 | top-k lexical | 2 | 1/2 | 190 |
 | CommitLore path scope | 2 | 2/2 | 335 |
 
-This measures exposure and recall at a fixed two-record output budget—not token cost, billed cost, accuracy, or agent behaviour. It is one corpus, one query, and one pinned embedding model.
-
-Then run `commitlore init` in each repository where you want validation hooks and a local index. The installer detects supported coding agents and registers the local MCP server where it can do so safely.
-
-## What happens after init
-
-- Commit normally. Most commits carry no record.
-- If a record is present, the commit-msg hook validates it; it never creates one.
-- Agents query decision context through MCP or receive it from the `PreToolUse` hook.
-- Before changing a path, they see its active limits, ruled-out alternatives, warnings, and verification gaps.
+This measures exposure and recall at a fixed two-record output budget—not token cost, billed cost, accuracy, or agent behaviour. It is one corpus, one query, and one pinned embedding model. Where recall ties, and what else has and has not been measured: [docs/evidence.md](docs/evidence.md).
 
 ## Try it in a repository
+
+Then run `commitlore init` in each repository where you want validation hooks and a local index. The installer detects supported coding agents and registers the local MCP server where it can do so safely.
 
 ```bash
 cd your-repository
@@ -123,7 +108,14 @@ commitlore init
 commitlore context .
 ```
 
-Then keep working through your coding agent. When a change contains decision context the diff cannot preserve, ask the agent to include a CommitLore record in the commit.
+After that:
+
+- Commit normally. Most commits carry no record.
+- If a record is present, the commit-msg hook validates it; it never creates one.
+- Agents query decision context through MCP or receive it from the `PreToolUse` hook.
+- Before changing a path, they see its active limits, ruled-out alternatives, warnings, and verification gaps.
+
+Keep working through your coding agent. When a change contains decision context the diff cannot preserve, ask the agent to include a CommitLore record in the commit.
 
 <details>
 <summary>Prefer to inspect or pin the installation?</summary>
@@ -189,36 +181,21 @@ there.
 ## What it looks like on a real repository
 
 From a field report on a ~768-commit Swift MCP server, one day after installing.
-The engineer had already run a full census of the codebase before installing
-CommitLore, and was working through the files that census had flagged.
-
-```
-$ commitlore context Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
-context for … — 0 limits, 0 ruled-out, 0 warnings, 2 other in 2 records
-
-other
-  -  01ff2705  [claim]  ax: eliminate clear-win coordinate actuations (8 sites)
-                        with live-verified AX paths
-```
+Naming one file path surfaced a merged pull request the engineer did not know
+existed, and it changed what the surviving code meant.
 
 > **I did not know that commit existed.** It is a merged PR from two weeks
 > earlier that had already removed eight of these sites and replaced each with
 > an accessibility-native equivalent, every one fail-closed and live-verified.
->
-> It relocated my census. I had been treating the surviving sites as *the*
-> problem. They are the **residual** after a shipped removal campaign — the ones
-> that survived a deliberate attempt to remove them. That is a different
-> engineering problem and a different risk assessment.
 >
 > None of this was in any chat history. It was in the repository, and I got it
 > by naming a file path.
 
 The alternative was reading two weeks of merged pull requests to find it. That is
 not something an agent does spontaneously, and not something a person does before
-every edit.
-
-Adoption cost, from the same report: one command, and 7.4 seconds to index 768
-commits. Nothing touched history or the working tree.
+every edit. Adoption cost, from the same report: one command, and 7.4 seconds to
+index 768 commits. Nothing touched history or the working tree. The console
+output and the full report are in [docs/evidence.md](docs/evidence.md).
 
 **Three properties no hosted chat-history product can offer**, and the reason the
 authority is Git rather than a service:
@@ -259,38 +236,15 @@ Each is a sentence a diff cannot carry and a reviewer would otherwise have to sa
 
 You do not hand-write a trailer for every commit. Most commits should carry no record at all. Add one only for a decision the diff cannot recover: an external constraint, a rejected alternative, a warning, or a verification gap.
 
-### Through a coding agent
-
 Ask the agent to commit normally and preserve only the decision context the diff cannot explain:
 
 > Commit this change. Add a CommitLore record only if the diff cannot recover an important constraint, rejected alternative, warning, or verification gap.
 
-Most commits should still carry no record. The agent instructions live in `skills/commitlore-commits/`, and the commit hook validates any record the agent adds.
-
-### Advanced: harvest
-
-`commitlore harvest` builds a prompt contract from a session transcript and staged diff; `commitlore harvest-verify` checks a draft against them. They support drafting, not automatic commits. Interactive record building is not implemented.
-
-### By hand
-
-As an escape hatch, a human can write ordinary Git trailers by hand. The commit-msg hook validates records that are already present; it never invents or silently adds one.
-
-## A minimal record
-
-A record can be small. Include only the context that would otherwise be lost:
-
-```text
-Fix expired-token refresh
-
-Ruled-out: Extend token TTL to 24h | security policy violation
-Warn: Do not narrow the 4xx handler without verifying upstream behavior
-```
-
-Most records do not need every protocol field. Identity, lifecycle, risk, provenance, and verification fields are available when the decision needs them.
+The agent instructions live in `skills/commitlore-commits/`, and the commit-msg hook validates any record the agent adds — it never invents or silently adds one. The `harvest` route, the `capture` transaction, and the escape hatch of writing trailers by hand are all in [docs/capture.md](docs/capture.md).
 
 ## A complete record
 
-This example is also a conformance fixture. Git's trailer parser reads the code block identically in every translated README.
+A record can be much smaller than this; most need only a few fields. This one uses the whole vocabulary because it is also a conformance fixture — Git's trailer parser reads the code block identically in every translated README.
 
 ```text
 Prevent silent session drops during long-running operations
@@ -331,13 +285,7 @@ CommitLore-Version: 2.0.0
 | `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
 | `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
 
-Read a path's history with `commitlore context <path>`, or use Git directly:
-
-```bash
-git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
-```
-
-Use Git's trailer parser, not a text search: prose containing `Key:` is not necessarily a trailer.
+Read a path's history with `commitlore context <path>`. Smaller examples, and how to read records with plain Git instead, are in [docs/protocol.md](docs/protocol.md); the normative definitions are in [SPEC §3](spec/SPEC.md).
 
 ## What the repository proves
 
@@ -352,13 +300,7 @@ These are product claims about Git-bound, human-verifiable decision history. The
 
 112 experiments were recorded, but M4 recorded no per-run guard exposure. Whether the treatment was present is unverifiable, so it does not test, support, or refute the agent-behavior claim. The narrower product claim above rests on independently testable behavior; read the [M4 verdict](bench/VERDICT-M4.md) for the clean dataset and withdrawal.
 
-### Latency, cost, and break-even
-
-At 100,000 commits, indexed `context` p50 is 496 ms; CommitLore's own `--no-index` fallback is 86,673 ms. That internal fallback gap grows 4.8× at 1k, 36× at 10k, and 175× at 100k ([complete deterministic run](https://github.com/MongLong0214/commitlore/blob/2fade893f25917fce1ffb497aab96b1eb271a185/bench/results/deterministic-20260729T032652Z.md)); it is a scaling shape, not a product-versus-alternative result.
-
-The guard costs injected context plus measured hook overhead: 185.85 ms p50 for commit-msg and 102.40 ms p50 for the injection hook ([deterministic measurements](bench/results/deterministic-20260727T174801Z.md)).
-
-A break-even figure would require a per-turn ledger of provider-reported token usage and an observed cost for work spent on an alternative the repository had already rejected.
+What is measured — retrieval, exposure, latency and scaling, hook overhead — and what is not — break-even, and any effect on agent behaviour — is set out in [docs/evidence.md](docs/evidence.md).
 
 <details>
 <summary>Full benchmark record (112 experiments)</summary>
@@ -405,16 +347,6 @@ A break-even figure would require a per-turn ledger of provider-reported token u
 
 </details>
 
-## Install from source
-
-To inspect or run the source distribution:
-
-```bash
-git clone https://github.com/MongLong0214/commitlore ~/.commitlore
-node ~/.commitlore/dist/commitlore.mjs init
-node ~/.commitlore/dist/commitlore.mjs context src/auth
-```
-
 ## Uninstall
 
 ```bash
@@ -423,11 +355,19 @@ commitlore uninstall
 
 Removes what `install.sh` or `install.ps1` wrote — the wrapper, the pinned
 checkout, and the MCP entry it added to each agent config. It removes nothing it
-did not write, and names what it leaves: the per-repository hooks — `commit-msg`,
-`prepare-commit-msg` and `post-commit`, all three removed by `commitlore hooks
-uninstall` — the agent hook (`commitlore inject uninstall-claude-hook`), and the
-Claude Code plugin (`/plugin uninstall commitlore@commitlore`). `--dry-run`
-reports without changing anything.
+did not write, and names what it leaves: the per-repository hooks, the agent
+hook, and the Claude Code plugin. `--dry-run` reports without changing anything.
+What removes each of those, and how to run from a source checkout instead:
+[docs/install.md](docs/install.md).
+
+## Documentation
+
+- [docs/install.md](docs/install.md) — the install paths, what each one writes, and how to undo it
+- [docs/cli.md](docs/cli.md) — every command, with its flags
+- [docs/capture.md](docs/capture.md) — how a record gets written
+- [docs/protocol.md](docs/protocol.md) — the record format, and reading it with plain Git
+- [docs/evidence.md](docs/evidence.md) — what is measured, and what is not
+- [spec/SPEC.md](spec/SPEC.md) — the normative protocol
 
 ## Known limitations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,21 +78,13 @@ warnings
   r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
 ```
 
-<details>
-<summary>复现完全相同的 PreToolUse hook path</summary>
-
-```bash
-printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
-  | node dist/commitlore.mjs inject --hook-input --budget 5000
-```
-
-</details>
+如何原样复现这条 `PreToolUse` hook path，以及其余全部命令：[docs/cli.md](docs/cli.md)。
 
 ## 检索能找到记录。路径范围会排除已经推翻的决策。
 
 漏掉一条记录，模型损失的是上下文；交给它一项已经推翻的决策，损失的是正确性。在这项[检索测量](bench/retrieval/result.md)中，从 0 到 10,000 条干扰记录的每个规模，BM25、embedding top-k、hybrid RRF 与带路径过滤的 embedding 都各返回了一条已被替代的记录。带生命周期的 CommitLore 路径范围返回零条过时记录，并返回两条当前记录 (2/2)。
 
-召回率是辅助结果：两种方式的检索大体找到相同的记录，但只有一条路由知道哪些仍然有效。在没有已被替代记录的 #166 语料库中，embedding 检索与路径范围同为 2/2。决策被推翻时优势才会出现——而这正是本产品存在的情形。
+召回率是辅助结果：两种方式的检索大体找到相同的记录，但只有一条路由知道哪些仍然有效。决策被推翻时优势才会出现——而这正是本产品存在的情形。
 
 独立的 #167 暴露运行仍然重要：10,002 条记录中只有 2 条到达模型。
 
@@ -102,18 +94,11 @@ printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
 | top-k 词法检索 | 2 | 1/2 | 190 |
 | CommitLore 路径范围 | 2 | 2/2 | 335 |
 
-这项测量是在固定的两条记录输出预算下进行的暴露与召回率测量，不测量令牌成本、计费成本、准确率或代理行为。它只涉及一个语料库、一个查询和一个固定的 embedding 模型。
-
-然后在每个需要验证 hook 与本地 index 的仓库运行 `commitlore init`。安装程序会检测受支持的编程代理，并在可以安全处理的地方注册本地 MCP server。
-
-## init 之后会发生什么
-
-- 照常提交。绝大多数提交没有 record。
-- 如果已有 record，commit-msg hook 会验证它；不会创建 record。
-- 代理通过 MCP 查询决策上下文，或从 `PreToolUse` hook 接收它。
-- 更改 path 前，它们会看到 active limit、ruled-out alternative、warning 和 verification gap。
+这项测量是在固定的两条记录输出预算下进行的暴露与召回率测量，不测量令牌成本、计费成本、准确率或代理行为。它只涉及一个语料库、一个查询和一个固定的 embedding 模型。召回率打平的地方，以及此外还测量了什么、没测量什么：[docs/evidence.md](docs/evidence.md)。
 
 ## 在仓库中试用
+
+然后在每个需要验证 hook 与本地 index 的仓库运行 `commitlore init`。安装程序会检测受支持的编程代理，并在可以安全处理的地方注册本地 MCP server。
 
 ```bash
 cd your-repository
@@ -121,7 +106,14 @@ commitlore init
 commitlore context .
 ```
 
-然后继续通过编程代理工作。若某项更改包含 diff 无法保存的决策上下文，请让代理在提交中加入 CommitLore record。
+在那之后：
+
+- 照常提交。绝大多数提交没有 record。
+- 如果已有 record，commit-msg hook 会验证它；不会创建 record。
+- 代理通过 MCP 查询决策上下文，或从 `PreToolUse` hook 接收它。
+- 更改 path 前，它们会看到 active limit、ruled-out alternative、warning 和 verification gap。
+
+继续通过编程代理工作。若某项更改包含 diff 无法保存的决策上下文，请让代理在提交中加入 CommitLore record。
 
 <details>
 <summary>想检查或固定安装版本？</summary>
@@ -182,30 +174,17 @@ Ruled-out
 
 ## 在真实仓库中的样子
 
-来自一份约 768 次提交的 Swift MCP 服务器现场报告，安装后第二天。工程师在安装 CommitLore
-之前已完成代码库的全面普查，当时正在处理普查标记出的文件。
-
-```
-$ commitlore context Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
-context for … — 0 limits, 0 ruled-out, 0 warnings, 2 other in 2 records
-
-other
-  -  01ff2705  [claim]  ax: eliminate clear-win coordinate actuations (8 sites)
-                        with live-verified AX paths
-```
+来自一份约 768 次提交的 Swift MCP 服务器现场报告，安装后第二天。只给出一个文件路径，
+就浮出了一个工程师并不知道其存在的已合并 PR，而它改变了留存代码的含义。
 
 > **我不知道那个提交存在。** 那是两周前合并的 PR，已经移除了其中八处，并把每一处都换成了
 > accessibility-native 的等价实现，全部 fail-closed 并经过真机验证。
 >
-> 它重新定位了我的普查。我一直把剩下的站点当作问题**本身**。不是的。它们是一次已发布的
-> 移除行动之后的**残余** — 是在一次有意的移除尝试中存活下来的那些。这是完全不同的工程
-> 问题，也是不同的风险评估。
->
 > 这些都不在任何聊天记录里。它们在仓库里，而我只是给出了一个文件路径。
 
 替代方案是通读两周的已合并 PR。这不是代理会主动做的事，也不是人在每次编辑前会做的事。
-
 同一份报告中的接入成本：一条命令，768 次提交索引耗时 7.4 秒。不触碰历史，也不触碰工作区。
+控制台输出与报告全文见 [docs/evidence.md](docs/evidence.md)。
 
 **托管式聊天记录产品无法提供的三个性质**，也是把权威放在 Git 而非服务上的理由：
 
@@ -243,38 +222,15 @@ other
 
 不必为每次提交手写 trailer。绝大多数提交都不应带 record。只在 diff 无法还原的决策中添加 record：外部限制、排除的方案、warning 或 verification gap。
 
-### 通过编程代理
-
 让代理照常提交，只保留 diff 无法解释的决策上下文：
 
 > 提交这项更改。只有当 diff 无法还原重要限制、排除的方案、warning 或 verification gap 时，才添加 CommitLore record。
 
-绝大多数提交仍不应带 record。代理说明位于 `skills/commitlore-commits/`，commit hook 会验证代理添加的任何 record。
-
-### 高级路径：harvest
-
-`commitlore harvest` 从 session transcript 和 staged diff 构建 prompt contract；`commitlore harvest-verify` 据此检查 draft。它们支持起草，而不会自动提交。interactive record builder 尚未实现。
-
-### 手写
-
-作为逃生出口，人可以手写普通 Git trailer。commit-msg hook 只验证已经存在的 record；它不会凭空创建或静默添加 record。
-
-## 最小 record
-
-record 可以很小。只包含否则会丢失的上下文：
-
-```text
-Fix expired-token refresh
-
-Ruled-out: Extend token TTL to 24h | security policy violation
-Warn: Do not narrow the 4xx handler without verifying upstream behavior
-```
-
-绝大多数 record 不需要所有 protocol field。决策需要时，可以使用 identity、lifecycle、risk、provenance 和 verification field。
+代理说明位于 `skills/commitlore-commits/`，commit-msg hook 只验证代理添加的 record，不会凭空创建或静默添加。`harvest` 路径、`capture` 事务，以及手写 trailer 这条逃生出口，都在 [docs/capture.md](docs/capture.md)。
 
 ## 完整 record
 
-这个示例也是 conformance fixture。Git trailer parser 会在所有翻译版 README 中以相同方式读取下面的 code block。
+record 可以比这小得多，绝大多数只需要几个 field。这个示例用上全部词汇，是因为它同时也是 conformance fixture —— Git trailer parser 会在所有翻译版 README 中以相同方式读取下面的 code block。
 
 ```text
 Prevent silent session drops during long-running operations
@@ -315,13 +271,7 @@ CommitLore-Version: 2.0.0
 | `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
 | `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
 
-用 `commitlore context <path>` 读取 path 的历史，或直接使用 Git：
-
-```bash
-git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
-```
-
-请使用 Git trailer parser，而不是 text search：正文里的 `Key:` 不一定是 trailer。
+用 `commitlore context <path>` 读取 path 的历史。更小的示例，以及只用 Git 读取 record 的方法，在 [docs/protocol.md](docs/protocol.md)；规范定义在 [SPEC §3](spec/SPEC.md)。
 
 ## 仓库能够证明什么
 
@@ -336,13 +286,7 @@ git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
 
 已记录 112 次实验，但 M4 没有逐次运行的 `guard_exposure` 记录。无法验证 treatment 是否存在，因此它没有检验、支持或反驳 agent behavior 的主张。上面更窄的产品主张基于可独立验证的行为。关于干净的数据集和撤回，请见 [M4 verdict](bench/VERDICT-M4.md)。
 
-### 延迟、成本与盈亏平衡
-
-在 100,000 次提交时，已建立索引的 `context` 的 p50 为 496 ms；CommitLore 自身的 `--no-index` 后备路径为 86,673 ms。这一内部后备路径差距在 1k 时为 4.8×、10k 时为 36×、100k 时为 175×（[完整的确定性运行](https://github.com/MongLong0214/commitlore/blob/2fade893f25917fce1ffb497aab96b1eb271a185/bench/results/deterministic-20260729T032652Z.md)）。这是扩展形态，不是产品与替代方案的比较结果。
-
-guard 每次运行的成本是注入的 context 加上测得的 hook overhead：commit-msg 的 p50 为 185.85 ms，injection hook 的 p50 为 102.40 ms（[deterministic measurements](bench/results/deterministic-20260727T174801Z.md)）。
-
-要重新给出盈亏平衡数值，需要一份逐轮记录、由提供商报告的令牌用量账本，以及为仓库已经否决的替代方案所花工作的观测成本。
+哪些已被测量——检索、暴露、延迟与扩展、hook overhead——以及哪些尚未被测量——盈亏平衡，以及对代理行为的任何影响——都写在 [docs/evidence.md](docs/evidence.md)。
 
 <details>
 <summary>完整 benchmark 记录（112 次实验）</summary>
@@ -389,16 +333,6 @@ guard 每次运行的成本是注入的 context 加上测得的 hook overhead：
 
 </details>
 
-## 从 source 安装
-
-要检查或运行 source distribution，请使用：
-
-```bash
-git clone https://github.com/MongLong0214/commitlore ~/.commitlore
-node ~/.commitlore/dist/commitlore.mjs init
-node ~/.commitlore/dist/commitlore.mjs context src/auth
-```
-
 ## 卸载
 
 ```bash
@@ -407,10 +341,18 @@ commitlore uninstall
 
 移除 `install.sh` 或 `install.ps1` 写入的内容 — wrapper、固定的 checkout，以及它
 添加到各 agent config 的 MCP 条目。它不会移除自己没有写入的东西，并会明确说明留下
-了什么：各仓库的 hook（`commit-msg`、`prepare-commit-msg`、`post-commit` 三个都由
-`commitlore hooks uninstall` 移除）、agent hook
-（`commitlore inject uninstall-claude-hook`）、Claude Code plugin
-（`/plugin uninstall commitlore@commitlore`）。`--dry-run` 只报告，不做任何更改。
+了什么：各仓库的 hook、agent hook、Claude Code plugin。`--dry-run` 只报告，不做任何
+更改。它们各自由什么移除，以及如何改从 source 检出运行，见
+[docs/install.md](docs/install.md)。
+
+## 文档
+
+- [docs/install.md](docs/install.md) — 各条安装路径、各自写入什么、如何撤销
+- [docs/cli.md](docs/cli.md) — 每条命令及其参数
+- [docs/capture.md](docs/capture.md) — record 是怎么写出来的
+- [docs/protocol.md](docs/protocol.md) — record 格式，以及只用 Git 读取的方法
+- [docs/evidence.md](docs/evidence.md) — 哪些已被测量，哪些没有
+- [spec/SPEC.md](spec/SPEC.md) — 规范协议
 
 ## 已知限制
 

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -1,0 +1,62 @@
+# How records get created
+
+You do not hand-write a trailer for every commit. Most commits should carry no
+record at all. Add one only for a decision the diff cannot recover: an external
+constraint, a rejected alternative, a warning, or a verification gap.
+
+CommitLore never invents a record. The commit-msg hook validates a record that
+is already present; it does not create one, and it does not silently add one.
+
+## Through a coding agent
+
+Ask the agent to commit normally and preserve only the decision context the diff
+cannot explain:
+
+> Commit this change. Add a CommitLore record only if the diff cannot recover an
+> important constraint, rejected alternative, warning, or verification gap.
+
+Most commits should still carry no record. The agent instructions live in
+[`skills/commitlore-commits/`](../skills/commitlore-commits/), and the commit
+hook validates any record the agent adds.
+
+## Advanced: harvest
+
+`commitlore harvest` builds a prompt contract from a session transcript and a
+staged diff, and `commitlore harvest-verify` checks a draft against them. They
+support drafting, not automatic commits. Interactive record building is not
+implemented.
+
+```bash
+# 1. Build the prompt contract for the session and hand it to the agent.
+commitlore harvest --transcript session.jsonl --prompt-only
+
+# 2. The agent answers with a draft. Check what survives the transcript and diff.
+commitlore harvest --transcript session.jsonl --draft draft.json
+commitlore harvest-verify --transcript session.jsonl --draft draft.json
+```
+
+`commitlore harvest --diff <file>` reads a diff other than the staged one, and
+`--out <file>` writes the output somewhere other than stdout.
+
+`commitlore capture` runs the same idea as one transaction — prepare, verify,
+then stage a record from a transcript and draft, with no trailer syntax to
+write. `commitlore pending` inspects capture transactions that have not reached
+a commit yet, and `commitlore capture gc` removes expired ones.
+
+Whatever route produces the draft, the record only becomes real when the
+commit-msg hook validates it on the commit.
+
+## By hand
+
+As an escape hatch, a human can write ordinary Git trailers by hand. The trailer
+grammar is in [protocol.md](protocol.md); the normative rules are in
+[`spec/SPEC.md`](../spec/SPEC.md).
+
+## What happens to a record afterwards
+
+- It lives in Git, with an identity (`Record-Id:`) that survives a rewritten
+  commit hash, and a lifecycle (`Supersedes:`, `Expires:`).
+- Before a path is edited, the next agent receives only the decisions still in
+  force — through MCP, or through the `PreToolUse` hook.
+- A decision that was later superseded or expired does not reach the agent as if
+  it still stood. `commitlore stale` lists the ones that no longer apply.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,95 @@
+# CLI reference
+
+`commitlore --help` is authoritative and always current; this page is the map.
+Every command prints its own exit codes under `--help`, following SPEC §10: `0`
+ran, `2` a usage error, and where a command can tell the difference, `3` for an
+unfetched notes mirror.
+
+Installing the CLI is in [install.md](install.md). Without the wrapper on
+`PATH`, every command below also works as
+`node <checkout>/dist/commitlore.mjs <command>`.
+
+## Reading decisions
+
+| Command | What it answers |
+|---|---|
+| `commitlore context [paths...]` | every active record for a path: limits, ruled-out alternatives and warnings |
+| `commitlore limits [paths...]` | the active `Limit:` records for a path |
+| `commitlore ruled-out [paths...]` | the active `Ruled-out:` records for a path |
+| `commitlore warnings [paths...]` | the active `Warn:` records for a path |
+| `commitlore stale` | records that are superseded, expired, or flagged for review |
+| `commitlore guard [paths...]` | *experimental advisory* — flags a proposal that may revive a ruled-out alternative |
+
+`context`, `limits`, `ruled-out` and `warnings` take the same flags: `--json`
+for structured output, `--all-history` to include superseded and expired records
+(each labelled), `--at <instant>` to evaluate as of an ISO 8601 instant,
+`--limit <n>`, `--no-index` to answer from Git alone, and `--trusted-author
+<author>` (repeatable) to name an author whose records may render as
+instructions rather than as claims. `stale` takes `--json`, `--at` and
+`--all-history`, which there means scanning the whole history rather than the
+most recent 1000 commits.
+
+`guard` is a lead to inspect, not evidence that a proposal is wrong: precision
+44.8%, recall 22.0%. See [evidence.md](evidence.md).
+
+## Delivering decisions to an agent
+
+| Command | What it does |
+|---|---|
+| `commitlore inject` | the deterministic, path-scoped projection an agent is given before it edits |
+| `commitlore mcp` | serves CommitLore over stdio MCP: `commitlore://context/<path>` and query tools |
+
+`inject --path <path> --budget <tokens>` produces the projection directly.
+`inject --hook-input` reads a `PreToolUse` payload on stdin and answers as hook
+JSON — which is exactly how the Claude Code hook calls it, and how to reproduce
+that path by hand:
+
+```bash
+printf '%s\n' '{"tool_name":"Edit","tool_input":{"file_path":"install.sh"}}' \
+  | node dist/commitlore.mjs inject --hook-input --budget 5000
+```
+
+`inject install-claude-hook`, `inject uninstall-claude-hook` and
+`inject claude-hook-status` manage that hook in a Claude Code `settings.json`,
+leaving every other setting untouched.
+
+## Writing decisions
+
+| Command | What it does |
+|---|---|
+| `commitlore harvest` | builds the harvest prompt contract, or checks a draft a session produced |
+| `commitlore harvest-verify` | checks a harvested draft against the transcript and diff it claims to quote |
+| `commitlore capture` | prepare → verify → stage a record from a transcript and draft, with no trailer syntax to write |
+| `commitlore pending` | inspects capture transactions that have not reached a commit yet |
+| `commitlore backfill` | reconstructs records for past commits that have none (all `Provenance: reconstructed`) |
+
+The workflow these belong to is in [capture.md](capture.md); the trailer grammar
+is in [protocol.md](protocol.md).
+
+## Validating and maintaining
+
+| Command | What it does |
+|---|---|
+| `commitlore init` | one-command onboarding: `hooks install`, `index --rebuild`, claude hook install, `doctor --fix` |
+| `commitlore doctor` | checks that this repository can carry and share records |
+| `commitlore hooks` | `install`, `uninstall`, `status` for the Git hooks |
+| `commitlore index` | builds or refreshes the derived record index (`.git/commitlore/index.db`) |
+| `commitlore parse` | parses a commit message into its CommitLore trailers (SPEC §2) |
+| `commitlore validate` | checks commit trailers against the protocol (SPEC §6) |
+| `commitlore squash-preserve <range>` | carries the records of a squashed branch onto the merge commit (ADR-0004) |
+| `commitlore demo` | runs a self-contained lifecycle demo in a temporary repository (no network, no model) |
+| `commitlore uninstall` | removes what `install.sh` or `install.ps1` wrote — see [install.md](install.md) |
+
+`hooks install` preserves and chains any existing `commit-msg` hook.
+`hooks uninstall` removes every CommitLore hook — `commit-msg`,
+`prepare-commit-msg`, `post-commit` — and restores any they replaced.
+
+`prepare-commit-msg` and `post-commit` are internal hook commands. Git invokes
+them; you do not.
+
+## The index is derived
+
+`.git/commitlore/index.db` is a cache. The authority is the commit trailers and
+`refs/notes/commitlore`, so `commitlore index --rebuild` can always reconstruct
+it, and `--no-index` answers the same questions from Git alone — more slowly.
+The gap between the two at scale is measured in [evidence.md](evidence.md).

--- a/docs/evidence.md
+++ b/docs/evidence.md
@@ -1,0 +1,120 @@
+# Evidence
+
+What this project has measured, what it has not, and where each figure comes
+from. Every number here is regenerated from a log in
+[`bench/`](../bench/README.md); the measurement rules are in
+[MEASUREMENT-PROTOCOL.md](MEASUREMENT-PROTOCOL.md).
+
+The README states the product claim; this page states what backs it. The
+benchmark summary block itself stays in the README, in all four languages,
+because CI regenerates it there from `bench/report.ts` and fails if a single
+byte differs (`scripts/check-readme-numbers.mjs`).
+
+## Measured
+
+### Exposure and recall under path scope
+
+In the [retrieval measurement](../bench/retrieval/result.md), at every size from
+0 to 10,000 distractors, BM25, embedding top-k, hybrid RRF, and embedding with a
+path filter each returned one superseded record. CommitLore path scope with
+lifecycle returned zero stale records and both current records (2/2).
+
+Recall is the supporting result: retrieval finds broadly the same records either
+way, but only one route knows which are still current. On #166's corpus with no
+superseded records, embedding retrieval matched path scope at 2/2. The advantage
+appears when decisions have been reversed — the case this product exists for.
+
+The separate #167 exposure run: only 2 of 10,002 records reached the model.
+
+| route | model-visible records | relevant records | model-visible tokens |
+|---|---:|---:|---:|
+| inject everything | 10,002 | 2/2 | 1,004,554 |
+| top-k lexical | 2 | 1/2 | 190 |
+| CommitLore path scope | 2 | 2/2 | 335 |
+
+This measures exposure and recall at a fixed two-record output budget — not
+token cost, billed cost, accuracy, or agent behaviour. It is one corpus, one
+query, and one pinned embedding model.
+
+### Latency and scaling
+
+At 100,000 commits, indexed `context` p50 is 496 ms; CommitLore's own
+`--no-index` fallback is 86,673 ms. That internal fallback gap grows 4.8× at 1k,
+36× at 10k, and 175× at 100k ([complete deterministic
+run](https://github.com/MongLong0214/commitlore/blob/2fade893f25917fce1ffb497aab96b1eb271a185/bench/results/deterministic-20260729T032652Z.md));
+it is a scaling shape, not a product-versus-alternative result.
+
+The guard costs injected context plus measured hook overhead: 185.85 ms p50 for
+commit-msg and 102.40 ms p50 for the injection hook ([deterministic
+measurements](../bench/results/deterministic-20260727T174801Z.md)).
+
+### Adoption cost, on a real repository
+
+From a field report on a ~768-commit Swift MCP server, one day after installing.
+The engineer had already run a full census of the codebase before installing
+CommitLore, and was working through the files that census had flagged.
+
+```
+$ commitlore context Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
+context for … — 0 limits, 0 ruled-out, 0 warnings, 2 other in 2 records
+
+other
+  -  01ff2705  [claim]  ax: eliminate clear-win coordinate actuations (8 sites)
+                        with live-verified AX paths
+```
+
+> **I did not know that commit existed.** It is a merged PR from two weeks
+> earlier that had already removed eight of these sites and replaced each with
+> an accessibility-native equivalent, every one fail-closed and live-verified.
+>
+> It relocated my census. I had been treating the surviving sites as *the*
+> problem. They are the **residual** after a shipped removal campaign — the ones
+> that survived a deliberate attempt to remove them. That is a different
+> engineering problem and a different risk assessment.
+>
+> None of this was in any chat history. It was in the repository, and I got it
+> by naming a file path.
+
+The alternative was reading two weeks of merged pull requests to find it. That
+is not something an agent does spontaneously, and not something a person does
+before every edit.
+
+Adoption cost, from the same report: one command, and 7.4 seconds to index 768
+commits. Nothing touched history or the working tree.
+
+### Behaviour the repository can demonstrate
+
+Decision history surviving rebase, squash, remote transfer and path renames;
+uniform trust grading on every route; injection-like text withheld from
+model-readable routes; an empty repository distinguished from an unfetched notes
+mirror. These are asserted by the test suite and listed under *What the
+repository proves* in the [README](../README.md).
+
+## Not yet measured
+
+### Whether the guard changes what an agent proposes
+
+112 experiments were recorded, but M4 recorded no per-run guard exposure.
+Whether the treatment was present is unverifiable, so it does not test, support,
+or refute the agent-behavior claim. Read the [M4
+verdict](../bench/VERDICT-M4.md) for the clean dataset and the withdrawal; the
+full run table is the generated block in the README.
+
+The matrix is only powered to detect a large effect, so a non-significant result
+from it is a statement about the sample size rather than about CommitLore. The
+power table is in [`bench/README.md`](../bench/README.md).
+
+### Break-even
+
+A break-even figure would require a per-turn ledger of provider-reported token
+usage and an observed cost for work spent on an alternative the repository had
+already rejected. Neither has been collected, so no such figure is published.
+
+### How reliable the guard is as a signal
+
+Guard (ruled-out alternative matching) is an experimental advisory: precision
+44.8% (95% Wilson CI 32.7%–57.5%), recall 22.0% on the 417-decision corpus
+([ADR-0020](adr/ADR-0020-guard-is-an-experimental-advisory.md)). An empty guard
+result does not guarantee a proposal avoids all ruled-out alternatives — at 22%
+recall, a miss is the common case. This disclosure also stays in the README's
+Known-limitations section, where a test asserts it is still there.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,84 @@
+# Installing, and taking it back out
+
+Which hosts are supported and what each install path requires is stated once, in
+[COMPATIBILITY.md](COMPATIBILITY.md). This page is what each path actually
+writes, and how to undo it.
+
+Prerequisites for every path: Node.js 22 or newer, and Git. `install.sh` and
+`install.ps1` check both before they write anything; the plugin path checks
+nothing.
+
+The copy-paste commands, pinned to the current release, are in the
+[README](../README.md) — the version there is asserted against
+`package.json` by `test/readme.test.ts`, so it is the one place a pin cannot go
+stale unnoticed.
+
+## The Claude Code plugin
+
+```
+/plugin marketplace add MongLong0214/commitlore
+/plugin install commitlore@commitlore
+```
+
+That is the whole plugin: the MCP server, the pre-edit `PreToolUse` hook, and
+the skills. It puts no `commitlore` on `PATH`, so the `commitlore …` commands
+need `install.sh` / `install.ps1` as well.
+
+## The install scripts
+
+`install.sh` (POSIX shell) and `install.ps1` (PowerShell) install a pinned
+source checkout and a thin wrapper that runs `node <checkout>/dist/commitlore.mjs`.
+They download no compiled artifact and run no build step, so what lands on the
+machine is source you can read.
+
+The one-liner is for convenience. For a reviewed or pinned install, download and
+inspect `install.sh` first, or clone the repository — the checkout the script
+makes is one you can make yourself. Both forms are shown in the README, under
+*Prefer to inspect or pin the installation?*.
+
+## From a source checkout
+
+To inspect or run the source distribution without the wrapper at all:
+
+```bash
+git clone https://github.com/MongLong0214/commitlore ~/.commitlore
+node ~/.commitlore/dist/commitlore.mjs init
+node ~/.commitlore/dist/commitlore.mjs context src/auth
+```
+
+Every `commitlore <command>` in the documentation works as
+`node ~/.commitlore/dist/commitlore.mjs <command>`.
+
+## Per repository
+
+Installing the CLI does not change any repository. Run this in each repository
+where you want validation hooks and a local index:
+
+```bash
+cd your-repository
+commitlore init
+```
+
+`init` installs the hooks, rebuilds the index, installs the Claude hook, and
+runs `doctor --fix`. The installer detects supported coding agents and registers
+the local MCP server where it can do so safely.
+
+## Uninstall
+
+```bash
+commitlore uninstall
+```
+
+Removes what `install.sh` or `install.ps1` wrote — the wrapper, the pinned
+checkout, and the MCP entry it added to each agent config. It removes nothing it
+did not write, and names what it leaves:
+
+| Left behind | Removed by |
+|---|---|
+| the per-repository hooks: `commit-msg`, `prepare-commit-msg`, `post-commit` | `commitlore hooks uninstall` |
+| the agent hook | `commitlore inject uninstall-claude-hook` |
+| the Claude Code plugin | `/plugin uninstall commitlore@commitlore` |
+
+`commitlore uninstall --dry-run` reports what would be removed and changes
+nothing. `commitlore hooks uninstall` restores any hook CommitLore replaced, and
+`commitlore inject uninstall-claude-hook` leaves every other setting untouched.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,59 @@
+# The record protocol
+
+A CommitLore record is an ordinary set of Git commit trailers. Nothing else is
+stored: the authority is the trailer block on the commit and
+`refs/notes/commitlore`. Indexes and reports are derived from those Git records
+and can be rebuilt from them.
+
+The normative definition is [`spec/SPEC.md`](../spec/SPEC.md) — §2 for parsing
+and canonical form, §3 for the vocabulary, §6 for validation. This page is the
+working summary the README used to carry.
+
+## A record can be small
+
+Include only the context that would otherwise be lost:
+
+```text
+Fix expired-token refresh
+
+Ruled-out: Extend token TTL to 24h | security policy violation
+Warn: Do not narrow the 4xx handler without verifying upstream behavior
+```
+
+Most records do not need every protocol field. Identity, lifecycle, risk,
+provenance, and verification fields are available when the decision needs them.
+
+Most commits should carry no record at all. Add one only for a decision the diff
+cannot recover: an external constraint, a rejected alternative, a warning, or a
+verification gap. How a record gets written is in [capture.md](capture.md).
+
+## A complete record
+
+The worked example that uses the full vocabulary stays in the README, in every
+language, because it is also a conformance fixture: `spec/verify.sh` compares it
+byte for byte with
+[`spec/fixtures/valid/11-readme-example.txt`](../spec/fixtures/valid/11-readme-example.txt)
+and fails if the two drift apart. See [A complete record](../README.md).
+
+## The vocabulary
+
+The summary table of every trailer key also stays in the README, in every
+language, and is checked against SPEC §3 by
+`spec/schema/readme-vocab-check.mjs`: a key in the table that the spec does not
+define is a key a user would write and the validator would reject, and a key the
+spec defines but the table omits is a field that effectively does not exist.
+
+For the normative meaning, cardinality, and value grammar of each key, read
+[SPEC §3](../spec/SPEC.md).
+
+## Reading records without CommitLore
+
+`commitlore context <path>` is the convenient route ([cli.md](cli.md)), but the
+data is plain Git and stays readable without the tool:
+
+```bash
+git log --follow --format='%h %(trailers:key=Limit,valueonly)' -- src/auth/
+```
+
+Use Git's trailer parser, not a text search: prose containing `Key:` is not
+necessarily a trailer.


### PR DESCRIPTION
Closes #344

The README carried the reference manual it should have been linking to: 440 lines holding the complete record example, every protocol key, the harvest walkthrough, the whole experiment table, latency and break-even detail, and source-install specifics. This moves the reference material into `docs/` and leaves the README pointing at it.

## What moved where

| From the README | To |
|---|---|
| minimal record example, reading trailers with plain Git | `docs/protocol.md` |
| the agent prompt, `harvest`, `capture`, writing trailers by hand | `docs/capture.md` |
| the field report, latency and scaling, hook overhead, break-even | `docs/evidence.md` |
| source checkout, what `uninstall` leaves behind | `docs/install.md` |
| the whole command surface, the `PreToolUse` hook reproduction | `docs/cli.md` |

Nothing was deleted. Every sentence the README used to carry is at the other end of a link, and a new **Documentation** section indexes the five files. `docs/evidence.md` is organised as **Measured** / **Not yet measured**, so the boundary is read rather than reconstructed from a table.

All four language files were restructured in parallel, each in its own voice.

| File | Before | After |
|---|---:|---:|
| `README.md` | 440 | 380 |
| `README.ja.md` | 430 | 371 |
| `README.ko.md` | 428 | 368 |
| `README.zh-CN.md` | 423 | 365 |

## Three pieces the issue asks to move, and did not

Each is pinned to the README by a check, and each check encodes a guarantee worth more than the lines it costs. None was loosened.

- **The complete record example.** `spec/verify.sh` compares the last fenced text block in every README byte for byte with `spec/fixtures/valid/11-readme-example.txt`. The check reads the README and has no second location to look at, so moving the example makes the READMEs violate the spec they document.
- **The protocol vocabulary table.** `spec/schema/readme-vocab-check.mjs` requires every SPEC §3 key to appear in a table row of each README. Removing the table reports every key as missing — the check exists because a key in the table that the spec does not define is a key a user writes and the validator rejects.
- **The generated benchmark block.** `scripts/check-readme-numbers.mjs` regenerates and byte-compares it in `README.md`, and `test/readme-numbers.test.ts` asserts the marker in all four files. A moved block is an absent block. It was already inside a `<details>`, so it costs a reader nothing to keep.

Also kept in place by their guards: the hero, the install one-liner, the pinned/inspected install example, and the Known-limitations disclosure of guard precision and recall.

A fourth constraint shaped the new Documentation index: `test/compatibility-matrix.test.ts` pins each README to exactly one `docs/COMPATIBILITY.md` pointer, so that document is linked from the hero only and is not repeated in the index.

## Verification

- `npx vitest run test/readme.test.ts test/readme-order.test.ts test/readme-numbers.test.ts test/readme-positioning.test.ts test/compatibility-matrix.test.ts test/manifest.test.ts` — 107 passed
- Full suite: 78 files, 1945 passed, 1 skipped
- `node scripts/check-readme-numbers.mjs` — exit 0, block byte-identical (39 lines, 2262 bytes)
- `bash spec/verify.sh` — 25 fixtures + README example sync + vocab table
- `git grep -n 'README.md#'` — no source link points into a moved section; every relative link in the four READMEs and the five new docs resolves on disk
