### PR TITLE
Give CDEB its schemas and a verifier that owns the whole study tree

### DIFF
--- a/bench/cdeb/schemas/attempt.schema.json
+++ b/bench/cdeb/schemas/attempt.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cdeb-attempt",
+  "title": "CDEB attempt record (PRD §10)",
+  "description": "One attempt at a logical run, preserved whether or not it produced an outcome. Pre-agent infrastructure retries each leave one of these; a measured run leaves exactly one that reached AGENT_STARTED or beyond.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "benchmark", "attempt_id", "logical_run_id",
+    "terminal_state", "started_at", "finished_at", "first_model_turn_observed"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "benchmark": { "const": "cdeb-v1" },
+    "attempt_id": { "type": "string", "minLength": 1 },
+    "logical_run_id": { "type": "string", "minLength": 1 },
+    "terminal_state": {
+      "enum": [
+        "MEASURED", "PRE_AGENT_INFRA_FAILURE", "MEASURED_AGENT_FAILURE",
+        "EVALUATOR_INFRA_FAILURE", "MEASUREMENT_INTEGRITY_FAILURE"
+      ]
+    },
+    "started_at": { "type": "string", "format": "date-time" },
+    "finished_at": { "type": "string", "format": "date-time" },
+    "first_model_turn_observed": { "type": "boolean" },
+    "failure_detail": { "type": "string" }
+  }
+}

--- a/bench/cdeb/schemas/candidate.schema.json
+++ b/bench/cdeb/schemas/candidate.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cdeb-candidate",
+  "title": "CDEB candidate registry entry (PRD §3.2)",
+  "description": "One eligible-or-rejected task candidate, frozen before task construction. Accepted and rejected entries are both preserved; selection over quota is by SHA-256(candidate_id + freeze_seed), never by model or by observed behaviour.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "benchmark", "candidate_id", "repository_id", "record_ids",
+    "decision_source_refs", "record_commit_or_note_ref", "record_created_at",
+    "natural_record", "benchmark_authored", "eligibility", "review_status", "rejection_reason"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "benchmark": { "const": "cdeb-v1" },
+    "candidate_id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+    "repository_id": { "type": "string", "minLength": 1 },
+    "record_ids": { "type": "array", "minItems": 1, "items": { "type": "string", "pattern": "^r-[a-z0-9]{6,}$" } },
+    "decision_source_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+    "record_commit_or_note_ref": { "type": "string", "minLength": 1 },
+    "record_created_at": { "type": "string", "format": "date-time" },
+    "natural_record": { "const": true },
+    "benchmark_authored": { "const": false },
+    "eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["explicit_rejection_reason", "wrong_path_functionally_viable", "deterministic_oracle_possible", "current_code_does_not_reveal_reason", "bounded_implementation"],
+      "properties": {
+        "explicit_rejection_reason": { "type": "boolean" },
+        "wrong_path_functionally_viable": { "type": "boolean" },
+        "deterministic_oracle_possible": { "type": "boolean" },
+        "current_code_does_not_reveal_reason": { "type": "boolean" },
+        "bounded_implementation": { "type": "boolean" }
+      }
+    },
+    "review_status": { "enum": ["accepted", "rejected"] },
+    "rejection_reason": { "type": ["string", "null"] }
+  }
+}

--- a/bench/cdeb/schemas/evaluator.schema.json
+++ b/bench/cdeb/schemas/evaluator.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cdeb-evaluator",
+  "title": "CDEB evaluator output (PRD §12.4)",
+  "description": "What the sealed evaluator image emits for one candidate tree. No free-form quality score is representable here, by design.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "task_id", "functional_pass", "rejected_decision_revived",
+    "functional_checks", "decision_oracle_code", "evaluator_image_digest", "candidate_tree_oid"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "functional_pass": { "type": "boolean" },
+    "rejected_decision_revived": { "type": "boolean" },
+    "functional_checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["passed", "failed"],
+      "properties": {
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "decision_oracle_code": { "enum": ["SAFE", "REVIVED"] },
+    "evaluator_image_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "candidate_tree_oid": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
+  }
+}

