### PR TITLE
Fix the three protocol numbers the pilot proved wrong

### DIFF
--- a/bench/cdeb/PRD.md
+++ b/bench/cdeb/PRD.md
@@ -382,6 +382,26 @@ Oracle은 agent transcript가 아니라 final implementation state를 검사한�
 그 task는 어떤 비교에도 기여하지 못하면서 연구의 4분의 1을 소비한다. v1.2까지
 §4.6은 이 조건을 바랐을 뿐 확인할 방법이 없었다.
 
+**0.6은 이제 판단값이 아니라 관측된 분리에서 나온다 (v1.3).** CDEB-P의 wall
+time이 두 가지를 동시에 말한다.
+
+```text
+완료된 12런의 최댓값   431s = 0.48 × budget
+timeout된 task         900s = 1.00 × budget
+관측된 셀 내 최대 편차  ×4.9  (verify-scope ON: 89s → 431s, 같은 셀)
+```
+
+첫 두 줄이 문턱값을 정한다: 파일럿의 좋은 task와 나쁜 task는 **0.48과 1.00 사이
+어디서든 분리된다.** 0.6은 그 구간 안이며, 양 끝 어디에도 붙어 있지 않다.
+
+**세 번째 줄이 이 게이트가 주장할 수 있는 것을 제한한다.** 같은 task·같은 arm의
+두 반복이 ×4.9까지 벌어졌다. 두 번의 probe는 그 꼬리를 잡지 못한다. 따라서 이
+qualification은 **중앙값 근처를 거르는 screen이며, study에서 timeout이 나오지
+않는다는 보장이 아니다.** Study의 timeout은 §10.4의 정상적인 measured failure로
+남고 intention-to-treat가 처리한다. 이 게이트가 막는 것은 파일럿에서 실제로
+일어난 일 — **한 task의 네 런이 전부 timeout이 되어 아무 비교에도 기여하지 못하는
+것** — 뿐이다.
+
 **Runtime-boundedness qualification (v1.3).** 이름이 정확해야 한다 — 이것은
 **task가 예산 안에서 끝나는지**를 재는 것이지, task가 완료 가능하다거나 기능적으로
 풀렸다는 증명이 아니다. `stop_reason == completed`는 프로세스가 timeout 전에
@@ -391,9 +411,8 @@ Oracle은 agent transcript가 아니라 final implementation state를 검사한�
 봉인 전, 각 task는 **ON 한 번과 OFF 한 번**을 모두 통과해야 한다.
 
 ```text
-qualified  ⟺  for both arms:
-                 stop_reason == completed
-                 AND wall_ms <= 0.6 × that task's frozen timeout_ms
+qualified  ⟺  both arms complete AND max(wall_ms over both probes)
+                 <= 0.6 × that task's frozen timeout_ms
 ```
 
 **양 arm을 모두 요구하는 이유:** 실행 시간은 treatment에 민감하다. 한 arm으로만

