### PR TITLE
Put the measured number where the README said the question was unanswered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ records re-proposed a ruled-out approach in **16 of 580** runs; without them,
 ```
 commitlore-on    16/580 =  2.8%   Wilson 95%  1.7 – 4.4%
 commitlore-off  109/579 = 18.8%   Wilson 95% 15.9 – 22.2%
-
-Fisher exact, two-tailed   p = 0.0000
-difference                 −16.1pp   Newcombe 95% −19.6 to −12.7
-registered threshold       6.6pp
 ```
+
+The significance test, the interval on the difference and the registered
+threshold are in `bench/VERDICT-M5.md`, not retyped here.
 
 Three things about how it was produced matter more than the number:
 
@@ -26,7 +25,8 @@ Three things about how it was produced matter more than the number:
   probabilities, and it was wrong.
 - **The control arm truncated more** (28.5% against 21.2%), and truncation
   suppresses re-proposal — so the artefact removes control-arm chances rather
-  than manufacturing treatment ones. 16.1pp is a floor with respect to it.
+  than manufacturing treatment ones. The measured difference is a floor with
+  respect to it.
 
 **Every record in this run rendered `[claim]`**, with the payload's own legend
 telling the agent not to act on it as an order. The `[directive]` tier below

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+### The behaviour claim is measured: 2.8% against 18.8%
+
+M5 is complete — 1,160 registered runs. An agent handed the repository's active
+records re-proposed a ruled-out approach in **16 of 580** runs; without them,
+**109 of 579**.
+
+```
+commitlore-on    16/580 =  2.8%   Wilson 95%  1.7 – 4.4%
+commitlore-off  109/579 = 18.8%   Wilson 95% 15.9 – 22.2%
+
+Fisher exact, two-tailed   p = 0.0000
+difference                 −16.1pp   Newcombe 95% −19.6 to −12.7
+registered threshold       6.6pp
+```
+
+Three things about how it was produced matter more than the number:
+
+- **The threshold was registered before the run**, not chosen after it.
+- **The preregistration predicted a *smaller* effect** and gave three reasons.
+  All three were conservative; the result is 2.4× the threshold. That
+  prediction is in `bench/PREREGISTRATION-M5.md` Appendix A.2 with its stated
+  probabilities, and it was wrong.
+- **The control arm truncated more** (28.5% against 21.2%), and truncation
+  suppresses re-proposal — so the artefact removes control-arm chances rather
+  than manufacturing treatment ones. 16.1pp is a floor with respect to it.
+
+**Every record in this run rendered `[claim]`**, with the payload's own legend
+telling the agent not to act on it as an order. The `[directive]` tier below
+became reachable only in this release, *after* the run. This number describes
+the weaker tier. One model, one harness, ten constructed fixtures, and an
+oracle that reads the final tree rather than establishing anything was read:
+`bench/VERDICT-M5.md`.
+
 ### `[directive]` became reachable
 
 Records reach an agent graded `directive`, `claim` or `blocked`. `directive`

--- a/README.md
+++ b/README.md
@@ -102,12 +102,14 @@ agent handed the repository's active records re-proposed a ruled-out approach in
 | the agent alone | **18.8%** (109/579) |
 | **with CommitLore** | **2.8%** (16/580) |
 
-Fisher exact two-tailed `p = 0.0000`; difference −16.1pp, Newcombe 95% −19.6 to
-−12.7. **The threshold was registered at 6.6pp before the run**, and the
-preregistration predicted a *smaller* effect than it got — that prediction, with
-its stated probabilities, is in
-[bench/PREREGISTRATION-M5.md](bench/PREREGISTRATION-M5.md) §A.2 and it was
-wrong.
+**The threshold was registered before the run**, and the preregistration
+predicted a *smaller* effect than it got — that prediction, with its stated
+probabilities, is in
+[bench/PREREGISTRATION-M5.md](bench/PREREGISTRATION-M5.md) §A.2, and it was
+wrong. The significance test, the interval and the registered threshold are in
+[bench/VERDICT-M5.md](bench/VERDICT-M5.md) rather than here: a statistic
+retyped into prose drifts from the log that produced it, and this repository
+gates against exactly that (`scripts/check-readme-numbers.mjs`).
 
 Three limits belong beside the number. Every record in that run rendered
 `[claim]`, with the payload telling the agent not to act on it as an order — the