--- a/bench/cdeb/schemas/result.schema.json
+++ b/bench/cdeb/schemas/result.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cdeb-result",
+  "title": "CDEB canonical measured row (PRD §19.2)",
+  "description": "One measured logical run. Every field is required and no other field is legal: a row the schema cannot fully describe is a row the verifier cannot vouch for. Derived fields (total_token_volume, decision_safe_success) are additionally recomputed by verify.mjs from their raw inputs — schema validity alone does not prove them.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "benchmark", "protocol_version", "study_id", "logical_run_id",
+    "repository_id", "task_id", "category", "condition", "repeat", "order",
+    "freeze_manifest_sha256", "sealed_task_bundle_sha256", "repository_bundle_sha256",
+    "repository_snapshot", "base_tree_oid", "refs_digest", "notes_ref_digest",
+    "requested_model", "observed_model_ids", "agent_cli_version", "agent_executable_sha256",
+    "node_version", "node_executable_sha256", "agent_runtime_image_digest",
+    "tool_policy_digest", "network_policy_digest", "settings_digest", "mcp_config_digest",
+    "harness_commit", "product_commit", "dist_digest", "hook_proxy_sha256",
+    "started_at", "finished_at", "stop_reason", "first_model_turn_observed", "wall_ms",
+    "exposure", "usage", "final_tree", "evaluation", "decision_safe_success", "simulated"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "benchmark": { "const": "cdeb-v1" },
+    "protocol_version": { "type": "string", "pattern": "^1\\.2\\.[0-9]+$" },
+    "study_id": { "type": "string", "minLength": 1 },
+    "logical_run_id": { "type": "string", "pattern": "^[a-z0-9-]+__[a-z0-9-]+__(on|off)__r[1-3]$" },
+    "repository_id": { "type": "string", "minLength": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "category": {
+      "enum": [
+        "rejected-architecture", "rejected-workaround", "compatibility-constraint",
+        "security-operational", "superseded-lifecycle"
+      ]
+    },
+    "condition": { "enum": ["commitlore-on", "commitlore-off"] },
+    "repeat": { "type": "integer", "minimum": 1, "maximum": 3 },
+    "order": { "type": "integer", "minimum": 1, "maximum": 180 },
+
+    "freeze_manifest_sha256": { "$ref": "#/$defs/sha256" },
+    "sealed_task_bundle_sha256": { "$ref": "#/$defs/sha256" },
+    "repository_bundle_sha256": { "$ref": "#/$defs/sha256" },
+    "repository_snapshot": { "$ref": "#/$defs/gitOid" },
+    "base_tree_oid": { "$ref": "#/$defs/gitOid" },
+    "refs_digest": { "$ref": "#/$defs/sha256" },
+    "notes_ref_digest": { "$ref": "#/$defs/sha256" },
+
+    "requested_model": { "type": "string", "minLength": 1 },
+    "observed_model_ids": {
+      "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }
+    },
+    "agent_cli_version": { "type": "string", "minLength": 1 },
+    "agent_executable_sha256": { "$ref": "#/$defs/sha256" },
+    "node_version": { "type": "string", "minLength": 1 },
+    "node_executable_sha256": { "$ref": "#/$defs/sha256" },
+    "agent_runtime_image_digest": { "$ref": "#/$defs/ociDigest" },
+    "tool_policy_digest": { "$ref": "#/$defs/sha256" },
+    "network_policy_digest": { "$ref": "#/$defs/sha256" },
+    "settings_digest": { "$ref": "#/$defs/sha256" },
+    "mcp_config_digest": { "$ref": "#/$defs/sha256" },
+
+    "harness_commit": { "$ref": "#/$defs/gitOid" },
+    "product_commit": { "$ref": "#/$defs/gitOid" },
+    "dist_digest": { "$ref": "#/$defs/sha256" },
+    "hook_proxy_sha256": { "$ref": "#/$defs/sha256" },
+
+    "started_at": { "type": "string", "format": "date-time" },
+    "finished_at": { "type": "string", "format": "date-time" },
+    "stop_reason": { "enum": ["completed", "timeout", "agent_error", "provider_error_after_start"] },
+    "first_model_turn_observed": { "type": "boolean" },
+    "wall_ms": { "type": "integer", "minimum": 0 },
+
+    "exposure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "instrumentation_complete", "hook_opportunities", "proxy_executions",
+        "expected_record_delivered", "delivered_before_first_mutation",
+        "delivered_record_ids", "payload_sha256s", "product_failures"
+      ],
+      "properties": {
+        "instrumentation_complete": { "const": true },
+        "hook_opportunities": { "type": "integer", "minimum": 0 },
+        "proxy_executions": { "type": "integer", "minimum": 0 },
+        "expected_record_delivered": { "type": "boolean" },
+        "delivered_before_first_mutation": { "type": "boolean" },
+        "delivered_record_ids": { "type": "array", "items": { "type": "string", "pattern": "^r-[a-z0-9]{6,}$" } },
+        "payload_sha256s": { "type": "array", "items": { "$ref": "#/$defs/sha256" } },
+        "product_failures": { "type": "integer", "minimum": 0 }
+      }
+    },
+
+    "usage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_tokens", "output_tokens", "cache_creation_input_tokens",
+        "cache_read_input_tokens", "total_token_volume", "reconciled",
+        "unparsed_lines", "raw_stream_sha256"
+      ],
+      "properties": {
+        "input_tokens": { "type": "integer", "minimum": 0 },
+        "output_tokens": { "type": "integer", "minimum": 0 },
+        "cache_creation_input_tokens": { "type": "integer", "minimum": 0 },
+        "cache_read_input_tokens": { "type": "integer", "minimum": 0 },
+        "total_token_volume": { "type": "integer", "minimum": 0 },
+        "reconciled": { "const": true },
+        "unparsed_lines": { "const": 0 },
+        "raw_stream_sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+
+    "final_tree": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["final_tree_oid", "canonical_diff_sha256", "archive_sha256", "workspace_status_digest"],
+      "properties": {
+        "final_tree_oid": { "$ref": "#/$defs/gitOid" },
+        "canonical_diff_sha256": { "$ref": "#/$defs/sha256" },
+        "archive_sha256": { "$ref": "#/$defs/sha256" },
+        "workspace_status_digest": { "$ref": "#/$defs/sha256" }
+      }
+    },
+
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evaluator_image_digest", "evaluator_attempts", "functional_pass",
+        "rejected_decision_revived", "normalized_result_sha256"
+      ],
+      "properties": {
+        "evaluator_image_digest": { "$ref": "#/$defs/ociDigest" },
+        "evaluator_attempts": { "type": "integer", "minimum": 1 },
+        "functional_pass": { "type": "boolean" },
+        "rejected_decision_revived": { "type": "boolean" },
+        "normalized_result_sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+
+    "decision_safe_success": { "type": "boolean" },
+    "simulated": { "const": false }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "gitOid": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "ociDigest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+  }
+}

