### PR TITLE
Run the result-schema gate, over a scope a new file lands inside by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,19 @@ jobs:
           COMMITLORE_PERF_LARGE: "1"
         run: npx vitest run test/index-perf.test.ts --reporter=basic
 
+      # #392: bench/verify.mjs existed for weeks with no npm script and no step
+      # here, so the result schema drifted five fields behind the runner and a
+      # committed matrix sat in the tree failing the gate for two days. It runs
+      # before the README check on purpose -- that step regenerates published
+      # figures out of these same rows, and there is no point trusting a number
+      # derived from a row whose shape was never checked.
+      #
+      # No file list: the gate reads bench/results/*.jsonl and decides scope
+      # from the rows. Its own header states the two exemptions and why; the
+      # step output names them per file on every run.
+      - name: Benchmark rows match the result schema
+        run: npm run bench:verify
+
       # Every measured figure in the README is regenerated from bench/results/
       # through bench/report.ts and compared byte for byte, and a short list of
       # statistics is refused outside the generated block. A rate somebody typed,

--- a/bench/README.md
+++ b/bench/README.md
@@ -796,6 +796,19 @@ conditional on* below.
 `node bench/verify.mjs <file>` validates every line and exits non-zero on any
 failure, on a malformed line, or on a file with no rows.
 
+`npm run bench:verify` — with no arguments — runs the same check over every
+`bench/results/*.jsonl`, and is the CI step. Scope is default-in: a results file
+is gated as soon as it is committed, with nothing to register. Two exemptions
+are decided per row and printed on every run, and the rule for each is stated at
+the top of `bench/verify.mjs`:
+
+- a file whose every row carries `schema_version` holds metric rows, not run
+  records, and this schema does not describe it (a file mixing the two is
+  failed, not classified);
+- rows recorded before `1073fa4` are not required to carry `harness_commit` and
+  `dist_digest`, which did not exist yet. Every other constraint still applies
+  to them, and `started_at` comes from the clock, so no new row can qualify.
+
 ## Per-turn usage
 
 `--per-turn-usage` writes a `turn_usage` object: one entry per assistant API

--- a/bench/verify.mjs
+++ b/bench/verify.mjs
@@ -1,6 +1,92 @@
 #!/usr/bin/env node
 // Schema gate for bench/results/*.jsonl (T-701 AC). Plain ESM so it runs with
 // no build step and no type stripping.
