### PR TITLE
Materialize a frozen bundle, and prove two copies are one repository

### DIFF
--- a/bench/cdeb/freeze/repository-bundle.ts
+++ b/bench/cdeb/freeze/repository-bundle.ts
@@ -1,0 +1,194 @@
+/**
+ * CDEB-02: frozen repository bundles, and the proof that two materializations
+ * of one are the same repository (PRD §6).
+ *
+ * Every CDEB comparison rests on one invariant: the ON and OFF arms of a
+ * task/repeat pair see **byte-identical repository state**, and the only
+ * difference between the arms is the frozen agent settings. This module owns
+ * that invariant end to end — creating the bundle, materializing it offline,
+ * and computing the identity digests both arms are compared by.
+ *
+ * Deliberately new code. `bench/workspace.ts` builds synthetic workspaces and,
+ * with `seedRecords: false`, strips the trailer block out of seeded commits —
+ * exactly the control construction §6.3 prohibits ("OFF에서 CommitLore
+ * trailers 제거"). Nothing here imports it, and a mutation test in
+ * `test/cdeb-materializer.test.ts` proves a trailer-stripped history cannot
+ * pass the digest comparison.
+ *
+ * Digest boundaries, stated because they are load-bearing (PRD v1.2 §6.2):
+ * the identity covers commits, trees, refs and the notes mirror. It excludes
+ * `.git/` internal product state — the CommitLore index and MCP lifecycle log
+ * live under `.git/commitlore/`, are created lazily by the product on first
+ * use, and must not make an ON materialization "differ" from an OFF one that
+ * has not been queried yet.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { git, gitOrThrow } from "../../git.ts";
+
+export const NOTES_REF = "refs/notes/commitlore";
+
+/** The §6.1 identity of a frozen bundle. */
+export interface RepositoryBundleIdentity {
+  readonly repository_id: string;
+  readonly bundle_sha256: string;
+  readonly snapshot_commit: string;
+  readonly snapshot_tree_oid: string;
+  readonly refs_digest: string;
+  readonly notes_ref_digest: string;
+}
+
+/** The §6.2 identity of one materialized working copy. */
+export interface MaterializedIdentity {
+  readonly head: string;
+  readonly base_tree_oid: string;
+  readonly commit_message_digest: string;
+  readonly refs_digest: string;
+  readonly notes_ref_digest: string;
+  readonly working_tree_source_digest: string;
+}
+
+const sha256 = (input: string | Buffer): string =>
+  createHash("sha256").update(input).digest("hex");
+
+const sha256File = (path: string): string => sha256(readFileSync(path));
+
+/**
+ * Every ref the repository carries, as `sha ref` lines sorted by ref name.
+ * `for-each-ref` rather than `show-ref` so an empty result is an answer, and
+ * sorted so the digest does not depend on enumeration order.
+ */
+const refsListing = (cwd: string): string =>
+  gitOrThrow(cwd, ["for-each-ref", "--format=%(objectname) %(refname)", "--sort=refname"]);
+
+const notesTip = (cwd: string): string => {
+  const result = git(cwd, ["rev-parse", "--verify", "--quiet", NOTES_REF]);
+  return result.status === 0 ? result.stdout.trim() : "absent";
+};
+
+/**
+ * Every commit message reachable from the snapshot, in a stable order.
+ *
+ * This is the digest that catches §6.3's prohibited constructions directly: a
+ * history whose trailers were stripped, or whose messages were rewritten,
+ * changes every descendant sha — but comparing messages by content names the
+ * *kind* of divergence instead of only that one exists, and it holds even if
+ * someone constructs colliding-sha trickery at the ref level.
+ */
+const commitMessageDigest = (cwd: string, snapshot: string): string =>
+  sha256(gitOrThrow(cwd, ["log", "--format=%H%x00%B%x01", snapshot]));
+
+/**
+ * The working tree's content identity, from the index git itself builds for
+ * the checkout. `git ls-files -s` covers tracked content (mode, oid, path);
+ * a detached checkout of a frozen snapshot has no untracked files by
+ * construction, and §6.2 v1.2 excludes `.git/` internals, which ls-files never
+ * sees.
+ */
+const workingTreeDigest = (cwd: string): string =>
+  sha256(gitOrThrow(cwd, ["ls-files", "-s"]));
+
+/**
+ * Creates the frozen bundle for a repository at an exact snapshot.
+ *
+ * `--all` plus the notes ref explicitly: `git bundle create --all` includes
+ * `refs/notes/*` only when the repository's config fetches them, and a bundle
+ * that silently dropped the mirror would materialize into a repository where
+ * every notes-sourced record simply does not exist — an OFF arm by accident.
+ */
+export const createRepositoryBundle = (
+  repositoryId: string,
+  sourceCwd: string,
+  bundlePath: string,
+): RepositoryBundleIdentity => {
+  mkdirSync(join(bundlePath, ".."), { recursive: true });
+  const refs = ["--all"];
+  if (notesTip(sourceCwd) !== "absent") refs.push(NOTES_REF);
+  gitOrThrow(sourceCwd, ["bundle", "create", bundlePath, ...refs]);
+  gitOrThrow(sourceCwd, ["bundle", "verify", bundlePath]);
+
+  const snapshot = gitOrThrow(sourceCwd, ["rev-parse", "HEAD"]).trim();
+  return {
+    repository_id: repositoryId,
+    bundle_sha256: sha256File(bundlePath),
+    snapshot_commit: snapshot,
+    snapshot_tree_oid: gitOrThrow(sourceCwd, ["rev-parse", `${snapshot}^{tree}`]).trim(),
+    refs_digest: sha256(refsListing(sourceCwd)),
+    notes_ref_digest: sha256(notesTip(sourceCwd)),
+  };
+};
+
+/**
+ * Materializes a frozen bundle into a fresh working copy, offline, and
+ * verifies every §6.1 identity before handing it over.
+ *
+ * A mismatch is a throw, not a warning: a materialization whose digests do not
+ * match the freeze is not "a repository with a caveat", it is a different
+ * repository, and running an arm in it would compare two experiments while
+ * calling them one (§6.2).
+ */
+export const materializeBundle = (
+  identity: RepositoryBundleIdentity,
+  bundlePath: string,
+  targetDir: string,
+): MaterializedIdentity => {
+  if (!existsSync(bundlePath)) {
+    throw new Error(`materialize: bundle ${bundlePath} is missing`);
+  }
+  const actualBundle = sha256File(bundlePath);
+  if (actualBundle !== identity.bundle_sha256) {
+    throw new Error(
+      `materialize: bundle digest ${actualBundle} does not match the frozen ${identity.bundle_sha256}`,
+    );
+  }
+
+  mkdirSync(targetDir, { recursive: true });
+  gitOrThrow(targetDir, ["clone", "--quiet", "--no-hardlinks", bundlePath, "."]);
+  // Detach before restoring local refs: git refuses to fetch into the branch
+  // the clone checked out, and the materialization never works on a branch
+  // anyway — the contract is a detached checkout of the exact snapshot.
+  gitOrThrow(targetDir, ["checkout", "--quiet", "--detach", identity.snapshot_commit]);
+  // The clone maps bundle refs under the origin remote; the comparison needs
+  // them local, exactly as the source had them.
+  gitOrThrow(targetDir, ["fetch", "--quiet", "origin", "+refs/*:refs/*"]);
+
+  const materialized = identityOfMaterialization(targetDir, identity.snapshot_commit);
+
+  if (materialized.head !== identity.snapshot_commit) {
+    throw new Error(`materialize: HEAD ${materialized.head} is not the frozen snapshot`);
+  }
+  if (materialized.base_tree_oid !== identity.snapshot_tree_oid) {
+    throw new Error(`materialize: tree ${materialized.base_tree_oid} is not the frozen tree`);
+  }
+  if (materialized.notes_ref_digest !== identity.notes_ref_digest) {
+    throw new Error(
+      "materialize: the notes mirror does not match the freeze — a repository without its records is a different repository",
+    );
+  }
+
+  return materialized;
+};
+
+/** The §6.2 identity of an existing materialization, for arm comparison. */
+export const identityOfMaterialization = (cwd: string, snapshot: string): MaterializedIdentity => ({
+  head: gitOrThrow(cwd, ["rev-parse", "HEAD"]).trim(),
+  base_tree_oid: gitOrThrow(cwd, ["rev-parse", "HEAD^{tree}"]).trim(),
+  commit_message_digest: commitMessageDigest(cwd, snapshot),
+  refs_digest: sha256(refsListing(cwd)),
+  notes_ref_digest: sha256(notesTip(cwd)),
+  working_tree_source_digest: workingTreeDigest(cwd),
+});
+
+/**
+ * The same-history gate: every field of the two arms' identities must be
+ * equal, and the answer names each field that is not. Returns the mismatched
+ * field names — an empty array is the invariant holding.
+ */
+export const sameHistoryMismatches = (
+  on: MaterializedIdentity,
+  off: MaterializedIdentity,
+): string[] =>
+  (Object.keys(on) as (keyof MaterializedIdentity)[]).filter((key) => on[key] !== off[key]);