--- a/bench/cdeb/schemas/study.schema.json
+++ b/bench/cdeb/schemas/study.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cdeb-study",
+  "title": "CDEB public freeze manifest (PRD §18.1, public-freeze.json)",
+  "description": "The pre-run public commitment. Sealed contents appear here only as digests; the randomization is opaque block indices (§18.2), never raw task IDs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "benchmark", "protocol_version", "study_id",
+    "protocol_digest", "candidate_registry_commitment", "sealed_task_bundle_sha256",
+    "repository_bundles", "agent_runtime_image_digest", "requested_model",
+    "observed_model_id", "agent_cli_version", "agent_executable_sha256",
+    "product_commit", "dist_digest", "hook_proxy_sha256", "byte_identity_verified",
+    "evaluator_image_digests", "analysis_source_digest", "bootstrap_seed",
+    "claim_thresholds", "expected_logical_runs"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "benchmark": { "const": "cdeb-v1" },
+    "protocol_version": { "type": "string", "pattern": "^1\\.2\\.[0-9]+$" },
+    "study_id": { "type": "string", "minLength": 1 },
+    "protocol_digest": { "$ref": "#/$defs/sha256" },
+    "candidate_registry_commitment": { "$ref": "#/$defs/sha256" },
+    "sealed_task_bundle_sha256": { "$ref": "#/$defs/sha256" },
+    "repository_bundles": {
+      "type": "array", "minItems": 5, "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repository_id", "bundle_sha256", "snapshot_commit", "snapshot_tree_oid", "refs_digest", "notes_ref_digest", "source_authorization_id"],
+        "properties": {
+          "repository_id": { "type": "string", "minLength": 1 },
+          "bundle_sha256": { "$ref": "#/$defs/sha256" },
+          "snapshot_commit": { "$ref": "#/$defs/gitOid" },
+          "snapshot_tree_oid": { "$ref": "#/$defs/gitOid" },
+          "refs_digest": { "$ref": "#/$defs/sha256" },
+          "notes_ref_digest": { "$ref": "#/$defs/sha256" },
+          "source_authorization_id": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "agent_runtime_image_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "requested_model": { "type": "string", "minLength": 1 },
+    "observed_model_id": { "type": "string", "minLength": 1 },
+    "agent_cli_version": { "type": "string", "minLength": 1 },
+    "agent_executable_sha256": { "$ref": "#/$defs/sha256" },
+    "product_commit": { "$ref": "#/$defs/gitOid" },
+    "dist_digest": { "$ref": "#/$defs/sha256" },
+    "hook_proxy_sha256": { "$ref": "#/$defs/sha256" },
+    "byte_identity_verified": { "const": true },
+    "evaluator_image_digests": {
+      "type": "array", "minItems": 1,
+      "items": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+    },
+    "analysis_source_digest": { "$ref": "#/$defs/sha256" },
+    "bootstrap_seed": { "type": "string", "minLength": 1 },
+    "claim_thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["safe_success_lift_pp", "token_volume_reduction", "revival_reduction", "min_off_revivals", "min_safe_successes_per_arm", "min_finite_replicates"],
+      "properties": {
+        "safe_success_lift_pp": { "const": 10 },
+        "token_volume_reduction": { "const": 0.15 },
+        "revival_reduction": { "const": 0.30 },
+        "min_off_revivals": { "const": 10 },
+        "min_safe_successes_per_arm": { "const": 10 },
+        "min_finite_replicates": { "const": 9900 }
+      }
+    },
+    "expected_logical_runs": { "const": 180 }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "gitOid": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
+  }
+}