+//
+// Run it with no arguments to gate the whole directory (`npm run bench:verify`,
+// and the CI step of the same name). Named files are a narrower manual run and
+// are judged by the identical rules, so a local verdict and CI's cannot differ.
+//
+// =====================================================================
+// WHICH FILES THIS GATE COVERS, AND WHY THAT IS A RULE AND NOT A LIST
+// =====================================================================
+//
+// #392: nothing ran this file. It had no npm script and no CI step, so the
+// schema drifted five fields behind the runner and
+// bench/results/m5-off-design-20-tasks.jsonl sat in the tree failing for two
+// days before anyone looked. #390 fixed that drift; this is the reason it went
+// unnoticed. docs/RELEASE-GATE.md: "A gate nobody can check is a slogan."
+//
+// Wiring it up needs an answer to "over which files?", and the answer has to
+// hold for the next results file, committed by someone who has never read this
+// comment. So the scope is default-in: every `*.jsonl` in bench/results/, with
+// nothing to register and nothing to remember. A new file is inside the gate
+// the moment it is committed. Neither of the two exemptions below can be
+// reached by forgetting something -- both are properties of the rows
+// themselves, both are decided per row rather than per filename, and both are
+// printed on every run, so a reader can check the scope by running the gate
+// instead of by trusting this paragraph.
+//
+// A declared list of filenames was the obvious alternative and is the one thing
+// that cannot work here: it is opt-in wearing a different hat. A file left off
+// it is silently ungated, which is the failure being fixed.
+//
+// ---------------------------------------------------------------------
+// Exemption 1 -- a file whose every row carries `schema_version` is not a
+// run record, and this schema does not describe it.
+// ---------------------------------------------------------------------
+//
+// bench/results/ holds two row families that share a directory and nothing
+// else. Run records (`RunRecord` in bench/types.ts, written by bench/runner.ts)
+// are what result.schema.json describes -- its own description says "One line =
+// one (task, condition, seed) run". Metric rows (`BaseRow` in
+// bench/deterministic/types.ts, written by bench/deterministic.ts and
+// bench/external/run.ts) are one row per measurement and have never carried a
+// run id, a task or a condition. Checking those against this schema is not a
+// drift check, it is a category error, and it would fail 7 of the 17 files here
+// forever.
+//
+// `schema_version` is the discriminator because it is already on the rows and
+// both sides guarantee the answer: `BaseRow` declares `readonly
+// schema_version: 1`, so every metric row has it, and result.schema.json is
+// `additionalProperties: false` with no such property, so no valid run record
+// can. Note the direction -- the marker belongs to the *other* family, so the
+// gate reads its absence as inclusion. Keying inclusion on its presence would
+// select exactly the files this schema cannot describe.
+//
+// A file carrying it on some rows and not others is failed rather than
+// classified. That is a corrupt file, and it also closes the only accident by
+// which a run-record file could drift out of this gate: leaving is not an
+// omission, it takes adding a field to every row, which the schema then rejects
+// the moment anyone points the gate at the file directly.
+//
+// ---------------------------------------------------------------------
+// Exemption 2 -- the two provenance fields are not required of rows that
+// were recorded before those fields existed.
+// ---------------------------------------------------------------------
+//
+// 1073fa4 ("A benchmark row now has to prove which binary produced it",
+// 2026-07-27T02:56:12Z) made `harness_commit` and `dist_digest` required. Six
+// matrices were measured before it and cannot be corrected: bench/results/
+// holds committed measurements, and ADR-0018 is the reason a superseded or
+// invalidated matrix stays in the tree rather than being deleted. Failing an
+// old file for lacking a field that did not exist is not a finding.
+//
+// Those files are not skipped, and the schema is not weakened to admit them.
+// Every other constraint still applies to them -- every type, every pattern,
+// and the closed property set -- and exactly two `required` entries are dropped,
+// for rows that identify themselves as old by their own `started_at`. The
+// schema file is untouched; the relaxation is built here, at the gate, from the
+// schema as committed.
+//
+// The exemption cannot creep into the present, which is what makes it a rule
+// rather than a description of today: `started_at` comes from the clock when
+// the runner writes the row, so no new file can fall before a cutoff in the
+// past. And the cutoff is not a judgement call -- the last row without
+// provenance started at 2026-07-27T02:21:50.808Z, the first row with it at
+// 2026-07-27T07:21:31.025Z, and the commit that introduced the requirement
+// sits inside that gap. A row with no parseable `started_at` is treated as
+// current and gets no relaxation, so a malformed row fails rather than
+// qualifying for an exemption by being unreadable.
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
@@ -9,40 +95,77 @@ import { Ajv } from "ajv";
 import addFormats from "ajv-formats";
 
 const SCHEMA_PATH = path.join(import.meta.dirname, "schema", "result.schema.json");
+const RESULTS_DIR = path.join(import.meta.dirname, "results");
+
+/** Commit 1073fa4, which made both fields below `required`. */
+const PROVENANCE_REQUIRED_FROM = Date.parse("2026-07-27T02:56:12Z");
+const PROVENANCE_FIELDS = ["harness_commit", "dist_digest"];
 
 const formatErrors = (errors) =>
   (errors ?? [])
     .map((error) => `${error.instancePath === "" ? "/" : error.instancePath} ${error.message}`)
     .join("; ");
 