--- a/README.md
+++ b/README.md
@@ -91,9 +91,33 @@ the repository, so the agent is told to treat it as information rather than as a
 order. A record that *was* signed by a trusted author renders as `[directive]`.
 
 The module boundary is in front of the agent before it proposes the change,
-rather than in a review comment after. Whether it acts on that is an
-agent-behaviour question this project has not answered — see the measurement
-below, and [what it does not show](docs/evidence.md).
+rather than in a review comment after.
+
+**Whether it acts on that is now measured.** Across 1,160 registered runs, an
+agent handed the repository's active records re-proposed a ruled-out approach in
+**2.8%** of them (16/580). Without them: **18.8%** (109/579).
+
+| arm | re-proposed a ruled-out approach |
+|---|---:|
+| the agent alone | **18.8%** (109/579) |
+| **with CommitLore** | **2.8%** (16/580) |
+
+Fisher exact two-tailed `p = 0.0000`; difference −16.1pp, Newcombe 95% −19.6 to
+−12.7. **The threshold was registered at 6.6pp before the run**, and the
+preregistration predicted a *smaller* effect than it got — that prediction, with
+its stated probabilities, is in
+[bench/PREREGISTRATION-M5.md](bench/PREREGISTRATION-M5.md) §A.2 and it was
+wrong.
+
+Three limits belong beside the number. Every record in that run rendered
+`[claim]`, with the payload telling the agent not to act on it as an order — the
+`[directive]` tier became reachable only afterwards, so **this measures the
+weaker of the two**. It is one model, one harness, and ten constructed
+fixtures. And the oracle reads the final implementation state: it shows agents
+which received records re-proposed less often, not that any of them read
+anything. Method, exclusions and the per-arm truncation split:
+[bench/VERDICT-M5.md](bench/VERDICT-M5.md) and
+[what it does not show](docs/evidence.md).
 
 ## See it work
 


### PR DESCRIPTION
Release prep for 0.7.0. `README.md` + `CHANGELOG.md`.

## The sentence being replaced

The README carried an admission that the central question was open:

> *"Whether it acts on that is an agent-behaviour question this project has not answered."*

**That has been true since the first release and is now false.** It is replaced by the measurement rather than left standing beside it.

| arm | re-proposed a ruled-out approach |
|---|---:|
| the agent alone | **18.8%** (109/579) |
| **with CommitLore** | **2.8%** (16/580) |

Fisher exact two-tailed `p = 0.0000`; −16.1pp, Newcombe 95% −19.6 to −12.7.

## Three things travel with the number

- **The 6.6pp threshold was registered before the run**, not chosen after it.
- **The preregistration predicted a *smaller* effect** and gave three reasons. All three were conservative; the result is 2.4× the threshold. That prediction, with its stated probabilities, is in `bench/PREREGISTRATION-M5.md` §A.2 — and it was wrong.
- **The control arm truncated more** (28.5% vs 21.2%), and truncation suppresses re-proposal, so the artefact removes control chances rather than manufacturing treatment ones.

## Three limits, in the same paragraph as the number

Not a page away, because **a reader who stops at the table has then read a claim without its scope** — and the scope is what makes the claim survivable.

Every record rendered `[claim]`, with the payload telling the agent not to act on it as an order, so this measures **the weaker of the two tiers** — the stronger one became reachable only in this release, after the run. One model, one harness, ten constructed fixtures. And the oracle reads the final tree: it shows agents which received records re-proposed less often, **not that any of them read anything.**

## Deliberately not in the headline

The 6.7× ratio. It is arithmetic on two small counts and moves fast with either; the two rates and the interval are what the study actually bounds.

## Stated limit

The README now leads its behaviour claim with a `[claim]`-tier number while shipping a `[directive]` tier nobody has measured. **That gap will widen until something measures it.**

82 cases across the readme, compatibility-matrix and manifest suites; changelog suite accepts the entry. Dogfood re-run after committing.

One note: the commit gate rejected the first attempt — `Record-Id: r-readme-m5` fails `r-[a-z0-9]{6,}`. The product's own hook caught it.