### PR TITLE
Release 0.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.7.0
 
 ### The behaviour claim is measured: 2.8% against 18.8%
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,7 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.6.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.0/install.sh | sh
 ```
 
 どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
@@ -138,11 +138,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.6.0/install.sh
-sh install.sh v0.6.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.0/install.sh
+sh install.sh v0.7.0
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v0.6.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.7.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -48,7 +48,7 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.6.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.0/install.sh | sh
 ```
 
 어떤 host를 지원하는지, 각 설치 경로가 무엇을 요구하는지: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
@@ -138,11 +138,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.6.0/install.sh
-sh install.sh v0.6.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.0/install.sh
+sh install.sh v0.7.0
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v0.6.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.7.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Prerequisites for either path: Node.js 22+ and Git. The script checks both befor
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.6.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.0/install.sh | sh
 ```
 
 Which hosts are supported, and what each install path requires: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
@@ -191,11 +191,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.6.0/install.sh
-sh install.sh v0.6.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.0/install.sh
+sh install.sh v0.7.0
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v0.6.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.7.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@ Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.6.0/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.0/install.sh | sh
 ```
 
 支持哪些 host，以及各条安装路径需要什么：[docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
@@ -137,11 +137,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.6.0/install.sh
-sh install.sh v0.6.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.0/install.sh
+sh install.sh v0.7.0
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v0.6.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.7.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump into `dev`. Eighteen pins, one commit.

## Why one commit

`test/readme.test.ts` asserts the README pins match `package.json`. Splitting them leaves an intermediate commit where **CI is red and the documented install points at a tag that does not exist.**

| | |
|---|---|
| manifests | `package.json`, `.claude-plugin/plugin.json` |
| README pins | 4 files × 4 — install one-liner, `sh install.sh v…`, `git clone --branch v…`, inspect-first variant |
| `dist/` | **no diff** — the CLI reads its version at runtime |

That last point matters beyond tidiness: the built tree stays byte-identical to the one **every M5 row was produced against**.

## What the release carries

The first measurement of the thing the product is for — an agent handed this repository's active records re-proposed a ruled-out approach in **16 of 580** runs against **109 of 579** without them — and, in the same release, the change that makes that number describe the *weaker* case. `[directive]` was unreachable on every install that has ever existed and became reachable here, **after** the run that measured `[claim]`.

## Verification

**103 files, 2,265 cases pass at this version.** No `v0.6.0` pin remains in any README; both manifests read `0.7.0`; `dist/` has no diff; readme, changelog, readme-numbers and compatibility-matrix suites accept the entry. Dogfood re-run after committing.

## Stated limit

The README's behaviour claim now rests on M5 while the generated numbers block beneath it still publishes M4. That is [#480](https://github.com/MongLong0214/commitlore/issues/480) — repointing `README_SOURCES` needs a status note written with the care the M4 one took, not an edit squeezed between a CI failure and a tag.

## Note for the promotion that follows

Between the `main` merge and the tag push, **every README install one-liner points at a tag that does not exist.** Tag promptly and confirm the URL rather than assuming.

One gate hit en route: `Blast: repo` is not in the vocabulary (`local|module|system`). The product's own validator rejected the commit.