### PR TITLE
Decide what a diagnostic must prove before it says a repository is healthy

### DIFF
--- a/docs/DOCTOR-PRD.md
+++ b/docs/DOCTOR-PRD.md
@@ -1,7 +1,9 @@
 # PRD — `commitlore doctor`: the diagnostic rebuild
 
 - ADR: [ADR-0032](adr/ADR-0032-doctor-diagnostic-model.md) (the decisions;
-  this document is the requirements)
+  this document is the requirements). Both documents were revised after an
+  adversarial review; what was wrong and what replaced it is listed in the
+  ADR's "What the adversarial review changed" section.
 - Issue: [#458](https://github.com/MongLong0214/commitlore/issues/458) ·
   Category: `docs/SELF-AUDIT.md` §4, "The first screen lied"
 - References: logic-pro-mcp SetupDoctor (inspected — file paths in ADR-0032);
@@ -20,7 +22,10 @@ capture had silently stopped for eight days, and doctor reported every check
 `ok`. The information existed in `commitlore pending ls`; the command people
 actually run did not carry it. The rebuild makes that shape structurally
 hard: a subsystem doctor reports on cannot be verifiably stopped while the
-report says `ok`, and "we did not look" is a typed state, never a pass.
+report says `ok`, and "we did not look" is a typed state, never a pass. The
+inverse lie is banned with the same force: a healthy repository must be able
+to reach `status: "ok"` — the first revision of this document failed that
+(routine skips made `ok` unreachable) and §5.1 now pins both directions.
 
 ## Non-goals
 
@@ -29,15 +34,19 @@ report says `ok`, and "we did not look" is a typed state, never a pass.
   is too slow for a surface.
 - **A capability/operation-readiness matrix.** SetupDoctor needs one because
   it routes operations across channels; CommitLore has no operation router.
-- **Any network access**, including an opt-in update check. Version skew is
-  checked against local executables; distribution staleness (#433) is fixed
-  in distribution.
+- **Any non-git network access** — no HTTP client, no update check even
+  opt-in, no telemetry. The git transport probes doctor already performs are
+  kept and scoped in §8.1; they are not a licence for anything else.
 - **A `manual` check status.** No CommitLore remediation is outside a
   command.
+- **A `severity` field.** Cut on review: derived totally from `status`, it
+  was a second spelling of the same fact with no consumer (ADR-0032 §3).
 - **Structured remediation objects.** `fix` stays `string | null`; every
   remediation this doctor names is a shell command, and SetupDoctor's
   `{type, value}` shape exists for System Settings deep links we do not have.
 - **Changing any hook path.** Hooks are fail-open (ADR-0021 §5) and stay so.
+- **A capture-recency heuristic.** See §2.2 — the one invariant hole this
+  document leaves open, named, with the reason.
 - **Watch mode, daemons, HTML output, trend history.**
 
 ## User stories
@@ -47,9 +56,12 @@ report says `ok`, and "we did not look" is a typed state, never a pass.
   me the stranded work — I do not need to know `pending ls` exists.
 - As a user with a broken hook runtime, I see one instruction, not four
   warnings that all mean "your hook does not run".
+- As a user on a healthy repository, I see `status: "ok"` — not a permanent
+  `degraded` manufactured from checks that had nothing to inspect.
 - As a CI author, I run `doctor --json`, pin `schema:
-  "commitlore_doctor.v2"`, branch on `status`, and never re-read the docs
-  when CommitLore upgrades.
+  "commitlore_doctor.v2"`, branch on `status` (the exit code alone cannot
+  distinguish `ok` from `degraded` — §7), and never re-read the docs when
+  CommitLore upgrades.
 - As a contributor adding a check, I write one registry entry and one test
   against an injected context; I cannot forget a category, a skip reason, or
   an evidence field, because the types refuse.
@@ -70,8 +82,7 @@ interface DoctorCheck {
   fixed: boolean;                // whether this run's --fix changed it
   // v2 additive fields
   category: 'runtime' | 'transport' | 'capture' | 'delivery' | 'history' | 'index';
-  severity: 'error' | 'warning' | 'info';   // derived from status, total
-  evidence: Record<string, string>;          // §1.3
+  evidence: Record<string, string>;          // §1.3 — non-empty on EVERY status
   durationMs: number;                        // monotonic clock, whole ms
   blockedBy?: string;            // §3 — omitted, never null, when unset
   skipReason?: SkipReason;       // §1.2 — present iff status === 'skipped'
@@ -85,39 +96,59 @@ Requirements:
    (`src/commands/doctor.ts:62-67`): `fail` — the tool cannot work correctly
    here; `warn` — incomplete but nothing answers wrongly locally; `skipped` —
    nothing to inspect, which is not a pass.
-2. `severity` is derived from `status` at the single check factory (`fail` →
-   `error`; `warn` → `warning`; `ok`/`skipped` → `info`) and is display
-   ordering only. It never drives the exit code.
-3. Every check is built through one factory. A check constructed outside it
-   (inconsistent severity, a skip without a reason) must not typecheck.
+2. Every check is built through one factory. A row constructed outside it —
+   a skip without a reason, empty evidence, a hand-set `blockedBy` — must
+   not typecheck.
+3. There is no `severity` field. The first revision derived one from
+   `status`; the review cut it (see Non-goals). Ordering (§4.2) uses
+   `status` directly.
 
-### 1.2 Typed skip reasons
+### 1.2 Typed skip reasons, in two classes
 
-`SkipReason` is a closed union. Initial values, each mapped to an existing
-skip site whose `detail` text does not change:
+`SkipReason` is a closed union, and every member declares a class at its
+definition — a reason without a class does not typecheck:
 
-| Reason | Emitting check(s) |
-|---|---|
-| `command_unrecognized` | inject-runtime, inject-version |
-| `hook_not_installed` | inject-version |
-| `probe_path_unavailable` | inject-runtime |
-| `version_unreadable` | inject-version |
-| `unborn_head` | squash-conservation |
-| `nothing_applicable` | squash-conservation |
+- **`not_applicable`** — the check looked and observed a true empty; the
+  observation is in evidence. Does not degrade the overall status (§5.1).
+- **`unverified`** — something exists that the check could not read.
+  Degrades the overall status: "could not verify" is what `degraded` means.
 
-Adding a skip site requires adding or reusing a union member; a bare
-`'skipped'` with no reason is unrepresentable. (SetupDoctor's equivalent enum
-holds 18 values grown one check at a time; this table is expected to grow the
-same way, per check, never speculatively.)
+Initial values, each mapped to an existing skip site whose `detail` text
+does not change. There are **ten** return sites carrying six reasons — the
+first revision counted "six sites", a review finding (line numbers are
+`src/commands/doctor.ts` on `origin/dev`):
+
+| Reason | Class | Emitting sites |
+|---|---|---|
+| `command_unrecognized` | `unverified` | inject-runtime `:608`, `:621`; inject-version `:703` |
+| `hook_not_installed` | `not_applicable` | inject-version `:699` |
+| `probe_path_unavailable` | `not_applicable` | inject-runtime `:628` |
+| `version_unreadable` | `unverified` | inject-version `:721`, `:733` |
+| `unborn_head` | `not_applicable` | squash-conservation `:934` |
+| `nothing_applicable` | `not_applicable` | squash-conservation `:942`, `:992` |
+
+Two classification notes, because they carry the honesty argument: a skip
+whose row carries `blockedBy` never degrades on its own — its root already
+does (§3.5), which is why `version_unreadable` under a dead `inject-runtime`
+does not double-count; and `command_unrecognized` is `unverified` because a
+hook *is* configured and doctor declined to run it — that is a gap in what
+was verified, not an empty world. (SetupDoctor's equivalent enum holds 18
+values grown one check at a time; this table is expected to grow the same
+way, per check, never speculatively.)
 
 ### 1.3 Evidence
 
 `evidence` is a flat `Record<string, string>`: snake_case keys, string
 values. Rules:
 
-1. Any non-`ok` status carries the evidence that produced it (the exit code
-   observed, the path probed, the count found). A status with empty evidence
-   and a non-ok value fails the test suite.
+1. **Every row carries non-empty evidence, whatever its status.** A non-ok
+   row records what produced the status (the exit code observed, the path
+   probed, the count found); an `ok` row records the observation that
+   licenses the claim; a `not_applicable` skip records the observed empty
+   (`branches_seen: "0"`). The first revision required evidence only for
+   non-ok rows, which let `ok` with `{}` evidence typecheck — the review's
+   sharpest hole in the central invariant. The factory rejects an empty
+   evidence object for any status, and a test asserts it over every fixture.
 2. Process output appears as a bounded excerpt: first line, hard cap 200
    characters, plus `<stream>_truncated: "true"|"false"`. The excerpt stays
    because CommitLore's checks diagnose from stderr first lines
@@ -152,24 +183,33 @@ interface CheckDefinition {
   id: string;
   title: string;
   category: Category;
-  dependencies: string[];        // ids of earlier registry entries only
+  dependencies: string[];        // ids of registry entries; acyclic
   optional: boolean;
-  run: (ctx: DoctorContext) => DoctorCheck;
+  run: (ctx: DoctorContext, deps: Record<string, DoctorCheck>) => DoctorCheck;
 }
 ```
 
 Requirements:
 
-1. The registry is the only source of check ordering. Text output, JSON
-   `checks[]`, and the fix plan all derive their order from it.
-2. `dependencies` may name only ids declared **earlier** in the array —
-   cycles and forward references are a build-time error, tested by a
-   registry-shape test (ids unique, dependencies resolvable, categories
-   non-empty).
+1. The registry is the only source of check ordering, and its order is
+   **frozen to `runDoctor`'s shipping array order**
+   (`src/commands/doctor.ts:1021-1036`). Text output, JSON `checks[]`, and
+   the fix plan all derive their order from it. The first revision's table
+   reordered checks while §9 promised byte-identical output — both could not
+   hold (a review finding); order now wins and the table below matches the
+   code.
+2. `dependencies` must form an acyclic graph over registry ids — cycles and
+   unresolvable ids are a build-time error, tested by a registry-shape test
+   (ids unique, dependencies resolvable, categories non-empty). Forward
+   references are allowed, because the frozen presentation order puts
+   `commit-msg-hook` before its dependency `hook-runtime`; the runner
+   completes dependencies before dependents (§3.1) while emitting rows in
+   registry order.
 3. `run` receives an injected `DoctorContext` (cwd, git runner, spawn,
-   clock, index opener) so every check is unit-testable without a real
-   repository where the probe allows it. This is SetupDoctor's `Runtime`
-   struct-of-functions pattern, in plain TypeScript.
+   clock, index opener) and the completed rows of its declared dependencies,
+   so every check is unit-testable without a real repository where the probe
+   allows it. This is SetupDoctor's `Runtime` struct-of-functions pattern,
+   in plain TypeScript.
 4. The runner wraps every `run` in a try/catch. A thrown check becomes a
    `fail` row for that id with the error message in evidence
    (`error: <first line>`). Doctor never terminates because one of its own
@@ -179,46 +219,144 @@ Requirements:
 
 ### 2.1 The shipping check set
 
-The 12 checks on `origin/dev` plus #458's `pending-backlog`, unchanged in id,
-title, and detail text:
+The 12 checks on `origin/dev`, in their exact current output order,
+unchanged in id, title, and detail text:
 
 | id | category | dependencies |
 |---|---|---|
 | cli-runtime | runtime | — |
-| git-trailers | runtime | — |
 | notes-refspec | transport | — |
 | notes-push | transport | — |
 | commit-msg-hook | capture | hook-runtime |
 | hook-runtime | capture | — |
-| pending-backlog | capture | — |
 | inject-runtime | delivery | — |
 | inject-version | delivery | inject-runtime |
 | mcp-lifecycle | delivery | — |
+| git-trailers | runtime | — |
 | history-depth | history | — |
-| squash-conservation | history | — |
 | index-health | index | — |
+| squash-conservation | history | — |
 
-The two declared dependencies are the two that exist implicitly today:
-`commit-msg-hook` already consumes `hook-runtime`'s result as a parameter,
-and `inject-version` already defers to `inject-runtime` by comment ("Saying
-it twice would be noise"). No other edge is declared without a demonstrated
-collapse — a speculative edge is how a fix plan hides a real failure.
+Plus three additions, appended (the migration freezes whatever `dev` order
+exists when Step 1 lands; `pending-backlog`'s final position is set by its
+own merge):
+
+| id | category | dependencies |
+|---|---|---|
+| pending-backlog (#458, in flight) | capture | — |
+| notes-availability (§2.2) | transport | notes-refspec |
+| capture-liveness (§2.2) | capture | commit-msg-hook, hook-runtime |
+
+The declared dependencies are the ones with a demonstrated collapse:
+`commit-msg-hook` already consumes `hook-runtime`'s result as a parameter;
+`inject-version` already defers to `inject-runtime` by comment ("Saying it
+twice would be noise"); the §2.2 checks would each restate their listed
+dependency's failure verbatim if it were broken. No other edge is declared —
+a speculative edge is how a fix plan hides a real failure.
+
+### 2.2 The two checks this PRD adds
+
+The adversarial review demonstrated that without these, the specified design
+still reports healthy on two broken repositories. Each is a mechanical
+predicate, not an aspiration.
+
+**`notes-availability`** (transport, depends on notes-refspec) — closes the
+"repaired refspec, unfetched mirror" hole. Today `notes-refspec` reports `ok`
+after `--fix` while nothing was fetched (its detail says so; its status does
+not — `doctor.ts:211-225`), `notes-push` reports `ok` "no local mirror yet —
+nothing to push" (`doctor.ts:239-246`), and nothing consults mirror content —
+so a repository whose teammates' records sit unfetched upstream aggregates
+`ok`. `notesAvailability()` (`src/core/notes.ts:287`) cannot power this
+alone: it reads config only and deliberately reports `absent` for a
+written-but-never-fetched refspec (its comment explains why). The missing
+signal is the remote's advertisement, which doctor already holds from
+`notes-push`'s `git ls-remote` probe (one probe per run, shared):
+
+- local `refs/notes/commitlore` resolves → `ok` (evidence: `local_sha`).
+- else, no remotes → `skipped` / `not_applicable` — "no remote, so there is
+  nowhere for unseen records to be" (the same reasoning
+  `notesAvailability()` documents for its `absent`).
+- else, the `ls-remote` probe failed → `skipped` / `unverified` (degrades).
+- else, the remote advertises the ref → **`warn`**: records exist upstream
+  and have never been fetched here; fix: `git fetch <remote>
+  '<notes refspec>'`. This fires after `doctor --fix` writes the refspec,
+  so "fixed but unfetched" can never aggregate `ok` — the #402 shape,
+  closed at the aggregate.
+- else → `ok`: upstream advertises nothing; the empty mirror is a true empty
+  (evidence: `remote_advertises: "false"`).
+- `notes-refspec` non-ok → blocked skip (§3), `blockedBy: "notes-refspec"`.
+
+**`capture-liveness`** (capture, depends on commit-msg-hook and
+hook-runtime) — closes the "capture never worked and nothing was stranded"
+hole. #458's literal shape was 815 commits, zero records, all checks green;
+`pending-backlog` catches the stranded form, but an expired-and-cleaned
+pending directory leaves nothing for it to see:
+
+- either dependency non-ok → blocked skip (§3) — a dead hook explains zero
+  records; saying it again would be the noise §3 exists to collapse.
+- records exist (message trailers or notes, via the existing query path) or
+  pending entries exist → `ok` (evidence: `records_seen`, `commits_seen`).
+- zero records anywhere and HEAD has ≥ `MIN_COMMITS_FOR_LIVENESS` commits →
+  **`warn`**: the capture chain is green yet no commit here has ever carried
+  a record. `fix: null`; the detail says what clears it — the first captured
+  commit — and names `commitlore pending ls` for the stranded case.
+  `MIN_COMMITS_FOR_LIVENESS = 50`, a named constant: far below #458's 815,
+  above a day-one repository, and changing it is a reviewed diff, not a
+  buried literal. A long-lived repository that adopts CommitLore today will
+  warn until its first capture; that is honest — capture is unverified
+  end-to-end until one record flows — and the detail says so.
+- zero records and fewer commits than the threshold → `skipped` /
+  `not_applicable`: too little history to judge (evidence: `commits_seen`).
+
+**The hole this document does not close, and why.** A repository that
+produced records before, stopped, and has a clean pending directory still
+aggregates `ok`. SPEC line 155 makes a record per commit optional — "A
+commit with no trailers is not an error" — so recent recordless commits are
+not evidence of breakage, and a recency-or-ratio heuristic would be the
+guessing SPEC §2.1 B3 taught this project to refuse. `pending-backlog`
+covers the stranded form of that failure; `capture-liveness` covers the
+never-fired form; the strip between them is open, named here, and wired into
+ADR-0032's falsification clause 1: a mechanical local predicate for it, when
+one exists, converts the open case into a falsifier.
 
 ## 3. Dependency collapse and `blocked_by`
 
-1. When a declared dependency's status is not `ok`, the dependent check
-   carries `blockedBy` set to the **earliest non-ok ancestor's id** (chains
-   resolve to the root), and reports `skipped` when it could not meaningfully
-   probe, or its natural status when it could.
-2. `blockedBy` never points at an `ok` check.
-3. Collapse annotates; it never suppresses. Every applicable registered
+The first revision stated intent ("the runner sets `blockedBy` only when the
+non-ok status is the dependency's failure surfacing again") without an
+algorithm — two implementers could satisfy it incompatibly, and the design it
+attributed to SetupDoctor is not SetupDoctor's (whose checks set `blockedBy`
+at construction via `blockingCause`, `SetupDoctor.swift:634`; its runner does
+not stamp it). The normative design:
+
+1. The runner completes declared dependencies before dependents (the
+   registry-shape test proves the graph acyclic) and passes each completed
+   dependency row into the dependent's `run` as `deps`.
+2. `blockedBy` has exactly one producer: the factory's `blocked(dep, ...)`
+   constructor. It requires `dep` to be a declared dependency whose row is
+   non-`ok` (asserted), and yields one of two shapes:
+   - **inherited** — status and detail derived from the dependency row: the
+     `commit-msg-hook` shape today (`doctor.ts:336-343` copies the runtime
+     row's status and embeds its detail), reproduced byte-for-byte;
+   - **blocked skip** — `status: 'skipped'` with a typed reason: the
+     `inject-version` shape today (`did not report a version` when the
+     runtime probe is the thing that is broken).
+3. A row built by any other constructor has no `blockedBy`, and the runner
+   never adds one. An independent defect can therefore only be reported
+   unblocked; burying it would require the check to reach for the blocked
+   constructor explicitly, which is visible in review and pinned by the §11
+   fixture.
+4. After the run, the runner normalises chains to the root — while
+   `blockedBy` names a row that itself carries `blockedBy`, follow it (if A
+   blocks B blocks C, C carries A) — then asserts: `blockedBy` names a
+   declared dependency; the named row is non-`ok`; a blocked row's status
+   never exceeds its root's.
+5. Collapse annotates; it never suppresses. Every applicable registered
    check appears in `checks[]` exactly once, with its own evidence, whatever
-   `blockedBy` says. Only the fix plan (§4) filters blocked entries.
-4. A check that fails for its own reason keeps `blockedBy` unset even when a
-   dependency also failed. The runner sets `blockedBy` only when the check's
-   non-ok status is the dependency's failure surfacing again — a check that
-   observed an independent defect reports it unblocked, so the fix plan
-   cannot bury it.
+   `blockedBy` says. Rows with `blockedBy` set are excluded from the fix
+   plan (§4) and from the overall status derivation (§5.1) — their root
+   already represents them there.
+6. The §11 collapse fixtures are the definition of this section. Where this
+   prose and a fixture disagree, the fixture wins and the prose is the bug.
 
 ## 4. The fix plan
 
@@ -228,19 +366,20 @@ collapse — a speculative edge is how a fix plan hides a real failure.
    `blockedBy` is unset. Root-cause collapse is the noise control: one dead
    hook runtime is one entry, not four.
 2. **Order:** `fail` entries before `warn` entries; registry order within
-   each tier. Severity sorts, declaration order breaks ties — stable across
+   each tier. Status sorts, declaration order breaks ties — stable across
    runs.
 3. **No cap.** A cap would hide findings, which is the one thing this
    command exists not to do. The wall-of-text control is collapse (§3) plus
    render-time dedup: the human renderer prints one line per entry
    (`N. [status] id — detail (fix)`) and prints each distinct `fix` string
    once, on its first appearance (SetupDoctor's `seenRemediations` dedup,
-   `SetupDoctor+Rendering.swift:110-122`).
+   `SetupDoctor+Rendering.swift:109-122`).
 4. `headline` is derived from `fixPlan[0]`: `Next action [<id>]: <detail> —
    <fix>`. With an empty fix plan the headline distinguishes a clean run
    from a merely-unverified one: `status: "ok"` → healthy wording; `status:
-   "degraded"` with no actionable entry (non-optional skips) → "usable; some
-   checks could not be verified". Never "healthy" while status is non-ok.
+   "degraded"` with no actionable entry (unverified skips only) → "usable;
+   some checks could not be verified". Never "healthy" while status is
+   non-ok.
 
 ## 5. The report envelope and `--json`
 
@@ -251,7 +390,7 @@ collapse — a speculative edge is how a fix plan hides a real failure.
   "status": "ok" | "degraded" | "failed",
   "installSource": "plugin" | "npm" | "npx" | "source" | "unknown",
   "headline": "Next action [pending-backlog]: ...",
-  "summary": { "total": 13, "ok": 9, "warn": 2, "fail": 1, "skipped": 1, "durationMs": 412 },
+  "summary": { "total": 15, "ok": 11, "warn": 2, "fail": 1, "skipped": 1, "durationMs": 412 },
   "fixPlan": ["hook-runtime", "pending-backlog"],
   "selection": ["capture"],      // only under --only / --category; omitted on a full run
   "checks": [ /* §1 rows, registry order */ ],
@@ -259,8 +398,16 @@ collapse — a speculative edge is how a fix plan hides a real failure.
 }
 ```
 
-1. `status` derives from non-optional checks only: any `fail` → `failed`;
-   else any `warn` or non-optional `skipped` → `degraded`; else `ok`.
+1. `status` derives from non-optional rows whose `blockedBy` is unset: any
+   `fail` → `failed`; else any `warn`, or any `skipped` whose reason class
+   is `unverified` → `degraded`; else `ok`. Both directions are pinned by
+   tests: the #458 fixture must not reach `ok`, and the healthy fixture —
+   records present, hook current, mirror fetched, no squash-shaped branches
+   (so `squash-conservation` skips `not_applicable`) — **must** reach `ok`.
+   The first revision's rule (any non-optional skip degrades) made `ok`
+   unreachable on ordinary repositories; the review caught it as a
+   first-screen lie of the opposite polarity, and the class split in §1.2 is
+   the fix.
 2. `summary` counts satisfy `ok + warn + fail + skipped === total ===
    checks.length`, asserted in tests.
 3. **The additive contract (ADR-0032 §6):** v2 is a strict superset of the
@@ -284,13 +431,16 @@ collapse — a speculative edge is how a fix plan hides a real failure.
 in the environment or the resolved entry path under the plugin root →
 `plugin`; entry path under a global `node_modules` prefix → `npm`; under an
 npx cache segment (`_npx`) → `npx`; a checkout (entry next to a `.git` with
-this package's name) → `source`; otherwise `unknown`. The resolved entry
-path goes into the report's evidence trail via a `runtime`-category check so
-the classification is itself inspectable. These heuristics are asserted
-per-surface in tests; until a surface has a test, its detection is marked
-`unknown` rather than guessed. Why the field earns its place: #433 — an
-installed plugin pinned three releases behind meant no fix reached that user;
-a report that names its channel lets the remediation name the right updater.
+this package's name) → `source`; otherwise `unknown`. These heuristics are
+asserted per-surface in tests; until a surface has a test, its detection is
+marked `unknown` rather than guessed. The resolved entry path is recorded as
+`entry_path` in `cli-runtime`'s evidence — a v2-additive evidence key on an
+existing check, so the classification is inspectable without the dedicated
+fourteenth check the first revision implied (a review finding: that check
+was either a behaviour change the migration would have to sequence, or
+buried evidence). Why the field earns its place: #433 — an installed plugin
+pinned three releases behind meant no fix reached that user; a report that
+names its channel lets the remediation name the right updater.
 
 SetupDoctor's fourth source, `homebrew`, and its brew-probing detection
 (`SetupDoctor+InstallChecks.swift:193-216`) are not carried: CommitLore is
@@ -299,7 +449,7 @@ Node-only by decision (ADR-0026) and has no brew channel.
 ## 6. Text output
 
 1. Line one is `headline`. Line two is the summary roll-up
-   (`9 ok, 2 warnings, 1 failed, 1 skipped (412ms)`).
+   (`11 ok, 2 warnings, 1 failed, 1 skipped (412ms)`).
 2. Then the fix plan (§4.3 rendering), then one line per check in registry
    order — the current `status  title — detail` format and the current
    detail strings, unchanged.
@@ -316,30 +466,57 @@ Node-only by decision (ADR-0026) and has no brew channel.
 | `1` | Ran; at least one non-optional check failed (SPEC §10: a finding) |
 | `2` | Could not run: usage error, unknown `--only`/`--category` value |
 
-1. `degraded` exits `0`. The distinction lives in `status`, not the exit
-   code. This preserves `docs/RELEASE-GATE.md` §4 (fresh-clone doctor exits
-   0 with warns present) and `init`'s `doctor --fix` step, and it keeps `3`
-   from acquiring a doctor-private meaning SPEC §10 forbids (`3` means the
-   *command* could not see everything; a shallow clone is something doctor
-   sees perfectly well).
-2. There is no `manual` state, so nothing maps to SetupDoctor's exit `2` for
+1. `degraded` exits `0`, and the distinction lives in `status`. The
+   grounds, stated honestly: `docs/RELEASE-GATE.md` §4 requires fresh-clone
+   doctor to exit 0 with warns present, and SPEC §10 permits a command not
+   to use every code (`spec/SPEC.md:276`). This is **compatibility debt,
+   not protocol purity**: a consumer that branches only on the exit code
+   stays green while `status` says `degraded`; a consumer that cares must
+   read `status` (the CI user story above says so).
+2. **Correction.** The first revision claimed SPEC §10 forbids doctor from
+   exiting `3`. That was false: an unfetched notes mirror and shallow
+   history are code `3`'s own named examples (`spec/SPEC.md:274`), and
+   RELEASE-GATE §1 already requires `guard` to exit `3` on an unfetched
+   mirror. A blanket `degraded → 3` would still be wrong — a "no remote"
+   warn is not a vision gap — but exit `3` for the vision-gap rows
+   specifically (`history-depth`'s shallow warn, `doctor.ts:837-845`;
+   `notes-availability`'s unfetched warn) is SPEC-aligned and **remains
+   open**, deferred only because RELEASE-GATE §4's fresh-clone row would
+   have to move in the same change (ADR-0032 §7.3). The first revision also
+   said `init`'s `doctor --fix` step depends on the exit code; it does not
+   — `init` branches on `needsAttention` (`src/commands/init.ts:104`).
+3. There is no `manual` state, so nothing maps to SetupDoctor's exit `2` for
    `manual_action_required` — and CommitLore's `2` is already taken by
    "could not run".
-3. `--help` documents the codes (SPEC §10 requires it); the current help
+4. `--help` documents the codes (SPEC §10 requires it); the current help
    line is updated to name `2`.
 
 ## 8. What doctor must never do
 
-1. **No network.** No socket, ever, on any flag. Enforced by a test that
-   runs the full check set with network syscalls stubbed to throw.
+1. **No non-git network.** Doctor's own process opens no socket — no HTTP,
+   no update lookup, no telemetry, on any flag — enforced by a test that
+   runs the full check set with Node's socket APIs stubbed to throw.
+   Network I/O happens only inside spawned `git` transport commands against
+   configured remotes — today `git fetch --dry-run` (`doctor.ts:196`) and
+   `git ls-remote` (`doctor.ts:248`, shared with `notes-availability`) —
+   only in `transport`-category checks, and an unreachable remote degrades
+   those rows to `warn` "could not verify" (`doctor.ts:199-208`,
+   `:249-256`), never a `fail`, never a crash: a second test points every
+   remote at an unreachable host and requires the full run to complete with
+   exit `0`. The first revision said "No network. No socket, ever" — false
+   against the shipping command, a review finding, corrected here rather
+   than narrowed silently.
 2. **No writes without `--fix`.** A plain run is read-only including under
    failure; `--fix` applies only reversible local config and reports every
    change via `fixed: true` on the row it fixed.
-3. **No claim it cannot evidence.** `ok` requires an observation, recorded
-   in the row; absence of signal is `skipped` + typed reason. The #458
-   property is owned by one tested invariant, not left emergent: no report
-   may have `status: "ok"` while any non-optional check is non-`ok` —
-   including checks the runner had to synthesize from a crash (§2.4).
+3. **No claim it cannot evidence.** Every row carries the observation that
+   produced it, `ok` included (§1.3.1) — the first revision required
+   evidence only for non-ok rows, and the review showed `ok` with `{}`
+   evidence typechecked. Absence of signal is `skipped` + typed reason. The
+   #458 property is owned by one tested invariant, not left emergent: no
+   report may have `status: "ok"` while any non-optional, unblocked check
+   is non-`ok` — including checks the runner had to synthesize from a crash
+   (§2.4).
 4. **No crash from its own checks.** §2.4.
 5. **No partial run presented as full.** §5.5.
 
@@ -348,29 +525,42 @@ Node-only by decision (ADR-0026) and has no brew channel.
 The existing checks keep working. Exactly:
 
 1. **Step 1 — envelope and registry, no behaviour change.** Move each
-   `const checkX` body into a registry entry's `run` unchanged. Wrap the
-   result in the v2 envelope. Text output for existing checks is
-   byte-identical (snapshot-tested); `--json` gains only new keys. All
-   existing doctor tests pass without edits; a new superset test (§5.3)
-   locks v1 compatibility.
-2. **Step 2 — typed skips.** Map the six existing skip sites to §1.2
-   reasons. `detail` strings unchanged; only `skipReason` appears.
+   `const checkX` body into a registry entry's `run` unchanged. Registry
+   order is `runDoctor`'s array order at that moment, frozen — no
+   reordering (the first revision's table reordered checks while this step
+   promised byte-identical text; both could not hold). Wrap the result in
+   the v2 envelope. Text output for existing checks is byte-identical
+   (snapshot-tested); `--json` gains only new keys. All existing doctor
+   tests pass without edits; a new superset test (§5.3) locks v1
+   compatibility.
+2. **Step 2 — typed skips.** Map the **ten** existing skip return sites
+   (three in inject-runtime, four in inject-version, three in
+   squash-conservation) onto the six §1.2 reasons and their classes.
+   `detail` strings unchanged; only `skipReason` appears.
 3. **Step 3 — declared dependencies.** Replace the `checkHook(opts,
-   hookRuntime)` parameter with the declared edge; add the
-   `inject-version → inject-runtime` edge. Behavioural test: with a dead
-   hook runtime, `commit-msg-hook` carries `blockedBy: "hook-runtime"` and
+   hookRuntime)` parameter with the declared edge built through the blocked
+   constructor, which reproduces today's copied status and detail
+   byte-for-byte (`doctor.ts:336-343`) — the observable changes are the
+   additive `blockedBy` key and fix-plan membership, nothing in
+   `checks[].status` or `detail`. Add the `inject-version →
+   inject-runtime` edge the same way. Behavioural test: with a dead hook
+   runtime, `commit-msg-hook` carries `blockedBy: "hook-runtime"` and
    `fixPlan` contains `hook-runtime` but not `commit-msg-hook`.
-4. **Step 4 — file split.** `src/commands/doctor/` with `registry.ts`,
+4. **Step 4 — the added checks.** `notes-availability` and
+   `capture-liveness` (§2.2) land here, each with its fixtures. They change
+   behaviour by design; that is the point of #458.
+5. **Step 5 — file split.** `src/commands/doctor/` with `registry.ts`,
    `runner.ts`, `report.ts`, `render.ts`, `checks/<category>-<id>.ts`. The
    public import surface (`runDoctor`, `formatReport`, `register`) is
-   re-exported so callers (`init`, tests) do not change.
-5. `pending-backlog` (#458, in flight on `doctor-pending-backlog`) merges on
+   re-exported so callers (`init`, tests) do not change. This step is
+   cleanup, not the honesty fix — it may trail the others.
+6. `pending-backlog` (#458, in flight on `doctor-pending-backlog`) merges on
    the current structure first; it becomes a registry entry in step 1 like
    the other twelve. This PRD does not block that fix, and that fix does not
    wait for this PRD.
 
-Steps land in order, each green on its own. No step changes an exit code, a
-check id, or a detail string.
+Steps 1–3 change no exit code, no check id, no detail string. Step 4 adds
+checks — new rows, new possible statuses — and is the only step that does.
 
 ## 10. Performance
 
@@ -382,11 +572,16 @@ Unmeasured today; made measurable by §1.5, then fixed:
    measured baseline plus headroom — this document deliberately does not
    invent the number before the instrument exists (the same rule commit
    1f8b4be applied to the 100k-commit criterion).
-2. `summary.durationMs` equals the sum of per-check `durationMs`, asserted
-   in tests, so a future regression names its check.
+2. `summary.durationMs` is the **wall time of the whole run**, from the same
+   monotonic clock — this is the quantity §10.1's budget binds. The sum of
+   per-check `durationMs` is asserted to be ≤ `summary.durationMs`; the
+   difference is runner overhead, itself now visible. (The first revision
+   defined `summary.durationMs` as the per-check sum while budgeting wall
+   time — two quantities under one name, a review finding.)
 3. `squash-conservation` keeps its existing cap
-   (`MAX_SQUASH_CANDIDATE_BRANCHES = 200`). Today the cap truncates
-   silently (`.slice(0, 200)` over the branch list); under this PRD a
+   (`MAX_SQUASH_CANDIDATE_BRANCHES = 200`, `doctor.ts:849`). Today the cap
+   truncates silently (`.slice(0, MAX_SQUASH_CANDIDATE_BRANCHES)` over the
+   branch list, `doctor.ts:875`); under this PRD a
    truncated scan must say so — `branches_seen` and `branches_checked` in
    evidence, and a detail that names the limit — because an `ok` over an
    unstated subset is the §8.3 rule violated in miniature.
@@ -398,19 +593,24 @@ Every line is a command or a test that decides the answer.
 | check | command | pass |
 |---|---|---|
 | #458 shape closed | doctor on a repo with stranded staged captures | `status` ≠ `ok`; `pending-backlog` in `fixPlan`; headline names it |
+| never-fired capture caught | doctor on a repo with ≥50 commits, green hook chain, zero records, empty pending | `status` ≠ `ok`; `capture-liveness` is `warn` |
+| unfetched mirror caught | doctor after `--fix` in a clone whose remote advertises `refs/notes/commitlore`, local ref absent | `status: "degraded"`; `notes-availability` is `warn` with the fetch fix |
+| `ok` is reachable | doctor on a healthy fixture: records present, hook current, mirror fetched, no squash-shaped branches | `status: "ok"`, exit 0 — skips present are all `not_applicable` |
 | v1 superset | decode `doctor --json` with a v1-shaped reader | every v1 key present, same types, `exitCode` unchanged |
 | schema pinned | `doctor --json \| jq -r .schema` | `commitlore_doctor.v2` |
-| collapse | dead hook runtime fixture | `commit-msg-hook.blockedBy == "hook-runtime"`; fixPlan omits the blocked id, keeps the root |
+| collapse | dead hook runtime fixture | `commit-msg-hook.blockedBy == "hook-runtime"`, its status/detail byte-identical to today's copied text; fixPlan omits the blocked id, keeps the root |
 | independent failure survives collapse | fixture failing both a dependency and the dependent for its own reason | dependent appears in `fixPlan` with `blockedBy` unset |
-| typed skips | every `skipped` row in the suite's fixtures | carries a §1.2 `skipReason` |
+| typed skips | every `skipped` row in the suite's fixtures | carries a §1.2 `skipReason`, whose class matches the §1.2 table |
+| evidence everywhere | every row in the suite's fixtures, all statuses | non-empty `evidence` |
 | crash containment | registry entry whose `run` throws (test-only) | doctor exits normally; that id is a `fail` row with `error` evidence |
 | exit codes | fixtures for ok / degraded / failed / bad `--only` | `0` / `0` / `1` / `2` |
 | release gate unchanged | `dist/commitlore.mjs doctor` on a fresh clone | exit 0, no `fail` (RELEASE-GATE §4 row still passes) |
-| no network | full run with sockets stubbed to throw | all checks complete |
+| no non-git network | full run with Node socket APIs stubbed to throw | all checks complete |
+| offline honesty | full run with every remote pointed at an unreachable host | run completes, exit 0; transport rows `warn` "could not verify" |
 | read-only | full run without `--fix` under a watched fs | zero writes |
-| partial honesty | `doctor --only cli-runtime --json` | `selection` present; headline prefixed `1 of 13 checks run` |
-| summary invariant | property test over fixtures | counts sum to `total == checks.length`; `durationMs` sums |
-| budget | timed run per §10.1 | within the recorded budget |
+| partial honesty | `doctor --only cli-runtime --json` | `selection` present; headline prefixed `1 of 15 checks run` |
+| summary invariant | property test over fixtures | counts sum to `total == checks.length`; per-check `durationMs` sums to ≤ `summary.durationMs` |
+| budget | timed run per §10.1 | `summary.durationMs` within the recorded budget |
 
 Each fix in this table has a test that fails when that one fix is reverted —
 reverting is the evidence, as the release gate already requires of its own

--- a/docs/DOCTOR-PRD.md
+++ b/docs/DOCTOR-PRD.md
@@ -1,0 +1,417 @@
+# PRD — `commitlore doctor`: the diagnostic rebuild
+
+- ADR: [ADR-0032](adr/ADR-0032-doctor-diagnostic-model.md) (the decisions;
+  this document is the requirements)
+- Issue: [#458](https://github.com/MongLong0214/commitlore/issues/458) ·
+  Category: `docs/SELF-AUDIT.md` §4, "The first screen lied"
+- References: logic-pro-mcp SetupDoctor (inspected — file paths in ADR-0032);
+  OpenClaw doctor artefacts (filenames only — its implementation was not
+  available for inspection, and nothing below depends on details of it)
+
+## Goal
+
+A user who runs `commitlore doctor` learns, in one screen, whether this
+repository can carry and share records — and when it cannot, the first line
+tells them the one thing to fix first. A CI job that runs `doctor --json`
+gets a versioned document it can pin without fear of the next release.
+
+The failure this rebuild exists to prevent is #458: a repository where
+capture had silently stopped for eight days, and doctor reported every check
+`ok`. The information existed in `commitlore pending ls`; the command people
+actually run did not carry it. The rebuild makes that shape structurally
+hard: a subsystem doctor reports on cannot be verifiably stopped while the
+report says `ok`, and "we did not look" is a typed state, never a pass.
+
+## Non-goals
+
+- **Profiles** (`--profile`, per-surface check subsets). Rejected in
+  ADR-0032 with the reopening condition: a measurement showing the full set
+  is too slow for a surface.
+- **A capability/operation-readiness matrix.** SetupDoctor needs one because
+  it routes operations across channels; CommitLore has no operation router.
+- **Any network access**, including an opt-in update check. Version skew is
+  checked against local executables; distribution staleness (#433) is fixed
+  in distribution.
+- **A `manual` check status.** No CommitLore remediation is outside a
+  command.
+- **Structured remediation objects.** `fix` stays `string | null`; every
+  remediation this doctor names is a shell command, and SetupDoctor's
+  `{type, value}` shape exists for System Settings deep links we do not have.
+- **Changing any hook path.** Hooks are fail-open (ADR-0021 §5) and stay so.
+- **Watch mode, daemons, HTML output, trend history.**
+
+## User stories
+
+- As a user whose captures have silently stopped, I run `commitlore doctor`
+  and the first line names the stopped subsystem and the command that shows
+  me the stranded work — I do not need to know `pending ls` exists.
+- As a user with a broken hook runtime, I see one instruction, not four
+  warnings that all mean "your hook does not run".
+- As a CI author, I run `doctor --json`, pin `schema:
+  "commitlore_doctor.v2"`, branch on `status`, and never re-read the docs
+  when CommitLore upgrades.
+- As a contributor adding a check, I write one registry entry and one test
+  against an injected context; I cannot forget a category, a skip reason, or
+  an evidence field, because the types refuse.
+
+## 1. The check model
+
+Every check produces one row:
+
+```ts
+interface DoctorCheck {
+  // v1 fields — names, types and meanings frozen (ADR-0032 §6)
+  id: string;                    // stable, kebab-case, e.g. 'hook-runtime'
+  title: string;
+  status: 'ok' | 'warn' | 'fail' | 'skipped';
+  needsAttention: boolean;
+  detail: string;                // one human sentence; existing texts unchanged
+  fix: string | null;            // the command that makes this check ok
+  fixed: boolean;                // whether this run's --fix changed it
+  // v2 additive fields
+  category: 'runtime' | 'transport' | 'capture' | 'delivery' | 'history' | 'index';
+  severity: 'error' | 'warning' | 'info';   // derived from status, total
+  evidence: Record<string, string>;          // §1.3
+  durationMs: number;                        // monotonic clock, whole ms
+  blockedBy?: string;            // §3 — omitted, never null, when unset
+  skipReason?: SkipReason;       // §1.2 — present iff status === 'skipped'
+  optional: boolean;             // §1.4
+}
+```
+
+Requirements:
+
+1. `status` values and meanings are unchanged from the shipping type
+   (`src/commands/doctor.ts:62-67`): `fail` — the tool cannot work correctly
+   here; `warn` — incomplete but nothing answers wrongly locally; `skipped` —
+   nothing to inspect, which is not a pass.
+2. `severity` is derived from `status` at the single check factory (`fail` →
+   `error`; `warn` → `warning`; `ok`/`skipped` → `info`) and is display
+   ordering only. It never drives the exit code.
+3. Every check is built through one factory. A check constructed outside it
+   (inconsistent severity, a skip without a reason) must not typecheck.
+
+### 1.2 Typed skip reasons
+
+`SkipReason` is a closed union. Initial values, each mapped to an existing
+skip site whose `detail` text does not change:
+
+| Reason | Emitting check(s) |
+|---|---|
+| `command_unrecognized` | inject-runtime, inject-version |
+| `hook_not_installed` | inject-version |
+| `probe_path_unavailable` | inject-runtime |
+| `version_unreadable` | inject-version |
+| `unborn_head` | squash-conservation |
+| `nothing_applicable` | squash-conservation |
+
+Adding a skip site requires adding or reusing a union member; a bare
+`'skipped'` with no reason is unrepresentable. (SetupDoctor's equivalent enum
+holds 18 values grown one check at a time; this table is expected to grow the
+same way, per check, never speculatively.)
+
+### 1.3 Evidence
+
+`evidence` is a flat `Record<string, string>`: snake_case keys, string
+values. Rules:
+
+1. Any non-`ok` status carries the evidence that produced it (the exit code
+   observed, the path probed, the count found). A status with empty evidence
+   and a non-ok value fails the test suite.
+2. Process output appears as a bounded excerpt: first line, hard cap 200
+   characters, plus `<stream>_truncated: "true"|"false"`. The excerpt stays
+   because CommitLore's checks diagnose from stderr first lines
+   (hook-runtime, inject-runtime); the bound exists so `--json` output size
+   is independent of what a broken tool prints.
+3. Evidence never contains an absolute `$HOME` prefix — paths are rendered
+   home-relative (`~/...`), matching what the text output already avoids
+   leaking into pasted bug reports.
+
+### 1.4 Optionality
+
+`optional: true` marks a check that informs but never gates: it is excluded
+from the overall `status` derivation and from the exit code. No shipping
+check is optional at introduction; the field exists so a future informational
+check (and `--only` selections of it) does not force a semantics debate into
+a patch. An optional check that should gate is a one-line change, visible in
+review.
+
+### 1.5 Per-check timing
+
+`durationMs` is stamped by the runner from a monotonic clock
+(`process.hrtime.bigint()`), rounded to whole milliseconds, never negative.
+The current doctor's per-check wall time is **unmeasured**; this field is how
+the budget in §10 becomes a measurement instead of an assertion.
+
+## 2. The registry
+
+Checks are declared as data, in one ordered array:
+
+```ts
+interface CheckDefinition {
+  id: string;
+  title: string;
+  category: Category;
+  dependencies: string[];        // ids of earlier registry entries only
+  optional: boolean;
+  run: (ctx: DoctorContext) => DoctorCheck;
+}
+```
+
+Requirements:
+
+1. The registry is the only source of check ordering. Text output, JSON
+   `checks[]`, and the fix plan all derive their order from it.
+2. `dependencies` may name only ids declared **earlier** in the array —
+   cycles and forward references are a build-time error, tested by a
+   registry-shape test (ids unique, dependencies resolvable, categories
+   non-empty).
+3. `run` receives an injected `DoctorContext` (cwd, git runner, spawn,
+   clock, index opener) so every check is unit-testable without a real
+   repository where the probe allows it. This is SetupDoctor's `Runtime`
+   struct-of-functions pattern, in plain TypeScript.
+4. The runner wraps every `run` in a try/catch. A thrown check becomes a
+   `fail` row for that id with the error message in evidence
+   (`error: <first line>`). Doctor never terminates because one of its own
+   checks threw; today it does.
+5. `--only a,b` and `--category capture` filter the registry before the run.
+   An unknown id or category is a usage error: exit `2`, nothing runs.
+
+### 2.1 The shipping check set
+
+The 12 checks on `origin/dev` plus #458's `pending-backlog`, unchanged in id,
+title, and detail text:
+
+| id | category | dependencies |
+|---|---|---|
+| cli-runtime | runtime | — |
+| git-trailers | runtime | — |
+| notes-refspec | transport | — |
+| notes-push | transport | — |
+| commit-msg-hook | capture | hook-runtime |
+| hook-runtime | capture | — |
+| pending-backlog | capture | — |
+| inject-runtime | delivery | — |
+| inject-version | delivery | inject-runtime |
+| mcp-lifecycle | delivery | — |
+| history-depth | history | — |
+| squash-conservation | history | — |
+| index-health | index | — |
+
+The two declared dependencies are the two that exist implicitly today:
+`commit-msg-hook` already consumes `hook-runtime`'s result as a parameter,
+and `inject-version` already defers to `inject-runtime` by comment ("Saying
+it twice would be noise"). No other edge is declared without a demonstrated
+collapse — a speculative edge is how a fix plan hides a real failure.
+
+## 3. Dependency collapse and `blocked_by`
+
+1. When a declared dependency's status is not `ok`, the dependent check
+   carries `blockedBy` set to the **earliest non-ok ancestor's id** (chains
+   resolve to the root), and reports `skipped` when it could not meaningfully
+   probe, or its natural status when it could.
+2. `blockedBy` never points at an `ok` check.
+3. Collapse annotates; it never suppresses. Every applicable registered
+   check appears in `checks[]` exactly once, with its own evidence, whatever
+   `blockedBy` says. Only the fix plan (§4) filters blocked entries.
+4. A check that fails for its own reason keeps `blockedBy` unset even when a
+   dependency also failed. The runner sets `blockedBy` only when the check's
+   non-ok status is the dependency's failure surfacing again — a check that
+   observed an independent defect reports it unblocked, so the fix plan
+   cannot bury it.
+
+## 4. The fix plan
+
+`fixPlan` is an ordered array of check ids:
+
+1. **Membership:** checks whose status is `fail` or `warn` and whose
+   `blockedBy` is unset. Root-cause collapse is the noise control: one dead
+   hook runtime is one entry, not four.
+2. **Order:** `fail` entries before `warn` entries; registry order within
+   each tier. Severity sorts, declaration order breaks ties — stable across
+   runs.
+3. **No cap.** A cap would hide findings, which is the one thing this
+   command exists not to do. The wall-of-text control is collapse (§3) plus
+   render-time dedup: the human renderer prints one line per entry
+   (`N. [status] id — detail (fix)`) and prints each distinct `fix` string
+   once, on its first appearance (SetupDoctor's `seenRemediations` dedup,
+   `SetupDoctor+Rendering.swift:110-122`).
+4. `headline` is derived from `fixPlan[0]`: `Next action [<id>]: <detail> —
+   <fix>`. With an empty fix plan the headline distinguishes a clean run
+   from a merely-unverified one: `status: "ok"` → healthy wording; `status:
+   "degraded"` with no actionable entry (non-optional skips) → "usable; some
+   checks could not be verified". Never "healthy" while status is non-ok.
+
+## 5. The report envelope and `--json`
+
+```jsonc
+{
+  "schema": "commitlore_doctor.v2",
+  "version": "<CLI version>",
+  "status": "ok" | "degraded" | "failed",
+  "installSource": "plugin" | "npm" | "npx" | "source" | "unknown",
+  "headline": "Next action [pending-backlog]: ...",
+  "summary": { "total": 13, "ok": 9, "warn": 2, "fail": 1, "skipped": 1, "durationMs": 412 },
+  "fixPlan": ["hook-runtime", "pending-backlog"],
+  "selection": ["capture"],      // only under --only / --category; omitted on a full run
+  "checks": [ /* §1 rows, registry order */ ],
+  "exitCode": 0
+}
+```
+
+1. `status` derives from non-optional checks only: any `fail` → `failed`;
+   else any `warn` or non-optional `skipped` → `degraded`; else `ok`.
+2. `summary` counts satisfy `ok + warn + fail + skipped === total ===
+   checks.length`, asserted in tests.
+3. **The additive contract (ADR-0032 §6):** v2 is a strict superset of the
+   current unversioned shape. Every v1 key (`checks[].{id, title, status,
+   needsAttention, detail, fix, fixed}`, `exitCode`) keeps its exact name,
+   type, and meaning. New optional fields are omitted when absent, never
+   null. Fields are added without a version bump; removal or repurposing
+   requires a new schema id and a superseding ADR. A regression test decodes
+   a v2 report with a v1-shaped reader and must pass forever.
+4. New keys are camelCase, matching the surface they extend (`exitCode`,
+   `needsAttention`). Rejected: snake_case for new keys — a mixed-case
+   document costs every consumer more than a consistently legacy-cased one.
+5. A partial run (`--only`, `--category`) always carries `selection`, and
+   its `status`/`headline` speak only for the selected checks. A partial
+   report must not be publishable as the repository's health: the headline
+   prefixes `N of M checks run`.
+
+### 5.1 Install source
+
+`installSource` is detected without spawning anything: `CLAUDE_PLUGIN_ROOT`
+in the environment or the resolved entry path under the plugin root →
+`plugin`; entry path under a global `node_modules` prefix → `npm`; under an
+npx cache segment (`_npx`) → `npx`; a checkout (entry next to a `.git` with
+this package's name) → `source`; otherwise `unknown`. The resolved entry
+path goes into the report's evidence trail via a `runtime`-category check so
+the classification is itself inspectable. These heuristics are asserted
+per-surface in tests; until a surface has a test, its detection is marked
+`unknown` rather than guessed. Why the field earns its place: #433 — an
+installed plugin pinned three releases behind meant no fix reached that user;
+a report that names its channel lets the remediation name the right updater.
+
+SetupDoctor's fourth source, `homebrew`, and its brew-probing detection
+(`SetupDoctor+InstallChecks.swift:193-216`) are not carried: CommitLore is
+Node-only by decision (ADR-0026) and has no brew channel.
+
+## 6. Text output
+
+1. Line one is `headline`. Line two is the summary roll-up
+   (`9 ok, 2 warnings, 1 failed, 1 skipped (412ms)`).
+2. Then the fix plan (§4.3 rendering), then one line per check in registry
+   order — the current `status  title — detail` format and the current
+   detail strings, unchanged.
+3. `--verbose` adds evidence keys, `skipReason`, and `durationMs` under each
+   check. The default stays one line per check.
+4. No color unless a TTY, and none under `NO_COLOR`. Plain output is
+   byte-stable for the release gate's greps.
+
+## 7. Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Ran; no non-optional check failed (`ok` or `degraded`) |
+| `1` | Ran; at least one non-optional check failed (SPEC §10: a finding) |
+| `2` | Could not run: usage error, unknown `--only`/`--category` value |
+
+1. `degraded` exits `0`. The distinction lives in `status`, not the exit
+   code. This preserves `docs/RELEASE-GATE.md` §4 (fresh-clone doctor exits
+   0 with warns present) and `init`'s `doctor --fix` step, and it keeps `3`
+   from acquiring a doctor-private meaning SPEC §10 forbids (`3` means the
+   *command* could not see everything; a shallow clone is something doctor
+   sees perfectly well).
+2. There is no `manual` state, so nothing maps to SetupDoctor's exit `2` for
+   `manual_action_required` — and CommitLore's `2` is already taken by
+   "could not run".
+3. `--help` documents the codes (SPEC §10 requires it); the current help
+   line is updated to name `2`.
+
+## 8. What doctor must never do
+
+1. **No network.** No socket, ever, on any flag. Enforced by a test that
+   runs the full check set with network syscalls stubbed to throw.
+2. **No writes without `--fix`.** A plain run is read-only including under
+   failure; `--fix` applies only reversible local config and reports every
+   change via `fixed: true` on the row it fixed.
+3. **No claim it cannot evidence.** `ok` requires an observation, recorded
+   in the row; absence of signal is `skipped` + typed reason. The #458
+   property is owned by one tested invariant, not left emergent: no report
+   may have `status: "ok"` while any non-optional check is non-`ok` —
+   including checks the runner had to synthesize from a crash (§2.4).
+4. **No crash from its own checks.** §2.4.
+5. **No partial run presented as full.** §5.5.
+
+## 9. Migration
+
+The existing checks keep working. Exactly:
+
+1. **Step 1 — envelope and registry, no behaviour change.** Move each
+   `const checkX` body into a registry entry's `run` unchanged. Wrap the
+   result in the v2 envelope. Text output for existing checks is
+   byte-identical (snapshot-tested); `--json` gains only new keys. All
+   existing doctor tests pass without edits; a new superset test (§5.3)
+   locks v1 compatibility.
+2. **Step 2 — typed skips.** Map the six existing skip sites to §1.2
+   reasons. `detail` strings unchanged; only `skipReason` appears.
+3. **Step 3 — declared dependencies.** Replace the `checkHook(opts,
+   hookRuntime)` parameter with the declared edge; add the
+   `inject-version → inject-runtime` edge. Behavioural test: with a dead
+   hook runtime, `commit-msg-hook` carries `blockedBy: "hook-runtime"` and
+   `fixPlan` contains `hook-runtime` but not `commit-msg-hook`.
+4. **Step 4 — file split.** `src/commands/doctor/` with `registry.ts`,
+   `runner.ts`, `report.ts`, `render.ts`, `checks/<category>-<id>.ts`. The
+   public import surface (`runDoctor`, `formatReport`, `register`) is
+   re-exported so callers (`init`, tests) do not change.
+5. `pending-backlog` (#458, in flight on `doctor-pending-backlog`) merges on
+   the current structure first; it becomes a registry entry in step 1 like
+   the other twelve. This PRD does not block that fix, and that fix does not
+   wait for this PRD.
+
+Steps land in order, each green on its own. No step changes an exit code, a
+check id, or a detail string.
+
+## 10. Performance
+
+Unmeasured today; made measurable by §1.5, then fixed:
+
+1. A full `doctor` run on this repository (the reference used by the
+   RELEASE-GATE fresh-clone row) completes within a budget recorded in the
+   acceptance test at the time of measurement. The budget is set from the
+   measured baseline plus headroom — this document deliberately does not
+   invent the number before the instrument exists (the same rule commit
+   1f8b4be applied to the 100k-commit criterion).
+2. `summary.durationMs` equals the sum of per-check `durationMs`, asserted
+   in tests, so a future regression names its check.
+3. `squash-conservation` keeps its existing cap
+   (`MAX_SQUASH_CANDIDATE_BRANCHES = 200`). Today the cap truncates
+   silently (`.slice(0, 200)` over the branch list); under this PRD a
+   truncated scan must say so — `branches_seen` and `branches_checked` in
+   evidence, and a detail that names the limit — because an `ok` over an
+   unstated subset is the §8.3 rule violated in miniature.
+
+## 11. Acceptance
+
+Every line is a command or a test that decides the answer.
+
+| check | command | pass |
+|---|---|---|
+| #458 shape closed | doctor on a repo with stranded staged captures | `status` ≠ `ok`; `pending-backlog` in `fixPlan`; headline names it |
+| v1 superset | decode `doctor --json` with a v1-shaped reader | every v1 key present, same types, `exitCode` unchanged |
+| schema pinned | `doctor --json \| jq -r .schema` | `commitlore_doctor.v2` |
+| collapse | dead hook runtime fixture | `commit-msg-hook.blockedBy == "hook-runtime"`; fixPlan omits the blocked id, keeps the root |
+| independent failure survives collapse | fixture failing both a dependency and the dependent for its own reason | dependent appears in `fixPlan` with `blockedBy` unset |
+| typed skips | every `skipped` row in the suite's fixtures | carries a §1.2 `skipReason` |
+| crash containment | registry entry whose `run` throws (test-only) | doctor exits normally; that id is a `fail` row with `error` evidence |
+| exit codes | fixtures for ok / degraded / failed / bad `--only` | `0` / `0` / `1` / `2` |
+| release gate unchanged | `dist/commitlore.mjs doctor` on a fresh clone | exit 0, no `fail` (RELEASE-GATE §4 row still passes) |
+| no network | full run with sockets stubbed to throw | all checks complete |
+| read-only | full run without `--fix` under a watched fs | zero writes |
+| partial honesty | `doctor --only cli-runtime --json` | `selection` present; headline prefixed `1 of 13 checks run` |
+| summary invariant | property test over fixtures | counts sum to `total == checks.length`; `durationMs` sums |
+| budget | timed run per §10.1 | within the recorded budget |
+
+Each fix in this table has a test that fails when that one fix is reverted —
+reverting is the evidence, as the release gate already requires of its own
+sections.

--- a/docs/adr/ADR-0032-doctor-diagnostic-model.md
+++ b/docs/adr/ADR-0032-doctor-diagnostic-model.md
@@ -9,6 +9,70 @@
   to see); SPEC §10 (exit codes); `docs/DOCTOR-PRD.md` (the requirements this
   decision authorises)
 
+## What the adversarial review changed
+
+The first revision of this ADR and its PRD went through an adversarial review
+that returned three blocking findings, seven major, three minor. The review
+was right on every point we could verify against source, and two of its
+findings were not refinements but reversals of claims this document stated as
+fact. A silent fix would be the same failure this ADR exists to prevent, so
+the corrections are listed here:
+
+1. **`status: "ok"` was unreachable.** The first revision derived `degraded`
+   from *any* non-optional skip. `squash-conservation`, `inject-runtime`, and
+   `inject-version` skip routinely on ordinary healthy repositories, so the
+   healthy default was permanent `degraded` — the #458 first-screen lie with
+   its polarity flipped. Replaced by skip classes (§2): only a
+   could-not-verify skip degrades; an observed true empty does not.
+2. **The central invariant had three demonstrated holes.** A repaired-but-
+   unfetched notes mirror could still aggregate `ok` (nothing consulted the
+   remote's advertisement); a repository that never produced a record could
+   aggregate `ok`; and `ok` with empty evidence typechecked. Closed by the
+   `notes-availability` and `capture-liveness` checks (PRD §2.2) and by
+   requiring evidence on every row, `ok` included (§8.3). One adjacent case
+   is deliberately left open and named, with the reason (PRD §2.2).
+3. **"No network. No socket, ever" was false as written.** The shipping
+   command already probes remotes: `git fetch --dry-run`
+   (`src/commands/doctor.ts:196`) and `git ls-remote` (`doctor.ts:248`). The
+   ban is rescoped honestly in §8.1: doctor's own process opens no socket;
+   git transport probes are existing, bounded, and degrade to `warn` offline.
+4. **The exit-code reasoning was wrong, not merely overstated.** The first
+   revision claimed SPEC §10 *forbids* doctor from exiting `3`. False: an
+   unfetched notes mirror and shallow history are code `3`'s own named
+   examples (`spec/SPEC.md:274`), and RELEASE-GATE §1 already requires
+   `guard` to exit `3` on an unfetched mirror. It also claimed `init` depends
+   on doctor's exit code; `init` branches on `needsAttention`
+   (`src/commands/init.ts:104`) and ignores the exit code. §7 restates the
+   decision on its true grounds — RELEASE-GATE §4 compatibility and SPEC's
+   "a command need not use every code" — and leaves a narrow vision-gap `3`
+   open instead of pretending SPEC closed it.
+5. **The check-order table contradicted the migration.** It reordered checks
+   relative to `runDoctor` while Step 1 promised byte-identical text.
+   Registry order is now frozen to the shipping array order (§4, PRD §2.1).
+6. **`blocked_by` had no algorithm**, and this ADR misattributed
+   SetupDoctor's design: collapse there is construction-time, via a
+   `blockingCause` helper each check calls (`SetupDoctor.swift:634`) — the
+   runner does not stamp it. §5 now specifies one mechanical design: a
+   factory constructor is `blockedBy`'s only producer, and the runner only
+   normalises chains and asserts invariants.
+7. **Provenance errors.** The severity quote sits at `SetupDoctor.swift:63-64`,
+   not `:548` (that line is `severity(for:)`, a different comment); the scale
+   is 3,754 lines across 21 `SetupDoctor*.swift` files (3,784 across 22 only
+   if `DoctorTool.swift` is counted in); the #457 comment cited for `manual`
+   is about check ordering, not the status's definition; several skip strings
+   were quoted inexactly; and the "six skip sites" are ten return sites
+   carrying six reasons. All corrected in place, against re-verified line
+   numbers.
+8. **Cut on review:** the `severity` field (a total function of `status` is a
+   second spelling of `status`; nothing consumed it) and the dedicated
+   install-source check (the entry path now rides `cli-runtime`'s evidence).
+   `summary.durationMs` was two quantities under one name; it is now defined
+   as wall time, with the per-check sum bounded by it (PRD §10.2).
+9. **Kept against the review's advice, with reasons stated:** `--only` /
+   `--category` (filters over registry data that the partial-honesty rule
+   needs defined the moment they exist — PRD §5.5); the OpenClaw reference
+   (it already claims filenames and nothing else).
+
 ## Context
 
 `commitlore doctor` is the command a user runs to learn whether this
@@ -49,9 +113,11 @@ consumer can build against.
 
 ### Reference 1: logic-pro-mcp SetupDoctor (inspected)
 
-`/Users/isaac/projects/logic-pro-mcp/Sources/LogicProMCP/Utilities/` carries a
-doctor grown to 3,784 lines across 22 `SetupDoctor*.swift` files. The files
-read for this ADR: `SetupDoctor.swift`, `SetupDoctor+CheckRegistry.swift`,
+A local checkout of logic-pro-mcp
+(`Sources/LogicProMCP/Utilities/`) carries a doctor grown to 3,754 lines
+across 21 `SetupDoctor*.swift` files (3,784 across 22 counting the
+`DoctorTool.swift` entry point). The files read for this ADR:
+`SetupDoctor.swift`, `SetupDoctor+CheckRegistry.swift`,
 `SetupDoctor+CheckRunner.swift`, `SetupDoctor+Rendering.swift`,
 `SetupDoctor+V4.swift`, and the install-source detection in
 `SetupDoctor+InstallChecks.swift`. Its verified model:
@@ -65,24 +131,27 @@ read for this ADR: `SetupDoctor.swift`, `SetupDoctor+CheckRegistry.swift`,
   optionality, remediation anchor. A runner walks the registry, times each
   check with a monotonic clock, and stamps `duration_ms`.
 - Root-cause collapse: a check whose declared dependency is not `pass` carries
-  `blocked_by: <root cause id>`; `computeFixPlan` (SetupDoctor.swift:599)
-  filters blocked checks out and sorts the remainder fail-first, so the fix
-  plan names causes, not symptoms.
+  `blocked_by: <root cause id>`, set at construction — each dependent check
+  consults the shared `blockingCause(for:checks:)` helper
+  (`SetupDoctor.swift:634`), which walks the declared dependency table and
+  returns the first non-pass dependency; the runner does not stamp it.
+  `computeFixPlan` (`SetupDoctor.swift:599`) filters blocked checks out and
+  sorts the remainder fail-first, so the fix plan names causes, not symptoms.
 - Additive-only schema versioning. The comments are explicit: `blockedBy` is
   `String?` "so the synthesized Codable emits `encodeIfPresent` — the
   `blocked_by` key is OMITTED when nil, keeping v3 a strict superset a v1/v2
-  decoder never trips over" (SetupDoctor.swift:88-91), and CodingKeys
+  decoder never trips over" (`SetupDoctor.swift:88-91`), and CodingKeys
   "enumerate EVERY key — the six v1 keys keep their exact wire names so a v2
-  payload stays a strict field-superset of v1" (SetupDoctor.swift:96-98).
+  payload stays a strict field-superset of v1" (`SetupDoctor.swift:96-98`).
 - An honesty chokepoint: `clampStatusForPermissions`
-  (SetupDoctor+Rendering.swift:207) makes it structurally impossible for the
+  (`SetupDoctor+Rendering.swift:207`) makes it structurally impossible for the
   report to say `ok` while a required permission is ungranted — the invariant
   is owned by one tested function, not left emergent on each check.
 
 ### Reference 2: OpenClaw (not inspectable)
 
 OpenClaw's doctor implementation is not on this machine. What exists is output
-artefacts under `/Users/isaac/.openclaw/tmp/`: files named `doctor-ent-*`
+artefacts under `~/.openclaw/tmp/`: files named `doctor-ent-*`
 (440), `doctor-cli-*` (40), and `doctor-degraded-*` (40), counted by filename
 prefix. The taxonomy is evidence that per-surface report profiles and a
 distinct `degraded` overall state are established practice in a shipped tool.
@@ -100,62 +169,84 @@ meanings: `fail` — the tool cannot work correctly here; `warn` — the setup i
 incomplete but nothing gives a wrong answer locally; `skipped` — the check
 exists but had nothing it could inspect, which is not a pass.
 
-SetupDoctor's fifth status, `manual`, names an operator attestation for setup
-steps the tool can neither perform nor verify (macOS TCC panels, MIDI Learn —
-see the #457 comment in `SetupDoctor+CheckRegistry.swift:118-126`). CommitLore
-has no such surface: every remediation this doctor can name is a command. A
-status no check can emit is a report state every consumer must handle and none
-can ever observe. If a genuinely unverifiable manual step ever appears, adding
-the status then is additive under §6.
+SetupDoctor's fifth status, `manual` (`SetupDoctor.swift:9`), names an
+operator attestation for setup steps the tool can neither perform nor verify.
+The #457 comment in `SetupDoctor+CheckRegistry.swift:118-126` — which is
+about ordering the attestation check after the staging it attests, not about
+the status's definition — shows the surface class: manual MIDI Learn "that no
+file presence can prove". CommitLore has no such surface: every remediation
+this doctor can name is a command. A status no check can emit is a report
+state every consumer must handle and none can ever observe. If a genuinely
+unverifiable manual step ever appears, adding the status then is additive
+under §6.
 
-### 2. A skip carries a typed reason
+### 2. A skip carries a typed reason, and every reason carries a class
 
-`skipReason` becomes a closed union alongside the human `detail`. The initial
-values are exactly the reasons the current checks already emit as prose, one
-per distinct site:
+`skipReason` becomes a closed union alongside the human `detail`. Each member
+is classified, in its declaration, as one of two classes:
 
-| Reason | Current site (detail text on `origin/dev`) |
-|---|---|
-| `command_unrecognized` | "not checked: the configured command is not recognised" (inject-runtime, inject-version) |
-| `hook_not_installed` | "no installed hook to compare against" (inject-version) |
-| `probe_path_unavailable` | "no recorded path is available for a runtime probe" (inject-runtime) |
-| `version_unreadable` | "did not report a version" / "answered --version with something that is not a version" (inject-version) |
-| `unborn_head` | "no HEAD yet — nothing to compare against" (squash-conservation) |
-| `nothing_applicable` | "no local branch looks like the source of a squash" / "recorded nothing checkable" (squash-conservation) |
+- **`not_applicable`** — the check looked and observed a true empty: the
+  world contains nothing for this check to inspect, and that observation is
+  in evidence. Does **not** degrade the overall status.
+- **`unverified`** — something exists that the check could not read. Degrades
+  the overall status (§6), because "could not verify" is precisely what
+  `degraded` exists to say.
+
+The initial values are exactly the reasons the current checks already emit as
+prose — ten return sites carrying six reasons (the first revision said "six
+sites" and quoted several strings inexactly; both were review findings). Line
+numbers are the `origin/dev` file:
+
+| Reason | Class | Sites (exact `detail` on `origin/dev`) |
+|---|---|---|
+| `command_unrecognized` | `unverified` | inject-runtime `:608` ("not checked: configured command `<cmd>` is not recognised; running it might have side effects"), `:621` and inject-version `:703` ("not checked: the configured command is not recognised") |
+| `hook_not_installed` | `not_applicable` | inject-version `:699` ("no installed hook to compare against `<version>`") |
+| `probe_path_unavailable` | `not_applicable` | inject-runtime `:628` ("no recorded path is available for a runtime probe") |
+| `version_unreadable` | `unverified` | inject-version `:721` ("`<executable>` did not report a version"), `:733` ("`<executable>` answered --version with something that is not a version") |
+| `unborn_head` | `not_applicable` | squash-conservation `:934` ("no HEAD yet — nothing to compare against") |
+| `nothing_applicable` | `not_applicable` | squash-conservation `:942` ("no local branch looks like the source of a squash — nothing to check"), `:992` ("`<n>` branch(es) looked like a squash source, but recorded nothing checkable") |
 
 SetupDoctor's enum has 18 values because its check set earned them one at a
 time; ours starts with the six we can point at and grows the same way. The
-rule: a check may not report `skipped` without a reason from the union, so
-adding a new skip site forces the taxonomy to grow — the type system enforces
-what a free string cannot.
+rule: a check may not report `skipped` without a reason from the union, and a
+reason cannot be declared without a class — the type system enforces both.
 
-### 3. Category and severity are derived at one chokepoint
+### 3. Each check declares one of six categories
 
-Each check declares one of six categories: `runtime` (cli-runtime,
-git-trailers), `transport` (notes-refspec, notes-push), `capture`
-(commit-msg-hook, hook-runtime, pending-backlog), `delivery` (inject-runtime,
+`runtime` (cli-runtime, git-trailers), `transport` (notes-refspec,
+notes-push, notes-availability), `capture` (commit-msg-hook, hook-runtime,
+pending-backlog, capture-liveness), `delivery` (inject-runtime,
 inject-version, mcp-lifecycle), `history` (history-depth,
 squash-conservation), `index` (index-health). Every category is non-empty and
 answers the question a category exists to answer: which subsystem is broken,
 and what can `--category` select.
 
-Severity is `error | warning | info`, derived totally from status (`fail` →
-error; `warn` → warning; `ok`/`skipped` → info) in the single `check(...)`
-factory, exactly as SetupDoctor derives it (SetupDoctor.swift:548, "Display-
-grade severity derived from `CheckStatus` … never drives the exit code"). It
-orders the fix plan and the headline. An independent severity axis was
-considered and rejected below.
+The first revision also carried a `severity` field (`error | warning | info`,
+derived totally from `status`). The review cut it: a field that is a total
+function of another field is a second spelling of the same fact, and nothing
+here consumed it — the fix plan orders by `status` directly (§7 of the PRD).
+SetupDoctor carries one ("Display-grade severity derived from `CheckStatus`
+… never drives the exit code", `SetupDoctor.swift:63-64` — the first revision
+mis-cited this to `:548`, which is the `severity(for:)` mapping function)
+because its renderer consumes it; ours had no consumer. If a multi-axis need
+ever appears, adding a field is additive under §6.
 
 ### 4. Checks are registry entries, and dependencies are declared data
 
 The hand-written array in `runDoctor` becomes a registry: an ordered array of
 definitions `{ id, title, category, dependencies, optional, run }`. The
-runner walks it, times each check with a monotonic clock
-(`process.hrtime.bigint()`, whole milliseconds, so a duration can never go
-negative across a clock step — the same choice as SetupDoctor's
-`monotonicNowMs`), stamps `durationMs`, and catches a thrown check into a
-`fail` row carrying the error as evidence. Doctor must never die of its own
-check; today a throw in any `checkX` kills the whole command.
+registry array order is the presentation order for text and JSON, and it is
+frozen to `runDoctor`'s shipping array order (`src/commands/doctor.ts:1021-1036`)
+— which presents `commit-msg-hook` before its dependency `hook-runtime`, so a
+dependency edge may point forward in the array. The graph must be acyclic
+(enforced by the registry-shape test); the runner completes dependencies
+before dependents while emitting rows in registry order. The runner times
+each check with a monotonic clock (`process.hrtime.bigint()`, whole
+milliseconds, so a duration can never go negative across a clock step — the
+same choice as SetupDoctor's `monotonicNowMs`), stamps `durationMs`, and
+catches a thrown check into a `fail` row carrying the error as evidence.
+Doctor must never die of its own check; today a throw in any `checkX` kills
+the whole command.
 
 What the registry buys, concretely: stable ordering that tests can assert;
 `--only <id,...>` and `--category <name>` as filters over data instead of new
@@ -168,24 +259,37 @@ a comment: "`checkInjectRuntime` owns 'the hook does not run at all'. Saying
 it twice would be noise"). Only demonstrated dependencies are declared;
 speculative edges are how a fix plan hides a real failure.
 
-### 5. Root-cause collapse: `blocked_by` annotates, never suppresses
+### 5. Root-cause collapse: `blocked_by` annotates, never suppresses — and has one producer
 
-When a check's declared dependency is not `ok`, the check carries
-`blockedBy: <the earliest non-ok ancestor's id>` and reports `skipped` if it
-could not meaningfully probe, or its natural status if it could. Three
-invariants bound what collapse may do:
+The first revision described collapse in prose loose enough that two
+implementers could satisfy it incompatibly (a review finding), and it
+attributed the collapse to the runner — which is also not how SetupDoctor
+works (its checks call `blockingCause` at construction,
+`SetupDoctor.swift:634`). The specified design, normative in PRD §3:
 
-1. Every applicable registered check appears in `checks[]` exactly once —
-   `blocked_by` never removes a row or its evidence.
-2. `blockedBy` never points at an `ok` check, and chains resolve to the root
-   (if A blocks B blocks C, C carries A).
-3. A check that fails *for its own reason* keeps `blockedBy` unset even when
-   a dependency also failed. Collapse is for failures the root cause
-   explains; attributing an independent defect to the root cause is exactly
-   the hiding this section's invariants exist to prevent.
+1. The runner completes declared dependencies first and passes their finished
+   rows into the dependent's `run`.
+2. `blockedBy` has exactly one producer: the check factory's `blocked(dep, …)`
+   constructor, which requires `dep` to be a declared dependency whose row is
+   non-`ok`, and yields either a row whose status and detail derive from the
+   dependency's row (the `commit-msg-hook` shape today,
+   `doctor.ts:336-343`) or a `skipped` row with a typed reason (the
+   `inject-version` shape today). A row built any other way has `blockedBy`
+   unset, and the runner never adds it — so an independent defect can only be
+   reported unblocked.
+3. After the run, the runner normalises chains to the root (if A blocks B
+   blocks C, C carries A) and asserts the invariants: `blockedBy` names a
+   declared dependency; the target row is non-`ok`; a blocked row's status
+   never exceeds its root's.
+4. Every applicable registered check appears in `checks[]` exactly once —
+   `blocked_by` never removes a row or its evidence. Only the fix plan and
+   the overall-status derivation exclude blocked rows, because their root
+   already represents them.
 
 The fix plan (§7 of the PRD) is where collapse pays: blocked entries are
 filtered out, so one dead hook runtime is one instruction, not four warnings.
+The collapse fixtures in PRD §11 are the definition of this behaviour; where
+prose and fixture disagree, the fixture wins.
 
 ### 6. The report is versioned, and the version contract is additive-only
 
@@ -197,66 +301,105 @@ v2 is a strict superset of it: every v1 key keeps its exact name, type, and
 meaning, including the camelCase `needsAttention` and `exitCode`.
 
 The compatibility contract, taken directly from what SetupDoctor wrote down
-and we verified (SetupDoctor.swift:88-98): new fields may be added without a
+and we verified (`SetupDoctor.swift:88-98`): new fields may be added without a
 version bump; optional fields are **omitted when absent, never null** (the
 JavaScript analogue of `encodeIfPresent`), so an old consumer never meets a
 key it must learn to ignore as null; a field is never removed or repurposed —
 that requires a new schema id and a superseding ADR. A consumer that pins
 `commitlore_doctor.v2` and reads only the keys it knows is safe forever.
 
-Overall `status` derives from non-optional checks only: any `fail` → `failed`;
-else any `warn` or non-optional `skipped` → `degraded`; else `ok`. `degraded`
-is the state #458 needed a word for — usable, but something this repository
-relies on has stopped or cannot be verified — and both references treat it as
-a first-class state (SetupDoctor's `ReportStatus.degraded`; OpenClaw's
-`doctor-degraded-*` artefacts).
+Overall `status` derives from non-optional rows whose `blockedBy` is unset:
+any `fail` → `failed`; else any `warn`, or any `skipped` whose reason class
+is `unverified` → `degraded`; else `ok`. The classes exist because the first
+revision's rule — any non-optional skip degrades — made `ok` unreachable:
+`squash-conservation` skips on every repository with no squash-shaped branch
+(`doctor.ts:942`), `inject-runtime` on any repository with no recorded path
+to probe (`doctor.ts:628`). Permanent `degraded` on a healthy repository is
+the #458 lie with its polarity flipped, which is exactly what the adversarial
+review caught. `degraded` is the state #458 needed a word for — usable, but
+something this repository relies on has stopped or cannot be verified — and
+both references treat it as a first-class state (SetupDoctor's
+`ReportStatus.degraded`; OpenClaw's `doctor-degraded-*` artefacts).
 
-### 7. Exit codes: `0` and `1`, exactly as SPEC §10 assigns them
+### 7. Exit codes: `0` and `1`, with the earlier SPEC reasoning corrected
 
 Doctor keeps two codes: `0` — ran, no non-optional check failed; `1` — ran,
 at least one non-optional check failed. `1` is a finding, which is precisely
-SPEC §10's meaning for it. `degraded` (warns, skips) stays exit `0` and lives
-in the `status` field.
+SPEC §10's meaning for it. `degraded` (warns, unverified skips) stays exit
+`0` and lives in the `status` field.
 
-SetupDoctor maps its four report statuses onto 0/1/2/3
-(`strictExitCode`, SetupDoctor+Rendering.swift:181). That mapping is not
-carried over, for a reason SPEC §10 states outright: a code "must mean the
-same thing regardless of which command produced it", `2` means *could not
-run*, and `3` means *the command itself could not see everything*. A degraded
-repository is not doctor failing to run, and doctor reporting a shallow clone
-is doctor seeing fine — the incompleteness belongs to the repository, not to
-doctor's own vision. Mapping `degraded → 3` would give `3` a meaning no other
-command gives it, which §10 forbids. `2` remains what commander already emits
-for usage errors (an unknown flag, an unknown `--only` id).
+The first revision justified this by claiming SPEC §10 *forbids* doctor from
+exiting `3` for a degraded repository. **That was wrong**, and it is
+corrected here rather than softened: SPEC §10 defines `3` as "Ran and
+answered, but could not see everything — an unfetched notes mirror, shallow
+history" (`spec/SPEC.md:274`). Those are `3`'s own named examples — the
+shared protocol meaning, not a doctor-private one — and RELEASE-GATE §1
+already requires `guard` to exit `3` on an unfetched mirror. What SPEC
+actually forbids is a command-private meaning, and what it actually permits
+is the licence doctor relies on: "A command need not use every code"
+(`spec/SPEC.md:276`).
 
-Two existing contracts also depend on warn-exits-zero and would break:
-`docs/RELEASE-GATE.md` §4 requires `dist/commitlore.mjs doctor` on a fresh
-clone to exit 0 with no `fail` (a fresh clone legitimately warns), and `init`
-runs `doctor --fix` on its success path. Hooks are fail-open (ADR-0021 §5);
+The decision therefore stands on its true grounds:
+
+1. **Warn keeps exiting `0` for RELEASE-GATE §4 compatibility.** The gate
+   requires `dist/commitlore.mjs doctor` on a fresh clone to exit 0 with no
+   `fail`, and a fresh clone legitimately warns. This is compatibility debt,
+   not protocol purity: a consumer that branches only on the exit code stays
+   green while `status` says `degraded`, and a consumer that cares must read
+   `status`. The documents say so plainly instead of dressing it as a SPEC
+   theorem.
+2. **A blanket `degraded → 3` would still be wrong** — a "no remote
+   configured" warn is not a vision gap, and stretching `3` over it would be
+   the private meaning SPEC forbids.
+3. **Exit `3` for the vision-gap rows specifically** — `history-depth`'s
+   shallow-clone warn (`doctor.ts:837-845`) and `notes-availability`'s
+   unfetched-mirror warn — **remains open, and is arguably better aligned**
+   with SPEC and with `guard`/`stale`. It is deferred, not rejected: the
+   RELEASE-GATE §4 fresh-clone row (where notes are legitimately unfetched)
+   would have to move in the same change, and that is a gate decision, not a
+   doctor-local one.
+
+The first revision also claimed `init`'s `doctor --fix` step depends on
+warn-exits-zero. It does not: `init` branches on
+`report.checks.some((entry) => entry.needsAttention)`
+(`src/commands/init.ts:104`) and ignores the exit code entirely. The claim is
+deleted. `2` remains what commander already emits for usage errors (an
+unknown flag, an unknown `--only` id). Hooks are fail-open (ADR-0021 §5);
 nothing doctor reports may ever block a commit, and nothing in this decision
 touches a hook path.
 
 ### 8. What doctor must never do
 
-1. **No network, ever.** Not opt-in, not with a flag. SetupDoctor made its
-   update lookup opt-in and its default airtight ("nil ⇒ the opt-in update
-   check is not emitted and no network is touched",
-   SetupDoctor.swift:302-303); we go further and do not ship the lookup.
-   Version skew is already checked against *local* executables
-   (inject-version), and the #433 class of staleness (a plugin pinned three
-   releases behind) is a distribution defect whose fix lives in distribution
-   — `installSource` exists so the report can name which channel to update,
-   not so doctor can go ask the internet.
+1. **No non-git network.** The first revision said "No network, ever." That
+   was false against the shipping command — the transport checks already
+   probe remotes with `git fetch --dry-run` (`doctor.ts:196`) and
+   `git ls-remote` (`doctor.ts:248`) — and the review caught it, so the ban
+   is rescoped rather than quietly narrowed. The rule: doctor's own process
+   opens no socket — no HTTP client, no update lookup (SetupDoctor made its
+   update check opt-in, "nil ⇒ the opt-in update check is not emitted and no
+   network is touched", `SetupDoctor.swift:302-303`; we do not ship the
+   lookup at all), no telemetry, on any flag. Network I/O happens only inside
+   spawned `git` transport commands against the repository's configured
+   remotes, only in `transport`-category checks, and an unreachable remote
+   degrades those rows to `warn` "could not verify" — never a `fail`, never a
+   crash, never a hang without git's own timeout semantics. Version skew is
+   checked against *local* executables (inject-version), and the #433 class
+   of staleness is a distribution defect whose fix lives in distribution —
+   `installSource` exists so the report can name which channel to update, not
+   so doctor can go ask the internet.
 2. **No writes without `--fix`**, and `--fix` applies only reversible local
    configuration (today: the notes fetch refspec), reporting each change in
    the check row it fixed (`fixed: true`). This is current behaviour,
    promoted to an invariant.
-3. **No claim without evidence.** A check may not report `ok` about a
-   subsystem it did not observe; absence of signal is `skipped` with a typed
-   reason, never `ok`. Every non-ok check carries the evidence that produced
-   its status. This is the #458 rule, and it is owned by the registry runner
-   the way SetupDoctor owns its honesty clamp in one tested function — not
-   left emergent on each check happening to behave.
+3. **No claim without evidence — on any status.** Every row records the
+   observation that produced it: `ok` carries what was observed, not just
+   asserted (the first revision required evidence only for non-ok rows,
+   which let an implementer emit `ok` with empty evidence and typecheck — a
+   review finding); absence of signal is `skipped` with a typed reason,
+   never `ok`. This is the #458 rule, owned by the factory and the runner
+   the way SetupDoctor owns its honesty clamp in one tested function
+   (`clampStatusForPermissions`) — not left emergent on each check happening
+   to behave.
 4. **A partial run never masquerades as a full one.** Under `--only` or
    `--category` the report carries the selection, and its `status` speaks
    only for the selected checks.
@@ -264,28 +407,44 @@ touches a hook path.
 ### 9. Migration: the existing checks keep working, verbatim
 
 The 12 checks on `origin/dev` (13 with #458's `pending-backlog`) keep their
-ids, titles, statuses, and detail strings byte-for-byte. Each `const checkX`
-body becomes the `run` of a registry entry; the `hookRuntime` parameter
-threading becomes the declared `commit-msg-hook → hook-runtime` dependency
-with identical observable behaviour; the six skip-detail strings map onto the
-§2 reasons without changing the text a human reads. Existing doctor tests
-pass unchanged, and a new test asserts the v1 → v2 superset property
+ids, titles, statuses, and detail strings byte-for-byte, in their current
+output order — the registry freezes `runDoctor`'s array order, it does not
+reorder it. Each `const checkX` body becomes the `run` of a registry entry;
+the `hookRuntime` parameter threading becomes the declared
+`commit-msg-hook → hook-runtime` dependency built through the blocked
+constructor, which reproduces today's copied status and detail exactly
+(`doctor.ts:336-343`) — the only observable change is the additive
+`blockedBy` key and the fix-plan membership. The ten skip return sites map
+onto the §2 reasons without changing the text a human reads. Existing doctor
+tests pass unchanged, and a new test asserts the v1 → v2 superset property
 directly: every key of the old JSON shape is present with the same value in
-the new one. The exact sequencing is in `docs/DOCTOR-PRD.md` §9.
+the new one. The two checks this decision adds beyond `pending-backlog` —
+`notes-availability` and `capture-liveness` (PRD §2.2) — are behaviour
+changes by design and land after the mechanical steps. The exact sequencing
+is in `docs/DOCTOR-PRD.md` §9.
 
 ## Rejected
 
 - **`manual` status and `manual_action_required` report state** | no
   CommitLore check has a remediation outside a command; a status nothing
   emits is dead contract surface. Additive to add later if one appears
-- **SetupDoctor's `strictExitCode` 0/1/2/3 mapping** | collides with SPEC
-  §10's fixed protocol-wide meanings for 2 and 3; breaks RELEASE-GATE §4 and
-  `init`'s doctor invocation. The distinction it encodes lives in the
-  `status` field instead
-- **Independent severity axis (severity declared per check, not derived)** |
-  two axes that can disagree ("a `fail` marked `info`") make every consumer
-  resolve the disagreement; deriving at one chokepoint makes inconsistency
-  unrepresentable. SetupDoctor reached the same conclusion
+- **SetupDoctor's `strictExitCode` 0/1/2/3 mapping, wholesale** | a blanket
+  `degraded → 3` gives `3` to warns that are not vision gaps — the private
+  meaning SPEC §10 forbids — and any non-zero on warns breaks RELEASE-GATE
+  §4. A narrow `3` for vision-gap rows only is *not* rejected; it is open
+  (§7.3). The first revision's grounds for this rejection ("SPEC forbids
+  doctor exiting 3"; "breaks `init`") were wrong and are corrected in §7
+- **A `severity` field, derived or declared** | the first revision kept a
+  derived field and rejected only an independently-declared axis; the review
+  cut the field itself. A total function of `status` on the wire is a second
+  spelling of `status`, and no CommitLore consumer reads it — the fix plan
+  orders by `status`. SetupDoctor's field has a consumer (its renderer);
+  ours would not
+- **A dedicated install-source check** | it was either a fourteenth check
+  (a behaviour change the migration would have to sequence) or buried
+  evidence. The envelope keeps the `installSource` field (#433 justifies
+  naming the channel), and the resolved entry path rides `cli-runtime`'s
+  evidence as `entry_path` — inspectable without a new row
 - **SetupDoctor's capability/operation-readiness matrix** (`capabilities`,
   `OperationReadinessRow`) | it exists because logic-pro-mcp routes
   operations across channels with per-operation planners; CommitLore has no
@@ -297,10 +456,13 @@ the new one. The exact sequencing is in `docs/DOCTOR-PRD.md` §9.
   screen that lied by not looking. CommitLore has one install shape per
   repository and no check yet measured expensive enough to need exclusion;
   not-applicable is expressed per check via typed skip, and `--only`/
-  `--category` cover the debugging and CI subset uses. Revisit only with a
-  measurement showing the full set is too slow for a surface
+  `--category` cover the debugging and CI subset uses. The review suggested
+  deferring `--only`/`--category` as well; they stay, because they are
+  filters over registry data — not new code paths — and the partial-honesty
+  rule (§8.4) must be defined the moment any filter exists. Revisit profiles
+  only with a measurement showing the full set is too slow for a surface
 - **Collapsing evidence stdout/stderr to `present`/`empty`**
-  (SetupDoctor.swift:497-515) | SetupDoctor sanitises because its evidence
+  (`SetupDoctor.swift:497-515`) | SetupDoctor sanitises because its evidence
   can carry TCC paths and tokens; CommitLore's checks diagnose *from* stderr
   first lines (`hook-runtime`, `inject-runtime`) and have no secret-bearing
   streams. Evidence keeps bounded excerpts (first line, capped length)
@@ -310,6 +472,12 @@ the new one. The exact sequencing is in `docs/DOCTOR-PRD.md` §9.
   one report, not our style preference, and a mixed-case document is worse
   than a consistently legacy-cased one
 - **A network update check, even opt-in** | see §8.1
+- **A capture-recency heuristic** (flagging a repository whose records
+  stopped recently while pending is clean) | SPEC line 155 makes a record
+  per commit optional, so recent recordless commits are not evidence of
+  breakage, and a ratio-or-recency guess would be the heuristic class SPEC
+  §2.1 B3 already taught this project to refuse. The gap this leaves is
+  named, not hidden: PRD §2.2
 - **Patching #458 inside the current structure and stopping** | the pending-
   backlog check ships regardless (it is in flight on `doctor-pending-backlog`
   now), but a 13th ad-hoc function in a 1,159-line file leaves the next #458
@@ -318,14 +486,19 @@ the new one. The exact sequencing is in `docs/DOCTOR-PRD.md` §9.
 ## Consequences
 
 - `src/commands/doctor.ts` splits into a registry, a runner, per-check
-  modules, and a renderer; the PRD fixes the layout. The command's observable
-  text output for existing checks does not change.
+  modules, and a renderer; the PRD fixes the layout and marks the split as
+  cleanup that may trail the honesty fixes. The command's observable text
+  output for existing checks does not change.
 - `--json` becomes a documented, versioned contract; `docs/cli.md` documents
   the envelope and the additive rule, and the release gate can script against
   `status` instead of grepping.
 - `pending ls`-shaped knowledge now has a place doctor can carry it to — the
   #458 check is the first registry entry in the `capture` category with a
   dependency-free root position.
+- Two checks are added beyond #458's: `notes-availability` (the mirror-content
+  gap that let "refspec fixed, nothing fetched" aggregate `ok` — the #402
+  shape) and `capture-liveness` (the never-produced-a-record gap — #458's
+  literal shape). Both are specified with mechanical predicates in PRD §2.2.
 - The report grows fields (`durationMs`, `evidence`) that make doctor's own
   performance and claims measurable. The current per-check wall time is
   unmeasured; per-check timing is how the PRD's budget stops being an
@@ -341,17 +514,26 @@ is demonstrated:
 
 1. A repository state in which a subsystem doctor reports on has verifiably
    stopped working while the report's overall `status` is `ok` (the #458
-   invariant, restated as a property).
+   invariant, restated as a property). One case is already named as open
+   rather than closed — capture that produced records before, stopped, with
+   a clean pending directory (PRD §2.2) — because no mechanical local
+   predicate for it exists; producing such a predicate converts that case
+   into this clause.
 2. A `blocked_by` annotation that suppresses evidence of an independent
    failure — a check failing for its own reason rendered invisible in both
    `checks[]` and `fixPlan` because an unrelated dependency also failed.
 3. A published v2 report that a correct v1 consumer (`report.checks.some(c =>
    c.status === 'fail')`, `report.exitCode`) mis-reads — any removed key,
    renamed key, or null-instead-of-omitted optional.