--- a/bench/cdeb/schemas/task.schema.json
+++ b/bench/cdeb/schemas/task.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cdeb-task",
+  "title": "CDEB sealed task metadata (PRD §4, §5)",
+  "description": "The non-secret metadata of one sealed task. Prompt text, expected record IDs and evaluator sources live in the sealed bundle and appear here only as digests, alongside the reviewer attestation §4.8 requires.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "benchmark", "task_id", "candidate_id", "repository_id", "category",
+    "timeout_ms", "prompt_sha256", "evaluator_image_digest",
+    "good_control_sha256", "bad_control_sha256", "noop_control_sha256",
+    "oracle_kind", "reviewer_attestation"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "benchmark": { "const": "cdeb-v1" },
+    "task_id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+    "candidate_id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+    "repository_id": { "type": "string", "minLength": 1 },
+    "category": {
+      "enum": [
+        "rejected-architecture", "rejected-workaround", "compatibility-constraint",
+        "security-operational", "superseded-lifecycle"
+      ]
+    },
+    "timeout_ms": { "type": "integer", "minimum": 60000 },
+    "prompt_sha256": { "$ref": "#/$defs/sha256" },
+    "evaluator_image_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "good_control_sha256": { "$ref": "#/$defs/sha256" },
+    "bad_control_sha256": { "$ref": "#/$defs/sha256" },
+    "noop_control_sha256": { "$ref": "#/$defs/sha256" },
+    "oracle_kind": {
+      "enum": ["runtime-invariant", "ast-structure", "config-topology", "structural-predicate", "lexical-approved"]
+    },
+    "reviewer_attestation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reviewer_identity", "artifact_digest", "attested_at"],
+      "properties": {
+        "reviewer_identity": { "type": "string", "minLength": 1 },
+        "artifact_digest": { "$ref": "#/$defs/sha256" },
+        "attested_at": { "type": "string", "format": "date-time" }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/bench/cdeb/verify.mjs
+++ b/bench/cdeb/verify.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+// CDEB recursive verifier (PRD §21). Plain ESM, no build step.
+//
+// The legacy gate (bench/verify.mjs) is default-in over top-level
+// bench/results/*.jsonl and deliberately does not recurse — CDEB studies are
+// nested directories with a fixed layout, and #441 showed what happens when an
+// analysis surface discovers its inputs instead of naming them: the M5 analyzer
+// globbed 1,835 rows from four different experiments and would have passed its
+// own stopping rule on the contamination. So this verifier owns
+// bench/results/cdeb/ recursively, and CDEB rows carry an explicit
+// `benchmark: "cdeb-v1"` — `schema_version` is NOT reused as a skip
+// discriminator (PRD §21.2).
+//
+// Everything here fails loudly and specifically:
+//   - an empty study directory is a finding, not a skip
+//   - an unknown file anywhere in a study is a finding
+//   - a schema-invalid row, attempt, evaluator output or freeze manifest fails
+//   - a derived field that does not equal its recomputation fails
+//     (total_token_volume vs the raw category sum; decision_safe_success vs
+//     stop_reason/functional_pass/rejected_decision_revived — §14.7)
+//   - a duplicate logical_run_id fails
+//   - if randomization.json names the expected logical runs, a missing or
+//     extra row fails; RESULT.json with an incomplete matrix fails (§22.6)
+//
+// Exit 0: every study verifies, or there are no studies. Exit 1 otherwise.
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `ajv`'s default export ships the draft-07 meta-schema only; these schemas
+// declare draft 2020-12, which lives in its own entry point.
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = join(HERE, "..", "results", "cdeb");
+
+const SCHEMA_DIR = join(HERE, "schemas");
+const loadSchema = (name) => JSON.parse(readFileSync(join(SCHEMA_DIR, `${name}.schema.json`), "utf8"));
+
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+addFormats(ajv);
+const validators = {
+  result: ajv.compile(loadSchema("result")),
+  evaluator: ajv.compile(loadSchema("evaluator")),
+  attempt: ajv.compile(loadSchema("attempt")),
+  study: ajv.compile(loadSchema("study")),
+};
+
+/** Entries a study directory may contain, and nothing else (PRD §20.1). */
+const STUDY_ENTRIES = new Set([
+  "public-freeze.json", "randomization.json", "deviations.md",
+  "RESULT.json", "RESULT.md", "runs", "rows", "attempts",
+]);
+
+/** Entries a runs/<logical-run-id>/ directory may contain (PRD §19.1). */
+const RUN_ENTRIES = new Set([
+  "attempts", "provider.ndjson.zst", "provider.ndjson.sha256",
+  "exposure.jsonl", "exposure.sha256", "final-tree.tar.zst", "final-tree.json",
+  "evaluator-attempts", "evaluator.json", "row.json",
+]);
+
+const findings = [];
+const fail = (study, message) => findings.push(`${study}: ${message}`);
+
+const readJson = (study, path) => {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    fail(study, `${path} is not valid JSON: ${error.message}`);
+    return null;
+  }
+};
+
+const validateAgainst = (study, kind, path, value) => {
+  if (value === null) return false;
+  if (validators[kind](value)) return true;
+  for (const err of validators[kind].errors ?? []) {
+    fail(study, `${path}: ${err.instancePath || "/"} ${err.message}`);
+  }
+  return false;
+};
+
+/**
+ * §14.7: stored derived fields are recomputed from their raw inputs. Schema
+ * validity proves the shape; only recomputation proves the value.
+ */
+const checkDerived = (study, path, row) => {
+  const u = row.usage;
+  const sum = u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens;
+  if (u.total_token_volume !== sum) {
+    fail(study, `${path}: total_token_volume ${u.total_token_volume} != raw category sum ${sum}`);
+  }
+  const recomputed =
+    row.stop_reason === "completed" &&
+    row.evaluation.functional_pass === true &&
+    row.evaluation.rejected_decision_revived === false;
+  if (row.decision_safe_success !== recomputed) {
+    fail(study, `${path}: decision_safe_success ${row.decision_safe_success} != recomputed ${recomputed} from stop_reason/evaluation`);
+  }
+};
+
+const verifyStudy = (root, studyName) => {
+  const study = studyName;
+  const dir = join(root, studyName);
+  const entries = readdirSync(dir);
+
+  if (entries.length === 0) {
+    fail(study, "study directory is empty — a study that produced nothing is a finding, not a skip");
+    return;
+  }
+  for (const entry of entries) {
+    if (!STUDY_ENTRIES.has(entry)) {
+      fail(study, `unknown entry "${entry}" — every file in a study is accounted for or the study fails`);
+    }
+  }
+
+  const freezePath = join(dir, "public-freeze.json");
+  let expectedRuns = null;
+  if (existsSync(freezePath)) {
+    const freeze = readJson(study, freezePath);
+    if (freeze !== null && validateAgainst(study, "study", freezePath, freeze)) {
+      expectedRuns = freeze.expected_logical_runs;
+    }
+  }
+
+  // Expected logical run ids, when the randomization names them. Kept minimal:
+  // the file may hold opaque blocks pre-reveal, so ids are only enforced when
+  // present.
+  let expectedIds = null;
+  const randPath = join(dir, "randomization.json");
+  if (existsSync(randPath)) {
+    const rand = readJson(study, randPath);
+    if (rand !== null && Array.isArray(rand.expected_logical_run_ids)) {
+      expectedIds = new Set(rand.expected_logical_run_ids);
+    }
+  }
+
+  const seenIds = new Map(); // logical_run_id -> path
+
+  const verifyRow = (path) => {
+    const row = readJson(study, path);
+    if (!validateAgainst(study, "result", path, row)) return;
+    checkDerived(study, path, row);
+    if (seenIds.has(row.logical_run_id)) {
+      fail(study, `duplicate logical_run_id ${row.logical_run_id} in ${path} and ${seenIds.get(row.logical_run_id)}`);
+    } else {
+      seenIds.set(row.logical_run_id, path);
+    }
+    if (expectedIds !== null && !expectedIds.has(row.logical_run_id)) {
+      fail(study, `${path}: logical_run_id ${row.logical_run_id} is not in the randomization's expected set`);
+    }
+  };
+
+  const rowsDir = join(dir, "rows");
+  if (existsSync(rowsDir)) {
+    for (const name of readdirSync(rowsDir).sort()) {
+      const path = join(rowsDir, name);
+      if (!name.endsWith(".json") || !statSync(path).isFile()) {
+        fail(study, `rows/${name}: only row .json files belong here`);
+        continue;
+      }
+      verifyRow(path);
+    }
+  }
+
+  const runsDir = join(dir, "runs");
+  if (existsSync(runsDir)) {
+    for (const runName of readdirSync(runsDir).sort()) {
+      const runDir = join(runsDir, runName);
+      if (!statSync(runDir).isDirectory()) {
+        fail(study, `runs/${runName}: only per-run directories belong here`);
+        continue;
+      }
+      for (const entry of readdirSync(runDir)) {
+        if (!RUN_ENTRIES.has(entry)) fail(study, `runs/${runName}/${entry}: unknown entry`);
+      }
+      const rowPath = join(runDir, "row.json");
+      if (existsSync(rowPath)) verifyRow(rowPath);
+      const evalPath = join(runDir, "evaluator.json");
+      if (existsSync(evalPath)) {
+        validateAgainst(study, "evaluator", evalPath, readJson(study, evalPath));
+      }
+    }
+  }
+
+  const attemptsDir = join(dir, "attempts");
+  if (existsSync(attemptsDir)) {
+    for (const name of readdirSync(attemptsDir).sort()) {
+      const path = join(attemptsDir, name);
+      if (!name.endsWith(".json") || !statSync(path).isFile()) {
+        fail(study, `attempts/${name}: only attempt .json files belong here`);
+        continue;
+      }
+      validateAgainst(study, "attempt", path, readJson(study, path));
+    }
+  }
+
+  if (expectedIds !== null) {
+    for (const id of expectedIds) {
+      if (!seenIds.has(id)) fail(study, `expected logical run ${id} has no row`);
+    }
+  }
+  if (expectedRuns !== null && expectedIds !== null && expectedIds.size !== expectedRuns) {
+    fail(study, `randomization names ${expectedIds.size} runs but the freeze expects ${expectedRuns}`);
+  }
+
+  // A verdict requires the complete matrix (§22.6). RESULT.json sitting beside
+  // missing rows is the exact artifact the analyzer must never have produced.
+  if (existsSync(join(dir, "RESULT.json")) && expectedIds !== null) {
+    const missing = [...expectedIds].filter((id) => !seenIds.has(id));
+    if (missing.length > 0) {
+      fail(study, `RESULT.json exists but ${missing.length} expected row(s) are missing — a verdict from an incomplete matrix`);
+    }
+  }
+};
+
+const main = () => {
+  const root = process.argv[2] ?? DEFAULT_ROOT;
+  if (!existsSync(root)) {
+    console.log(`cdeb verify: no studies at ${root} — nothing to verify`);
+    return 0;
+  }
+  const studies = readdirSync(root).sort();
+  for (const name of studies) {
+    const path = join(root, name);
+    if (!statSync(path).isDirectory()) {
+      fail("(root)", `unknown file "${name}" — the CDEB root holds study directories only`);
+      continue;
+    }
+    verifyStudy(root, name);
+  }
+
+  if (findings.length > 0) {
+    for (const finding of findings) console.error(`cdeb verify: ${finding}`);
+    console.error(`cdeb verify: ${findings.length} finding(s)`);
+    return 1;
+  }
+  console.log(`cdeb verify: ${studies.length} study(ies) verified clean`);
+  return 0;
+};
+
+process.exit(main());

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
     "build": "tsc -p tsconfig.json && npm run bundle",
     "bench:deterministic": "npm run build && node --experimental-strip-types bench/deterministic.ts",
     "bench:external": "npm run build && node --experimental-strip-types bench/external/run.ts",
