### PR TITLE
Say that the plugin does not update itself, and that updating is two steps

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -24,6 +24,40 @@ That is the whole plugin: the MCP server, the pre-edit `PreToolUse` hook, and
 the skills. It puts no `commitlore` on `PATH`, so the `commitlore …` commands
 need `install.sh` / `install.ps1` as well.
 
+### Staying current
+
+Nothing updates the plugin on its own, and updating it is **two steps**:
+
+```
+/plugin marketplace update commitlore
+/reload-plugins
+```
+
+The first downloads the new version beside the old one. The second is what makes
+the running MCP server and hook use it — until then the cache holds the new
+version while the process keeps serving the old one, and both are true at once:
+
+```
+$ ls ~/.claude/plugins/cache/commitlore/commitlore/
+0.4.0
+0.6.0
+$ ps
+… node .../commitlore/0.4.0/dist/commitlore.mjs mcp
+```
+
+This matters more than a stale dependency usually does, because **the agent runs
+the hook, not the CLI**. A plugin left behind grades every edit by an older
+build's rules while `commitlore --version` in your terminal reports something
+newer.
+
+`commitlore doctor` reports it, by asking the executable the hook actually
+resolves to for its version:
+
+```
+warn    PreToolUse hook version — the agent's hook runs 0.4.0 but this CLI is 0.6.0
+        — every edit is graded by 0.4.0's rules, not this one's
+```
+
 ## The install scripts
 
 `install.sh` (POSIX shell) and `install.ps1` (PowerShell) install a pinned


### PR DESCRIPTION
Closes #433. Docs only.

## What the investigation found

A cache on this machine held **0.4.0** while the repository, the manifest and the latest release were all **0.6.0** — four releases, including two security fixes, never reaching a user who had installed the plugin.

**The distribution was never at fault.** Run from a client session:

```
/plugin marketplace update commitlore
⎿ ✔ Updated 1 marketplace (1 plugin bumped)

Plugins changed. Run /reload-plugins to activate.
```

```
$ ls ~/.claude/plugins/cache/commitlore/commitlore/
0.4.0
0.6.0
```

The marketplace advertises 0.6.0 off the default branch and the client fetches it on request. What was missing is that nothing anywhere said to ask.

## The second step is the finding

Updating is **two steps**, and the gap between them is a real state. Immediately after that update, in the same session:

```
$ ps
49700 node .../commitlore/0.4.0/dist/commitlore.mjs mcp
```

0.6.0 on disk, 0.4.0 serving. Both true at once, with no signal to the user.

That costs more here than a stale dependency usually does, because **the agent runs the hook, not the CLI**. A plugin left behind grades every edit by an older build's rules while `commitlore --version` in the terminal reports something newer.

`doctor` reports it — and it is worth noting that #434's check catches *this* shape too, not only the never-updated one, because it asks the executable the hook resolves to rather than reading a manifest:

```
warn    PreToolUse hook version — the agent's hook runs 0.4.0 but this CLI is 0.6.0
        — every edit is graded by 0.4.0's rules, not this one's
```

## Scope

`docs/install.md` gains a "Staying current" section with both commands, the intermediate state, and what `doctor` says about it. No code change — #434 already shipped the detection.

`test/dogfood.test.ts` re-run after committing: 9 passed.