### PR TITLE
Make the hero image say what the heading below it says

### DIFF
--- a/assets/readme/commitlore-demo.svg
+++ b/assets/readme/commitlore-demo.svg
@@ -1,5 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 704 488" width="704" height="488" role="img" aria-label="commitlore demo: lifecycle filtering shows only active decisions">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 704 488" width="704" height="488" role="img" aria-labelledby="demo-title demo-desc">
   <!-- T-1016: deterministic animated SVG — do not edit by hand; regenerate with: node scripts/record-demo.mjs -->
+  <title id="demo-title">commitlore demo: lifecycle filtering shows only active decisions</title>
+  <desc id="demo-desc">A terminal recording. Two decisions are recorded for one path and the later supersedes the first. When an agent proposes reverting to the superseded approach, only the active record is returned.</desc>
   <rect width="100%" height="100%" rx="8" fill="#1d1f21"/>
   <!-- Title bar -->
   <rect width="100%" height="32" rx="8" fill="#282a2e"/>

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,25 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400" role="img" aria-labelledby="title desc">
-  <title id="title">CommitLore — Git remembers what changed. CommitLore remembers why.</title>
-  <desc id="desc">A Git-native decision record carries a rejected alternative and its reason to a fresh coding-agent session.</desc>
+  <title id="title">CommitLore — Your agents inherit the code. Make them inherit the judgment.</title>
+  <desc id="desc">A fresh coding agent receives the active decision for a path, carrying a ruled-out alternative and its reason, while a superseded record is withheld because a later decision reversed it.</desc>
   <rect width="1200" height="400" rx="24" fill="#f7f5f0"/>
   <path d="M48 48H1152M48 334H1152" stroke="#d8d3c8"/>
   <g transform="translate(64 76)">
-    <text fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600" letter-spacing="2">GIT-NATIVE DECISION MEMORY</text>
-    <text y="66" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">Git remembers</text>
-    <text y="122" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">what changed.</text>
-    <text y="178" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">CommitLore</text>
-    <text y="234" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">remembers why.</text>
-    <text y="282" fill="#3e3b35" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="22">Reviewable decisions that travel with the code.</text>
+    <text fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600" letter-spacing="2">GIT-NATIVE DECISION LAYER</text>
+    <text y="66" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">Your agents</text>
+    <text y="122" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">inherit the code.</text>
+    <text y="178" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">Make them inherit</text>
+    <text y="234" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">the judgment.</text>
+    <text y="282" fill="#3e3b35" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="22">Only the decisions still in force reach the next edit.</text>
   </g>
   <g transform="translate(712 76)">
     <rect width="424" height="246" rx="14" fill="#fffdf9" stroke="#bdb6aa"/>
-    <text x="28" y="40" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600">A FRESH AGENT SEES</text>
+    <text x="28" y="40" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600">A FRESH AGENT RECEIVES</text>
     <path d="M28 58H396" stroke="#ded9d0"/>
-    <text x="28" y="94" fill="#181714" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700">Ruled-out:</text>
-    <text x="28" y="124" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">publish a -musl release target</text>
-    <text x="28" y="164" fill="#181714" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700">because:</text>
-    <text x="28" y="194" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">a release-matrix change, not a</text>
-    <text x="28" y="220" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">fix for this installer defect</text>
+    <text x="28" y="96" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700"><tspan fill="#3f6b4f">[active]</tspan><tspan fill="#6d675e" x="150">r-demo02</tspan></text>
+    <text x="28" y="128" fill="#181714" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700">Ruled-out: Redis cluster</text>
+    <text x="28" y="154" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">| cost disproportionate</text>
+    <path d="M28 180H396" stroke="#ede9e2"/>
+    <text x="28" y="212" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700"><tspan fill="#9a8f80">[superseded]</tspan><tspan fill="#9a8f80" x="212">r-demo01</tspan></text>
+    <text x="28" y="238" fill="#9a8f80" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">withheld — reversed later</text>
   </g>
-  <text x="712" y="356" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">commit trailer → hook context</text>
+  <text x="712" y="356" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">commit trailer → lifecycle → hook context</text>
 </svg>

