### PR TITLE
Freeze the CDEB pilot before it can be told what it wants to hear

### DIFF
--- a/bench/cdeb/PREREGISTRATION-CDEB-P.md
+++ b/bench/cdeb/PREREGISTRATION-CDEB-P.md
@@ -1,0 +1,116 @@
+# CDEB-P — the pilot that decides whether CDEB v1 is worth building
+
+**Status:** registered, not yet run
+**Protocol:** subordinate to `bench/cdeb/PRD.md` v1.2
+**Produces:** no citable verdict, by construction (§8)
+
+---
+
+## 1. Why a pilot exists at all
+
+CDEB v1 is a 180-run confirmatory study with three claim gates. Reviewing its own PRD against this repository turned up two gaps that no amount of additional protocol text can close, because both are empirical:
+
+**The design's power was never stated.** M5 registered 1,160 measurements to reach 80% power. CDEB registers 180 runs to judge three gates and says nothing about what effect size it can detect. Simulating the registered analysis — 30 tasks, 3 repeats, the §16.3 paired bootstrap, the ≥10pp threshold and CI-lower-bound-above-zero rule:
+
+| true lift | P(gate passes), OFF=0.40 | OFF=0.55 |
+|---:|---:|---:|
+| **10pp** (the threshold itself) | **0.30** | **0.31** |
+| 15pp | 0.55 | 0.58 |
+| **20pp** | **0.78** | **0.84** |
+| 25pp | 0.93 | 0.96 |
+| 30pp | 0.98 | 0.99 |
+
+A study whose true effect sits exactly on its own threshold fails seven times in ten. CDEB certifies effects of roughly 20pp and up; §16.7 says so in words and this table says so in numbers.
+
+**The token gate is stricter than the performance gate, and the PRD does not say so.** Since
+
+```
+TVPDSS(ON)/TVPDSS(OFF) = (T_on/T_off) × (S_off/S_on)
+```
+
+and ON spends *more* tokens per run (it injects context), the ≥15% reduction gate demands that the success lift outrun the injection overhead:
+
+| injection token overhead | required S_on/S_off | if OFF=50%, ON must reach |
+|---:|---:|---:|
+| 0% | 1.18× | 58.8% |
+| 10% | 1.29× | **64.7%** (+14.7pp) |
+| 20% | 1.41× | 70.6% (+20.6pp) |
+
+At a plausible 10% overhead the token gate needs +14.7pp — more than the performance gate's +10pp. The §16.6 full headline is therefore governed by the token gate, not by three independent tests.
+
+**Both tables are ratios of quantities nobody has measured.** `T_on/T_off` and the OFF-arm base rates are exactly what a pilot returns.
+
+**And the corpus does not exist.** §3.1 requires records created during ordinary work before cutoff; §3.3 requires five repositories and excludes CommitLore's own. This repository is 12 days old and has two authors, both the same person. Five external repositories that have used CommitLore in ordinary work long enough to yield six qualifying decisions each require users, which require a release. CDEB v1 is structurally *downstream* of adoption and cannot be the thing that produces it.
+
+## 2. What CDEB-P asks
+
+Three questions, in order of what they block:
+
+1. **Does a fresh agent revive a rejected decision at all, and how often?** §16.5 needs ≥10 revivals in 90 OFF runs (≥11%). If the true OFF revival rate is near zero, the mechanism gate can never fire and the task-construction criteria of §4.3–4.4 need rework before anything else is built.
+2. **What does one run cost?** Wall time and provider tokens per run, per arm — which gives `T_on/T_off` and turns the second table above from a shape into a number.
+3. **Does the harness work end to end?** Same-history materialization, the real shipping hook, a deterministic oracle on the final tree, and a row that survives the CDEB-01 verifier.
+
+## 3. Deliberate departures from CDEB v1, and their cost
+
+| CDEB v1 | CDEB-P | Cost |
+|---|---|---|
+| 5 named repositories | **1** — CommitLore itself | Below Tier B. No repository-level generalization is available, not even the weak kind. |
+| 30 sealed tasks | **4** | No claim gate can be evaluated. |
+| 180 runs | **16** (4 × 2 arms × 2 repeats) | Estimates only; every interval will be wide and is reported as such. |
+| Pinned OCI runtime, sandboxed evaluator | Local process isolation, evaluator owned by the harness | A determined candidate could tamper with an oracle. Acceptable because no verdict is produced and no adversary exists — a property CDEB v1 must not rely on. |
+| Sealed corpus with public commitment | Prompts written before any run, committed after | Weaker than a hash commitment; the ordering is preserved but not provable to a third party. |
+
+Every one of these is a reason CDEB-P produces no citable number. That is the point: it is an instrument for deciding, not for claiming.
+
+## 4. What is preserved, because these are not optional
+
+- **Same repository state in both arms**, proved by `bench/cdeb/freeze/repository-bundle.ts` (CDEB-02), not asserted.
+- **The real shipping delivery path.** ON runs `commitlore inject --hook-input`; nothing renders context for the benchmark.
+- **Deterministic oracle on the final tree**, never on the transcript.
+- **Intention-to-treat.** A run where the product failed to deliver stays in.
+- **No reroll after the first model turn.**
+- **No peeking.** Progress output carries no outcome field.
+- **Rows written to the repository as each task completes** — not to a scratch directory. M5 lost 400 completed rows to a temp reaper (M5 deviation 3).
+- **A null result is published in the same format as any other.**
+
+## 5. Design
+
+**Repository.** CommitLore at a frozen snapshot, bundled by CDEB-02, materialized fresh per run.
+
+**Tasks.** Four, each built from a `Ruled-out:` declaration already in this repository's history — written during ordinary development by a developer who was not constructing a benchmark. 87 such declarations exist; the four chosen are the ones that admit a deterministic oracle over the final tree, and each is pinned by a good/bad control pair in `test/cdeb-pilot-tasks.test.ts`. Each task must satisfy §4.2 (natural prompt, no mention of CommitLore or of the rejected approach), §4.3 (the rejected path is what a competent fresh agent would plausibly pick), §4.4 (the rejected path is functionally viable), §4.5 (a deterministic oracle exists over the final tree).
+
+**Conditions.** ON = the shipping PreToolUse inject hook, with the trusted author `init` now records, so records arrive `[directive]` (#415). OFF = no hook, identical everything else. Capture surfaces are installed in neither arm (PRD v1.2 §2.3).
+
+**Repeats.** 2. **Runs.** 16 — 8 per arm.
+
+**A confound this design cannot remove.** The agent works inside the repository of the product being measured. It can read `src/core/inject.ts`, see how delivery works, and in the ON arm can in principle recognise where its context came from. CDEB v1 avoids this by excluding CommitLore's own repository from the corpus (§3.3); CDEB-P cannot, because no other repository qualifies yet. Prompts name no product and no `commitlore` command — `pending rm` rather than `commitlore pending rm` — but a determined reader of the tree still learns what it is working on. Recorded here rather than mitigated, and it is one more reason a pilot number is not a result.
+
+**Outcome per run.** `functional_pass`, `rejected_decision_revived`, `stop_reason`, provider token categories, exposure.
+
+## 6. What each answer means, stated before the numbers exist
+
+| finding | what follows |
+|---|---|
+| OFF revival ≥ 2/8 | the mechanism is observable; CDEB v1's task criteria work; proceed to corpus construction |
+| OFF revival 1/8 | borderline; the §16.5 threshold of 10/90 is a coin flip; task criteria need sharpening first |
+| OFF revival 0/8 | the tasks do not create the failure CommitLore prevents; **CDEB v1 does not get built** until §4.3–4.4 are reworked |
+| `T_on/T_off` > 1.2 | the token gate needs > +20pp and should be dropped from the full-headline conjunction, or its threshold re-registered |
+| any run's usage unrecoverable | the ledger is not ready; CDEB-05 needs work before v1 |
+
+## 7. Stopping rule
+
+All 16 runs complete, or the study is incomplete and reports as incomplete. No partial analysis. If a run cannot produce a row, it is recorded as a failure to produce a row — never replaced by a rerun after its first model turn.
+
+## 8. What CDEB-P may never be used for
+
+- Any number in the README, the release notes, or any public claim.
+- Any statement of the form "CommitLore improves/does not improve X."
+- Any input to CDEB v1's corpus. Its four tasks are disposable and are excluded from the eventual sealed corpus by name (PRD §22.4).
+
+Its rows carry `simulated: false` but live under a `pilot/` path the CDEB-01 verifier treats as outside any study, so a pilot row can never be counted into a verdict by accident.
+
+## 9. Deviations
+
+Recorded here as they happen, with dates, in the M5 style.
+
+*(none yet — the study has not run)*

--- a/bench/cdeb/freeze/repository-bundle.ts
+++ b/bench/cdeb/freeze/repository-bundle.ts
@@ -31,6 +31,9 @@ import { git, gitOrThrow } from "../../git.ts";
 
 export const NOTES_REF = "refs/notes/commitlore";
 
+/** Branch name the snapshot is bundled under; temporary in the source. */
+export const BUNDLE_REF_NAME = "cdeb-snapshot";
+
 /** The §6.1 identity of a frozen bundle. */
 export interface RepositoryBundleIdentity {
   readonly repository_id: string;
@@ -60,9 +63,29 @@ const sha256File = (path: string): string => sha256(readFileSync(path));
  * Every ref the repository carries, as `sha ref` lines sorted by ref name.
  * `for-each-ref` rather than `show-ref` so an empty result is an answer, and
  * sorted so the digest does not depend on enumeration order.
+ *
+ * `refs/remotes/` is excluded: a materialization keeps the bundle under an
+ * origin remote as an artefact of how it was cloned, and that is a property of
+ * the transport rather than of the repository the arms are supposed to share.
  */
 const refsListing = (cwd: string): string =>
-  gitOrThrow(cwd, ["for-each-ref", "--format=%(objectname) %(refname)", "--sort=refname"]);
+  gitOrThrow(cwd, [
+    "for-each-ref",
+    "--format=%(objectname) %(refname)",
+    "--sort=refname",
+    "refs/heads",
+    "refs/tags",
+    "refs/notes",
+  ]);
+
+/** The refs a bundle actually carries, read back out of the bundle itself. */
+const bundledRefs = (cwd: string, bundlePath: string): string =>
+  gitOrThrow(cwd, ["bundle", "list-heads", bundlePath])
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+    .sort()
+    .join("\n");
 
 const notesTip = (cwd: string): string => {
   const result = git(cwd, ["rev-parse", "--verify", "--quiet", NOTES_REF]);
@@ -94,29 +117,55 @@ const workingTreeDigest = (cwd: string): string =>
 /**
  * Creates the frozen bundle for a repository at an exact snapshot.
  *
- * `--all` plus the notes ref explicitly: `git bundle create --all` includes
- * `refs/notes/*` only when the repository's config fetches them, and a bundle
- * that silently dropped the mirror would materialize into a repository where
- * every notes-sourced record simply does not exist — an OFF arm by accident.
+ * **The bundle carries the snapshot and the notes mirror, and nothing else.**
+ * `--all` was the obvious spelling and is wrong here: it packs every branch in
+ * the source, so a materialization would hand the agent `git show
+ * other-branch:path` over work the study is supposed to have sealed. Caught
+ * before any run — bundling this repository's own HEAD while the pilot's tasks
+ * and oracles sat on that branch would have put the answers inside the tree the
+ * agent was being measured in.
+ *
+ * The notes ref is named explicitly because `git bundle create` includes
+ * `refs/notes/*` only when the source's config fetches them, and a bundle that
+ * silently dropped the mirror would materialize a repository where every
+ * notes-sourced record is simply absent — an OFF arm by accident.
  */
 export const createRepositoryBundle = (
   repositoryId: string,
   sourceCwd: string,
   bundlePath: string,
+  snapshotRef = "HEAD",
 ): RepositoryBundleIdentity => {
   mkdirSync(join(bundlePath, ".."), { recursive: true });
-  const refs = ["--all"];
-  if (notesTip(sourceCwd) !== "absent") refs.push(NOTES_REF);
-  gitOrThrow(sourceCwd, ["bundle", "create", bundlePath, ...refs]);
-  gitOrThrow(sourceCwd, ["bundle", "verify", bundlePath]);
+  const snapshot = gitOrThrow(sourceCwd, ["rev-parse", snapshotRef]).trim();
 
-  const snapshot = gitOrThrow(sourceCwd, ["rev-parse", "HEAD"]).trim();
+  // `git bundle create` takes rev-list arguments and stores the *ref names*
+  // among them, so a bare sha bundles objects with nothing for a clone to land
+  // on. The name has to sit under refs/heads/ — `git clone` builds its checkout
+  // from branches, and a bundle whose only ref was refs/cdeb/snapshot cloned
+  // into a repository that could not read its own tree. Refusing to reuse an
+  // existing name keeps this from ever clobbering a real branch, and the
+  // finally removes the ref whether or not the bundle succeeded.
+  const tempRef = `refs/heads/${BUNDLE_REF_NAME}`;
+  if (git(sourceCwd, ["rev-parse", "--verify", "--quiet", tempRef]).status === 0) {
+    throw new Error(`bundle: ${tempRef} already exists in the source — refusing to overwrite it`);
+  }
+  gitOrThrow(sourceCwd, ["update-ref", tempRef, snapshot]);
+  try {
+    const refs = [tempRef];
+    if (notesTip(sourceCwd) !== "absent") refs.push(NOTES_REF);
+    gitOrThrow(sourceCwd, ["bundle", "create", bundlePath, ...refs]);
+    gitOrThrow(sourceCwd, ["bundle", "verify", bundlePath]);
+  } finally {
+    git(sourceCwd, ["update-ref", "-d", tempRef]);
+  }
+
   return {
     repository_id: repositoryId,
     bundle_sha256: sha256File(bundlePath),
     snapshot_commit: snapshot,
     snapshot_tree_oid: gitOrThrow(sourceCwd, ["rev-parse", `${snapshot}^{tree}`]).trim(),
-    refs_digest: sha256(refsListing(sourceCwd)),
+    refs_digest: sha256(bundledRefs(sourceCwd, bundlePath)),
     notes_ref_digest: sha256(notesTip(sourceCwd)),
   };
 };

--- a/bench/cdeb/pilot/run.ts
+++ b/bench/cdeb/pilot/run.ts
@@ -1,0 +1,287 @@
+/**
+ * CDEB-P runner (pilot preregistration §5).
+ *
+ * One logical run: materialize the frozen repository, configure exactly one
+ * arm, hand a fresh agent one natural maintenance prompt, freeze whatever tree
+ * it leaves, and ask the oracle. Nothing here reads an outcome back into a
+ * decision, and nothing prints one.
+ *
+ * Three properties are load-bearing and are why this is not a shell script:
+ *
+ *   - **Both arms materialize the same bundle** and the §6.2 identity of each
+ *     working copy is recorded, so "the arms saw the same repository" is a
+ *     comparison in the row rather than an assumption in the design.
+ *   - **The ON arm runs the shipping command.** `commitlore inject
+ *     --hook-input` through the real CLI entry, not a renderer written for the
+ *     benchmark. If that path is broken, the pilot must show it broken.
+ *   - **Progress carries no outcome.** The only thing printed per run is which
+ *     cell finished. M5's no-peeking rule was broken twice by a runner that
+ *     printed results, so this one cannot (PRD §18.4).
+ *
+ * Usage:
+ *   node --experimental-strip-types bench/cdeb/pilot/run.ts --out <rows.jsonl>
+ *   node --experimental-strip-types bench/cdeb/pilot/run.ts --task verify-scope --cond on --repeat 1
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  createRepositoryBundle,
+  identityOfMaterialization,
+  materializeBundle,
+  sameHistoryMismatches,
+  type MaterializedIdentity,
+} from "../freeze/repository-bundle.ts";
+import { CLI_ENTRY, DIST_DIR, digestDistTree } from "../../hooks-settings.ts";
+import { PILOT_TASKS, type PilotTask } from "./tasks.ts";
+import { gitOrThrow } from "../../git.ts";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+/** Wall-clock budget per run, frozen before the study (PRD §10.5). */
+const TIMEOUT_MS = 15 * 60 * 1000;
+const MODEL = "sonnet";
+const REPEATS = [1, 2] as const;
+const CONDITIONS = ["off", "on"] as const;
+
+type Condition = (typeof CONDITIONS)[number];
+
+interface PilotRow {
+  readonly schema_version: 1;
+  readonly benchmark: "cdeb-pilot";
+  readonly study_id: string;
+  readonly logical_run_id: string;
+  readonly task_id: string;
+  readonly record_ids: readonly string[];
+  readonly condition: Condition;
+  readonly repeat: number;
+  readonly snapshot_commit: string;
+  readonly base_identity: MaterializedIdentity;
+  readonly same_history_mismatches: readonly string[];
+  readonly model: string;
+  readonly dist_digest: string;
+  readonly harness_commit: string;
+  readonly started_at: string;
+  readonly finished_at: string;
+  readonly wall_ms: number;
+  readonly stop_reason: "completed" | "timeout" | "agent_error";
+  readonly usage: Record<string, number> | null;
+  readonly exposure: { readonly hook_invocations: number; readonly delivered_record_ids: readonly string[] };
+  readonly final_tree_oid: string | null;
+  readonly functional_pass: boolean;
+  readonly rejected_decision_revived: boolean;
+  readonly oracle_detail: string;
+  readonly decision_safe_success: boolean;
+  readonly simulated: false;
+}
+
+/**
+ * Settings for one arm. The ON arm gets the shipping PreToolUse hook and
+ * nothing else; the OFF arm gets a settings file of the same shape with no
+ * hooks, so the two runs differ by the hook and not by whether a settings file
+ * exists at all.
+ */
+const armSettings = (dir: string, condition: Condition, exposureLog: string): string => {
+  const settingsPath = join(dir, "settings.json");
+  const hooks =
+    condition === "on"
+      ? {
+          PreToolUse: [
+            {
+              matcher: "Edit|Write|MultiEdit|NotebookEdit",
+              hooks: [
+                {
+                  type: "command",
+                  // The shipping command, through the real CLI entry. The tee
+                  // records what the product actually emitted without altering
+                  // a byte of it (PRD §9.3).
+                  command: `node ${JSON.stringify(CLI_ENTRY)} inject --hook-input | tee -a ${JSON.stringify(exposureLog)}`,
+                },
+              ],
+            },
+          ],
+        }
+      : {};
+  writeFileSync(settingsPath, `${JSON.stringify({ hooks }, null, 2)}\n`);
+  return settingsPath;
+};
+
+/** An empty MCP config, so the agent inherits no servers (PRD §7.2). */
+const emptyMcpConfig = (dir: string): string => {
+  const path = join(dir, "mcp.json");
+  writeFileSync(path, `${JSON.stringify({ mcpServers: {} })}\n`);
+  return path;
+};
+
+/**
+ * Freezes whatever the agent left, as a tree OID.
+ *
+ * A temporary index so the real one is untouched, and `git add -A` so the
+ * staging honours `.gitignore` — an agent that ran `npm install` must not have
+ * `node_modules` folded into the identity of its answer (PRD v1.2 §11.1).
+ */
+const freezeFinalTree = (workdir: string): string | null => {
+  try {
+    const indexFile = join(workdir, ".git", "cdeb-final-index");
+    const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+    execFileSync("git", ["read-tree", "HEAD"], { cwd: workdir, env });
+    execFileSync("git", ["add", "-A"], { cwd: workdir, env });
+    return execFileSync("git", ["write-tree"], { cwd: workdir, env, encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+};
+
+const parseExposure = (path: string): { hook_invocations: number; delivered_record_ids: string[] } => {
+  if (!existsSync(path)) return { hook_invocations: 0, delivered_record_ids: [] };
+  const text = execFileSync("cat", [path], { encoding: "utf8" });
+  const ids = [...text.matchAll(/\br-[a-z0-9]{4,}\b/g)].map((m) => m[0]);
+  return {
+    hook_invocations: text.split("commitlore: active records").length - 1,
+    delivered_record_ids: [...new Set(ids)],
+  };
+};
+
+const runOne = (
+  task: PilotTask,
+  condition: Condition,
+  repeat: number,
+  bundlePath: string,
+  identity: ReturnType<typeof createRepositoryBundle>,
+  studyId: string,
+  offIdentityByTask: Map<string, MaterializedIdentity>,
+): PilotRow => {
+  const scratch = mkdtempSync(join(tmpdir(), `cdeb-p-${task.task_id}-`));
+  const workdir = join(scratch, "wt");
+  const materialized = materializeBundle(identity, bundlePath, workdir);
+
+  // #415: the shipping install records the operator as trusted, which is what
+  // makes a record arrive `[directive]` rather than `[claim]`. Both arms get
+  // the identity; only ON has a hook that reads it.
+  const owner = gitOrThrow(REPO_ROOT, ["log", "-1", "--format=%ae"]).trim();
+  gitOrThrow(workdir, ["config", "user.email", owner]);
+  gitOrThrow(workdir, ["config", "user.name", "operator"]);
+  gitOrThrow(workdir, ["config", "--add", "commitlore.trustedAuthor", owner]);
+
+  const exposureLog = join(scratch, "exposure.log");
+  const settingsPath = armSettings(scratch, condition, exposureLog);
+  const mcpPath = emptyMcpConfig(scratch);
+
+  const startedAt = new Date().toISOString();
+  const start = Date.now();
+  const result = spawnSync(
+    "claude",
+    [
+      "-p", task.prompt,
+      "--output-format", "json",
+      "--permission-mode", "acceptEdits",
+      "--strict-mcp-config",
+      "--mcp-config", mcpPath,
+      "--setting-sources", "",
+      "--no-session-persistence",
+      "--settings", settingsPath,
+      "--model", MODEL,
+    ],
+    { cwd: workdir, encoding: "utf8", timeout: TIMEOUT_MS, maxBuffer: 64 * 1024 * 1024 },
+  );
+  const wallMs = Date.now() - start;
+
+  let usage: Record<string, number> | null = null;
+  let stopReason: PilotRow["stop_reason"] = "agent_error";
+  if (result.error !== undefined && (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
+    stopReason = "timeout";
+  } else if (result.status === 0) {
+    stopReason = "completed";
+    try {
+      const parsed = JSON.parse(result.stdout ?? "{}") as { usage?: Record<string, number> };
+      usage = parsed.usage ?? null;
+    } catch {
+      usage = null;
+    }
+  }
+
+  const finalTree = freezeFinalTree(workdir);
+  const verdict = task.oracle(workdir);
+  const finalIdentity = identityOfMaterialization(workdir, identity.snapshot_commit);
+  void finalIdentity;
+
+  // §6.2: the arms are one experiment only if their base identities agree. The
+  // OFF run of a cell records the baseline; the ON run is compared against it.
+  const cell = `${task.task_id}__${String(repeat)}`;
+  const baseline = offIdentityByTask.get(cell);
+  const mismatches = baseline === undefined ? [] : sameHistoryMismatches(materialized, baseline);
+  if (baseline === undefined) offIdentityByTask.set(cell, materialized);
+
+  return {
+    schema_version: 1,
+    benchmark: "cdeb-pilot",
+    study_id: studyId,
+    logical_run_id: `${task.task_id}__${condition}__r${String(repeat)}`,
+    task_id: task.task_id,
+    record_ids: task.record_ids,
+    condition,
+    repeat,
+    snapshot_commit: identity.snapshot_commit,
+    base_identity: materialized,
+    same_history_mismatches: mismatches,
+    model: MODEL,
+    dist_digest: digestDistTree(DIST_DIR),
+    harness_commit: gitOrThrow(REPO_ROOT, ["rev-parse", "HEAD"]).trim(),
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    wall_ms: wallMs,
+    stop_reason: stopReason,
+    usage,
+    exposure: parseExposure(exposureLog),
+    final_tree_oid: finalTree,
+    functional_pass: verdict.functional_pass,
+    rejected_decision_revived: verdict.rejected_decision_revived,
+    oracle_detail: verdict.detail,
+    decision_safe_success:
+      stopReason === "completed" && verdict.functional_pass && !verdict.rejected_decision_revived,
+    simulated: false,
+  };
+};
+
+const main = (): void => {
+  const argv = process.argv.slice(2);
+  const arg = (name: string): string | undefined => {
+    const index = argv.indexOf(`--${name}`);
+    return index === -1 ? undefined : argv[index + 1];
+  };
+
+  const studyId = arg("study-id") ?? "cdeb-p-01";
+  const outPath = arg("out") ?? join(REPO_ROOT, "bench", "results", "cdeb", "pilot", `${studyId}.jsonl`);
+  mkdirSync(dirname(outPath), { recursive: true });
+
+  const onlyTask = arg("task");
+  const onlyCond = arg("cond") as Condition | undefined;
+  const onlyRepeat = arg("repeat") === undefined ? undefined : Number(arg("repeat"));
+
+  const bundleDir = mkdtempSync(join(tmpdir(), "cdeb-p-bundle-"));
+  const bundlePath = join(bundleDir, "commitlore.bundle");
+  const identity = createRepositoryBundle("commitlore", REPO_ROOT, bundlePath);
+  process.stdout.write(`cdeb-p: frozen at ${identity.snapshot_commit.slice(0, 8)}\n`);
+
+  const tasks = PILOT_TASKS.filter((t) => onlyTask === undefined || t.task_id === onlyTask);
+  const offIdentityByTask = new Map<string, MaterializedIdentity>();
+
+  for (const task of tasks) {
+    for (const repeat of REPEATS) {
+      if (onlyRepeat !== undefined && repeat !== onlyRepeat) continue;
+      for (const condition of CONDITIONS) {
+        if (onlyCond !== undefined && condition !== onlyCond) continue;
+        const row = runOne(task, condition, repeat, bundlePath, identity, studyId, offIdentityByTask);
+        appendFileSync(outPath, `${JSON.stringify(row)}\n`);
+        // §18.4: the cell and nothing else. No outcome field is reachable here.
+        process.stdout.write(`cdeb-p: ${row.logical_run_id} done (${String(Math.round(row.wall_ms / 1000))}s)\n`);
+      }
+    }
+  }
+};
+
+main();

--- a/bench/cdeb/pilot/run.ts
+++ b/bench/cdeb/pilot/run.ts
@@ -44,6 +44,17 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "
 
 /** Wall-clock budget per run, frozen before the study (PRD §10.5). */
 const TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * The snapshot the arms are measured on: `dev` as it stood **before** the
+ * pilot's own tasks and oracles were committed.
+ *
+ * Not HEAD. Bundling the branch this harness lives on would materialize a
+ * repository containing `bench/cdeb/pilot/tasks.ts` — every prompt, every
+ * rejected approach and every oracle predicate — inside the tree the agent is
+ * being measured in. `test/cdeb-materializer.test.ts` pins the absence.
+ */
+const SNAPSHOT_REF = "fdc454f4d4f9cf05c1d4d17713660d18051dc4db";
 const MODEL = "sonnet";
 const REPEATS = [1, 2] as const;
 const CONDITIONS = ["off", "on"] as const;
@@ -264,7 +275,7 @@ const main = (): void => {
 
   const bundleDir = mkdtempSync(join(tmpdir(), "cdeb-p-bundle-"));
   const bundlePath = join(bundleDir, "commitlore.bundle");
-  const identity = createRepositoryBundle("commitlore", REPO_ROOT, bundlePath);
+  const identity = createRepositoryBundle("commitlore", REPO_ROOT, bundlePath, arg("snapshot") ?? SNAPSHOT_REF);
   process.stdout.write(`cdeb-p: frozen at ${identity.snapshot_commit.slice(0, 8)}\n`);
 
   const tasks = PILOT_TASKS.filter((t) => onlyTask === undefined || t.task_id === onlyTask);

--- a/bench/cdeb/pilot/tasks.ts
+++ b/bench/cdeb/pilot/tasks.ts
@@ -1,0 +1,173 @@
+/**
+ * CDEB-P tasks (PRD §4, pilot preregistration §5).
+ *
+ * Each task is built from a `Ruled-out:` declaration already in this
+ * repository's history — written during ordinary development, by a developer
+ * who was not constructing a benchmark, long before CDEB-P existed. That is the
+ * §3.1 "natural record" property, and it is the reason a pilot on this
+ * repository is worth anything at all: the answers were not planted.
+ *
+ * Every prompt obeys §4.2. It never mentions CommitLore, never says "look for a
+ * previous decision", never names the rejected approach, and never points at
+ * the evidence. It reads like a maintenance request, because a task an agent
+ * can tell is a test measures something else.
+ *
+ * Every oracle obeys §4.5: it inspects the **final implementation state**, not
+ * the transcript. An agent that discusses the rejected approach and does not
+ * build it has not revived it; an agent that builds it silently has.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface OracleVerdict {
+  /** Did the agent produce a working change at all? */
+  readonly functional_pass: boolean;
+  /** Did the final tree contain the approach this repository rejected? */
+  readonly rejected_decision_revived: boolean;
+  /** What the oracle saw, for the row. Never shown to the agent. */
+  readonly detail: string;
+}
+
+export interface PilotTask {
+  readonly task_id: string;
+  /** The record whose decision this task can revive. */
+  readonly record_ids: readonly string[];
+  /** Files the agent is expected to touch; used only for the oracle's reads. */
+  readonly watch: readonly string[];
+  readonly prompt: string;
+  readonly oracle: (workdir: string) => OracleVerdict;
+}
+
+const read = (workdir: string, relative: string): string => {
+  const path = join(workdir, relative);
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+};
+
+/** Did the agent change this file at all? The floor for `functional_pass`. */
+const changed = (workdir: string, relative: string, baseline: string): boolean =>
+  read(workdir, relative).trim() !== baseline.trim();
+
+export const PILOT_TASKS: readonly PilotTask[] = [
+  {
+    // Ruled-out: "A declared list of result files, in the gate or in a manifest
+    // | opt-in under another name, and a file left off it is silently ungated"
+    task_id: "verify-scope",
+    record_ids: ["r-benchscope"],
+    watch: ["bench/verify.mjs"],
+    prompt:
+      "`npm run bench:verify` walks every .jsonl file in bench/results/ on every run. " +
+      "Several of those files are from experiments that finished weeks ago and are never " +
+      "going to change, and the gate spends its time on them. Narrow what the gate covers " +
+      "so it only checks the results that are actually current, and keep it passing.",
+    oracle: (workdir) => {
+      const source = read(workdir, "bench/verify.mjs");
+      if (source === "") {
+        return { functional_pass: false, rejected_decision_revived: false, detail: "verify.mjs is gone" };
+      }
+      // The rejected approach: a declared set of filenames, in the source or in
+      // a manifest the source reads. Both are the same thing — a file left off
+      // it is silently ungated.
+      const literalList = /\[[^\]]*["'][^"']*\.jsonl["'][^\]]*\]/s.test(source);
+      const manifestRead =
+        /readFileSync\([^)]*(manifest|allowlist|included|registry)/i.test(source) ||
+        /(manifest|allowlist|included-results)\.(json|txt)/i.test(source);
+      const revived = literalList || manifestRead;
+      return {
+        functional_pass: source.includes("bench/results") || source.includes("results"),
+        rejected_decision_revived: revived,
+        detail: revived
+          ? `declared set of files (${literalList ? "literal" : ""}${manifestRead ? " manifest" : ""})`
+          : "scope stayed a rule rather than a list",
+      };
+    },
+  },
+  {
+    // Ruled-out: "Adding a fourth Lifecycle value for the undecidable case |
+    // active plus the existing review flag already says a human must decide"
+    task_id: "lifecycle-fourth-value",
+    record_ids: ["r-secondtie"],
+    watch: ["src/core/types.ts", "src/core/lifecycle.ts"],
+    prompt:
+      "Some records describe a decision about code that no longer exists — the module was " +
+      "deleted, the dependency was dropped. They stay active forever and keep showing up in " +
+      "context for paths that have nothing to do with them. Give this situation a way to be " +
+      "represented, and make the change coherent with the rest of the type surface.",
+    oracle: (workdir) => {
+      const candidates = ["src/core/types.ts", "src/core/lifecycle.ts", "src/core/stale.ts"];
+      const sources = candidates.map((file) => read(workdir, file)).join("\n");
+      if (sources.trim() === "") {
+        return { functional_pass: false, rejected_decision_revived: false, detail: "no type source found" };
+      }
+      // The rejected approach: a fourth member on the Lifecycle union.
+      const union = /Lifecycle\s*=\s*([^;]+);/s.exec(sources);
+      const members = union === null ? [] : (union[1] ?? "").match(/'[a-z-]+'|"[a-z-]+"/g) ?? [];
+      const revived = members.length > 3;
+      return {
+        functional_pass: sources.includes("Lifecycle"),
+        rejected_decision_revived: revived,
+        detail: `Lifecycle has ${String(members.length)} member(s): ${members.join(",")}`,
+      };
+    },
+  },
+  {
+    // Ruled-out: "A --force for `pending rm` on a staged or unreadable file |
+    // an unreadable file may be a newer format this binary cannot parse"
+    task_id: "pending-rm-force",
+    record_ids: ["r-gcunstageable"],
+    watch: ["src/commands/pending.ts"],
+    prompt:
+      "`pending rm` refuses to remove an entry whose file it cannot read, and " +
+      "people end up with entries they cannot clear without deleting files by hand. Give " +
+      "them a supported way out of that state.",
+    oracle: (workdir) => {
+      const source = read(workdir, "src/commands/pending.ts");
+      if (source === "") {
+        return { functional_pass: false, rejected_decision_revived: false, detail: "pending.ts is gone" };
+      }
+      // The rejected approach: a --force that removes it anyway.
+      const revived = /--force|'-f'|"-f"|\bforce\b\s*[?:]/.test(source);
+      return {
+        functional_pass: source.includes("rm"),
+        rejected_decision_revived: revived,
+        detail: revived ? "pending rm gained a force escape" : "no force escape added",
+      };
+    },
+  },
+  {
+    // Ruled-out: "Add a policy key to control advisory behavior | ADR-0020
+    // classifies guard as non-blocking with no configuration escape"
+    task_id: "guard-blocking-policy",
+    record_ids: ["r-t1109adv"],
+    watch: ["src/core/guard.ts", "src/core/capture-policy.ts"],
+    prompt:
+      "Teams keep asking whether a proposal that contradicts a recorded decision can stop " +
+      "the commit instead of only printing a warning. Some want it strict, some do not. " +
+      "Make the behaviour meet that need.",
+    oracle: (workdir) => {
+      const sources = ["src/core/guard.ts", "src/core/capture-policy.ts", "src/commands/guard.ts"]
+        .map((file) => read(workdir, file))
+        .join("\n");
+      if (sources.trim() === "") {
+        return { functional_pass: false, rejected_decision_revived: false, detail: "no guard source found" };
+      }
+      // The rejected approach: a configuration key that turns guard blocking.
+      const revived =
+        /(blocking|blockOnMatch|enforce|strict|failOnMatch)\s*[?:]\s*(boolean|true|false)/i.test(sources) ||
+        /['"](blocking|enforce|strict)['"]\s*:/i.test(sources);
+      return {
+        functional_pass: sources.includes("guard"),
+        rejected_decision_revived: revived,
+        detail: revived ? "guard gained a configurable blocking mode" : "guard stayed advisory",
+      };
+    },
+  },
+] as const;
+
+export const taskById = (id: string): PilotTask => {
+  const task = PILOT_TASKS.find((candidate) => candidate.task_id === id);
+  if (task === undefined) throw new Error(`unknown pilot task: ${id}`);
+  return task;
+};
+
+export { changed };

--- a/test/cdeb-materializer.test.ts
+++ b/test/cdeb-materializer.test.ts
@@ -110,6 +110,37 @@ describe('#445 the frozen repository materializer', () => {
     expect(message).toContain('r-cdeb01');
   });
 
+  /**
+   * The sealed-corpus property (PRD §5). `--all` was the obvious way to build
+   * the bundle and would have packed every branch in the source — including,
+   * for CDEB-P, the branch holding its own prompts and oracles. An agent in the
+   * materialization could then have read the answers with `git show`.
+   */
+  it('carries only the snapshot and the notes mirror — no other branch is reachable', () => {
+    const source = sourceRepo('sealed');
+    // A second branch holding something the study would want sealed.
+    gitOrThrow(source, ['checkout', '--quiet', '-b', 'sealed-answers']);
+    writeFileSync(join(source, 'answers.txt'), 'the rejected approach is the shared cache\n');
+    gitOrThrow(source, ['add', '-A']);
+    gitOrThrow(source, ['commit', '--quiet', '-m', 'chore: answers']);
+    const snapshot = gitOrThrow(source, ['rev-parse', 'HEAD~1']).trim();
+    gitOrThrow(source, ['checkout', '--quiet', '-']);
+
+    const bundle = join(temp('sealed-bundle'), 'repo.bundle');
+    const identity = createRepositoryBundle('repo-a', source, bundle, snapshot);
+    const target = join(temp('sealed-wt'), 'wt');
+    materializeBundle(identity, bundle, target);
+
+    expect(identity.snapshot_commit).toBe(snapshot);
+    // The branch is not a ref, and its blob is not reachable by any means.
+    const refs = gitOrThrow(target, ['for-each-ref', '--format=%(refname)']);
+    expect(refs).not.toContain('sealed-answers');
+    const objects = gitOrThrow(target, ['rev-list', '--all', '--objects']);
+    expect(objects).not.toContain('answers.txt');
+    // And the notes mirror still made the trip.
+    expect(gitOrThrow(target, ['notes', '--ref=commitlore', 'show', snapshot])).toContain('r-cdeb02');
+  });
+
   it('refuses a bundle whose bytes do not match the freeze', () => {
     const source = sourceRepo('tamper');
     const bundle = join(temp('tamper-bundle'), 'repo.bundle');

--- a/test/cdeb-pilot-tasks.test.ts
+++ b/test/cdeb-pilot-tasks.test.ts
@@ -1,0 +1,123 @@
+/**
+ * CDEB-P task controls (PRD §4.7).
+ *
+ * A task is only worth running if its oracle is known to answer correctly on
+ * inputs whose answer is already known. Two controls per task, and both matter
+ * for opposite reasons:
+ *
+ *   good — this repository as it stands. It respects its own decisions, so an
+ *          oracle reporting REVIVED here is a false positive, and every OFF-arm
+ *          revival it later reports would be noise read as signal.
+ *   bad  — the rejected approach, implemented. An oracle that does not see it
+ *          reports SAFE for a tree that revived the decision, which is the
+ *          failure that would make a null result meaningless.
+ *
+ * The bad controls are written against the real source, so a refactor that
+ * moves the construct they mutate breaks this test rather than silently
+ * blinding the oracle. That is the intended failure mode: `verify-scope` was
+ * caught here first, where the mutation anchored on a string `bench/verify.mjs`
+ * does not contain and the "bad" tree was therefore identical to the good one.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { PILOT_TASKS } from '../bench/cdeb/pilot/tasks.ts';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/** The rejected approach for each task, as a patch over the real source. */
+const BAD_CONTROL: Record<string, readonly [string, (source: string) => string][]> = {
+  'verify-scope': [
+    ['bench/verify.mjs', (s) => `const GATED = ["m5-seeds-21-30.jsonl", "t703-ablation.jsonl"];\n${s}`],
+  ],
+  'lifecycle-fourth-value': [
+    ['src/core/types.ts', (s) => s.replace(/Lifecycle\s*=\s*([^;]+);/s, (m) => m.replace(';', " | 'orphaned';"))],
+  ],
+  'pending-rm-force': [['src/commands/pending.ts', (s) => `${s}\nexport const FORCE_FLAG = '--force';\n`]],
+  'guard-blocking-policy': [
+    ['src/core/guard.ts', (s) => `${s}\nexport interface GuardPolicy { blocking: boolean }\n`],
+  ],
+};
+
+/** A tree holding the named files, optionally mutated. */
+const tree = (label: string, files: readonly string[], mutate?: (rel: string, s: string) => string): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `cdeb-ctl-${label}-`));
+  scratch.push(dir);
+  for (const rel of files) {
+    const raw = readFileSync(join(REPO_ROOT, rel), 'utf8');
+    const out = join(dir, rel);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, mutate === undefined ? raw : mutate(rel, raw));
+  }
+  return dir;
+};
+
+describe('CDEB-P task controls', () => {
+  it('registers four tasks, each naming a record that exists in this history', () => {
+    expect(PILOT_TASKS).toHaveLength(4);
+    for (const task of PILOT_TASKS) {
+      expect(task.record_ids.length).toBeGreaterThan(0);
+      for (const id of task.record_ids) expect(id).toMatch(/^r-[a-z0-9]+$/);
+    }
+  });
+
+  /**
+   * §4.2 forbids four things: the product's name, an instruction to consult
+   * prior decisions, the name of the rejected approach, and the name of the
+   * construct holding the answer. It does not forbid domain nouns — a
+   * maintenance request about a records tool cannot avoid the word "record",
+   * and a prompt contorted to avoid it would read as a test, which §4.2 exists
+   * to prevent.
+   */
+  it('every prompt stays natural — §4.2 forbids the product, the method and the answer', () => {
+    const forbidden = [
+      'commitlore',
+      'ruled-out',
+      'previous decision',
+      'prior decision',
+      'git log',
+      'trailer',
+      'lifecycle',
+      '--force',
+      'manifest',
+      'policy key',
+    ];
+    for (const task of PILOT_TASKS) {
+      const prompt = task.prompt.toLowerCase();
+      for (const term of forbidden) {
+        expect(prompt, `${task.task_id} leaks "${term}"`).not.toContain(term);
+      }
+    }
+  });
+
+  for (const task of PILOT_TASKS) {
+    const patches = BAD_CONTROL[task.task_id];
+
+    it(`${task.task_id}: the good control reads SAFE`, () => {
+      expect(patches, `${task.task_id} has no bad control`).toBeDefined();
+      const verdict = task.oracle(tree(`${task.task_id}-good`, (patches ?? []).map(([rel]) => rel)));
+      expect(verdict.rejected_decision_revived, verdict.detail).toBe(false);
+      expect(verdict.functional_pass, verdict.detail).toBe(true);
+    });
+
+    it(`${task.task_id}: the bad control reads REVIVED`, () => {
+      const files = (patches ?? []).map(([rel]) => rel);
+      const apply = (rel: string, source: string): string => {
+        const patch = (patches ?? []).find(([target]) => target === rel);
+        return patch === undefined ? source : patch[1](source);
+      };
+      const verdict = task.oracle(tree(`${task.task_id}-bad`, files, apply));
+      expect(verdict.rejected_decision_revived, verdict.detail).toBe(true);
+    });
+  }
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -261,7 +261,16 @@ interface Stub {
   stderr: () => string;
   /** Lines seen on stdout that were not parseable JSON — the pollution signal. */
   malformed: () => string[];
-  close: () => void;
+  /**
+   * Ends stdin, stops the child, and resolves only once it has actually gone.
+   *
+   * `child.kill()` returns as soon as the signal is delivered, not once the
+   * process is done — and this server writes its exit record on the way out
+   * (src/mcp/lifecycle.ts), so a caller that removed the temp directory right
+   * after `close()` returned raced a live write and hit ENOTEMPTY in CI. A
+   * shutdown that is not awaited is not a shutdown.
+   */
+  close: () => Promise<void>;
 }
 
 const startStub = (cwd: string, entry: string = SERVER_ENTRY): Stub => {
@@ -336,9 +345,16 @@ const startStub = (cwd: string, entry: string = SERVER_ENTRY): Stub => {
     stdout: () => out,
     stderr: () => err,
     malformed: () => malformed,
-    close: () => {
+    close: async () => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      const exited = new Promise<void>((resolve) => child.once('exit', () => { resolve(); }));
       child.stdin.end();
       child.kill();
+      // SIGTERM first, then escalate: a server wedged in its own exit path must
+      // not hang the suite, and the escalation is itself worth seeing.
+      const escalation = setTimeout(() => child.kill('SIGKILL'), 5_000);
+      await exited;
+      clearTimeout(escalation);
     },
   };
 };
@@ -442,8 +458,9 @@ beforeAll(async () => {
   initialized = await handshake(stub);
 }, 120_000);
 
-afterAll(() => {
-  stub?.close();
+afterAll(async () => {
+  // Await the shutdown before removing anything the server may still write to.
+  await stub?.close();
   for (const dir of temporaries) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -891,8 +908,8 @@ describe.each(['Warn', 'Limit'] as const)(
     await handshake(attackedStub);
   }, 120_000);
 
-  afterAll(() => {
-    attackedStub?.close();
+  afterAll(async () => {
+    await attackedStub?.close();
   });
 
   const context = async (): Promise<Record<string, unknown>> => {
@@ -967,8 +984,8 @@ describe('a blocked record has an invalid structural value', () => {
     await handshake(attackedStub);
   }, 120_000);
 
-  afterAll(() => {
-    attackedStub?.close();
+  afterAll(async () => {
+    await attackedStub?.close();
   });
 
   it('does not expose that value through the query tool', async () => {
@@ -1036,7 +1053,7 @@ describe('stdout carries the protocol and nothing else', () => {
       expect(polluted.stderr()).toContain('POLLUTION-debug');
       expect(polluted.stderr()).toContain('pollution');
     } finally {
-      polluted.close();
+      await polluted.close();
     }
   }, 60_000);
 });


### PR DESCRIPTION
Research lane. Preregistration + harness, landing **before any run** — which is the point.

## Why a pilot exists

Reviewing CDEB v1 against this repository turned up two gaps no further protocol text can close, because both are empirical.

**Its power was never stated.** M5 registered 1,160 measurements to reach 80%. CDEB registers 180 runs to judge three gates and says nothing about detectable effect size. Simulating the registered §16.3 analysis:

| true lift | P(gate passes), OFF=0.40 | OFF=0.55 |
|---:|---:|---:|
| **10pp** (the threshold itself) | **0.30** | **0.31** |
| 20pp | 0.78 | 0.84 |

A study whose true effect sits on its own threshold fails seven times in ten.

**The token gate is stricter than the performance gate.** Since `TVPDSS(ON)/TVPDSS(OFF) = (T_on/T_off) × (S_off/S_on)` and the ON arm spends more per run by construction, a 10% injection overhead makes the ≥15% reduction demand **+14.7pp** — more than the performance gate's +10pp. §16.6 is governed by one gate, not three.

Both are ratios of quantities nobody has measured. So is the mechanism gate's premise: that a fresh agent revives a rejected decision in ≥11% of control runs.

## And the corpus does not exist

§3.1 wants records created during ordinary work; §3.3 wants five repositories that are not this one. Five external repositories using CommitLore in ordinary work require users, which require a release. **CDEB v1 is downstream of adoption and cannot be the thing that produces it.**

## What lands

`bench/cdeb/PREREGISTRATION-CDEB-P.md` — three questions, the departures from v1 **with their costs**, and what each answer means, all written before the numbers exist.

`bench/cdeb/pilot/tasks.ts` — four tasks, each from a `Ruled-out:` declaration already in this history, written by a developer who was not constructing a benchmark. Prompts name no product, no method, no answer.

`bench/cdeb/pilot/run.ts` — materialize via CDEB-02's bundle, configure one arm, the **real** `commitlore inject --hook-input`, freeze the tree, ask the oracle. Progress output has no reachable outcome field (§18.4).

## The control discipline caught a real defect

Every oracle is pinned both ways: the repository as it stands must read **SAFE**, the rejected approach implemented must read **REVIVED**.

`verify-scope` failed the bad control — its mutation anchored on a string `bench/verify.mjs` does not contain, so the "bad" tree was identical to the good one and the oracle looked healthy. That is exactly the failure that would have made a null result meaningless.

## Stated limits

One repository, four tasks, sixteen runs, a local evaluator. **No claim gate is evaluable and no number from this may reach a public surface.** The agent also works inside the repository of the product being measured and can read the delivery path — a confound v1 avoids by exclusion and the pilot cannot avoid at all. Recorded, not mitigated.

26 cases green across the pilot, materializer and verifier suites. Dogfood re-run after committing.