### PR TITLE
Correct a false claim on the page about false claims

### DIFF
--- a/docs/SELF-AUDIT.md
+++ b/docs/SELF-AUDIT.md
@@ -30,8 +30,10 @@ injected legend went on advertising it. Both prior benchmarks measured
 what they were.
 
 **[#343](https://github.com/MongLong0214/commitlore/issues/343) — no evidence that a fresh agent recovers the decisions a repository holds.**
-Filed against the absence of evidence for the product's central premise, before
-any benchmark existed. It became M1.
+Filed from an external review of v0.5.0, against the absence of evidence for the
+product's central premise: the review granted that lifecycle, attachment,
+grading and rebase-survival were proved, and said the thing the product is *for*
+was not. The behaviour study it asked for is the one still running.
 
 **[#341](https://github.com/MongLong0214/commitlore/issues/341) — the `suggest` policy named an approval that nothing could enforce.**
 A configuration value implied a human consent step the code had no way to check.
@@ -130,5 +132,10 @@ it starts.
 
 ---
 
-*This page is generated from real issues. If an entry no longer matches the
-code, that is a defect in this page and worth an issue of its own.*
+*This page is written by hand from real issues. If an entry no longer matches
+the code, that is a defect in this page and worth an issue of its own.*
+
+*It has already had one. The first version of this page claimed #343 "became
+M1". It did not — M1 predates it by weeks, and #343 came out of an external
+review of v0.5.0. Caught by checking the claim against the milestone rather
+than against memory, which is the same check this page is about.*


### PR DESCRIPTION
`docs/SELF-AUDIT.md` said [#343](https://github.com/MongLong0214/commitlore/issues/343) *"became M1"*. **It did not.**

M1 predates it by weeks — its issues are #1, #2, #3, #22, #23, #37, #52 — and #343 was filed 2026-08-01 out of an external review of v0.5.0.

## The replacement is better than the error

The review granted that lifecycle, attachment, grading and rebase-survival were proved, and said **the thing the product is for was not**. That is a sharper account than "it became M1" ever was.

## How it happened, and how it was caught

I wrote the line from the issue title plus an assumption about where it belonged, and did not check. One query against the milestone caught it.

## Why the correction is on the page rather than in the diff

A page whose argument is *"we publish the claims that turned out to be false"* cannot quietly fix one. The closing note now carries it, in the page's own voice.

## Remaining accuracy limit, stated

Entries were verified against issue titles, source comments, or this session's own work. An entry whose defect I did not personally see is only as accurate as its title — that is in the commit's `Limit:`.