+/** Every `*.jsonl` directly in bench/results/, sorted so the output is stable. */
+const scopeFiles = () =>
+  fs
+    .readdirSync(RESULTS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+    .map((entry) => path.join(RESULTS_DIR, entry.name))
+    .sort();
+
+const isPreProvenance = (row) => {
+  const startedAt = Date.parse(row?.started_at ?? "");
+  return Number.isFinite(startedAt) && startedAt < PROVENANCE_REQUIRED_FROM;
+};
+
 const main = () => {
-  const files = process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
-  if (files.length === 0) {
-    process.stderr.write("usage: verify.mjs <results.jsonl> [more.jsonl ...]\n");
-    return 2;
+  const named = process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
+  let files;
+  if (named.length > 0) {
+    files = named.map((file) => path.resolve(file));
+  } else {
+    if (!fs.existsSync(RESULTS_DIR)) {
+      process.stderr.write(`verify: no results directory at ${RESULTS_DIR}\n`);
+      return 2;
+    }
+    files = scopeFiles();
+    // A gate that finds nothing to check must not report success -- the same
+    // reading the empty-file case below already takes.
+    if (files.length === 0) {
+      process.stderr.write(`verify: no *.jsonl in ${RESULTS_DIR}; the gate checked nothing\n`);
+      return 2;
+    }
   }
 
+  const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, "utf8"));
+  const relaxed = {
+    ...schema,
+    $id: `${schema.$id}#pre-provenance`,
+    required: schema.required.filter((name) => !PROVENANCE_FIELDS.includes(name)),
+  };
   const ajv = new Ajv({ allErrors: true, strict: true });
   addFormats(ajv);
-  const validate = ajv.compile(JSON.parse(fs.readFileSync(SCHEMA_PATH, "utf8")));
+  const validate = ajv.compile(schema);
+  const validatePreProvenance = ajv.compile(relaxed);
 
   let checked = 0;
   let failed = 0;
+  let skipped = 0;
 
-  for (const file of files) {
-    const resolved = path.resolve(file);
+  for (const resolved of files) {
     if (!fs.existsSync(resolved)) {
       process.stderr.write(`verify: no such file: ${resolved}\n`);
       return 2;
     }
     const lines = fs.readFileSync(resolved, "utf8").split("\n");
-    let rowsInFile = 0;
+    const rows = [];
     let failedInFile = 0;
+    let rowsInFile = 0;
 
     lines.forEach((line, index) => {
       if (line.trim() === "") return;
       rowsInFile += 1;
-      checked += 1;
       let row;
       try {
         row = JSON.parse(line);
@@ -51,18 +174,59 @@ const main = () => {
         process.stderr.write(`FAIL ${resolved}:${index + 1} invalid JSON — ${error.message}\n`);
         return;
       }
-      if (!validate(row)) {
-        failedInFile += 1;
-        process.stderr.write(`FAIL ${resolved}:${index + 1} ${formatErrors(validate.errors)}\n`);
-      }
+      rows.push({ row, line: index + 1 });
     });
 
     if (rowsInFile === 0) {
       // An empty results file is a failed run, not a passing verification.
       process.stderr.write(`FAIL ${resolved} contains no rows\n`);
-      failedInFile += 1;
-    } else if (failedInFile === 0) {
-      process.stdout.write(`ok   ${resolved} — ${rowsInFile} rows\n`);
+      failed += 1;
+      continue;
+    }
+    if (failedInFile > 0) {
+      failed += failedInFile;
+      continue;
+    }
+
+    const versioned = rows.filter(({ row }) => row?.schema_version !== undefined).length;
+    if (versioned === rows.length) {
+      skipped += 1;
+      process.stdout.write(
+        `skip ${resolved} — ${rows.length} metric row(s) (schema_version present); ` +
+          `result.schema.json describes run records\n`,
+      );
+      continue;
+    }
+    if (versioned > 0) {
+      process.stderr.write(
+        `FAIL ${resolved} mixes ${versioned} row(s) carrying schema_version with ` +
+          `${rows.length - versioned} that do not; one file, one row family\n`,
+      );
+      failed += 1;
+      continue;
+    }
+
+    let legacy = 0;
+    for (const { row, line } of rows) {
+      checked += 1;
+      const old = isPreProvenance(row);
+      if (old) legacy += 1;
+      const check = old ? validatePreProvenance : validate;
+      if (!check(row)) {
+        failedInFile += 1;
+        process.stderr.write(`FAIL ${resolved}:${line} ${formatErrors(check.errors)}\n`);
+      }
+    }
+
+    if (failedInFile === 0) {
+      // The exemption is named on the passing line, not only in the comment
+      // above: a reader who runs the gate sees which rows were held to a
+      // shorter list of requirements and how many.
+      const note =
+        legacy === 0
+          ? ""
+          : ` (${legacy} recorded before 1073fa4: ${PROVENANCE_FIELDS.join(", ")} not yet required)`;
+      process.stdout.write(`ok   ${resolved} — ${rows.length} rows${note}\n`);
     }
     failed += failedInFile;
   }
@@ -71,7 +235,10 @@ const main = () => {
     process.stderr.write(`\nverify: ${failed} problem(s) across ${checked} rows\n`);
     return 1;
   }
-  process.stdout.write(`\nverify: ${checked} rows valid against ${path.basename(SCHEMA_PATH)}\n`);
+  process.stdout.write(
+    `\nverify: ${checked} rows in ${files.length - skipped} file(s) valid against ` +
+      `${path.basename(SCHEMA_PATH)}; ${skipped} metric-row file(s) out of scope\n`,
+  );
   return 0;
 };
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "tsc -p tsconfig.json && npm run bundle",
     "bench:deterministic": "npm run build && node --experimental-strip-types bench/deterministic.ts",
     "bench:external": "npm run build && node --experimental-strip-types bench/external/run.ts",
+    "bench:verify": "node bench/verify.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/test/bench-result-scope.test.ts
+++ b/test/bench-result-scope.test.ts
@@ -1,0 +1,183 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const RESULTS_DIR = path.join(REPO_ROOT, 'bench', 'results');
+const tempDirs: string[] = [];
+
+const runGate = (...args: string[]) => {
+  const result = spawnSync(process.execPath, ['bench/verify.mjs', ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+};
+
+/**
+ * Scratch files live outside bench/results/ on purpose. Every file in there is
+ * a committed measurement, and a test that writes one — even briefly — can
+ * leave it behind when it fails. Named files go through the same classifier as
+ * the directory scan, so nothing is lost by keeping them elsewhere.
+ */
+const scratch = (name: string, rows: readonly unknown[]): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'commitlore-bench-scope-'));
+  tempDirs.push(dir);
+  const target = path.join(dir, name);
+  fs.writeFileSync(target, rows.map((row) => JSON.stringify(row)).join('\n') + (rows.length > 0 ? '\n' : ''));
+  return target;
+};
+
+/** A row the current schema accepts in full, with provenance. */
+const runRecord = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  run_id: 'scope-test',
+  harness_commit: '1111111111111111111111111111111111111111',
+  dist_digest: '2'.repeat(64),
+  task: 'reproposal-redis-cache',
+  cond: 'commitlore-on',
+  seed: 1,
+  reproposed: false,
+  violations: 0,
+  turns: 3,
+  tokens: 1000,
+  stopped_by: 'completed',
+  duration_ms: 1200,
+  driver: 'dry-run',
+  started_at: '2026-08-01T00:00:00.000Z',
+  simulated: true,
+  ...overrides,
+});
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('the result-schema gate covers bench/results/ by default', () => {
+  it('accounts for every .jsonl on disk, and passes', () => {
+    // The property #392 is about: scope is default-in, so a results file cannot
+    // be outside the gate by omission. This fails the moment anyone replaces
+    // the directory scan with a list, a prefix filter or a "files that pass
+    // today" set — every one of those leaves a file on disk unmentioned.
+    const onDisk = fs
+      .readdirSync(RESULTS_DIR)
+      .filter((name) => name.endsWith('.jsonl'))
+      .sort();
+    expect(onDisk.length).toBeGreaterThan(0);
+
+    const gate = runGate();
+    expect(gate.status, gate.stderr).toBe(0);
+
+    for (const name of onDisk) {
+      const mentions = gate.stdout.split('\n').filter((line) => line.includes(`/${name} `));
+      expect(mentions, `${name} was neither checked nor skipped`).toHaveLength(1);
+      expect(mentions[0]).toMatch(/^(ok|skip) /);
+    }
+  });
+
+  it('refuses to report success over a file with nothing in it', () => {
+    // A gate that checked zero rows and reported green is the failure this
+    // issue is about, wearing a tick.
+    const gate = runGate(scratch('no-rows.jsonl', []));
+    expect(gate.status).toBe(1);
+    expect(gate.stderr).toContain('contains no rows');
+  });
+});
+
+describe('the gate bites', () => {
+  it('fails a row carrying a field the schema does not declare', () => {
+    // The exact drift shape from #390: a field reaches the runner's rows before
+    // it reaches the schema.
+    const file = scratch('drift.jsonl', [runRecord({ invented_field: 1 })]);
+    const gate = runGate(file);
+    expect(gate.status).toBe(1);
+    expect(gate.stderr).toContain('must NOT have additional properties');
+  });
+
+  it('fails a row whose declared field has the wrong type', () => {
+    const file = scratch('typed.jsonl', [runRecord({ turns: 'three' })]);
+    const gate = runGate(file);
+    expect(gate.status).toBe(1);
+  });
+});
+
+describe('the pre-provenance exemption is bounded by the rows, not by filename', () => {
+  const withoutProvenance = () => {
+    const { harness_commit: _c, dist_digest: _d, ...rest } = runRecord();
+    return rest;
+  };
+
+  it('accepts a row recorded before 1073fa4 made the provenance fields required', () => {
+    const file = scratch('legacy.jsonl', [
+      { ...withoutProvenance(), started_at: '2026-07-26T08:55:15.468Z' },
+    ]);
+    const gate = runGate(file);
+    expect(gate.status, gate.stderr).toBe(0);
+    expect(gate.stdout).toContain('recorded before 1073fa4');
+  });
+
+  it('rejects the same row once it claims a start after that commit', () => {
+    // What stops the exemption from rotting into a permanent hole: a new run's
+    // started_at comes from the clock, so it can never land before the cutoff.
+    const file = scratch('current.jsonl', [
+      { ...withoutProvenance(), started_at: '2026-08-01T00:00:00.000Z' },
+    ]);
+    const gate = runGate(file);
+    expect(gate.status).toBe(1);
+    expect(gate.stderr).toContain("must have required property 'harness_commit'");
+  });
+
+  it('still applies every other constraint to an exempt row', () => {
+    // The exemption drops two `required` entries, not the schema.
+    const file = scratch('legacy-invalid.jsonl', [
+      { ...withoutProvenance(), started_at: '2026-07-26T08:55:15.468Z', invented_field: 1 },
+    ]);
+    const gate = runGate(file);
+    expect(gate.status).toBe(1);
+    expect(gate.stderr).toContain('must NOT have additional properties');
+  });
+
+  it('gives no exemption to a row whose started_at cannot be read', () => {
+    const file = scratch('undated.jsonl', [{ ...withoutProvenance(), started_at: 'whenever' }]);
+    const gate = runGate(file);
+    expect(gate.status).toBe(1);
+  });
+});
+
+describe('metric rows are a different family, and the split is not silent', () => {
+  const metricRow = (overrides: Record<string, unknown> = {}) => ({
+    schema_version: 1,
+    harness_commit: '1111111111111111111111111111111111111111',
+    harness_digest: '3'.repeat(40),
+    dist_digest: '2'.repeat(64),
+    measured_at: '2026-07-29T01:13:43.000Z',
+    metric: 'record_density',
+    ...overrides,
+  });
+
+  it('skips a file whose every row carries schema_version, and says so', () => {
+    const file = scratch('metrics.jsonl', [metricRow(), metricRow()]);
+    const gate = runGate(file);
+    expect(gate.status, gate.stderr).toBe(0);
+    expect(gate.stdout).toContain('metric row(s) (schema_version present)');
+  });
+
+  it('fails a file that mixes the two families rather than classifying it', () => {
+    // The only route by which a run-record file could leave this gate is
+    // someone adding schema_version to its rows. Partway through, that is a
+    // corrupt file and is failed; all the way through, the schema itself
+    // rejects the field the moment the file is named directly.
+    const file = scratch('mixed.jsonl', [runRecord(), metricRow()]);
+    const gate = runGate(file);
+    expect(gate.status).toBe(1);
+    expect(gate.stderr).toContain('one file, one row family');
+  });
+
+  it('rejects schema_version on a run record when the file is checked directly', () => {
+    const file = scratch('tagged.jsonl', [runRecord({ schema_version: 1 }), runRecord()]);
+    const gate = runGate(file);
+    expect(gate.status).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #392.

`bench/verify.mjs` had no npm script and no CI step, so the result schema drifted five fields behind the runner and a committed matrix failed the gate for two days with nobody looking. #390 fixed that drift; this fixes the reason it went unnoticed.

## The gap, confirmed

```
$ git rev-parse --short HEAD          # dev
85ea006
$ grep -rn "verify.mjs" .github/workflows/ package.json
$ echo $?
1
```

Reproduced at `6d4e828^` (the commit before #390 fixed the schema):

```
$ node bench/verify.mjs bench/results/m5-off-design-20-tasks.jsonl
FAIL …/m5-off-design-20-tasks.jsonl:1 / must NOT have additional properties; …
FAIL …/m5-off-design-20-tasks.jsonl:2 / must NOT have additional properties; …
…
verify: 80 problem(s) across 80 rows
```

## Survey of `bench/results/`

17 `*.jsonl` files, 802 rows, and two row families that share a directory and nothing else.

| family | files | rows | `schema_version` | written by | verify.mjs before this PR |
|---|---|---|---|---|---|
| run records (`RunRecord`) | 9 | 632 | absent on every row | `bench/runner.ts` | 3 pass, 6 fail |
| metric rows (`BaseRow`) | 8 | 203 | present on every row | `bench/deterministic.ts`, `bench/external/run.ts` | 8 fail |

The 6 failing run-record files fail on one axis only: `harness_commit` and `dist_digest`, which `1073fa4` made `required` on 2026-07-27. The 8 metric-row files fail on `run_id`, `task`, `cond` and the rest — they are one row per *measurement*, not per `(task, condition, seed)` run, so `result.schema.json` was never meant to describe them.

## Scope, and why

The gate is **default-in**: `npm run bench:verify` reads `bench/results/*.jsonl`, all of it. Nothing registers, nothing opts in, and a new results file is gated the moment it is committed. Two exemptions, both decided **per row** rather than per filename, both printed on every run. The rule for each is stated at the top of `bench/verify.mjs`, where the scope is defined.

**1. A file whose every row carries `schema_version` holds metric rows, and this schema does not describe them.** The field is the discriminator because both sides guarantee the answer: `BaseRow` declares `readonly schema_version: 1`, and `result.schema.json` is `additionalProperties: false` with no such property. Note the direction — the marker belongs to the *other* family, so the gate reads its **absence** as inclusion. Keying inclusion on its presence, as the issue suggested, would select exactly the files this schema cannot describe. A file carrying it on some rows and not others is **failed**, not classified — that is a corrupt file, and it closes the only accident by which a run-record file could leave the gate.

**2. Rows recorded before `1073fa4` are not required to carry the two provenance fields.** Those six matrices cannot be corrected — `bench/results/` holds committed measurements, and ADR-0018 is why a superseded or invalidated matrix stays in the tree. They are **not skipped** and the schema is **not weakened**: the gate compiles a second validator from the committed schema with exactly those two `required` entries dropped. Every other constraint — every type, every pattern, the closed property set — still applies to all 380 rows. The cutoff is not a judgement call: the last pre-provenance row started at `2026-07-27T02:21:50.808Z`, the first post-provenance row at `2026-07-27T07:21:31.025Z`, and `1073fa4` is dated `2026-07-27T02:56:12Z`, inside that gap. It cannot creep forward, because `started_at` comes from the clock.

Ruled out, in the commit trailers: a declared file list (opt-in under another name), validating only what passes today (a description, not a rule), a naming convention (every run-record file in the tree was named by hand through `--out`), a marker file (still a step to remember), widening the schema to cover both families (they share no required field, so the union rejects nothing), and making the provenance fields optional (weakens every future row to admit six old files).

## The gate bites

A scratch file added to `bench/results/`, carrying one field the schema does not declare:

```
$ npm run bench:verify
…
skip …/token-ledger-20260801T122953Z.jsonl — 1 metric row(s) (schema_version present); result.schema.json describes run records
FAIL …/zz-scratch-gate-proof.jsonl:1 / must NOT have additional properties

verify: 1 problem(s) across 633 rows
exit=1
```

Removed again:

```
$ rm bench/results/zz-scratch-gate-proof.jsonl
$ git status --porcelain bench/results/     # clean
$ npm run bench:verify
…
verify: 632 rows in 9 file(s) valid against result.schema.json; 8 metric-row file(s) out of scope
exit=0
```

Eleven tests in `test/bench-result-scope.test.ts` hold the rules, including the one that matters most: the gate's output must account for **every** `.jsonl` on disk, so replacing the directory scan with a list, a prefix filter or a "passes today" set fails immediately.

## Verification

`npx vitest run` — Test Files 83 passed, Tests 2092 passed | 1 skipped. `npm run typecheck`, `npx tsc -p bench/tsconfig.json --noEmit`, `npm run build` (dist/ byte-unchanged), `node scripts/check-readme-numbers.mjs`, `bash spec/verify.sh` (OK: 26 fixtures), `npm run bench:verify` — all exit 0. `node dist/commitlore.mjs validate -c HEAD` — shape ok, references ok.

No file under `bench/results/` was modified, and neither `README.md` nor any translation was touched.