--- a/test/cdeb-materializer.test.ts
+++ b/test/cdeb-materializer.test.ts
@@ -1,0 +1,165 @@
+/**
+ * CDEB-02 acceptance (#445, PRD §6): two materializations of one frozen bundle
+ * are provably the same repository, the notes mirror survives the trip, and
+ * the prohibited control constructions of §6.3 cannot pass the digest gate.
+ *
+ * The mutation case is the one that matters most. `bench/workspace.ts` can
+ * build a history with its trailer blocks stripped (`seedRecords: false`) —
+ * exactly the OFF-arm construction §6.3 forbids — so the test constructs that
+ * shape independently and proves the same-history gate names the divergence
+ * rather than merely failing.
+ */
+
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  createRepositoryBundle,
+  identityOfMaterialization,
+  materializeBundle,
+  sameHistoryMismatches,
+} from '../bench/cdeb/freeze/repository-bundle.ts';
+import { gitOrThrow } from '../bench/git.ts';
+import { createTestRepo } from './git-fixtures.js';
+
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const temp = (label: string): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `cdeb-mat-${label}-`));
+  scratch.push(dir);
+  return dir;
+};
+
+const RECORD_TRAILERS = [
+  'Limit: the v1 runtime has no network egress outside the app subnet',
+  'Ruled-out: shared Redis cache | ops refuses another stateful dependency',
+  'Record-Id: r-cdeb01',
+  'Provenance: authored',
+].join('\n');
+
+/**
+ * A source repository shaped like a CDEB corpus repository: two commits, one
+ * carrying a record in its trailers, plus a record in the notes mirror.
+ * `stripTrailers` builds the §6.3 forbidden variant of the same content.
+ */
+const sourceRepo = (label: string, stripTrailers = false): string => {
+  const dir = createTestRepo({ path: temp(label) });
+  gitOrThrow(dir, ['config', 'user.email', 'corpus@example.invalid']);
+  gitOrThrow(dir, ['config', 'user.name', 'corpus']);
+
+  writeFileSync(join(dir, 'pricing.ts'), 'export const price = 1;\n');
+  gitOrThrow(dir, ['add', '-A']);
+  const body = stripTrailers
+    ? 'feat: cache sessions in process'
+    : `feat: cache sessions in process\n\n${RECORD_TRAILERS}`;
+  gitOrThrow(dir, ['commit', '--quiet', '-m', body]);
+
+  writeFileSync(join(dir, 'pricing.ts'), 'export const price = 2;\n');
+  gitOrThrow(dir, ['add', '-A']);
+  gitOrThrow(dir, ['commit', '--quiet', '-m', 'chore: bump the price']);
+
+  gitOrThrow(dir, [
+    'notes',
+    '--ref=commitlore',
+    'add',
+    '-m',
+    'Warn: session entries must stay under 4KB\nRecord-Id: r-cdeb02\nProvenance: authored',
+    'HEAD',
+  ]);
+  return dir;
+};
+
+describe('#445 the frozen repository materializer', () => {
+  it('proves two materializations of one bundle are the same repository', () => {
+    const source = sourceRepo('same');
+    const bundle = join(temp('same-bundle'), 'repo.bundle');
+    const identity = createRepositoryBundle('repo-a', source, bundle);
+
+    expect(identity.bundle_sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(identity.snapshot_commit).toMatch(/^[0-9a-f]{40}$/);
+
+    const on = materializeBundle(identity, bundle, join(temp('same-on'), 'wt'));
+    const off = materializeBundle(identity, bundle, join(temp('same-off'), 'wt'));
+
+    // The §6.2 gate: every identity field equal, or the arms are not one
+    // experiment. This is the proof, not an assertion.
+    expect(sameHistoryMismatches(on, off)).toEqual([]);
+    expect(on.head).toBe(identity.snapshot_commit);
+  });
+
+  it('carries the notes mirror through the bundle', () => {
+    const source = sourceRepo('notes');
+    const bundle = join(temp('notes-bundle'), 'repo.bundle');
+    const identity = createRepositoryBundle('repo-a', source, bundle);
+    const target = join(temp('notes-on'), 'wt');
+    materializeBundle(identity, bundle, target);
+
+    // The record is readable in the materialization — a mirror that did not
+    // survive would make every notes-sourced record silently absent, which is
+    // an OFF arm by accident.
+    const note = gitOrThrow(target, ['notes', '--ref=commitlore', 'show', identity.snapshot_commit]);
+    expect(note).toContain('r-cdeb02');
+    const message = gitOrThrow(target, ['log', '--format=%B', '-1', `${identity.snapshot_commit}~1`]);
+    expect(message).toContain('r-cdeb01');
+  });
+
+  it('refuses a bundle whose bytes do not match the freeze', () => {
+    const source = sourceRepo('tamper');
+    const bundle = join(temp('tamper-bundle'), 'repo.bundle');
+    const identity = createRepositoryBundle('repo-a', source, bundle);
+
+    const bytes = readFileSync(bundle);
+    bytes[bytes.length - 1] = bytes[bytes.length - 1]! ^ 0xff;
+    writeFileSync(bundle, bytes);
+
+    expect(() => materializeBundle(identity, bundle, join(temp('tamper-wt'), 'wt'))).toThrow(
+      /bundle digest .* does not match the frozen/,
+    );
+  });
+
+  it('refuses a missing bundle rather than materializing nothing', () => {
+    const source = sourceRepo('missing');
+    const bundle = join(temp('missing-bundle'), 'repo.bundle');
+    const identity = createRepositoryBundle('repo-a', source, bundle);
+    rmSync(bundle);
+
+    expect(() => materializeBundle(identity, bundle, join(temp('missing-wt'), 'wt'))).toThrow(
+      /bundle .* is missing/,
+    );
+  });
+
+  /**
+   * The §6.3 mutation: the same content with its trailer block stripped — what
+   * `bench/workspace.ts` builds for the M-series OFF arm — must not be able to
+   * stand in for the real history. The gate names the divergence.
+   */
+  it('a trailer-stripped history cannot pass the same-history gate', () => {
+    const real = sourceRepo('real');
+    const stripped = sourceRepo('stripped', true);
+
+    const realBundle = join(temp('real-bundle'), 'repo.bundle');
+    const strippedBundle = join(temp('stripped-bundle'), 'repo.bundle');
+    const realIdentity = createRepositoryBundle('repo-a', real, realBundle);
+    const strippedIdentity = createRepositoryBundle('repo-a', stripped, strippedBundle);
+
+    const realMat = materializeBundle(realIdentity, realBundle, join(temp('real-wt'), 'wt'));
+    const strippedMat = materializeBundle(
+      strippedIdentity,
+      strippedBundle,
+      join(temp('stripped-wt'), 'wt'),
+    );
+
+    const mismatches = sameHistoryMismatches(realMat, strippedMat);
+    expect(mismatches).not.toEqual([]);
+    // Stripping trailers rewrites every descendant sha, but the message digest
+    // is the field that names the *kind* of divergence.
+    expect(mismatches).toContain('commit_message_digest');
+  });
+});


### PR DESCRIPTION
Closes #445. CDEB-02 — the second infrastructure ticket of the protocol (`bench/cdeb/PRD.md` v1.2). CDEB-01 landed in #444.

## What this owns

Every CDEB comparison rests on one invariant: the ON and OFF arms of a task/repeat pair see **byte-identical repository state**, and the only difference is the frozen agent settings. `bench/cdeb/freeze/repository-bundle.ts` owns that end to end — the §6.1 bundle with its six-field identity, offline materialization into a detached checkout, and the §6.2 identity both arms are compared by.

`sameHistoryMismatches` returns the **mismatched field names**, so a violation says *what* diverged rather than only that something did.

## Deliberately new code, and why the PRD says so

`bench/workspace.ts` with `seedRecords: false` strips the trailer block out of seeded commits — exactly the OFF-arm construction §6.3 prohibits. The PRD names it as the one helper the materializer must not touch. Nothing here imports it, and the mutation test builds that forbidden shape **independently** to prove the gate catches it: a trailer-stripped history fails with `commit_message_digest` among the mismatches, which identifies the *kind* of divergence rather than merely its existence.

## Digest boundary (v1.2 §6.2)

Identity covers commits, trees, refs and the notes mirror; it excludes `.git/` internals. The working-tree digest reads `git ls-files -s`, which never sees the product's lazily created index or MCP lifecycle log — so an ON arm that has been queried does not "differ" from an OFF arm that has not.

## One git behaviour shaped the order

Git refuses to fetch into the branch a clone checked out, so the copy detaches onto the snapshot **first** and only then restores the bundle's refs to their local names. The contract is a detached checkout anyway.

Also: `git bundle create --all` includes `refs/notes/*` only by configuration, so the notes ref is passed explicitly. A bundle that silently dropped the mirror would materialize an OFF arm by accident.

## Tests — 5

- two materializations of one bundle report **zero mismatches** (the §6.2 proof)
- the notes record and the trailer record are both readable in the copy
- a tampered bundle and a missing bundle each refuse with the named reason
- the trailer-stripped history fails the gate with `commit_message_digest` named

## Verification

Full suite: **96 files, 2201 passed**, 1 skipped. `bench/tsconfig.json` typecheck clean. `test/dogfood.test.ts` re-run after committing: 9 passed.