-    "bench:verify": "node bench/verify.mjs",
+    "bench:verify": "node bench/verify.mjs && node bench/cdeb/verify.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "bundle": "esbuild src/cli.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/commitlore.mjs",
-    "bench:m5": "node --experimental-strip-types bench/m5-analysis.ts"
+    "bench:m5": "node --experimental-strip-types bench/m5-analysis.ts",
+    "bench:cdeb:verify": "node bench/cdeb/verify.mjs"
   },
   "keywords": [
     "git",

--- a/test/cdeb-verify.test.ts
+++ b/test/cdeb-verify.test.ts
@@ -1,0 +1,221 @@
+/**
+ * CDEB-01 acceptance (#443, PRD §21): the recursive verifier fails on every
+ * class of defect the protocol names, and passes a clean study.
+ *
+ * Each case drives the real `bench/cdeb/verify.mjs` as a subprocess against a
+ * fixture study built in a temp directory, because the acceptance criteria are
+ * about exit codes CI will see — not about functions.
+ *
+ * The valid-row builder is the load-bearing fixture: every failure case is the
+ * valid row with exactly one thing broken, so a case that fails proves the
+ * verifier caught *that* defect and not an accident of the fixture.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const VERIFIER = join(REPO_ROOT, 'bench', 'cdeb', 'verify.mjs');
+
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const temp = (label: string): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `cdeb-${label}-`));
+  scratch.push(dir);
+  return dir;
+};
+
+const HEX64 = 'a'.repeat(64);
+const OID = 'b'.repeat(40);
+
+/** A row that satisfies result.schema.json and both derived recomputations. */
+const validRow = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  schema_version: 1,
+  benchmark: 'cdeb-v1',
+  protocol_version: '1.2.0',
+  study_id: 'cdeb-test-01',
+  logical_run_id: 'repo-a__task-a__on__r1',
+  repository_id: 'repo-a',
+  task_id: 'task-a',
+  category: 'rejected-architecture',
+  condition: 'commitlore-on',
+  repeat: 1,
+  order: 1,
+  freeze_manifest_sha256: HEX64,
+  sealed_task_bundle_sha256: HEX64,
+  repository_bundle_sha256: HEX64,
+  repository_snapshot: OID,
+  base_tree_oid: OID,
+  refs_digest: HEX64,
+  notes_ref_digest: HEX64,
+  requested_model: 'sonnet',
+  observed_model_ids: ['claude-sonnet-5'],
+  agent_cli_version: '3.0.0',
+  agent_executable_sha256: HEX64,
+  node_version: 'v24.18.0',
+  node_executable_sha256: HEX64,
+  agent_runtime_image_digest: `sha256:${HEX64}`,
+  tool_policy_digest: HEX64,
+  network_policy_digest: HEX64,
+  settings_digest: HEX64,
+  mcp_config_digest: HEX64,
+  harness_commit: OID,
+  product_commit: OID,
+  dist_digest: HEX64,
+  hook_proxy_sha256: HEX64,
+  started_at: '2026-08-07T00:00:00Z',
+  finished_at: '2026-08-07T00:10:00Z',
+  stop_reason: 'completed',
+  first_model_turn_observed: true,
+  wall_ms: 600000,
+  exposure: {
+    instrumentation_complete: true,
+    hook_opportunities: 2,
+    proxy_executions: 2,
+    expected_record_delivered: true,
+    delivered_before_first_mutation: true,
+    delivered_record_ids: ['r-abc123'],
+    payload_sha256s: [HEX64],
+    product_failures: 0,
+  },
+  usage: {
+    input_tokens: 1000,
+    output_tokens: 200,
+    cache_creation_input_tokens: 300,
+    cache_read_input_tokens: 500,
+    total_token_volume: 2000,
+    reconciled: true,
+    unparsed_lines: 0,
+    raw_stream_sha256: HEX64,
+  },
+  final_tree: {
+    final_tree_oid: OID,
+    canonical_diff_sha256: HEX64,
+    archive_sha256: HEX64,
+    workspace_status_digest: HEX64,
+  },
+  evaluation: {
+    evaluator_image_digest: `sha256:${HEX64}`,
+    evaluator_attempts: 1,
+    functional_pass: true,
+    rejected_decision_revived: false,
+    normalized_result_sha256: HEX64,
+  },
+  decision_safe_success: true,
+  simulated: false,
+  ...overrides,
+});
+
+/** A study directory holding the given rows under rows/. */
+const study = (label: string, rows: Record<string, unknown>[]): string => {
+  const root = temp(label);
+  const rowsDir = join(root, 'cdeb-test-01', 'rows');
+  mkdirSync(rowsDir, { recursive: true });
+  rows.forEach((row, index) => {
+    writeFileSync(join(rowsDir, `row-${String(index)}.json`), `${JSON.stringify(row, null, 2)}\n`);
+  });
+  return root;
+};
+
+const verify = (root: string): { code: number; output: string } => {
+  try {
+    const output = execFileSync(process.execPath, [VERIFIER, root], { encoding: 'utf8' });
+    return { code: 0, output };
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string; stdout?: string };
+    return { code: failure.status ?? 1, output: `${failure.stdout ?? ''}${failure.stderr ?? ''}` };
+  }
+};
+
+describe('#443 the CDEB recursive verifier', () => {
+  it('passes a clean study — the control every failure case depends on', () => {
+    const result = verify(study('clean', [validRow()]));
+    expect(result.code, result.output).toBe(0);
+    expect(result.output).toContain('verified clean');
+  });
+
+  it('is silent-and-zero when there are no studies at all', () => {
+    const result = verify(join(temp('absent'), 'does-not-exist'));
+    expect(result.code).toBe(0);
+    expect(result.output).toContain('nothing to verify');
+  });
+
+  it('fails an empty study directory rather than skipping it', () => {
+    const root = temp('empty');
+    mkdirSync(join(root, 'cdeb-test-01'), { recursive: true });
+    const result = verify(root);
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/empty/);
+  });
+
+  it('fails an unknown file inside a study', () => {
+    const root = study('unknown', [validRow()]);
+    writeFileSync(join(root, 'cdeb-test-01', 'notes.txt'), 'stray\n');
+    const result = verify(root);
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/unknown entry "notes\.txt"/);
+  });
+
+  it('fails a schema-invalid nested row', () => {
+    const result = verify(study('invalid', [validRow({ condition: 'commitlore-maybe' })]));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/condition/);
+  });
+
+  it('fails a row missing the explicit benchmark discriminator', () => {
+    // §21.2: CDEB classification is `benchmark: "cdeb-v1"`, never a reused
+    // schema_version. A row without it is not a CDEB row and must not pass.
+    const result = verify(study('nobench', [validRow({ benchmark: 'something-else' })]));
+    expect(result.code).toBe(1);
+  });
+
+  it('fails when total_token_volume does not equal the raw category sum', () => {
+    const row = validRow();
+    (row.usage as Record<string, unknown>).total_token_volume = 1999;
+    const result = verify(study('tokensum', [row]));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/total_token_volume 1999 != raw category sum 2000/);
+  });
+
+  it('fails when decision_safe_success does not match its recomputation', () => {
+    // A timeout can never be a safe success (§13.3), whatever the row claims.
+    const result = verify(study('derived', [validRow({ stop_reason: 'timeout' })]));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/decision_safe_success true != recomputed false/);
+  });
+
+  it('fails a simulated row — smoke output must never sit in a study', () => {
+    const result = verify(study('simulated', [validRow({ simulated: true })]));
+    expect(result.code).toBe(1);
+  });
+
+  it('fails a duplicate logical_run_id', () => {
+    const result = verify(study('dup', [validRow(), validRow()]));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/duplicate logical_run_id/);
+  });
+
+  it('fails a missing expected row, and a verdict sitting beside the gap', () => {
+    const root = study('missing', [validRow()]);
+    writeFileSync(
+      join(root, 'cdeb-test-01', 'randomization.json'),
+      `${JSON.stringify({
+        expected_logical_run_ids: ['repo-a__task-a__on__r1', 'repo-a__task-a__off__r1'],
+      })}\n`,
+    );
+    writeFileSync(join(root, 'cdeb-test-01', 'RESULT.json'), '{}\n');
+    const result = verify(root);
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/repo-a__task-a__off__r1 has no row/);
+    expect(result.output).toMatch(/verdict from an incomplete matrix/);
+  });
+});