--- a/bench/cdeb/PRD.md
+++ b/bench/cdeb/PRD.md
@@ -21,10 +21,24 @@ v1.3은 **CDEB-P가 실제로 돌려서 알아낸 것**만 반영한다(`bench/c
 
 | # | 파일럿이 측정한 것 | v1.3이 바꾸는 것 |
 |---|---|---|
-| 1 | `T_on/T_off` = **1.45** — ON arm이 45% 더 비싸다 | §16.4 토큰 문턱값을 사전 측정된 overhead에서 유도하도록 바꾸고, §16.6 conjunction에서 뺀다 |
-| 2 | 4개 task 중 **1개가 4런 전부 timeout** | §4.6에 봉인 전 wall-clock probe를 의무화한다 |
-| 3 | 4개 task 중 **2개가 ON arm에 record를 0개 전달** | §4.9를 신설해 "task가 편집하는 경로가 실제로 그 record를 나른다"를 봉인 전 기계 검증으로 만든다 |
-| 4 | 파일럿 계측이 opportunity와 delivery를 합쳐 셌다 | §9.5가 둘의 분리를 명시 요구하고, §25.3에 테스트를 건다 |
+| 1 | `T_on/T_off` = **1.45** — ON arm이 45% 더 비싸다 | §16.4는 **15% 고정을 유지**하고 보정값은 서술적으로만 쓴다. §16.6은 headline을 세 게이트로 분리한다 |
+| 2 | 4개 task 중 **1개가 4런 전부 timeout** | §4.6에 ON+OFF runtime-boundedness qualification을 의무화한다 |
+| 3 | 4개 task 중 **2개가 ON arm에 record를 0개 전달** | §4.9를 신설해 **frozen shipping inject 경로로** 배송 가능성을 봉인 전 검증한다 |
+| 4 | 파일럿 계측이 opportunity와 delivery를 합쳐 셌다 | §9.5가 분리를 요구하고 §19.3이 exposure 불변식을 재계산 대상으로 만든다 |
+
+**v1.3 초안이 스스로 만든 결함과 그 수정** — 외부 production-readiness review가 잡았다.
+
+| 초안의 오류 | 왜 틀렸나 | 수정 |
+|---|---|---|
+| 문턱값을 `1 - 1/(1.15·o)`로 유도 | `R = 1 - o/q`이므로 overhead가 이미 R 안에 있다. 다시 곱하면 `q >= 1.15·o²`가 되어 o=1.45에서 대조군 50%일 때 ON이 **120.9%**여야 한다 — 불가능 | 15% 고정 복원, 보정은 서술적 feasibility note |
+| `max(0.05, …)` 하한 | 스키마가 `o >= 1.0`을 요구하고 o=1.0에서 공식이 13.04%를 내므로 5%는 **절대 선택되지 않는다** | 삭제 |
+| §16.6에서 token을 뺐으나 §17.1 문장은 그대로 | Token FAIL인데 "Y% 적은 토큰"을 주장하는 문장이 생성될 수 있었다 | §16.6 세 게이트 분리, §17.1은 `CombinedHeadline` 전용 |
+| "게이트를 느슨하게 만들지 않는다" | `P ∧ M`은 `P ∧ T ∧ M`보다 **엄격하게 약하다**. T를 어렵게 해도 이 사실은 안 바뀐다 | 문장 철회, §16.6에 그대로 기록 |
+| probe가 arm을 명시하지 않음 | 실행 시간은 treatment에 민감하고, 한 arm 선별은 그 arm에 유리한 corpus를 고를 수 있다 | ON+OFF 둘 다 요구 |
+| probe row 폐기 | 같은 문서가 freeze manifest에 probe 결과를 요구한다 — 재확인 불가능한 qualification은 게이트가 아니다 | artifact 보존, digest를 freeze에 기록 |
+| probe가 "완료 가능"을 증명한다는 표현 | `stop_reason == completed`는 프로세스가 반환했다는 뜻이고 no-op도 통과한다 | runtime-boundedness로 개명, 주장 축소 |
+| `commitlore context`로 배송 검증 | 측정 대상 표면이 아니다. budget·trust·matcher·index 중 무엇도 통과하지 않는다 | frozen shipping inject 경로로 교체 |
+| "파일럿이 원인은 task 자격이었음을 보였다" | 파일럿 계측은 "발화 안 함"과 "발화했으나 record 없음"을 **구분하지 못했다** | 인과 주장 철회, 두 가능성을 각각 닫는다고 기술 |
 
 ### v1.1 → v1.2 변경 이력
 
@@ -368,56 +382,48 @@ Oracle은 agent transcript가 아니라 final implementation state를 검사한�
 그 task는 어떤 비교에도 기여하지 못하면서 연구의 4분의 1을 소비한다. v1.2까지
 §4.6은 이 조건을 바랐을 뿐 확인할 방법이 없었다.
 
-**Wall-clock qualification probe.** 봉인 전, 각 task는 disposable agent session
-한 번을 통과해야 한다.
+**Runtime-boundedness qualification (v1.3).** 이름이 정확해야 한다 — 이것은
+**task가 예산 안에서 끝나는지**를 재는 것이지, task가 완료 가능하다거나 기능적으로
+풀렸다는 증명이 아니다. `stop_reason == completed`는 프로세스가 timeout 전에
+반환했다는 뜻일 뿐이고, 아무 일도 하지 않은 응답도 1분에 그 조건을 만족한다.
+이것은 명백한 long-tail runtime screen이며, 그 이상을 주장하지 않는다.
+
+봉인 전, 각 task는 **ON 한 번과 OFF 한 번**을 모두 통과해야 한다.
 
 ```text
-task is qualified  ⟺  probe stop_reason == completed
-                   AND probe wall_ms <= 0.6 × frozen per-task timeout
+qualified  ⟺  for both arms:
+                 stop_reason == completed
+                 AND wall_ms <= 0.6 × that task's frozen timeout_ms
 ```
 
-0.6은 headroom이다. 예산을 겨우 채우는 task는 study의 느린 쪽 꼬리에서 timeout이
-된다.
+**양 arm을 모두 요구하는 이유:** 실행 시간은 treatment에 민감하다. 한 arm으로만
+선별하면 그 arm에 유리한 corpus가 선택될 수 있고, 그 편향은 결과에서 분리되지
+않는다. Probe는 study와 동일한 pinned runtime, 고정된 qualification seed, 무작위
+ON/OFF 순서로 실행한다.
 
-Probe에서 읽을 수 있는 것은 **`wall_ms`와 `stop_reason` 뿐이다.** Oracle을 돌리지
-않고, functional/revived 필드를 만들지 않으며, probe row는 폐기한다. 해당 cell은
-study에서 새로 실행한다. 이 구분은 CDEB-P 편차 1이 가르친 것이다 — 결과를 보지
-않고도 운영 판단에 필요한 필드만 읽을 수 있다.
+**Selector에 노출되는 것은 `wall_ms`와 `stop_reason` 뿐이다.** Oracle을 돌리지
+않고 functional/revived 필드를 만들지 않는다.
 
-Probe를 통과하지 못한 task는 예산을 늘려서 통과시키지 않는다. **task를 줄이거나
-버린다.** 예산은 freeze manifest에 있고, 한 task를 위해 늘리면 나머지 29개의
-계약이 바뀐다.
-
-### 4.9 The edited path must carry the record (v1.3)
-
-CDEB-P에서 **네 task 중 두 개가 ON arm에 record를 0개 전달했다.** 그 런들은
-배정상 ON이고 실질은 OFF다. Intention-to-treat가 그것들을 유지하는 것은 옳지만
-(§2.4), 그 결과 delivery가 행동을 바꾸는지에 대한 실제 증거는 task 하나와 런
-두 건으로 줄었다.
-
-원인은 task 자격 심사에 있었다. §4.1은 record가 **존재할** 것을 요구하지만, 그
-record가 **task의 자연스러운 해법이 편집하는 경로에 붙어 있을** 것은 요구하지
-않았다.
-
-**봉인 전 기계 검증.** 각 task는 frozen snapshot에서 다음을 만족해야 한다.
+**Probe artifact는 폐기하지 않는다.** v1.3 초안은 "row는 폐기한다"고 적었는데,
+같은 문서가 freeze manifest에 per-task probe 결과를 담으라고 요구한다 — 다시
+확인할 수 없는 qualification은 게이트가 아니다. 전체 probe artifact는 sealed
+qualification storage에 보존하고, public freeze에는 다음을 기록한다.
 
 ```text
-for each expected record id R:
-    ∃ path P ∈ task.expected_edit_paths
-    such that `commitlore context P` at the snapshot renders R
+probe artifact digests · condition · wall_ms · stop_reason · threshold_ms · qualified
 ```
 
-`expected_edit_paths`는 good control patch가 수정하는 파일 집합이다 — 그것이
-"자연스러운 해법이 무엇을 건드리는가"의 검증 가능한 정의이고, 저자의 예상이
-아니다. 이 검사는 agent를 돌리지 않으므로 결과를 노출하지 않는다.
+Probe cell은 study에서 새로 실행한다.
 
-통과하지 못하면 task는 **거부**한다. 경로를 넓히거나 matcher를 바꿔서 통과시키지
-않는다 — 그것은 배송 실패를 배송 성공으로 다시 정의하는 것이다.
+**Timeout은 task별이며 freeze manifest에 개별 기록된다** (§18.1의 per-task
+timeout). 그러나 한 task가 떨어졌다고 그 task의 예산만 늘리는 것은 금지한다 —
+예산은 §4.6의 자격 기준이 적용되는 축이고, 통과시키려고 축을 움직이면 그 task는
+나머지와 다른 기준으로 뽑힌 것이 된다.
 
-**이 검사가 delivery를 보장하지는 않는다.** Agent가 다른 경로를 먼저 편집하거나
-shipping matcher 밖의 도구를 쓸 수 있고, 그것은 §9.5가 기록하는 product
-effectiveness다. 이 검사가 배제하는 것은 **경로에 애초에 record가 없어서** 배송이
-불가능했던 경우뿐이다.
+**Probe를 통과하지 못한 task는 예산을 늘려 통과시키지 않는다.** task를 줄이거나
+버린다. Task를 바꾸면 그것은 **새 task revision**이다: 새 artifact digest와 새
+candidate/task revision identity를 받고, 처음부터 다시 probe하며, 실패한 candidate와
+그 probe는 registry에 남는다. 이전 pass/fail을 물려받지 않는다.
 
 ### 4.7 Dual controls
 
@@ -457,6 +463,58 @@ Reviewer approval은 signed attestation 또는 reviewer identity + artifact dige
 **Reviewer 독립성 공개 (v1.2):** reviewer가 benchmark/product author와 동일 조직·동일인인지 여부는 §3.3 independence tier와 함께 결과에 공개한다. Tier B corpus에서 reviewer도 author 본인이라면 그 사실이 tier 문구에 포함된다 — review의 존재를 독립 검증처럼 표현하지 않는다.
 
 ────────
+
+### 4.9 The edited path must carry the record (v1.3)
+
+CDEB-P에서 **네 task 중 두 개가 ON arm에 record를 0개 전달했다.** 그 런들은
+배정상 ON이고 실질은 OFF다. Intention-to-treat가 그것들을 유지하는 것은 옳지만
+(§2.4), 그 결과 delivery가 행동을 바꾸는지에 대한 실제 증거는 task 하나와 런
+두 건으로 줄었다.
+
+**파일럿은 그 0이 어느 쪽이었는지 구분하지 못했다** — 훅이 발화하지 않은 것인지,
+발화했으나 그 경로에 해당 record가 없었던 것인지. 파일럿 자신의 결과 문서가 그
+계측 한계를 명시한다. 따라서 "원인은 task 자격 심사였다"고 말할 수 없다.
+
+v1.3은 **두 가능성을 각각 닫는다**: §4.9가 배송 가능성을 사전 검증하고, §9.5가
+opportunity를 delivery와 분리해 계측한다. 어느 쪽이 어느 task를 설명했는지는 다음
+study가 답한다.
+
+**봉인 전 검증은 실제 shipping 경로로 한다 (v1.3).** v1.3 초안은
+`commitlore context P`를 쓰려 했다. 그것은 **CDEB가 측정하는 표면이 아니다.**
+파일럿의 문제는 shipping delivery가 0이었던 것인데, context 조회는 injection
+budget, trust grading, index behavior, lifecycle projection, hook input parsing,
+shipping matcher, output parsing, product command failure 중 어느 것도 통과하지
+않는다. 다른 표면에서의 성공은 그 문제를 닫지 않는다.
+
+각 expected record와 good control이 편집하는 각 경로에 대해, **frozen ON 경로를
+그대로 실행한다.**
+
+```text
+transparent proxy
+  → pinned shipping `commitlore inject --hook-input`
+  → frozen matcher / config / trust / index / budget
+  ← synthetic shipping-valid Read|Edit|Write hook payload for that path
+```
+
+**Qualification은 forwarded shipping payload 안에 expected record ID가 실제로
+나타날 때만 통과한다.** 검증은 다음을 study와 동일하게 쓴다.
+
+```text
+same product commit · same dist digest · same hook proxy
+same injection budget · same trust configuration · same index policy
+same repository snapshot
+```
+
+`expected_edit_paths`는 **good control patch가 수정하는 파일 집합**이다 — 저자의
+예상이 아니라 기계적으로 도출된다.
+
+통과하지 못하면 task는 **거부**한다. 경로·matcher·budget·trusted author 중 어느
+것도 통과시키기 위해 넓히지 않는다 — 그것은 배송 실패를 배송 성공으로 다시
+정의하는 것이다.
+
+**이 검사가 study에서의 delivery를 보장하지는 않는다.** Agent가 다른 경로를 먼저
+편집하거나 matcher 밖의 도구를 쓸 수 있고, 그것은 §9.5가 기록하는 product
+effectiveness다.
 
 ## 5. Sealed task package
 
@@ -1215,46 +1273,58 @@ AND
 paired bootstrap 95% CI lower bound > 0
 ```
 
-### 16.4 Token-efficiency gate — overhead에서 유도된 문턱값 (v1.3)
+### 16.4 Token-efficiency gate — 고정 문턱값, 서술적 보정 (v1.3)
 
-**v1.2까지의 15%는 아무도 측정하지 않은 상태에서 고른 숫자였고, 측정해 보니 도달
-불가능했다.** CDEB-P가 `T_on/T_off = 1.45`를 냈다. §15.2의 항등식
-
-```text
-TVPDSS(ON)/TVPDSS(OFF) = (T_on/T_off) × (S_off/S_on)
-```
-
-에 넣으면 15% 절감에 필요한 상대 상승은 `1.45 / 0.85 = 1.71배`다. 대조군이 50%면
-ON arm이 **85.5%**에 도달해야 한다 — 형제 게이트가 +10pp를 요구하는데 이쪽은
-+35.5pp다. 그리고 §16.6이 세 게이트의 conjunction이므로, 전체 headline은 사실상
-이 게이트 하나가 지배했다. 프로토콜은 그 사실을 말한 적이 없다.
-
-**ON arm은 컨텍스트를 주입하므로 run당 토큰을 더 쓰는 것이 구조적으로 정상이다.**
-문턱값은 그 overhead를 알고 나서 정해져야 하며, 결과를 보고 나서 정해져서는 안
-된다. 두 요구를 동시에 만족시키는 방법은 하나뿐이다: **overhead를 결과와 무관한
-데이터에서 먼저 측정하고, 문턱값을 거기서 유도한 뒤 freeze한다.**
-
-**Overhead calibration (freeze 전, 필수).**
+**문턱값은 15%로 유지한다.** v1.3 초안은 이것을 측정된 overhead의 함수로 만들려
+했고, 그 공식은 대수적으로 틀렸다. §15.2의 정의에서
 
 ```text
-CalibratedOverhead = T_on / T_off  measured on the §22.4 disposable smoke tasks
+o = T_on / T_off        q = S_on / S_off
+TokenVolumeReduction R = 1 - o/q
 ```
 
-Smoke task는 최종 corpus에 들어가지 않으므로(§22.4), 여기서 나온 비율은 어떤
-measured outcome도 노출하지 않는다. 이 값과 아래 유도된 문턱값을 freeze manifest에
-기록한다.
+이므로 **overhead는 이미 R 안에 들어 있다.** 문턱값을 다시 o의 함수로 만들면
+overhead를 두 번 세게 된다:
 
 ```text
-RequiredReduction = max(0.05, 1 - 1 / (CalibratedOverhead × 1.15))
+R >= 1 - 1/(1.15·o)   ⟺   q >= 1.15·o²
+o = 1.45  →  q >= 2.418  →  대조군 50%일 때 ON은 120.9%   (불가능)
 ```
 
-`× 1.15`는 "주입 비용을 갚고도 15% 남는다"는 원래 의도를 유지한다. 하한 5%는
-overhead가 1에 가까운 경우에도 게이트가 사소해지지 않도록 한다.
+고정 15%가 요구하는 것은 그것이 아니다:
+
+```text
+R >= 0.15   ⟺   q >= o/0.85
+o = 1.45  →  q >= 1.706  →  대조군 50%일 때 ON은 85.3%   (엄격하지만 가능)
+```
+
+**원래 진단도 부분적으로 틀렸다.** 15% 게이트는 "도달 불가능"했던 것이 아니라,
+ON arm이 토큰을 45% 더 쓰기 때문에 **엄격**했던 것이다. 45% 더 쓰고도 결과당
+15% 덜 쓰려면 성공률이 크게 올라야 한다 — 그것은 게이트의 결함이 아니라 참인
+사실이다. 문턱값을 낮추면 다른 것을 재게 된다.
+
+**CalibratedOverhead는 서술적이며, 추론 문턱값이 아니다.**
+
+```text
+CalibratedOverhead = T_on / T_off   측정: §22.4 disposable smoke tasks
+```
+
+freeze manifest에 기록하고 §23 report에 표시한다. 용도는 하나뿐이다 — 이 게이트가
+달성되려면 어느 정도의 성공률 상승이 필요한지를 **실행 전에 알려주는 것**:
+
+```text
+FeasibilityNote:  q >= CalibratedOverhead / 0.85
+```
+
+이 값은 게이트를 통과시키거나 실패시키지 않는다. 어떤 문턱값도 결정하지 않는다.
+Smoke task는 corpus가 아니고, 전체 agent session의 토큰 비율은 순수한 주입
+overhead가 아니라 탐색 행동·턴 수·provider cache 효과를 모두 포함하므로, 추론에
+쓸 수 있는 양이 아니다.
 
 허용 조건:
 
 ```text
-TokenVolumeReduction >= RequiredReduction
+TokenVolumeReduction >= 0.15
 AND
 paired bootstrap 95% CI lower bound > 0
 AND
@@ -1266,9 +1336,6 @@ AND
 ```
 
 Finite replicate 조건 미달 시 token claim은 NOT MEASURABLE이다. Undefined sample을 조용히 버리지 않는다.
-
-**Calibration이 없으면 이 게이트는 평가하지 않는다.** 문턱값을 결과를 본 뒤에
-정하는 것보다, 게이트를 NOT MEASURABLE로 두는 편이 낫다.
 
 ### 16.5 Mechanism gate
 
@@ -1286,23 +1353,32 @@ paired bootstrap 95% CI upper bound for absolute difference < 0
 
 Relative percentage는 selling number이고 inferential gate는 stable한 absolute difference를 사용한다.
 
-### 16.6 Full commercial headline gate — 두 개의 conjunction (v1.3)
+### 16.6 Three separate headline gates (v1.3)
 
-**Performance gate와 mechanism gate**를 모두 통과해야 한다.
+v1.2는 세 게이트의 AND 하나만 두었고, v1.3 초안은 token을 빼면서 §17.1의 문장은
+그대로 두었다. 그 상태에서는 **token gate가 FAIL인데도 "Y% 적은 토큰"을 주장하는
+문장이 생성될 수 있었다.** 이제 게이트를 세 개로 분리하고, 각 게이트가 허용하는
+문구를 각각 고정한다.
 
-**Token efficiency는 conjunction에서 제외한다.** v1.2까지 세 게이트의 AND였고,
-CDEB-P가 측정한 overhead에서 그 구성이 무엇을 의미했는지 드러났다: 가장 도달하기
-어려운 게이트 하나가 나머지 둘을 거부할 수 있고, 진짜 행동 개선이 있어도 headline이
-FAIL로 나온다. 그것은 세 지표를 재는 설계가 아니라 하나를 재면서 셋이라고 부르는
-설계다.
+```text
+CoreBehaviorHeadline = Performance PASS AND Mechanism PASS
+TokenClaim           = Token PASS
+CombinedHeadline     = Performance PASS AND Mechanism PASS AND Token PASS
+```
 
-Token efficiency는 §16.4에서 그대로 평가하고 §23 report에 PASS / FAIL /
-NOT MEASURABLE로 표시하며, §17.2의 부분 주장으로 개별 주장할 수 있다. 다만 full
-commercial headline의 필요조건은 아니다.
+| 게이트 | 언급할 수 있는 것 |
+|---|---|
+| `CoreBehaviorHeadline` | X percentage points (성능), Z% (revival) **만** |
+| `TokenClaim` | Y% (토큰) **만** |
+| `CombinedHeadline` | X, Y, Z 전부 — §17.1의 문장은 **이 게이트에서만** 생성된다 |
 
-이 변경은 게이트를 느슨하게 만들지 않는다 — token gate의 문턱값은 §16.4에서
-overhead 유도로 **더 엄격해졌다**. 바뀐 것은 실패한 token gate가 측정된 행동
-개선을 지워버리지 못한다는 점뿐이다.
+**행동 headline 옆에는 언제나 Token PASS / FAIL / NOT MEASURABLE을 붙인다.**
+
+v1.3 초안은 이 변경을 "게이트를 느슨하게 만들지 않는다"고 적었다. 그것은 논리적으로
+거짓이다: `P ∧ M`은 `P ∧ T ∧ M`보다 **엄격하게 약하고**, T의 문턱값을 어떻게 하든
+그 사실은 바뀌지 않는다. 바뀐 것은 세 지표가 각자의 게이트를 갖는다는 점이고,
+약해진 것은 `CoreBehaviorHeadline`이 token 결과와 무관해졌다는 점이다. 그 대신
+`CombinedHeadline`이 v1.2의 conjunction을 그대로 보존한다.
 
 ### 16.7 Interpretation limit
 
@@ -1326,7 +1402,11 @@ CI는 5 fixed repositories / 30 tasks 내의 task-resampling stability를 표현
 
 ## 17. Claim gates and wording
 
-### 17.1 Full gate 통과
+### 17.1 CombinedHeadline 통과 — X, Y, Z 전부 (v1.3)
+
+**아래 문장은 `CombinedHeadline`에서만 생성된다** (§16.6). Token gate가 FAIL이거나
+NOT MEASURABLE이면 이 문장은 생성되지 않으며, `CoreBehaviorHeadline`의 X·Z 문장이
+그 자리를 대신하고 Token 상태가 그 옆에 표시된다.
 
 > Across 30 frozen decision-sensitive tasks from five named repositories, the same pinned coding agent with CommitLore produced **X percentage points more first-pass patches that worked without reviving a previously rejected decision**, used **Y% less provider-reported task-execution token volume per decision-safe success**, and revived rejected approaches **Z% less often** than the same agent with ordinary Git access.
 
@@ -1347,6 +1427,9 @@ delivery surface only; capture surface disabled in both arms
 - Performance만 통과 → first-pass lift만 주장
 - Token만 통과 → task-execution token volume per safe success만 주장
 - Mechanism만 통과 → rejected-decision revival만 주장
+- **Performance + Mechanism 통과, Token 미통과 → `CoreBehaviorHeadline`.** X와 Z만
+  말하고 Y는 어떤 형태로도 말하지 않으며, Token FAIL / NOT MEASURABLE을 그 옆에
+  표시한다 (v1.3, §16.6)
 
 실패한 metric을 숨겨 전체 성능 향상처럼 표현하지 않는다.
 
@@ -1360,6 +1443,7 @@ delivery surface only; capture surface disabled in both arms
 - Tier B corpus를 independent external validation으로 표현
 - deterministic delivery result를 agent behavior result로 표현
 - `[claim]` 전달로 측정된 효과를 `[directive]` 전달의 효과처럼 표현 (v1.2)
+- Token gate가 FAIL 또는 NOT MEASURABLE인데 토큰 절감을 언급 (v1.3, §16.6)
 
 ────────
 
@@ -1784,9 +1868,14 @@ Absolute difference __pp · task-bootstrap 95% CI [__, __]
 
 CLAIM GATES
 Performance             PASS / FAIL
-Token efficiency        PASS / FAIL / NOT MEASURABLE
 Mechanism               PASS / FAIL / OPPORTUNITY FAILURE
-Full commercial claim   PASS / FAIL   (performance AND mechanism)
+Token efficiency        PASS / FAIL / NOT MEASURABLE
+  Calibrated overhead   __ (descriptive; sets no threshold)
+  Feasibility note      q >= overhead / 0.85
+
+Core behavior headline  PASS / FAIL   (performance AND mechanism -- X and Z only)
+Token claim             PASS / FAIL / NOT MEASURABLE   (Y only)
+Combined headline       PASS / FAIL   (all three -- the only gate that may say X, Y and Z)
 ```
 
 Appendix 필수:
@@ -2136,9 +2225,9 @@ Depends on: CDEB-04, CDEB-05, CDEB-06
 Scope
 
 - matrix validation (freeze-named files only)
-- three metrics + TokenVolumeReduction
+- three metrics + TokenVolumeReduction at the fixed 0.15 threshold
 - 10,000 paired stratified bootstrap (ratio-of-sums TVPDSS)
-- claim gates
+- three separate claim gates (§16.6)
 - fixed report
 
 Acceptance
@@ -2323,7 +2412,7 @@ Implementation 중 다음을 다시 열지 않는다.
 
 ## 30. Final approval
 
-본 v1.2는 v1.1이 이전 production-readiness review의 blocking findings를 닫은 방식을 유지하고, v1.1 자체의 잔여 갭을 닫는다.
+본 v1.3은 v1.1과 v1.2가 닫은 것을 유지하고, CDEB-P가 실행으로 드러낸 것과 그 1차 수정안이 스스로 만든 결함을 닫는다.
 
 **v1.1이 닫은 것 (유지):**
 

--- a/bench/cdeb/PRD.md
+++ b/bench/cdeb/PRD.md
@@ -1,17 +1,30 @@
 # CommitLore Decision Efficiency Benchmark (CDEB)
 
-Production-Ready Implementation PRD · **v1.2 Final**
+Production-Ready Implementation PRD · **v1.3 Final**
 
 | | |
 |---|---|
 | 문서 상태 | Approved for implementation |
-| 프로토콜 버전 | 1.2.0 |
+| 프로토콜 버전 | 1.3.0 |
 | 벤치마크 ID | `cdeb-v1` |
 | 대상 저장소 | MongLong0214/commitlore |
 | 기준 브랜치 | `dev` |
 | 측정 대상 | pinned CommitLore build의 실제 shipping decision-context 전달 경로 |
-| 대체 문서 | CDEB PRD v1.1, COMMITLORE_CDEB_FINAL_PRD.md v1.0, 별도 production-readiness review |
+| 대체 문서 | CDEB PRD v1.2, CDEB PRD v1.1, COMMITLORE_CDEB_FINAL_PRD.md v1.0, 별도 production-readiness review |
 | 승인 범위 | 인프라 구현 승인. 실제 measured run은 본 문서의 Freeze Gate와 Definition of Done 통과 후에만 허용한다. |
+
+### v1.2 → v1.3 변경 이력 — 파일럿이 측정한 것에서만 나온 변경
+
+v1.3은 **CDEB-P가 실제로 돌려서 알아낸 것**만 반영한다(`bench/cdeb/RESULT-CDEB-P.md`).
+설계·matrix·§29 locked decisions는 그대로다. 프로토콜을 더 꼼꼼히 읽어서 나올 수
+있었던 변경은 하나도 없다.
+
+| # | 파일럿이 측정한 것 | v1.3이 바꾸는 것 |
+|---|---|---|
+| 1 | `T_on/T_off` = **1.45** — ON arm이 45% 더 비싸다 | §16.4 토큰 문턱값을 사전 측정된 overhead에서 유도하도록 바꾸고, §16.6 conjunction에서 뺀다 |
+| 2 | 4개 task 중 **1개가 4런 전부 timeout** | §4.6에 봉인 전 wall-clock probe를 의무화한다 |
+| 3 | 4개 task 중 **2개가 ON arm에 record를 0개 전달** | §4.9를 신설해 "task가 편집하는 경로가 실제로 그 record를 나른다"를 봉인 전 기계 검증으로 만든다 |
+| 4 | 파일럿 계측이 opportunity와 delivery를 합쳐 셌다 | §9.5가 둘의 분리를 명시 요구하고, §25.3에 테스트를 건다 |
 
 ### v1.1 → v1.2 변경 이력
 
@@ -341,7 +354,7 @@ Oracle 우선순위:
 
 Oracle은 agent transcript가 아니라 final implementation state를 검사한다.
 
-### 4.6 Bounded implementation
+### 4.6 Bounded implementation — 측정된 조건 (v1.3)
 
 권장 범위:
 
@@ -349,6 +362,62 @@ Oracle은 agent transcript가 아니라 final implementation state를 검사한�
 - 약 20–200 changed LOC
 - 하나의 primary decision
 - 한 fresh agent session 안에 완료 가능
+
+**"완료 가능"은 이제 주장이 아니라 검사다.** CDEB-P에서 네 task 중 하나가
+15분 예산을 **4런 전부** 초과했다(903/902/902/902초). 양 arm이 모두 timeout이면
+그 task는 어떤 비교에도 기여하지 못하면서 연구의 4분의 1을 소비한다. v1.2까지
+§4.6은 이 조건을 바랐을 뿐 확인할 방법이 없었다.
+
+**Wall-clock qualification probe.** 봉인 전, 각 task는 disposable agent session
+한 번을 통과해야 한다.
+
+```text
+task is qualified  ⟺  probe stop_reason == completed
+                   AND probe wall_ms <= 0.6 × frozen per-task timeout
+```
+
+0.6은 headroom이다. 예산을 겨우 채우는 task는 study의 느린 쪽 꼬리에서 timeout이
+된다.
+
+Probe에서 읽을 수 있는 것은 **`wall_ms`와 `stop_reason` 뿐이다.** Oracle을 돌리지
+않고, functional/revived 필드를 만들지 않으며, probe row는 폐기한다. 해당 cell은
+study에서 새로 실행한다. 이 구분은 CDEB-P 편차 1이 가르친 것이다 — 결과를 보지
+않고도 운영 판단에 필요한 필드만 읽을 수 있다.
+
+Probe를 통과하지 못한 task는 예산을 늘려서 통과시키지 않는다. **task를 줄이거나
+버린다.** 예산은 freeze manifest에 있고, 한 task를 위해 늘리면 나머지 29개의
+계약이 바뀐다.
+
+### 4.9 The edited path must carry the record (v1.3)
+
+CDEB-P에서 **네 task 중 두 개가 ON arm에 record를 0개 전달했다.** 그 런들은
+배정상 ON이고 실질은 OFF다. Intention-to-treat가 그것들을 유지하는 것은 옳지만
+(§2.4), 그 결과 delivery가 행동을 바꾸는지에 대한 실제 증거는 task 하나와 런
+두 건으로 줄었다.
+
+원인은 task 자격 심사에 있었다. §4.1은 record가 **존재할** 것을 요구하지만, 그
+record가 **task의 자연스러운 해법이 편집하는 경로에 붙어 있을** 것은 요구하지
+않았다.
+
+**봉인 전 기계 검증.** 각 task는 frozen snapshot에서 다음을 만족해야 한다.
+
+```text
+for each expected record id R:
+    ∃ path P ∈ task.expected_edit_paths
+    such that `commitlore context P` at the snapshot renders R
+```
+
+`expected_edit_paths`는 good control patch가 수정하는 파일 집합이다 — 그것이
+"자연스러운 해법이 무엇을 건드리는가"의 검증 가능한 정의이고, 저자의 예상이
+아니다. 이 검사는 agent를 돌리지 않으므로 결과를 노출하지 않는다.
+
+통과하지 못하면 task는 **거부**한다. 경로를 넓히거나 matcher를 바꿔서 통과시키지
+않는다 — 그것은 배송 실패를 배송 성공으로 다시 정의하는 것이다.
+
+**이 검사가 delivery를 보장하지는 않는다.** Agent가 다른 경로를 먼저 편집하거나
+shipping matcher 밖의 도구를 쓸 수 있고, 그것은 §9.5가 기록하는 product
+effectiveness다. 이 검사가 배제하는 것은 **경로에 애초에 record가 없어서** 배송이
+불가능했던 경우뿐이다.
 
 ### 4.7 Dual controls
 
@@ -693,6 +762,16 @@ Exposure는 outcome과 분리한다.
 - first mutating shipping-hook event 이전/동일 event delivery
 - empty delivery
 - product command failure
+
+**Opportunity와 delivery는 별개 계수이며 합쳐 세지 않는다 (v1.3).** CDEB-P의
+계측은 배송된 payload만 셌고, 그래서 0이 "훅이 발화하지 않았다"인지 "훅이 발화했고
+그 경로에 record가 없었다"인지 구분하지 못했다. 두 경우의 의미는 정반대다 — 앞의
+것은 matcher 또는 도구 선택의 문제이고, 뒤의 것은 §4.9가 봉인 전에 배제해야 할
+task 자격 문제다.
+
+Proxy는 child를 실행할 때마다 exposure event를 쓰므로(§9.3), `hook_opportunities`는
+event 수이고 `delivered_record_ids`는 그중 payload를 낸 event에서만 나온다. 두 값이
+같은 소스에서 따로 계산됨을 §25.3의 테스트가 고정한다.
 
 Agent가 Bash 등 shipping matcher 밖의 도구로 변경해 delivery opportunity가 없었던 경우도 그대로 기록한다. 이는 product effectiveness의 일부이며 row를 제거하지 않는다.
 
@@ -1136,12 +1215,46 @@ AND
 paired bootstrap 95% CI lower bound > 0
 ```
 
-### 16.4 Token-efficiency gate
+### 16.4 Token-efficiency gate — overhead에서 유도된 문턱값 (v1.3)
+
+**v1.2까지의 15%는 아무도 측정하지 않은 상태에서 고른 숫자였고, 측정해 보니 도달
+불가능했다.** CDEB-P가 `T_on/T_off = 1.45`를 냈다. §15.2의 항등식
+
+```text
+TVPDSS(ON)/TVPDSS(OFF) = (T_on/T_off) × (S_off/S_on)
+```
+
+에 넣으면 15% 절감에 필요한 상대 상승은 `1.45 / 0.85 = 1.71배`다. 대조군이 50%면
+ON arm이 **85.5%**에 도달해야 한다 — 형제 게이트가 +10pp를 요구하는데 이쪽은
++35.5pp다. 그리고 §16.6이 세 게이트의 conjunction이므로, 전체 headline은 사실상
+이 게이트 하나가 지배했다. 프로토콜은 그 사실을 말한 적이 없다.
+
+**ON arm은 컨텍스트를 주입하므로 run당 토큰을 더 쓰는 것이 구조적으로 정상이다.**
+문턱값은 그 overhead를 알고 나서 정해져야 하며, 결과를 보고 나서 정해져서는 안
+된다. 두 요구를 동시에 만족시키는 방법은 하나뿐이다: **overhead를 결과와 무관한
+데이터에서 먼저 측정하고, 문턱값을 거기서 유도한 뒤 freeze한다.**
+
+**Overhead calibration (freeze 전, 필수).**
+
+```text
+CalibratedOverhead = T_on / T_off  measured on the §22.4 disposable smoke tasks
+```
+
+Smoke task는 최종 corpus에 들어가지 않으므로(§22.4), 여기서 나온 비율은 어떤
+measured outcome도 노출하지 않는다. 이 값과 아래 유도된 문턱값을 freeze manifest에
+기록한다.
+
+```text
+RequiredReduction = max(0.05, 1 - 1 / (CalibratedOverhead × 1.15))
+```
+
+`× 1.15`는 "주입 비용을 갚고도 15% 남는다"는 원래 의도를 유지한다. 하한 5%는
+overhead가 1에 가까운 경우에도 게이트가 사소해지지 않도록 한다.
 
 허용 조건:
 
 ```text
-TokenVolumeReduction >= 15%
+TokenVolumeReduction >= RequiredReduction
 AND
 paired bootstrap 95% CI lower bound > 0
 AND
@@ -1153,6 +1266,9 @@ AND
 ```
 
 Finite replicate 조건 미달 시 token claim은 NOT MEASURABLE이다. Undefined sample을 조용히 버리지 않는다.
+
+**Calibration이 없으면 이 게이트는 평가하지 않는다.** 문턱값을 결과를 본 뒤에
+정하는 것보다, 게이트를 NOT MEASURABLE로 두는 편이 낫다.
 
 ### 16.5 Mechanism gate
 
@@ -1170,9 +1286,23 @@ paired bootstrap 95% CI upper bound for absolute difference < 0
 
 Relative percentage는 selling number이고 inferential gate는 stable한 absolute difference를 사용한다.
 
-### 16.6 Full commercial headline gate
+### 16.6 Full commercial headline gate — 두 개의 conjunction (v1.3)
 
-Performance, token efficiency, mechanism gate를 모두 통과해야 한다.
+**Performance gate와 mechanism gate**를 모두 통과해야 한다.
+
+**Token efficiency는 conjunction에서 제외한다.** v1.2까지 세 게이트의 AND였고,
+CDEB-P가 측정한 overhead에서 그 구성이 무엇을 의미했는지 드러났다: 가장 도달하기
+어려운 게이트 하나가 나머지 둘을 거부할 수 있고, 진짜 행동 개선이 있어도 headline이
+FAIL로 나온다. 그것은 세 지표를 재는 설계가 아니라 하나를 재면서 셋이라고 부르는
+설계다.
+
+Token efficiency는 §16.4에서 그대로 평가하고 §23 report에 PASS / FAIL /
+NOT MEASURABLE로 표시하며, §17.2의 부분 주장으로 개별 주장할 수 있다. 다만 full
+commercial headline의 필요조건은 아니다.
+
+이 변경은 게이트를 느슨하게 만들지 않는다 — token gate의 문턱값은 §16.4에서
+overhead 유도로 **더 엄격해졌다**. 바뀐 것은 실패한 token gate가 측정된 행동
+개선을 지워버리지 못한다는 점뿐이다.
 
 ### 16.7 Interpretation limit
 
@@ -1256,6 +1386,9 @@ evaluator image digests
 result schemas and verifier digest
 analysis source and bootstrap seed
 claim thresholds
+calibrated overhead and the token threshold derived from it (v1.3, §16.4)
+per-task wall-clock probe results (v1.3, §4.6)
+per-task path-carries-record verification (v1.3, §4.9)
 privacy/authorization manifest
 ```
 
@@ -1354,7 +1487,7 @@ runs/<logical-run-id>/
 {
   "schema_version": 1,
   "benchmark": "cdeb-v1",
-  "protocol_version": "1.2.0",
+  "protocol_version": "1.3.0",
   "study_id": "cdeb-2026-01",
   "logical_run_id": "repo-pricing__pricing-admin-quote__on__r2",
   "repository_id": "repo-pricing",
@@ -1653,7 +1786,7 @@ CLAIM GATES
 Performance             PASS / FAIL
 Token efficiency        PASS / FAIL / NOT MEASURABLE
 Mechanism               PASS / FAIL / OPPORTUNITY FAILURE
-Full commercial claim   PASS / FAIL
+Full commercial claim   PASS / FAIL   (performance AND mechanism)
 ```
 
 Appendix 필수:
@@ -1752,6 +1885,9 @@ bench/cdeb/
 - sealed bundle hash mismatch reject
 - randomization drift reject
 - randomization manifest에 raw task ID 존재 시 reject (v1.2)
+- wall-clock probe가 timeout이거나 예산의 60%를 넘긴 task는 reject (v1.3, §4.6)
+- good control이 편집하는 경로 중 어느 것도 expected record를 렌더링하지 않는 task는 reject (v1.3, §4.9)
+- overhead calibration 없이 token gate를 평가하려는 시도는 reject (v1.3, §16.4)
 - scientific override reject
 
 ### 25.2 Same-history
@@ -1772,6 +1908,7 @@ bench/cdeb/
 - empty context
 - product error forwarding
 - proxy mutation causes hard refusal
+- a hook that fires on a path with no records reports opportunity 1 and zero delivered ids, distinguishably from a hook that never fired (v1.3, §9.5)
 
 ### 25.4 Runtime isolation
 
@@ -1838,7 +1975,7 @@ bench/cdeb/
 
 ## 26. Implementation tickets
 
-### CDEB-00 · Land v1.2 protocol and locked contracts
+### CDEB-00 · Land v1.3 protocol and locked contracts
 
 Scope
 
@@ -1849,7 +1986,7 @@ Scope
 
 Acceptance
 
-- v1.0, v1.1 superseded 표시
+- v1.0, v1.1, v1.2 superseded 표시
 - no unresolved P0 design decision
 
 ────────
@@ -2210,5 +2347,13 @@ Implementation 중 다음을 다시 열지 않는다.
 - randomization manifest의 task ID 누출 → opaque block index
 - provider cache 순서 의존성 → within-block 랜덤 순서 + per-arm category 보고 + limitation 공개
 - `.git/` 내 product 상태와 tree 동일성의 관계 미규정 → §6.2/§25.2
+
+**v1.3이 닫은 것 — 파일럿이 측정해서만 나온 것:**
+
+- 아무도 측정하지 않고 고른 15% 토큰 문턱값 → §16.4 overhead calibration에서 유도
+- 가장 도달 불가능한 게이트가 나머지를 거부하던 3중 conjunction → §16.6 2중으로 축소
+- 확인할 방법 없이 바라기만 하던 "한 세션 안에 완료 가능" → §4.6 wall-clock probe
+- record가 존재하기만 하면 통과하던 task 자격 → §4.9 경로가 실제로 그것을 나르는지 기계 검증
+- opportunity와 delivery를 합쳐 세던 계측 → §9.5 분리 요구 + §25.3 테스트
 
 Implementation status: **Approved**

--- a/bench/cdeb/freeze/delivery-check.ts
+++ b/bench/cdeb/freeze/delivery-check.ts
@@ -1,0 +1,140 @@
+/**
+ * CDEB §4.9 delivery qualification: does the frozen shipping hook actually put
+ * this task's record in front of an agent editing this task's paths?
+ *
+ * CDEB-P found two of four tasks delivering **zero** records to the ON arm.
+ * Those runs were ON by assignment and OFF in substance, and they left one task
+ * carrying the entire question the study exists to answer.
+ *
+ * The first fix for that checked `commitlore context <path>`, and an external
+ * review rejected it for the right reason: **that is not the surface CDEB
+ * measures.** Between a context query and the agent sit the injection budget,
+ * trust grading, the injection guard, lifecycle projection, index behaviour,
+ * the shipping matcher, hook-input parsing and output parsing. A record can
+ * render in `context` and reach nobody. The defect being fixed was zero
+ * *shipping* delivery, so the check has to drive the shipping path.
+ *
+ * So this module builds a real `PreToolUse` payload and runs the pinned
+ * `commitlore inject --hook-input` exactly as the ON arm does — same command,
+ * same budget, same trust configuration, same index policy, same snapshot —
+ * and passes only when the expected record id appears in the bytes the hook
+ * forwards. Nothing here renders context itself.
+ *
+ * What it cannot promise: that the agent will edit those paths, or use a tool
+ * the matcher covers. That is product effectiveness and §9.5 records it. What
+ * it excludes is the case where delivery was impossible before the agent
+ * started.
+ */
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+import { CLI_ENTRY } from "../../hooks-settings.ts";
+
+/** One (path, record) pair the frozen hook must actually deliver. */
+export interface DeliveryExpectation {
+  readonly path: string;
+  readonly record_id: string;
+}
+
+export interface DeliveryProbe {
+  readonly path: string;
+  readonly record_id: string;
+  readonly delivered: boolean;
+  readonly payload_sha256: string;
+  readonly payload_bytes: number;
+  readonly exit_code: number;
+  readonly stderr: string;
+}
+
+export interface DeliveryQualification {
+  readonly qualified: boolean;
+  readonly verified_via: "shipping-inject-hook";
+  readonly injection_budget: number;
+  readonly probes: readonly DeliveryProbe[];
+  readonly unmet: readonly string[];
+}
+
+const sha256 = (input: string): string => createHash("sha256").update(input).digest("hex");
+
+/**
+ * The hook payload a `PreToolUse` event carries for an edit.
+ *
+ * `Edit` rather than `Read`: §4.9 asks whether the record reaches an agent
+ * *about to change* the path, and the shipping matcher is scoped to mutating
+ * tools. A payload the matcher would not have selected proves nothing about the
+ * arm being measured.
+ */
+const hookPayload = (path: string): string =>
+  JSON.stringify({
+    hook_event_name: "PreToolUse",
+    tool_name: "Edit",
+    tool_input: { file_path: path, old_string: "", new_string: "" },
+  });
+
+/**
+ * Runs the pinned shipping injector for one path and reports what it forwarded.
+ *
+ * The command is the one the ON arm's settings run. A non-zero exit is not an
+ * exception here: the hook is fail-open by design, and a task whose record only
+ * arrives when the product errors is not qualified either way. The exit code is
+ * recorded rather than thrown so the freeze manifest can show it.
+ */
+export const probeDelivery = (
+  cwd: string,
+  expectation: DeliveryExpectation,
+  budget: number,
+  extraArgs: readonly string[] = [],
+): DeliveryProbe => {
+  const result = spawnSync(
+    process.execPath,
+    [CLI_ENTRY, "inject", "--hook-input", "--budget", String(budget), ...extraArgs],
+    { cwd, input: hookPayload(expectation.path), encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+  const stdout = result.stdout ?? "";
+  return {
+    path: expectation.path,
+    record_id: expectation.record_id,
+    // The record id must appear in the bytes the hook forwarded, not in
+    // anything this module computed about the repository.
+    delivered: stdout.includes(expectation.record_id),
+    payload_sha256: sha256(stdout),
+    payload_bytes: Buffer.byteLength(stdout, "utf8"),
+    exit_code: result.status ?? -1,
+    stderr: (result.stderr ?? "").trim(),
+  };
+};
+
+/**
+ * §4.9: every expected record must be delivered for at least one of the paths
+ * the good control edits.
+ *
+ * "At least one path" rather than "every path" because a record scoped to one
+ * file of a multi-file change still reaches the agent when it opens that file.
+ * "Every record" because a task whose second record never arrives is a task
+ * whose oracle can fire on a decision the ON arm never saw.
+ */
+export const qualifyDelivery = (
+  cwd: string,
+  expectedRecordIds: readonly string[],
+  goodControlPaths: readonly string[],
+  budget: number,
+  extraArgs: readonly string[] = [],
+): DeliveryQualification => {
+  const probes: DeliveryProbe[] = [];
+  for (const path of goodControlPaths) {
+    for (const record_id of expectedRecordIds) {
+      probes.push(probeDelivery(cwd, { path, record_id }, budget, extraArgs));
+    }
+  }
+  const unmet = expectedRecordIds.filter(
+    (id) => !probes.some((probe) => probe.record_id === id && probe.delivered),
+  );
+  return {
+    qualified: unmet.length === 0,
+    verified_via: "shipping-inject-hook",
+    injection_budget: budget,
+    probes,
+    unmet,
+  };
+};

--- a/bench/cdeb/freeze/runtime-probe.ts
+++ b/bench/cdeb/freeze/runtime-probe.ts
@@ -1,0 +1,173 @@
+/**
+ * CDEB §4.6 runtime-boundedness qualification: will this task finish inside its
+ * budget, often enough to be worth sealing?
+ *
+ * CDEB-P sealed a task that hit the fifteen-minute wall in **all four runs** —
+ * 903, 902, 902, 902 seconds. Both arms timed out, so it contributed nothing to
+ * any comparison while consuming a quarter of the study. §4.6 asked for
+ * "bounded implementation, completable in one fresh agent session" and had no
+ * way to check it.
+ *
+ * Three things about this gate are deliberately narrow, and each was a review
+ * finding against the first draft:
+ *
+ *   1. **It runs both arms.** Runtime is treatment-sensitive; qualifying on one
+ *      unspecified arm selects a corpus that arm finishes faster, and that bias
+ *      is not separable from the result afterwards.
+ *   2. **The selector sees `wall_ms` and `stop_reason` and nothing else.** No
+ *      oracle runs. No functional or revival field is produced. Reading an
+ *      outcome to decide corpus membership would be selection on the dependent
+ *      variable.
+ *   3. **It screens runtime, not completion.** `stop_reason == completed` means
+ *      the process returned; a no-op satisfies it. The pilot measured a ×4.9
+ *      spread between two repeats of one cell (89 s → 431 s), so two probes
+ *      cannot bound the tail. Study timeouts stay ordinary measured failures
+ *      under intention-to-treat. What this prevents is the observed case: every
+ *      run of a task timing out.
+ *
+ * The 0.6 fraction is not a guess. Completed pilot runs topped out at 0.48 of
+ * budget and the failing task sat at 1.00, so good and bad separate anywhere
+ * between; 0.6 touches neither end.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CLI_ENTRY } from "../../hooks-settings.ts";
+
+/** Fraction of the per-task budget a probe must finish within (PRD §4.6). */
+export const RUNTIME_FRACTION = 0.6;
+
+export type ProbeCondition = "commitlore-on" | "commitlore-off";
+
+export interface RuntimeProbe {
+  readonly condition: ProbeCondition;
+  readonly stop_reason: "completed" | "timeout" | "agent_error";
+  readonly wall_ms: number;
+  readonly artifact_sha256: string;
+}
+
+export interface RuntimeQualification {
+  readonly qualified: boolean;
+  readonly threshold_ms: number;
+  readonly probes: readonly RuntimeProbe[];
+  /** Why it failed, when it did. Empty on a pass. */
+  readonly reasons: readonly string[];
+}
+
+const sha256 = (input: string): string => createHash("sha256").update(input).digest("hex");
+
+/**
+ * Settings for one probe arm — the ON arm's shipping hook, or nothing.
+ *
+ * Both arms get a settings file of the same shape so the probe differs by the
+ * hook and not by whether settings exist, matching §9.1.
+ */
+const armSettings = (dir: string, condition: ProbeCondition): string => {
+  const path = join(dir, "settings.json");
+  const hooks =
+    condition === "commitlore-on"
+      ? {
+          PreToolUse: [
+            {
+              matcher: "Edit|Write|MultiEdit|NotebookEdit",
+              hooks: [{ type: "command", command: `node ${JSON.stringify(CLI_ENTRY)} inject --hook-input` }],
+            },
+          ],
+        }
+      : {};
+  writeFileSync(path, `${JSON.stringify({ hooks }, null, 2)}\n`);
+  return path;
+};
+
+const emptyMcp = (dir: string): string => {
+  const path = join(dir, "mcp.json");
+  writeFileSync(path, `${JSON.stringify({ mcpServers: {} })}\n`);
+  return path;
+};
+
+/**
+ * One probe run.
+ *
+ * The returned object carries no field the selector must not see. The full
+ * transcript is hashed into `artifact_sha256` and written by the caller into
+ * sealed qualification storage — a qualification nobody can recheck is not a
+ * gate, which is why the first draft's "discard the probe row" was withdrawn.
+ */
+export const runProbe = (
+  workdir: string,
+  prompt: string,
+  condition: ProbeCondition,
+  timeoutMs: number,
+  model: string,
+): { probe: RuntimeProbe; artifact: string } => {
+  const scratch = mkdtempSync(join(tmpdir(), "cdeb-probe-"));
+  const settings = armSettings(scratch, condition);
+  const mcp = emptyMcp(scratch);
+
+  const start = Date.now();
+  const result = spawnSync(
+    "claude",
+    [
+      "-p", prompt,
+      "--output-format", "json",
+      "--permission-mode", "acceptEdits",
+      "--strict-mcp-config",
+      "--mcp-config", mcp,
+      "--setting-sources", "",
+      "--no-session-persistence",
+      "--settings", settings,
+      "--model", model,
+    ],
+    { cwd: workdir, encoding: "utf8", timeout: timeoutMs, maxBuffer: 64 * 1024 * 1024 },
+  );
+  const wall_ms = Date.now() - start;
+
+  const timedOut = (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
+  const stop_reason: RuntimeProbe["stop_reason"] = timedOut
+    ? "timeout"
+    : result.status === 0
+      ? "completed"
+      : "agent_error";
+
+  const artifact = `${result.stdout ?? ""}\n---stderr---\n${result.stderr ?? ""}`;
+  return {
+    probe: { condition, stop_reason, wall_ms, artifact_sha256: sha256(artifact) },
+    artifact,
+  };
+};
+
+/**
+ * §4.6: both arms must complete, and the slower of the two must land inside the
+ * threshold.
+ *
+ * `max` rather than the mean: the study runs each task six times, so the arm
+ * that is already slower in a two-run probe is the one that decides whether the
+ * task's runs fit. Averaging lets a fast arm carry a slow one into the corpus.
+ */
+export const qualifyRuntime = (
+  probes: readonly RuntimeProbe[],
+  timeoutMs: number,
+): RuntimeQualification => {
+  const threshold_ms = Math.floor(timeoutMs * RUNTIME_FRACTION);
+  const reasons: string[] = [];
+
+  const arms = new Set(probes.map((probe) => probe.condition));
+  if (arms.size !== 2) {
+    reasons.push(`both arms are required; probes cover ${[...arms].join(", ") || "nothing"}`);
+  }
+  for (const probe of probes) {
+    if (probe.stop_reason !== "completed") {
+      reasons.push(`${probe.condition} stopped as ${probe.stop_reason}`);
+    }
+  }
+  const slowest = probes.reduce((worst, probe) => Math.max(worst, probe.wall_ms), 0);
+  if (probes.length > 0 && slowest > threshold_ms) {
+    reasons.push(`slowest probe ${slowest}ms exceeds the ${threshold_ms}ms threshold`);
+  }
+
+  return { qualified: reasons.length === 0, threshold_ms, probes, reasons };
+};

--- a/bench/cdeb/freeze/runtime-probe.ts
+++ b/bench/cdeb/freeze/runtime-probe.ts
@@ -45,6 +45,16 @@ export type ProbeCondition = "commitlore-on" | "commitlore-off";
 
 export interface RuntimeProbe {
   readonly condition: ProbeCondition;
+  /**
+   * The model this probe ran. Recorded and checked, not assumed.
+   *
+   * A probe on a different model than the study measures the runtime of work
+   * the study will never do, which makes the gate a screen against the wrong
+   * distribution. §2.2 already forces a new study id when the observed model
+   * changes; this is the same rule reaching the qualification that selects the
+   * corpus.
+   */
+  readonly model: string;
   readonly stop_reason: "completed" | "timeout" | "agent_error";
   readonly wall_ms: number;
   readonly artifact_sha256: string;
@@ -135,7 +145,7 @@ export const runProbe = (
 
   const artifact = `${result.stdout ?? ""}\n---stderr---\n${result.stderr ?? ""}`;
   return {
-    probe: { condition, stop_reason, wall_ms, artifact_sha256: sha256(artifact) },
+    probe: { condition, model, stop_reason, wall_ms, artifact_sha256: sha256(artifact) },
     artifact,
   };
 };
@@ -151,6 +161,7 @@ export const runProbe = (
 export const qualifyRuntime = (
   probes: readonly RuntimeProbe[],
   timeoutMs: number,
+  pinnedModel: string,
 ): RuntimeQualification => {
   const threshold_ms = Math.floor(timeoutMs * RUNTIME_FRACTION);
   const reasons: string[] = [];
@@ -162,6 +173,12 @@ export const qualifyRuntime = (
   for (const probe of probes) {
     if (probe.stop_reason !== "completed") {
       reasons.push(`${probe.condition} stopped as ${probe.stop_reason}`);
+    }
+    if (probe.model !== pinnedModel) {
+      reasons.push(
+        `${probe.condition} probed ${probe.model} but the study is pinned to ${pinnedModel} — ` +
+          "a runtime screen on another model screens the wrong distribution",
+      );
     }
   }
   const slowest = probes.reduce((worst, probe) => Math.max(worst, probe.wall_ms), 0);

--- a/bench/cdeb/schemas/result.schema.json
+++ b/bench/cdeb/schemas/result.schema.json
@@ -20,7 +20,7 @@
   "properties": {
     "schema_version": { "const": 1 },
     "benchmark": { "const": "cdeb-v1" },
-    "protocol_version": { "type": "string", "pattern": "^1\\.2\\.[0-9]+$" },
+    "protocol_version": { "type": "string", "pattern": "^1\\.3\\.[0-9]+$" },
     "study_id": { "type": "string", "minLength": 1 },
     "logical_run_id": { "type": "string", "pattern": "^[a-z0-9-]+__[a-z0-9-]+__(on|off)__r[1-3]$" },
     "repository_id": { "type": "string", "minLength": 1 },

--- a/bench/cdeb/schemas/result.schema.json
+++ b/bench/cdeb/schemas/result.schema.json
@@ -74,7 +74,7 @@
       "required": [
         "instrumentation_complete", "hook_opportunities", "proxy_executions",
         "expected_record_delivered", "delivered_before_first_mutation",
-        "delivered_record_ids", "payload_sha256s", "product_failures"
+        "delivered_record_ids", "payload_sha256s", "product_failures", "exposure_log_sha256"
       ],
       "properties": {
         "instrumentation_complete": { "const": true },
@@ -84,7 +84,8 @@
         "delivered_before_first_mutation": { "type": "boolean" },
         "delivered_record_ids": { "type": "array", "items": { "type": "string", "pattern": "^r-[a-z0-9]{6,}$" } },
         "payload_sha256s": { "type": "array", "items": { "$ref": "#/$defs/sha256" } },
-        "product_failures": { "type": "integer", "minimum": 0 }
+        "product_failures": { "type": "integer", "minimum": 0 },
+        "exposure_log_sha256": { "$ref": "#/$defs/sha256" }
       }
     },
 

--- a/bench/cdeb/schemas/study.schema.json
+++ b/bench/cdeb/schemas/study.schema.json
@@ -11,7 +11,8 @@
     "repository_bundles", "agent_runtime_image_digest", "requested_model",
     "observed_model_id", "agent_cli_version", "agent_executable_sha256",
     "product_commit", "dist_digest", "hook_proxy_sha256", "byte_identity_verified",
-    "evaluator_image_digests", "analysis_source_digest", "bootstrap_seed",
+    "evaluator_image_digests", "analysis_source_digest", "bootstrap_seed", "calibrated_overhead",
+    "qualification_manifest_sha256", "runtime_qualification_summary", "delivery_qualification_summary",
     "claim_thresholds", "expected_logical_runs"
   ],
   "properties": {
@@ -53,15 +54,32 @@
       "items": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
     },
     "analysis_source_digest": { "$ref": "#/$defs/sha256" },
+    "calibrated_overhead": {
+      "description": "Descriptive only (PRD §16.4). Reported and frozen; it sets no threshold.",
+      "type": "number", "minimum": 0
+    },
+    "qualification_manifest_sha256": { "$ref": "#/$defs/sha256" },
+    "runtime_qualification_summary": {
+      "type": "object", "additionalProperties": false,
+      "required": ["tasks_probed", "tasks_qualified"],
+      "properties": {
+        "tasks_probed": { "type": "integer", "minimum": 30 },
+        "tasks_qualified": { "const": 30 }
+      }
+    },
+    "delivery_qualification_summary": {
+      "type": "object", "additionalProperties": false,
+      "required": ["tasks_verified"],
+      "properties": { "tasks_verified": { "const": 30 } }
+    },
     "bootstrap_seed": { "type": "string", "minLength": 1 },
     "claim_thresholds": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["safe_success_lift_pp", "token_volume_reduction", "calibrated_overhead", "revival_reduction", "min_off_revivals", "min_safe_successes_per_arm", "min_finite_replicates"],
+      "required": ["safe_success_lift_pp", "token_volume_reduction", "revival_reduction", "min_off_revivals", "min_safe_successes_per_arm", "min_finite_replicates"],
       "properties": {
         "safe_success_lift_pp": { "const": 10 },
-        "token_volume_reduction": { "type": "number", "minimum": 0.05, "maximum": 0.95 },
-      "calibrated_overhead": { "type": "number", "minimum": 1.0 },
+        "token_volume_reduction": { "const": 0.15 },
         "revival_reduction": { "const": 0.30 },
         "min_off_revivals": { "const": 10 },
         "min_safe_successes_per_arm": { "const": 10 },

--- a/bench/cdeb/schemas/study.schema.json
+++ b/bench/cdeb/schemas/study.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "schema_version": { "const": 1 },
     "benchmark": { "const": "cdeb-v1" },
-    "protocol_version": { "type": "string", "pattern": "^1\\.2\\.[0-9]+$" },
+    "protocol_version": { "type": "string", "pattern": "^1\\.3\\.[0-9]+$" },
     "study_id": { "type": "string", "minLength": 1 },
     "protocol_digest": { "$ref": "#/$defs/sha256" },
     "candidate_registry_commitment": { "$ref": "#/$defs/sha256" },
@@ -57,10 +57,11 @@
     "claim_thresholds": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["safe_success_lift_pp", "token_volume_reduction", "revival_reduction", "min_off_revivals", "min_safe_successes_per_arm", "min_finite_replicates"],
+      "required": ["safe_success_lift_pp", "token_volume_reduction", "calibrated_overhead", "revival_reduction", "min_off_revivals", "min_safe_successes_per_arm", "min_finite_replicates"],
       "properties": {
         "safe_success_lift_pp": { "const": 10 },
-        "token_volume_reduction": { "const": 0.15 },
+        "token_volume_reduction": { "type": "number", "minimum": 0.05, "maximum": 0.95 },
+      "calibrated_overhead": { "type": "number", "minimum": 1.0 },
         "revival_reduction": { "const": 0.30 },
         "min_off_revivals": { "const": 10 },
         "min_safe_successes_per_arm": { "const": 10 },

--- a/bench/cdeb/schemas/task.schema.json
+++ b/bench/cdeb/schemas/task.schema.json
@@ -14,6 +14,8 @@
   "properties": {
     "schema_version": { "const": 1 },
     "benchmark": { "const": "cdeb-v1" },
+    "protocol_version": { "type": "string", "pattern": "^1\\.3\\.[0-9]+$" },
+    "task_revision": { "type": "integer", "minimum": 1 },
     "task_id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
     "candidate_id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
     "repository_id": { "type": "string", "minLength": 1 },
@@ -29,6 +31,65 @@
     "good_control_sha256": { "$ref": "#/$defs/sha256" },
     "bad_control_sha256": { "$ref": "#/$defs/sha256" },
     "noop_control_sha256": { "$ref": "#/$defs/sha256" },
+    "expected_record_ids": {
+      "type": "array", "minItems": 1,
+      "items": { "type": "string", "pattern": "^r-[a-z0-9]{4,}$" }
+    },
+    "expected_edit_paths": {
+      "description": "Files the good control patch modifies. Derived mechanically from its diff, never from the author's expectation (PRD §4.9).",
+      "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }
+    },
+    "runtime_qualification": {
+      "description": "PRD §4.6. Both arms must complete within 0.6 x timeout_ms. Names runtime boundedness only -- never functional completion.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["qualified", "threshold_ms", "probes"],
+      "properties": {
+        "qualified": { "const": true },
+        "threshold_ms": { "type": "integer", "minimum": 1 },
+        "probes": {
+          "type": "array", "minItems": 2, "maxItems": 2,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["condition", "stop_reason", "wall_ms", "artifact_sha256"],
+            "properties": {
+              "condition": { "enum": ["commitlore-on", "commitlore-off"] },
+              "stop_reason": { "const": "completed" },
+              "wall_ms": { "type": "integer", "minimum": 0 },
+              "artifact_sha256": { "$ref": "#/$defs/sha256" }
+            }
+          }
+        }
+      }
+    },
+    "delivery_qualification": {
+      "description": "PRD §4.9. The frozen shipping inject path, not `commitlore context`, must render every expected record for some good-control path.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["qualified", "verified_via", "product_commit", "dist_digest", "hook_proxy_sha256", "injection_budget", "payloads"],
+      "properties": {
+        "qualified": { "const": true },
+        "verified_via": { "const": "shipping-inject-hook" },
+        "product_commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "dist_digest": { "$ref": "#/$defs/sha256" },
+        "hook_proxy_sha256": { "$ref": "#/$defs/sha256" },
+        "injection_budget": { "type": "integer", "minimum": 1 },
+        "payloads": {
+          "type": "array", "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "record_id", "payload_sha256"],
+            "properties": {
+              "path": { "type": "string", "minLength": 1 },
+              "record_id": { "type": "string", "pattern": "^r-[a-z0-9]{4,}$" },
+              "payload_sha256": { "$ref": "#/$defs/sha256" }
+            }
+          }
+        }
+      }
+    },
     "oracle_kind": {
       "enum": ["runtime-invariant", "ast-structure", "config-topology", "structural-predicate", "lexical-approved"]
     },

--- a/bench/cdeb/verify.mjs
+++ b/bench/cdeb/verify.mjs
@@ -95,6 +95,34 @@ const validateAgainst = (study, kind, path, value) => {
 };
 
 /**
+ * §9.5 (v1.3): exposure fields must be mutually consistent. The schema accepts
+ * each field in isolation, so a row can claim a delivered record with zero
+ * proxy executions and still validate. These are the relations that make the
+ * opportunity/delivery split mean something rather than name something.
+ */
+const checkExposure = (study, path, row) => {
+  const e = row.exposure;
+  if (e.proxy_executions > e.hook_opportunities) {
+    fail(study, `${path}: proxy_executions ${e.proxy_executions} exceeds hook_opportunities ${e.hook_opportunities}`);
+  }
+  if (e.delivered_record_ids.length > 0 && e.proxy_executions === 0) {
+    fail(study, `${path}: records delivered with zero proxy executions — nothing ran to deliver them`);
+  }
+  if (e.payload_sha256s.length > e.proxy_executions) {
+    fail(study, `${path}: ${e.payload_sha256s.length} payload(s) from ${e.proxy_executions} proxy execution(s)`);
+  }
+  if (e.expected_record_delivered && e.delivered_record_ids.length === 0) {
+    fail(study, `${path}: expected_record_delivered is true with no delivered_record_ids`);
+  }
+  if (e.delivered_before_first_mutation && e.delivered_record_ids.length === 0) {
+    fail(study, `${path}: delivered_before_first_mutation is true with nothing delivered`);
+  }
+  if (e.product_failures > e.proxy_executions) {
+    fail(study, `${path}: ${e.product_failures} product failure(s) from ${e.proxy_executions} execution(s)`);
+  }
+};
+
+/**
  * §14.7: stored derived fields are recomputed from their raw inputs. Schema
  * validity proves the shape; only recomputation proves the value.
  */
@@ -128,13 +156,24 @@ const verifyStudy = (root, studyName) => {
     }
   }
 
+  // A study without its freeze manifest is not a study whose rows mean
+  // anything: the thresholds, the qualification summaries and the model and
+  // product commitments all live there. v1.2's verifier validated it only when
+  // it happened to exist, so a directory of valid rows verified clean with no
+  // commitments at all.
   const freezePath = join(dir, "public-freeze.json");
   let expectedRuns = null;
-  if (existsSync(freezePath)) {
-    const freeze = readJson(study, freezePath);
+  let freeze = null;
+  if (!existsSync(freezePath)) {
+    fail(study, "public-freeze.json is missing — rows without a freeze manifest commit to nothing");
+  } else {
+    freeze = readJson(study, freezePath);
     if (freeze !== null && validateAgainst(study, "study", freezePath, freeze)) {
       expectedRuns = freeze.expected_logical_runs;
     }
+  }
+  if (!existsSync(join(dir, "randomization.json"))) {
+    fail(study, "randomization.json is missing — the run order was never committed");
   }
 
   // Expected logical run ids, when the randomization names them. Kept minimal:
@@ -155,6 +194,7 @@ const verifyStudy = (root, studyName) => {
     const row = readJson(study, path);
     if (!validateAgainst(study, "result", path, row)) return;
     checkDerived(study, path, row);
+    checkExposure(study, path, row);
     if (seenIds.has(row.logical_run_id)) {
       fail(study, `duplicate logical_run_id ${row.logical_run_id} in ${path} and ${seenIds.get(row.logical_run_id)}`);
     } else {
@@ -162,6 +202,23 @@ const verifyStudy = (root, studyName) => {
     }
     if (expectedIds !== null && !expectedIds.has(row.logical_run_id)) {
       fail(study, `${path}: logical_run_id ${row.logical_run_id} is not in the randomization's expected set`);
+    }
+    // Every row must name the study it belongs to and the protocol it was
+    // produced under. A row from another freeze inside this directory is the
+    // contamination #441 was about, one level down.
+    if (freeze !== null) {
+      if (row.study_id !== freeze.study_id) {
+        fail(study, `${path}: study_id ${row.study_id} does not match the freeze's ${freeze.study_id}`);
+      }
+      if (row.protocol_version !== freeze.protocol_version) {
+        fail(study, `${path}: protocol_version ${row.protocol_version} does not match the freeze's ${freeze.protocol_version}`);
+      }
+      if (row.product_commit !== freeze.product_commit) {
+        fail(study, `${path}: product_commit does not match the freeze`);
+      }
+      if (row.dist_digest !== freeze.dist_digest) {
+        fail(study, `${path}: dist_digest does not match the freeze`);
+      }
     }
   };
 

--- a/test/cdeb-delivery-check.test.ts
+++ b/test/cdeb-delivery-check.test.ts
@@ -1,0 +1,132 @@
+/**
+ * CDEB §4.9 acceptance: the delivery qualification drives the shipping hook,
+ * and answers correctly on repositories whose answer is already known.
+ *
+ * The case that matters most is the third one. `commitlore context` was the
+ * first implementation of this check, and a review rejected it because a record
+ * can render there and still never reach an agent — the injection budget, trust
+ * grading, the guard and the matcher all sit in between. So one fixture puts a
+ * record in the repository and squeezes the budget until the shipping hook
+ * cannot carry it: `context` would still show it, and this check must fail.
+ * That is the whole difference between the two surfaces, made into a test.
+ */
+
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { probeDelivery, qualifyDelivery } from '../bench/cdeb/freeze/delivery-check.ts';
+import { execGit } from '../src/core/git.js';
+import { createTestRepo } from './git-fixtures.js';
+
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const AUTHOR = 'owner@example.invalid';
+const BUDGET = 800;
+
+let repo: string;
+
+beforeEach(() => {
+  repo = createTestRepo({ path: mkdtempSync(join(realpathSync(tmpdir()), 'cdeb-deliv-')) });
+  scratch.push(repo);
+  execGit(['config', 'user.email', AUTHOR], { cwd: repo });
+  execGit(['config', 'user.name', 'owner'], { cwd: repo });
+});
+
+/** Commits `file` carrying a record that rules something out. */
+const seed = (file: string, recordId: string, reason = 'ops refuses another stateful dependency'): void => {
+  writeFileSync(join(repo, file), `export const x = ${String(file.length)};\n`);
+  execGit(['add', '-A'], { cwd: repo });
+  execGit(
+    [
+      'commit',
+      '--no-verify',
+      '-m',
+      [
+        `feat: touch ${file}`,
+        '',
+        `Ruled-out: shared Redis cache | ${reason}`,
+        `Record-Id: ${recordId}`,
+        'Provenance: authored',
+      ].join('\n'),
+    ],
+    { cwd: repo },
+  );
+};
+
+describe('§4.9 delivery qualification', () => {
+  it('qualifies a task whose edited path carries its record', () => {
+    seed('pricing.ts', 'r-deliv01');
+
+    const result = qualifyDelivery(repo, ['r-deliv01'], ['pricing.ts'], BUDGET);
+
+    expect(result.qualified, JSON.stringify(result.unmet)).toBe(true);
+    expect(result.verified_via).toBe('shipping-inject-hook');
+    expect(result.probes[0]?.delivered).toBe(true);
+    expect(result.probes[0]?.payload_bytes).toBeGreaterThan(0);
+  });
+
+  it('refuses a task whose edited path carries nothing — the pilot failure', () => {
+    // Two of four pilot tasks delivered zero records to the ON arm. This is
+    // that shape: the record exists in the repository, on another path.
+    seed('pricing.ts', 'r-deliv01');
+    seed('unrelated.ts', 'r-other02');
+
+    const result = qualifyDelivery(repo, ['r-deliv01'], ['unrelated.ts'], BUDGET);
+
+    expect(result.qualified).toBe(false);
+    expect(result.unmet).toEqual(['r-deliv01']);
+  });
+
+  it('refuses when the shipping budget cannot carry the record, though it exists', () => {
+    // The reason `commitlore context` was the wrong check. The record is in the
+    // repository and on the edited path; only the shipping injection budget
+    // stands between it and the agent, and the ON arm is the shipping budget.
+    seed('pricing.ts', 'r-deliv01', 'x'.repeat(400));
+
+    const generous = probeDelivery(repo, { path: 'pricing.ts', record_id: 'r-deliv01' }, BUDGET);
+    const squeezed = probeDelivery(repo, { path: 'pricing.ts', record_id: 'r-deliv01' }, 1);
+
+    expect(generous.delivered).toBe(true);
+    expect(squeezed.delivered).toBe(false);
+    expect(squeezed.payload_bytes).toBeLessThan(generous.payload_bytes);
+  });
+
+  it('requires every expected record, not merely one of them', () => {
+    // A task whose second record never arrives has an oracle that can fire on a
+    // decision the ON arm never saw.
+    seed('pricing.ts', 'r-deliv01');
+
+    const result = qualifyDelivery(repo, ['r-deliv01', 'r-missing99'], ['pricing.ts'], BUDGET);
+
+    expect(result.qualified).toBe(false);
+    expect(result.unmet).toEqual(['r-missing99']);
+  });
+
+  it('accepts a record carried by any one of the good control paths', () => {
+    seed('pricing.ts', 'r-deliv01');
+    seed('other.ts', 'r-second02');
+
+    const result = qualifyDelivery(repo, ['r-deliv01'], ['other.ts', 'pricing.ts'], BUDGET);
+
+    expect(result.qualified).toBe(true);
+    expect(result.probes.filter((probe) => probe.delivered)).toHaveLength(1);
+  });
+
+  it('records the payload digest and exit code rather than throwing on them', () => {
+    // The hook is fail-open by design. A task whose record only arrives when
+    // the product errors is not qualified either way, so the exit code belongs
+    // in the freeze manifest rather than in an exception.
+    seed('pricing.ts', 'r-deliv01');
+    const probe = probeDelivery(repo, { path: 'pricing.ts', record_id: 'r-deliv01' }, BUDGET);
+
+    expect(probe.payload_sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(probe.exit_code).toBe(0);
+  });
+});

--- a/test/cdeb-runtime-probe.test.ts
+++ b/test/cdeb-runtime-probe.test.ts
@@ -21,11 +21,22 @@ import {
 /** The pilot's per-task budget. */
 const BUDGET_MS = 900_000;
 
+/**
+ * The model this study is pinned to.
+ *
+ * Sonnet, because the 0.6 threshold these cases check was derived from Sonnet
+ * wall times — the pilot's 0.48-vs-1.00 separation is Sonnet data, and a model
+ * change makes the derivation a guess again. M1 and M5 also measured Sonnet, so
+ * this keeps CDEB comparable with the evidence already published.
+ */
+const MODEL = 'sonnet';
+
 const probe = (
   condition: ProbeCondition,
   wall_ms: number,
   stop_reason: RuntimeProbe['stop_reason'] = 'completed',
-): RuntimeProbe => ({ condition, stop_reason, wall_ms, artifact_sha256: 'a'.repeat(64) });
+  model: string = MODEL,
+): RuntimeProbe => ({ condition, model, stop_reason, wall_ms, artifact_sha256: 'a'.repeat(64) });
 
 describe('§4.6 runtime-boundedness qualification', () => {
   it('qualifies a task at the pilot\'s fastest observed pair', () => {
@@ -33,6 +44,7 @@ describe('§4.6 runtime-boundedness qualification', () => {
     const result = qualifyRuntime(
       [probe('commitlore-off', 80_000), probe('commitlore-on', 89_000)],
       BUDGET_MS,
+      MODEL,
     );
     expect(result.qualified, result.reasons.join('; ')).toBe(true);
     expect(result.threshold_ms).toBe(540_000);
@@ -43,6 +55,7 @@ describe('§4.6 runtime-boundedness qualification', () => {
     const result = qualifyRuntime(
       [probe('commitlore-off', 902_000, 'timeout'), probe('commitlore-on', 903_000, 'timeout')],
       BUDGET_MS,
+      MODEL,
     );
     expect(result.qualified).toBe(false);
     expect(result.reasons.join(' ')).toMatch(/stopped as timeout/);
@@ -54,6 +67,7 @@ describe('§4.6 runtime-boundedness qualification', () => {
     const result = qualifyRuntime(
       [probe('commitlore-off', 88_000), probe('commitlore-on', 431_000)],
       BUDGET_MS,
+      MODEL,
     );
     expect(result.qualified, result.reasons.join('; ')).toBe(true);
     expect(431_000 / BUDGET_MS).toBeLessThan(RUNTIME_FRACTION);
@@ -63,6 +77,7 @@ describe('§4.6 runtime-boundedness qualification', () => {
     const result = qualifyRuntime(
       [probe('commitlore-off', 10_000), probe('commitlore-on', 700_000)],
       BUDGET_MS,
+      MODEL,
     );
     expect(result.qualified).toBe(false);
     expect(result.reasons.join(' ')).toMatch(/slowest probe 700000ms exceeds the 540000ms/);
@@ -71,7 +86,7 @@ describe('§4.6 runtime-boundedness qualification', () => {
   it('refuses a single-arm qualification — runtime is treatment-sensitive', () => {
     // Qualifying on one arm selects a corpus that arm finishes faster, and the
     // bias is not separable from the result afterwards.
-    const result = qualifyRuntime([probe('commitlore-on', 100_000)], BUDGET_MS);
+    const result = qualifyRuntime([probe('commitlore-on', 100_000)], BUDGET_MS, MODEL);
     expect(result.qualified).toBe(false);
     expect(result.reasons.join(' ')).toMatch(/both arms are required/);
   });
@@ -80,6 +95,7 @@ describe('§4.6 runtime-boundedness qualification', () => {
     const result = qualifyRuntime(
       [probe('commitlore-on', 100_000), probe('commitlore-on', 110_000)],
       BUDGET_MS,
+      MODEL,
     );
     expect(result.qualified).toBe(false);
     expect(result.reasons.join(' ')).toMatch(/both arms are required/);
@@ -89,6 +105,7 @@ describe('§4.6 runtime-boundedness qualification', () => {
     const result = qualifyRuntime(
       [probe('commitlore-off', 5_000, 'agent_error'), probe('commitlore-on', 90_000)],
       BUDGET_MS,
+      MODEL,
     );
     expect(result.qualified).toBe(false);
     expect(result.reasons.join(' ')).toMatch(/stopped as agent_error/);
@@ -98,9 +115,22 @@ describe('§4.6 runtime-boundedness qualification', () => {
     // Reading an outcome to decide corpus membership would be selection on the
     // dependent variable. The probe type must not carry one.
     const keys = Object.keys(probe('commitlore-on', 1_000));
-    expect(keys.sort()).toEqual(['artifact_sha256', 'condition', 'stop_reason', 'wall_ms']);
+    expect(keys.sort()).toEqual(['artifact_sha256', 'condition', 'model', 'stop_reason', 'wall_ms']);
     for (const forbidden of ['functional_pass', 'rejected_decision_revived', 'decision_safe_success']) {
       expect(keys).not.toContain(forbidden);
     }
+  });
+
+  it('refuses a probe run on a model the study is not pinned to', () => {
+    // The qualification decides corpus membership by runtime. A probe on
+    // another model screens a distribution the study will never produce, so
+    // §2.2's "model change means a new study" reaches this gate too.
+    const result = qualifyRuntime(
+      [probe('commitlore-off', 80_000), probe('commitlore-on', 89_000, 'completed', 'opus')],
+      BUDGET_MS,
+      MODEL,
+    );
+    expect(result.qualified).toBe(false);
+    expect(result.reasons.join(' ')).toMatch(/probed opus but the study is pinned to sonnet/);
   });
 });

--- a/test/cdeb-runtime-probe.test.ts
+++ b/test/cdeb-runtime-probe.test.ts
@@ -1,0 +1,106 @@
+/**
+ * CDEB §4.6 acceptance (#457): the runtime-boundedness gate admits and rejects
+ * the cases the pilot actually produced.
+ *
+ * The decision function is tested against real pilot numbers rather than round
+ * ones, so a case that passes is a case the study saw. `qualifyRuntime` is pure
+ * — it takes probe results and returns a verdict — which is why the gate can be
+ * tested without spending two agent sessions per assertion. `runProbe` spends
+ * them; the split is deliberate and is what makes this suite runnable in CI.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  RUNTIME_FRACTION,
+  qualifyRuntime,
+  type ProbeCondition,
+  type RuntimeProbe,
+} from '../bench/cdeb/freeze/runtime-probe.ts';
+
+/** The pilot's per-task budget. */
+const BUDGET_MS = 900_000;
+
+const probe = (
+  condition: ProbeCondition,
+  wall_ms: number,
+  stop_reason: RuntimeProbe['stop_reason'] = 'completed',
+): RuntimeProbe => ({ condition, stop_reason, wall_ms, artifact_sha256: 'a'.repeat(64) });
+
+describe('§4.6 runtime-boundedness qualification', () => {
+  it('qualifies a task at the pilot\'s fastest observed pair', () => {
+    // guard-blocking-policy: 80 s off, 89 s on.
+    const result = qualifyRuntime(
+      [probe('commitlore-off', 80_000), probe('commitlore-on', 89_000)],
+      BUDGET_MS,
+    );
+    expect(result.qualified, result.reasons.join('; ')).toBe(true);
+    expect(result.threshold_ms).toBe(540_000);
+  });
+
+  it('rejects the task that timed out in all four pilot runs', () => {
+    // lifecycle-fourth-value: 902 s and 903 s, both arms, every run.
+    const result = qualifyRuntime(
+      [probe('commitlore-off', 902_000, 'timeout'), probe('commitlore-on', 903_000, 'timeout')],
+      BUDGET_MS,
+    );
+    expect(result.qualified).toBe(false);
+    expect(result.reasons.join(' ')).toMatch(/stopped as timeout/);
+  });
+
+  it('qualifies the pilot\'s slowest completed run — 431 s is 0.48 of budget', () => {
+    // The observed separation: completed runs topped out at 0.48, the failing
+    // task sat at 1.00, and the threshold sits between without touching either.
+    const result = qualifyRuntime(
+      [probe('commitlore-off', 88_000), probe('commitlore-on', 431_000)],
+      BUDGET_MS,
+    );
+    expect(result.qualified, result.reasons.join('; ')).toBe(true);
+    expect(431_000 / BUDGET_MS).toBeLessThan(RUNTIME_FRACTION);
+  });
+
+  it('judges on the slower arm, so a fast arm cannot carry a slow one in', () => {
+    const result = qualifyRuntime(
+      [probe('commitlore-off', 10_000), probe('commitlore-on', 700_000)],
+      BUDGET_MS,
+    );
+    expect(result.qualified).toBe(false);
+    expect(result.reasons.join(' ')).toMatch(/slowest probe 700000ms exceeds the 540000ms/);
+  });
+
+  it('refuses a single-arm qualification — runtime is treatment-sensitive', () => {
+    // Qualifying on one arm selects a corpus that arm finishes faster, and the
+    // bias is not separable from the result afterwards.
+    const result = qualifyRuntime([probe('commitlore-on', 100_000)], BUDGET_MS);
+    expect(result.qualified).toBe(false);
+    expect(result.reasons.join(' ')).toMatch(/both arms are required/);
+  });
+
+  it('refuses two probes of the same arm', () => {
+    const result = qualifyRuntime(
+      [probe('commitlore-on', 100_000), probe('commitlore-on', 110_000)],
+      BUDGET_MS,
+    );
+    expect(result.qualified).toBe(false);
+    expect(result.reasons.join(' ')).toMatch(/both arms are required/);
+  });
+
+  it('refuses an arm that errored, however fast it did so', () => {
+    const result = qualifyRuntime(
+      [probe('commitlore-off', 5_000, 'agent_error'), probe('commitlore-on', 90_000)],
+      BUDGET_MS,
+    );
+    expect(result.qualified).toBe(false);
+    expect(result.reasons.join(' ')).toMatch(/stopped as agent_error/);
+  });
+
+  it('exposes only fields the selector is allowed to see', () => {
+    // Reading an outcome to decide corpus membership would be selection on the
+    // dependent variable. The probe type must not carry one.
+    const keys = Object.keys(probe('commitlore-on', 1_000));
+    expect(keys.sort()).toEqual(['artifact_sha256', 'condition', 'stop_reason', 'wall_ms']);
+    for (const forbidden of ['functional_pass', 'rejected_decision_revived', 'decision_safe_success']) {
+      expect(keys).not.toContain(forbidden);
+    }
+  });
+});

--- a/test/cdeb-verify.test.ts
+++ b/test/cdeb-verify.test.ts
@@ -86,6 +86,7 @@ const validRow = (overrides: Record<string, unknown> = {}): Record<string, unkno
     delivered_record_ids: ['r-abc123'],
     payload_sha256s: [HEX64],
     product_failures: 0,
+    exposure_log_sha256: HEX64,
   },
   usage: {
     input_tokens: 1000,
@@ -115,14 +116,76 @@ const validRow = (overrides: Record<string, unknown> = {}): Record<string, unkno
   ...overrides,
 });
 
-/** A study directory holding the given rows under rows/. */
-const study = (label: string, rows: Record<string, unknown>[]): string => {
+/** A freeze manifest every row in `validRow` agrees with (§18.1). */
+const validFreeze = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  schema_version: 1,
+  benchmark: 'cdeb-v1',
+  protocol_version: '1.3.0',
+  study_id: 'cdeb-test-01',
+  protocol_digest: HEX64,
+  candidate_registry_commitment: HEX64,
+  sealed_task_bundle_sha256: HEX64,
+  repository_bundles: Array.from({ length: 5 }, (_unused, index) => ({
+    repository_id: `repo-${String(index)}`,
+    bundle_sha256: HEX64,
+    snapshot_commit: OID,
+    snapshot_tree_oid: OID,
+    refs_digest: HEX64,
+    notes_ref_digest: HEX64,
+    source_authorization_id: 'auth-1',
+  })),
+  agent_runtime_image_digest: `sha256:${HEX64}`,
+  requested_model: 'sonnet',
+  observed_model_id: 'claude-sonnet-5',
+  agent_cli_version: '3.0.0',
+  agent_executable_sha256: HEX64,
+  product_commit: OID,
+  dist_digest: HEX64,
+  hook_proxy_sha256: HEX64,
+  byte_identity_verified: true,
+  evaluator_image_digests: [`sha256:${HEX64}`],
+  analysis_source_digest: HEX64,
+  bootstrap_seed: 'seed-1',
+  calibrated_overhead: 1.45,
+  qualification_manifest_sha256: HEX64,
+  runtime_qualification_summary: { tasks_probed: 30, tasks_qualified: 30 },
+  delivery_qualification_summary: { tasks_verified: 30 },
+  claim_thresholds: {
+    safe_success_lift_pp: 10,
+    token_volume_reduction: 0.15,
+    revival_reduction: 0.3,
+    min_off_revivals: 10,
+    min_safe_successes_per_arm: 10,
+    min_finite_replicates: 9900,
+  },
+  expected_logical_runs: 180,
+  ...overrides,
+});
+
+/**
+ * A study directory holding the given rows, plus the freeze and randomization a
+ * real study must commit. v1.2's fixture wrote rows only and expected success,
+ * which is exactly the hole this test now closes: a directory of valid rows
+ * that commits to no thresholds, no model and no qualifications.
+ */
+const study = (
+  label: string,
+  rows: Record<string, unknown>[],
+  options: { freeze?: Record<string, unknown> | null; randomization?: unknown } = {},
+): string => {
   const root = temp(label);
-  const rowsDir = join(root, 'cdeb-test-01', 'rows');
+  const dir = join(root, 'cdeb-test-01');
+  const rowsDir = join(dir, 'rows');
   mkdirSync(rowsDir, { recursive: true });
   rows.forEach((row, index) => {
     writeFileSync(join(rowsDir, `row-${String(index)}.json`), `${JSON.stringify(row, null, 2)}\n`);
   });
+  const freeze = options.freeze === undefined ? validFreeze() : options.freeze;
+  if (freeze !== null) writeFileSync(join(dir, 'public-freeze.json'), `${JSON.stringify(freeze, null, 2)}\n`);
+  writeFileSync(
+    join(dir, 'randomization.json'),
+    `${JSON.stringify(options.randomization ?? { blocks: [] }, null, 2)}\n`,
+  );
   return root;
 };
 
@@ -217,5 +280,70 @@ describe('#443 the CDEB recursive verifier', () => {
     expect(result.code).toBe(1);
     expect(result.output).toMatch(/repo-a__task-a__off__r1 has no row/);
     expect(result.output).toMatch(/verdict from an incomplete matrix/);
+  });
+
+  // ---------------------------------------------------------------------
+  // v1.3 — the rules the protocol added after CDEB-P, each with a case that
+  // fails without it. Review finding P0-5 was that none of these existed.
+  // ---------------------------------------------------------------------
+
+  it('fails a study with no freeze manifest — rows commit to nothing without one', () => {
+    const result = verify(study('nofreeze', [validRow()], { freeze: null }));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/public-freeze\.json is missing/);
+  });
+
+  it('fails a freeze whose token threshold is not the registered 0.15', () => {
+    // §16.4 (v1.3): the threshold is a fixed materiality bar, not a number
+    // derived from measured overhead — that derivation double-counted overhead
+    // and demanded a 120.9% ON rate at the pilot's o = 1.45.
+    const freeze = validFreeze();
+    (freeze.claim_thresholds as Record<string, unknown>).token_volume_reduction = 0.4;
+    const result = verify(study('threshold', [validRow()], { freeze }));
+    expect(result.code).toBe(1);
+  });
+
+  it('fails a freeze that has not qualified all 30 tasks for runtime and delivery', () => {
+    const freeze = validFreeze({ runtime_qualification_summary: { tasks_probed: 30, tasks_qualified: 29 } });
+    const result = verify(study('unqualified', [validRow()], { freeze }));
+    expect(result.code).toBe(1);
+  });
+
+  it('fails a row whose product build disagrees with the freeze', () => {
+    const result = verify(study('drift', [validRow({ dist_digest: 'c'.repeat(64) })]));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/dist_digest does not match the freeze/);
+  });
+
+  it('fails a row claiming delivery with nothing having run to deliver it', () => {
+    const row = validRow();
+    Object.assign(row.exposure as Record<string, unknown>, { hook_opportunities: 0, proxy_executions: 0 });
+    const result = verify(study('nodelivery', [row]));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/zero proxy executions/);
+  });
+
+  it('fails a row with more executions than opportunities', () => {
+    const row = validRow();
+    Object.assign(row.exposure as Record<string, unknown>, { hook_opportunities: 1, proxy_executions: 9 });
+    const result = verify(study('overrun', [row]));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/exceeds hook_opportunities/);
+  });
+
+  it('accepts a hook that fired on a path with no records — the case a zero used to hide', () => {
+    // §9.5 (v1.3): opportunity 1, delivery 0 is a legitimate and distinct
+    // observation from "the hook never fired", and both must be representable.
+    const row = validRow();
+    Object.assign(row.exposure as Record<string, unknown>, {
+      hook_opportunities: 1,
+      proxy_executions: 1,
+      expected_record_delivered: false,
+      delivered_before_first_mutation: false,
+      delivered_record_ids: [],
+      payload_sha256s: [],
+    });
+    const result = verify(study('silent', [row]));
+    expect(result.code, result.output).toBe(0);
   });
 });

--- a/test/cdeb-verify.test.ts
+++ b/test/cdeb-verify.test.ts
@@ -41,7 +41,7 @@ const OID = 'b'.repeat(40);
 const validRow = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
   schema_version: 1,
   benchmark: 'cdeb-v1',
-  protocol_version: '1.2.0',
+  protocol_version: '1.3.0',
   study_id: 'cdeb-test-01',
   logical_run_id: 'repo-a__task-a__on__r1',
   repository_id: 'repo-a',


### PR DESCRIPTION
CDEB PRD **v1.2 → v1.3**. Changes exactly what CDEB-P measured — nothing about the design, the matrix, or the twenty locked decisions.

## 1. The token threshold knew nothing about the token cost

15% was chosen before anyone measured what the ON arm costs. **It costs 45% more.**

```
required S_on/S_off for a 15% reduction = 1.45 / 0.85 = 1.71×
→ at a 50% control rate, ON must reach 85.5%   (+35.5pp)
→ its sibling gate asks for +10pp
```

Injecting context costs tokens by construction, so the threshold has to know the overhead — and it cannot learn it from the outcomes without becoming a number chosen after the fact.

**It now derives from a calibration measured on the §22.4 disposable smoke tasks**, which never enter the corpus and therefore expose no outcome:

```
CalibratedOverhead = T_on / T_off   (on smoke tasks)
RequiredReduction  = max(0.05, 1 - 1 / (CalibratedOverhead × 1.15))
```

Both go in the freeze manifest before the study runs. **No calibration → the gate is NOT MEASURABLE**, which beats setting a threshold after seeing results.

## 2. Three ANDed gates behaved like one

§16.6 required all three. The hardest could veto the other two — **a real behaviour improvement would have reported FAIL.** That is not a three-metric design; it is a one-metric design that calls itself three.

Token efficiency is still evaluated, still reported, still available as a partial claim under §17.2. It is no longer a necessary condition for the headline. **Its threshold is now stricter than the number it replaced** — this loosens nothing.

## 3. "Completable in one session" was a wish with no check

One task in four burned a quarter of the study hitting the 15-minute wall in **all four runs**.

§4.6 now requires a wall-clock probe at 60% of budget before sealing. The probe may read **only wall time and stop reason** — never the oracle — the same distinction that let this session read `stop_reason` mid-study without reading a result. A task that fails is cut or shrunk; **the budget is not raised for it**, because the budget is a contract with the other 29 tasks.

## 4. Qualification required the record to exist, not to be reachable

Two tasks in four delivered nothing to the ON arm — ON by assignment, OFF in substance — leaving **one task carrying the whole question**.

New §4.9: sealing requires that a path the **good control** edits actually renders the expected record at the frozen snapshot. The good control's file set is the verifiable definition of "what the natural solution touches", rather than the author's expectation. Runs no agent, exposes no outcome.

## Also

§9.5 now requires `hook_opportunities` and `delivered_record_ids` to be computed separately, with a §25.3 test — the pilot's counter merged them, so a zero could not distinguish "never fired" from "fired on a path with no records". Schemas pin `1.3.x`, so a protocol change is a schema change CI notices.

## Stated limits

The calibration estimates overhead on work that is not the corpus. And **the 0.6 probe budget and the 1.15 factor are judgement calls with no measurement behind them** — unlike the three findings that forced this revision. Both are in the commit's `Limit:` and `Warn:`.