-4. A doctor run that exits `2` or `3` for a repository finding, or exits
-   non-zero for a `degraded` report — either would give a SPEC §10 code a
-   doctor-private meaning.
+4. A doctor run that exits `2` for anything other than failure to run, or
+   exits `1` on a report with no non-optional `fail` (which would break
+   RELEASE-GATE §4). Adopting exit `3` for vision-gap rows falsifies nothing
+   here — §7.3 leaves it open — provided RELEASE-GATE §4 moves in the same
+   change.
 5. A check crash that terminates doctor instead of producing a `fail` row.
-6. The full check set measured slow enough on a real repository that users
+6. A healthy repository — records present, hook current, mirror fetched —
+   whose overall `status` is not `ok` (the polarity the adversarial review
+   caught; PRD §11 pins it as a fixture).
+7. The full check set measured slow enough on a real repository that users
    skip running doctor — which would reopen the profiles rejection with the
    measurement the rejection asked for.

--- a/docs/adr/ADR-0032-doctor-diagnostic-model.md
+++ b/docs/adr/ADR-0032-doctor-diagnostic-model.md
@@ -1,0 +1,357 @@
+# ADR-0032: doctor's diagnostic model — typed checks, root-cause collapse, and an additive report schema
+
+- Status: Proposed (2026-08-08)
+- Issue: [#458](https://github.com/MongLong0214/commitlore/issues/458)
+- Related: [#402](https://github.com/MongLong0214/commitlore/issues/402),
+  [#400](https://github.com/MongLong0214/commitlore/issues/400) (the same
+  failure category, collected in `docs/SELF-AUDIT.md` §4 as "The first screen
+  lied"); ADR-0021 (the pending transaction whose silent expiry doctor failed
+  to see); SPEC §10 (exit codes); `docs/DOCTOR-PRD.md` (the requirements this
+  decision authorises)
+
+## Context
+
+`commitlore doctor` is the command a user runs to learn whether this
+repository can carry and share records. Today it is a single 1,159-line file
+(`src/commands/doctor.ts`, including the in-flight #458 check; 1,072 lines on
+`origin/dev`) whose model is two interfaces:
+
+```ts
+interface DoctorCheck { id, title, status, needsAttention, detail, fix: string|null, fixed: boolean }
+interface DoctorReport { checks: DoctorCheck[], exitCode: number }
+```
+
+Twelve checks are written as ad-hoc `const checkX = (opts) => DoctorCheck`
+functions and assembled in a hand-written array inside `runDoctor`. `--json`
+dumps the struct verbatim: no schema identifier, no version field, no
+machine-readable evidence. `skipped` exists as a status but its reason is a
+free-text `detail` string. One dependency between checks exists, and it is
+expressed by passing one check's result into another's parameter list
+(`checkHook(opts, hookRuntime)`).
+
+What forced this ADR is #458. A repository with 815 commits and **zero**
+CommitLore records had doctor report all ten of its checks `ok`. Four captures
+sat stranded in `.git/commitlore/pending/` for eight days — one of them staged
+with a passing validation. Every component behaved as designed (ADR-0021's
+five-minute staged expiry did its job) and the net effect was that the product
+had silently stopped producing records while its diagnostic said everything
+was fine. The information existed — `commitlore pending ls` printed it — but
+the command people actually run did not carry it. That is #402 (`init`
+reported ready on an unfetched mirror) and #400 (`index --rebuild` reported
+unqualified success on a mirror it could not read) again: the first screen
+lied, this time by not looking.
+
+A check-by-check patch closes #458. It does not close the category. The
+category needs a model in which "we did not look" is structurally distinct
+from "we looked and it is fine", in which one broken dependency does not
+produce twelve derivative warnings, and in which `--json` is a contract a CI
+consumer can build against.
+
+### Reference 1: logic-pro-mcp SetupDoctor (inspected)
+
+`/Users/isaac/projects/logic-pro-mcp/Sources/LogicProMCP/Utilities/` carries a
+doctor grown to 3,784 lines across 22 `SetupDoctor*.swift` files. The files
+read for this ADR: `SetupDoctor.swift`, `SetupDoctor+CheckRegistry.swift`,
+`SetupDoctor+CheckRunner.swift`, `SetupDoctor+Rendering.swift`,
+`SetupDoctor+V4.swift`, and the install-source detection in
+`SetupDoctor+InstallChecks.swift`. Its verified model:
+
+- Check statuses `pass | warn | fail | manual | skipped`; report statuses
+  `ok | degraded | failed | manual_action_required`.
+- A closed 18-value `DoctorSkipReason` enum — a skip always says *why* in a
+  value a machine can branch on.
+- 27 checks declared as data (`checkDefinitions` in
+  `SetupDoctor+CheckRegistry.swift`): id, dependencies, inclusion rule,
+  optionality, remediation anchor. A runner walks the registry, times each
+  check with a monotonic clock, and stamps `duration_ms`.
+- Root-cause collapse: a check whose declared dependency is not `pass` carries
+  `blocked_by: <root cause id>`; `computeFixPlan` (SetupDoctor.swift:599)
+  filters blocked checks out and sorts the remainder fail-first, so the fix
+  plan names causes, not symptoms.
+- Additive-only schema versioning. The comments are explicit: `blockedBy` is
+  `String?` "so the synthesized Codable emits `encodeIfPresent` — the
+  `blocked_by` key is OMITTED when nil, keeping v3 a strict superset a v1/v2
+  decoder never trips over" (SetupDoctor.swift:88-91), and CodingKeys
+  "enumerate EVERY key — the six v1 keys keep their exact wire names so a v2
+  payload stays a strict field-superset of v1" (SetupDoctor.swift:96-98).
+- An honesty chokepoint: `clampStatusForPermissions`
+  (SetupDoctor+Rendering.swift:207) makes it structurally impossible for the
+  report to say `ok` while a required permission is ungranted — the invariant
+  is owned by one tested function, not left emergent on each check.
+
+### Reference 2: OpenClaw (not inspectable)
+
+OpenClaw's doctor implementation is not on this machine. What exists is output
+artefacts under `/Users/isaac/.openclaw/tmp/`: files named `doctor-ent-*`
+(440), `doctor-cli-*` (40), and `doctor-degraded-*` (40), counted by filename
+prefix. The taxonomy is evidence that per-surface report profiles and a
+distinct `degraded` overall state are established practice in a shipped tool.
+Nothing more is claimed: the sampled files contain approval-store state, not
+report bodies, so OpenClaw's check model, schema, and exit codes are unknown
+here and this ADR does not cite them.
+
+## Decision
+
+### 1. The check statuses stay `ok | warn | fail | skipped`; there is no `manual`
+
+The four wire values already shipping in `CheckStatus`
+(`src/commands/doctor.ts:67`) are kept unchanged, with their existing
+meanings: `fail` — the tool cannot work correctly here; `warn` — the setup is
+incomplete but nothing gives a wrong answer locally; `skipped` — the check
+exists but had nothing it could inspect, which is not a pass.
+
+SetupDoctor's fifth status, `manual`, names an operator attestation for setup
+steps the tool can neither perform nor verify (macOS TCC panels, MIDI Learn —
+see the #457 comment in `SetupDoctor+CheckRegistry.swift:118-126`). CommitLore
+has no such surface: every remediation this doctor can name is a command. A
+status no check can emit is a report state every consumer must handle and none
+can ever observe. If a genuinely unverifiable manual step ever appears, adding
+the status then is additive under §6.
+
+### 2. A skip carries a typed reason
+
+`skipReason` becomes a closed union alongside the human `detail`. The initial
+values are exactly the reasons the current checks already emit as prose, one
+per distinct site:
+
+| Reason | Current site (detail text on `origin/dev`) |
+|---|---|
+| `command_unrecognized` | "not checked: the configured command is not recognised" (inject-runtime, inject-version) |
+| `hook_not_installed` | "no installed hook to compare against" (inject-version) |
+| `probe_path_unavailable` | "no recorded path is available for a runtime probe" (inject-runtime) |
+| `version_unreadable` | "did not report a version" / "answered --version with something that is not a version" (inject-version) |
+| `unborn_head` | "no HEAD yet — nothing to compare against" (squash-conservation) |
+| `nothing_applicable` | "no local branch looks like the source of a squash" / "recorded nothing checkable" (squash-conservation) |
+
+SetupDoctor's enum has 18 values because its check set earned them one at a
+time; ours starts with the six we can point at and grows the same way. The
+rule: a check may not report `skipped` without a reason from the union, so
+adding a new skip site forces the taxonomy to grow — the type system enforces
+what a free string cannot.
+
+### 3. Category and severity are derived at one chokepoint
+
+Each check declares one of six categories: `runtime` (cli-runtime,
+git-trailers), `transport` (notes-refspec, notes-push), `capture`
+(commit-msg-hook, hook-runtime, pending-backlog), `delivery` (inject-runtime,
+inject-version, mcp-lifecycle), `history` (history-depth,
+squash-conservation), `index` (index-health). Every category is non-empty and
+answers the question a category exists to answer: which subsystem is broken,
+and what can `--category` select.
+
+Severity is `error | warning | info`, derived totally from status (`fail` →
+error; `warn` → warning; `ok`/`skipped` → info) in the single `check(...)`
+factory, exactly as SetupDoctor derives it (SetupDoctor.swift:548, "Display-
+grade severity derived from `CheckStatus` … never drives the exit code"). It
+orders the fix plan and the headline. An independent severity axis was
+considered and rejected below.
+
+### 4. Checks are registry entries, and dependencies are declared data
+
+The hand-written array in `runDoctor` becomes a registry: an ordered array of
+definitions `{ id, title, category, dependencies, optional, run }`. The
+runner walks it, times each check with a monotonic clock
+(`process.hrtime.bigint()`, whole milliseconds, so a duration can never go
+negative across a clock step — the same choice as SetupDoctor's
+`monotonicNowMs`), stamps `durationMs`, and catches a thrown check into a
+`fail` row carrying the error as evidence. Doctor must never die of its own
+check; today a throw in any `checkX` kills the whole command.
+
+What the registry buys, concretely: stable ordering that tests can assert;
+`--only <id,...>` and `--category <name>` as filters over data instead of new
+code paths; each `run` testable in isolation with an injected context (the
+pattern SetupDoctor's `Runtime` struct of function fields exists for); and a
+place to hang the two dependencies that already exist implicitly —
+`commit-msg-hook → hook-runtime` (today a parameter:
+`checkHook(opts, hookRuntime)`) and `inject-version → inject-runtime` (today
+a comment: "`checkInjectRuntime` owns 'the hook does not run at all'. Saying
+it twice would be noise"). Only demonstrated dependencies are declared;
+speculative edges are how a fix plan hides a real failure.
+
+### 5. Root-cause collapse: `blocked_by` annotates, never suppresses
+
+When a check's declared dependency is not `ok`, the check carries
+`blockedBy: <the earliest non-ok ancestor's id>` and reports `skipped` if it
+could not meaningfully probe, or its natural status if it could. Three
+invariants bound what collapse may do:
+
+1. Every applicable registered check appears in `checks[]` exactly once —
+   `blocked_by` never removes a row or its evidence.
+2. `blockedBy` never points at an `ok` check, and chains resolve to the root
+   (if A blocks B blocks C, C carries A).
+3. A check that fails *for its own reason* keeps `blockedBy` unset even when
+   a dependency also failed. Collapse is for failures the root cause
+   explains; attributing an independent defect to the root cause is exactly
+   the hiding this section's invariants exist to prevent.
+
+The fix plan (§7 of the PRD) is where collapse pays: blocked entries are
+filtered out, so one dead hook runtime is one instruction, not four warnings.
+
+### 6. The report is versioned, and the version contract is additive-only
+
+`--json` gains an envelope: `schema: "commitlore_doctor.v2"`, `version` (the
+CLI version), `status: "ok" | "degraded" | "failed"`, `installSource`,
+`headline`, `summary`, `fixPlan`, and the existing `checks` and `exitCode`.
+The current unversioned `{ checks, exitCode }` shape is retroactively v1, and
+v2 is a strict superset of it: every v1 key keeps its exact name, type, and
+meaning, including the camelCase `needsAttention` and `exitCode`.
+
+The compatibility contract, taken directly from what SetupDoctor wrote down
+and we verified (SetupDoctor.swift:88-98): new fields may be added without a
+version bump; optional fields are **omitted when absent, never null** (the
+JavaScript analogue of `encodeIfPresent`), so an old consumer never meets a
+key it must learn to ignore as null; a field is never removed or repurposed —
+that requires a new schema id and a superseding ADR. A consumer that pins
+`commitlore_doctor.v2` and reads only the keys it knows is safe forever.
+
+Overall `status` derives from non-optional checks only: any `fail` → `failed`;
+else any `warn` or non-optional `skipped` → `degraded`; else `ok`. `degraded`
+is the state #458 needed a word for — usable, but something this repository
+relies on has stopped or cannot be verified — and both references treat it as
+a first-class state (SetupDoctor's `ReportStatus.degraded`; OpenClaw's
+`doctor-degraded-*` artefacts).
+
+### 7. Exit codes: `0` and `1`, exactly as SPEC §10 assigns them
+
+Doctor keeps two codes: `0` — ran, no non-optional check failed; `1` — ran,
+at least one non-optional check failed. `1` is a finding, which is precisely
+SPEC §10's meaning for it. `degraded` (warns, skips) stays exit `0` and lives
+in the `status` field.
+
+SetupDoctor maps its four report statuses onto 0/1/2/3
+(`strictExitCode`, SetupDoctor+Rendering.swift:181). That mapping is not
+carried over, for a reason SPEC §10 states outright: a code "must mean the
+same thing regardless of which command produced it", `2` means *could not
+run*, and `3` means *the command itself could not see everything*. A degraded
+repository is not doctor failing to run, and doctor reporting a shallow clone
+is doctor seeing fine — the incompleteness belongs to the repository, not to
+doctor's own vision. Mapping `degraded → 3` would give `3` a meaning no other
+command gives it, which §10 forbids. `2` remains what commander already emits
+for usage errors (an unknown flag, an unknown `--only` id).
+
+Two existing contracts also depend on warn-exits-zero and would break:
+`docs/RELEASE-GATE.md` §4 requires `dist/commitlore.mjs doctor` on a fresh
+clone to exit 0 with no `fail` (a fresh clone legitimately warns), and `init`
+runs `doctor --fix` on its success path. Hooks are fail-open (ADR-0021 §5);
+nothing doctor reports may ever block a commit, and nothing in this decision
+touches a hook path.
+
+### 8. What doctor must never do
+
+1. **No network, ever.** Not opt-in, not with a flag. SetupDoctor made its
+   update lookup opt-in and its default airtight ("nil ⇒ the opt-in update
+   check is not emitted and no network is touched",
+   SetupDoctor.swift:302-303); we go further and do not ship the lookup.
+   Version skew is already checked against *local* executables
+   (inject-version), and the #433 class of staleness (a plugin pinned three
+   releases behind) is a distribution defect whose fix lives in distribution
+   — `installSource` exists so the report can name which channel to update,
+   not so doctor can go ask the internet.
+2. **No writes without `--fix`**, and `--fix` applies only reversible local
+   configuration (today: the notes fetch refspec), reporting each change in
+   the check row it fixed (`fixed: true`). This is current behaviour,
+   promoted to an invariant.
+3. **No claim without evidence.** A check may not report `ok` about a
+   subsystem it did not observe; absence of signal is `skipped` with a typed
+   reason, never `ok`. Every non-ok check carries the evidence that produced
+   its status. This is the #458 rule, and it is owned by the registry runner
+   the way SetupDoctor owns its honesty clamp in one tested function — not
+   left emergent on each check happening to behave.
+4. **A partial run never masquerades as a full one.** Under `--only` or
+   `--category` the report carries the selection, and its `status` speaks
+   only for the selected checks.
+
+### 9. Migration: the existing checks keep working, verbatim
+
+The 12 checks on `origin/dev` (13 with #458's `pending-backlog`) keep their
+ids, titles, statuses, and detail strings byte-for-byte. Each `const checkX`
+body becomes the `run` of a registry entry; the `hookRuntime` parameter
+threading becomes the declared `commit-msg-hook → hook-runtime` dependency
+with identical observable behaviour; the six skip-detail strings map onto the
+§2 reasons without changing the text a human reads. Existing doctor tests
+pass unchanged, and a new test asserts the v1 → v2 superset property
+directly: every key of the old JSON shape is present with the same value in
+the new one. The exact sequencing is in `docs/DOCTOR-PRD.md` §9.
+
+## Rejected
+
+- **`manual` status and `manual_action_required` report state** | no
+  CommitLore check has a remediation outside a command; a status nothing
+  emits is dead contract surface. Additive to add later if one appears
+- **SetupDoctor's `strictExitCode` 0/1/2/3 mapping** | collides with SPEC
+  §10's fixed protocol-wide meanings for 2 and 3; breaks RELEASE-GATE §4 and
+  `init`'s doctor invocation. The distinction it encodes lives in the
+  `status` field instead
+- **Independent severity axis (severity declared per check, not derived)** |
+  two axes that can disagree ("a `fail` marked `info`") make every consumer
+  resolve the disagreement; deriving at one chokepoint makes inconsistency
+  unrepresentable. SetupDoctor reached the same conclusion
+- **SetupDoctor's capability/operation-readiness matrix** (`capabilities`,
+  `OperationReadinessRow`) | it exists because logic-pro-mcp routes
+  operations across channels with per-operation planners; CommitLore has no
+  operation router, and the category roll-up already answers "which subsystem
+  is broken". Carrying it would be structure without a consumer
+- **Profiles (`--profile`, per-surface check sets)** | both references have
+  them (SetupDoctor's `DoctorProfile`; OpenClaw's `ent`/`cli`/`degraded`
+  filenames), but a profile that omits checks reproduces the #458 shape — the
+  screen that lied by not looking. CommitLore has one install shape per
+  repository and no check yet measured expensive enough to need exclusion;
+  not-applicable is expressed per check via typed skip, and `--only`/
+  `--category` cover the debugging and CI subset uses. Revisit only with a
+  measurement showing the full set is too slow for a surface
+- **Collapsing evidence stdout/stderr to `present`/`empty`**
+  (SetupDoctor.swift:497-515) | SetupDoctor sanitises because its evidence
+  can carry TCC paths and tokens; CommitLore's checks diagnose *from* stderr
+  first lines (`hook-runtime`, `inject-runtime`) and have no secret-bearing
+  streams. Evidence keeps bounded excerpts (first line, capped length)
+  because removing them would delete the diagnosis
+- **snake_case keys for the new JSON fields** | the surface being extended
+  already speaks camelCase (`needsAttention`, `exitCode`); a consumer parses
+  one report, not our style preference, and a mixed-case document is worse
+  than a consistently legacy-cased one
+- **A network update check, even opt-in** | see §8.1
+- **Patching #458 inside the current structure and stopping** | the pending-
+  backlog check ships regardless (it is in flight on `doctor-pending-backlog`
+  now), but a 13th ad-hoc function in a 1,159-line file leaves the next #458
+  as likely as this one was
+
+## Consequences
+
+- `src/commands/doctor.ts` splits into a registry, a runner, per-check
+  modules, and a renderer; the PRD fixes the layout. The command's observable
+  text output for existing checks does not change.
+- `--json` becomes a documented, versioned contract; `docs/cli.md` documents
+  the envelope and the additive rule, and the release gate can script against
+  `status` instead of grepping.
+- `pending ls`-shaped knowledge now has a place doctor can carry it to — the
+  #458 check is the first registry entry in the `capture` category with a
+  dependency-free root position.
+- The report grows fields (`durationMs`, `evidence`) that make doctor's own
+  performance and claims measurable. The current per-check wall time is
+  unmeasured; per-check timing is how the PRD's budget stops being an
+  assertion (the same move as commit 1f8b4be made for the 100k-commit
+  criterion).
+- No new runtime dependency. Node 22+ (ADR-0010), TypeScript strict, and the
+  existing zero-native-dependency posture (ADR-0012) are unchanged.
+
+## Falsification
+
+This ADR's model is falsified — and must be revised — if any of the following
+is demonstrated:
+
+1. A repository state in which a subsystem doctor reports on has verifiably
+   stopped working while the report's overall `status` is `ok` (the #458
+   invariant, restated as a property).
+2. A `blocked_by` annotation that suppresses evidence of an independent
+   failure — a check failing for its own reason rendered invisible in both
+   `checks[]` and `fixPlan` because an unrelated dependency also failed.
+3. A published v2 report that a correct v1 consumer (`report.checks.some(c =>
+   c.status === 'fail')`, `report.exitCode`) mis-reads — any removed key,
+   renamed key, or null-instead-of-omitted optional.
+4. A doctor run that exits `2` or `3` for a repository finding, or exits
+   non-zero for a `degraded` report — either would give a SPEC §10 code a
+   doctor-private meaning.
+5. A check crash that terminates doctor instead of producing a `fail` row.
+6. The full check set measured slow enough on a real repository that users
+   skip running doctor — which would reopen the profiles rejection with the
+   measurement the rejection asked for.


### PR DESCRIPTION
ADR-0032 + `docs/DOCTOR-PRD.md`. Documents only — **no check changes behaviour and the shipping report is byte-identical.** Milestone: [Doctor · Diagnostic Rigor](https://github.com/MongLong0214/commitlore/milestone/11).

## Why now: eleven closed issues are one defect

| | |
|---|---|
| [#40](https://github.com/MongLong0214/commitlore/issues/40) [#128](https://github.com/MongLong0214/commitlore/issues/128) [#149](https://github.com/MongLong0214/commitlore/issues/149) | probed a path doctor **reconstructed** rather than the command that actually runs |
| [#49](https://github.com/MongLong0214/commitlore/issues/49) | the hook could be redirected to any executable and doctor still said `ok` |
| [#382](https://github.com/MongLong0214/commitlore/issues/382) | called a stale hook pin `ok` |
| [#335](https://github.com/MongLong0214/commitlore/issues/335) | reported 106 records where git had **zero** |
| [#296](https://github.com/MongLong0214/commitlore/issues/296) | prescribed a fix that could not repair the condition |
| [#63](https://github.com/MongLong0214/commitlore/issues/63) | its own fix broke `git fetch`, then reported `ok` |
| [#458](https://github.com/MongLong0214/commitlore/issues/458) | ten checks `ok` on a repository that stopped producing records eight days earlier |

**None of those is a missing check.** They are one structural failure: a verdict with no evidence behind it, in a command with no way to say *"I could not look"* and no way to say *"this failure is that failure's consequence"*.

## What the ADR decides

- **Typed evidence per check**, so a claim and the observation behind it travel together
- **`skipped` with a reason from a closed union** — a check that cannot run must not pass
- **`blocked_by` annotates, never suppresses.** A collapsed row still renders its own evidence, because a suppressed row is how a screen lies by not looking
- **Checks become registry data**, so a new one cannot be added without a category and a place in the order

## The two hardest calls, with reasons

**Exit codes stay `0`/`1`.** The Swift reference maps `degraded → 3`. SPEC §10 fixes `3` protocol-wide as *"ran and answered, but could not see everything"* and states a code **MUST NOT** carry a meaning another command does not give it — so that mapping would give `3` a doctor-private meaning §10 forbids. Verified against the spec table directly.

**Profiles rejected, with a reopening condition.** A profile that omits checks reproduces #458 exactly — the screen that lied by not looking. `--only`/`--category` cover the subset uses until a measurement shows the full set is too slow.

## References

`logic-pro-mcp` `SetupDoctor` (3,784 lines) read directly — root-cause collapse, additive `encodeIfPresent` schema versioning, registry-as-data, fix-plan dedup carried across with quoted provenance. Deliberately **not** carried: `manual` status, the strict exit mapping, the capability matrix, Homebrew probing, the network update check.

OpenClaw's implementation was **not inspectable on this machine**; both documents say so plainly and cite only its filename taxonomy. The sampled artefacts held approval-store state, not report bodies.

## Scope

The model and the specification. Implementation tickets follow under the same milestone.