--- a/scripts/record-demo.mjs
+++ b/scripts/record-demo.mjs
@@ -157,8 +157,14 @@ ${renderFrameText(FRAMES[FRAMES.length - 1].lines, `frame-${FRAMES.length - 1}`)
     <set attributeName="visibility" to="visible" begin="${((FRAMES.length - 1) * frameDuration).toFixed(2)}s" fill="freeze"/>
   </g>`;
 
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="${WIDTH}" height="${HEIGHT}" role="img" aria-label="commitlore demo: lifecycle filtering shows only active decisions">
+  // `aria-label` on the root is not enough on its own: a reader who opens the
+  // file directly, rather than through the README's `img` tag, gets nothing to
+  // name it by. `<title>` is the element SVG defines for that, and `<desc>`
+  // carries what the animation shows to anyone who cannot watch it run.
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="${WIDTH}" height="${HEIGHT}" role="img" aria-labelledby="demo-title demo-desc">
   <!-- T-1016: deterministic animated SVG — do not edit by hand; regenerate with: node scripts/record-demo.mjs -->
+  <title id="demo-title">commitlore demo: lifecycle filtering shows only active decisions</title>
+  <desc id="demo-desc">A terminal recording. Two decisions are recorded for one path and the later supersedes the first. When an agent proposes reverting to the superseded approach, only the active record is returned.</desc>
   <rect width="100%" height="100%" rx="8" fill="#1d1f21"/>
   <!-- Title bar -->
   <rect width="100%" height="${TITLE_H}" rx="8" fill="#282a2e"/>


### PR DESCRIPTION
Applied the `beautify-github-readme` skill in **README mode**, then scoped to the smallest change that produced a real improvement — which is what the skill asks for.

### The finding

The first screen carried **three different taglines**:

| where | what it said |
|---|---|
| alt text | "a coding agent must not revive a decision the repository already reversed" |
| **hero.svg** | **"Git remembers what changed. CommitLore remembers why."** |
| the `##` heading directly below | "Your agents inherit the code. Make them inherit the judgment." |

The image was left behind by a positioning change that moved the heading twice and never reopened the SVG.

### Changed

- **`hero.svg` rebuilt.** Keeps the split composition, the warm paper palette, and real material from this repository. The headline is now the current positioning. The right-hand card used to show one ruled-out alternative; it now shows an **active record beside a superseded one that is withheld** — the lifecycle filter is the part of this product no comparable tool has, and the old card demonstrated the part several of them do.
- **`commitlore-demo.svg` gained `<title>` and `<desc>`**, via the generator (`scripts/record-demo.mjs`), not by hand — the file says not to edit it by hand. `aria-label` on the root served the README's `img` embed and nothing else.

### Two things I checked rather than assumed

- **The skill states GitHub does not play animation embedded inside SVG.** That would make our demo render as a nearly blank terminal. Verified against the live page: GitHub serves the file through a plain `<img src>` **byte-identical**, all five SMIL `<set>` elements intact. The animation works. Converting to GIF would have cost the text layer, accessibility and file size for nothing — so it was not done.
- **A rendered preview caught a real defect** the first attempt introduced: the bottom caption was clipped at the canvas edge, reading `hook con`. A well-formedness check would not have found it. Shortened until it fits.

### Not done, deliberately

The delivery table stays Markdown. Tables belong in the text layer where they stay selectable and diffable, and the skill says the same.

### Verified

| check | result |
|---|---|
| skill's `audit_readme.py` | **OK** — was reporting a missing `<title>`, now clean |
| rendered at 1200 and inspected | nothing clipped; active and superseded rows both legible |
| both SVGs parse | ok |
| `readme`, `readme-order`, `readme-numbers`, `readme-positioning`, `compatibility-matrix`, `demo`, `manifest` | 114 passed |
| `check-readme-numbers.mjs` | exit 0, BENCH block byte-identical |
| `spec/verify.sh` | OK: 26 fixtures |

**Known limit**, recorded in the commit: the card text is 19–20 units, so at a 360px mobile render it falls below the legible threshold. The headline and alt text carry the message there and the same content is in the Markdown below, but the card is decoration at that width.