### PR DESCRIPTION
Closes #443. CDEB-01 — the first infrastructure ticket of the protocol landed in #442.

## What lands

**Six schemas** in `bench/cdeb/schemas/`, all `additionalProperties: false`, all requiring the explicit `benchmark: "cdeb-v1"` discriminator:

| schema | describes |
|---|---|
| `result` | the canonical measured row (PRD §19.2), every field required |
| `evaluator` | the sealed evaluator output (§12.4) — no free-form score is representable |
| `attempt` | one attempt with its terminal state (§10) |
| `study` | the public freeze manifest (§18.1), thresholds pinned as constants |
| `candidate` | a registry entry (§3.2) — `natural_record` and `benchmark_authored` are consts |
| `task` | sealed-task metadata with the §4.8 reviewer attestation |

**`bench/cdeb/verify.mjs`** — the recursive verifier of §21.1, and **CI integration**: `npm run bench:verify` now chains the legacy gate and this one. The CI yaml invokes the npm script, verified, so nothing bypasses it.

## The design inversion, stated

The legacy gate is deliberately **default-in** over flat `bench/results/*.jsonl` because its failure mode was a file nobody registered (#392). CDEB's failure mode is the opposite — an analysis surface discovering inputs it was never meant to read. #441 showed the M5 analyzer glob 1,835 rows from four experiments and nearly pass its own stopping rule on the contamination.

So in a CDEB study **every entry is accounted for or the study fails**, and classification is the explicit `benchmark` field — `schema_version` is never reused as a skip discriminator (§21.2).

## Derived fields are recomputed, not trusted (§14.7)

- `total_token_volume` against the raw category sum
- `decision_safe_success` against `stop_reason` + evaluator fields — a row claiming a safe success on a timeout fails whatever its schema-valid shape says

And a `RESULT.json` sitting beside missing expected rows fails as *"a verdict from an incomplete matrix"* — the artifact the analyzer must never produce (§22.6).

## One dependency gotcha

The schemas declare draft 2020-12; `ajv`'s default entry ships only the draft-07 meta-schema and refuses them at compile time. `Ajv2020` from `ajv/dist/2020.js`, with the reason at the import. Weakening six schemas to fit a meta-schema would have been backwards.

## Tests — 11, structured as control + single mutation

The clean study passes (the control), and each failure case is that same valid row with exactly one thing broken — so a passing case proves the verifier caught *that* defect, not an accident of the fixture: empty study, unknown file, invalid row, wrong `benchmark`, token-sum mismatch, derived mismatch, simulated row, duplicate id, missing-row-with-verdict. All drive the real verifier as a subprocess, because the acceptance criteria are exit codes CI will see.

## Verification

- Full suite: **95 files, 2196 passed**, 1 skipped.
- `npm run bench:verify` green with both verifiers chained (legacy: 1,592 rows in 14 files; CDEB: no studies yet, exits 0).
- `test/dogfood.test.ts` re-run after committing: 9 passed.