### PR TITLE
Ask the release gate which commitlore the plugin actually ran

### DIFF
--- a/docs/RELEASE-GATE.md
+++ b/docs/RELEASE-GATE.md
@@ -53,7 +53,16 @@ exclusion, so this table is a spot check of the rule, not the rule itself.
 | fresh clone doctor | `dist/commitlore.mjs doctor` | exit 0, no `fail` |
 | hook survives a PATH without node | commit under `env -i PATH=/usr/bin:/bin` | validated, bad message rejected |
 | a stale hook is reported | doctor on a repo whose stub predates the current one | `warn`, not `ok` |
-| plugin entry point resolves | `CLAUDE_PLUGIN_ROOT=<clone> scripts/commitlore-run.sh --version` | exit 0 |
+| plugin entry point resolves | `env PATH=/usr/bin:/bin:<node-dir> CLAUDE_PLUGIN_ROOT=<clone> scripts/commitlore-run.sh --version` | exit 0 **and the version equals the clone's** |
+
+The `PATH` is narrowed on purpose. `commitlore-run.sh` tries `commitlore` on
+`PATH` before `CLAUDE_PLUGIN_ROOT`, deliberately — the installer's wrapper execs
+node itself, so it works where this script would otherwise have to find node,
+and on the hook hot path a missing node means no context at all. The
+consequence is that **a machine with both a CLI install and the plugin runs
+whichever the CLI install is**, and the release check passed for two releases
+while reporting the wrong version, because it only asked whether *something*
+resolved (#483). Leaving `PATH` alone here would keep asking that question.
 
 ## 5. Every published claim is reproducible
 

--- a/test/plugin-entry-point.test.ts
+++ b/test/plugin-entry-point.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #483: the release gate asked whether the plugin entry point resolved, not
+ * whether it resolved to the plugin.
+ *
+ * `scripts/commitlore-run.sh` tries `commitlore` on `PATH` before
+ * `CLAUDE_PLUGIN_ROOT`. That order is deliberate — the installer's wrapper
+ * execs node itself, so it works where this script would otherwise have to
+ * find node, and on the hook hot path a missing node means no context at all.
+ *
+ * The consequence is that a machine carrying both a CLI install and the plugin
+ * runs whichever the CLI install is, silently. Found running the gate against a
+ * fresh v0.7.0 clone on a machine with 0.6.0 installed: the clone answered
+ * 0.7.0 and the entry point answered 0.6.0, and the gate passed because it
+ * only checked the exit code.
+ *
+ * These cases pin both halves: the entry point reaches the plugin when nothing
+ * shadows it, and PATH wins when something does. The second is not a bug being
+ * enshrined — it is the documented order, asserted so that changing it becomes
+ * a decision someone makes rather than a side effect.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = join(REPO_ROOT, 'scripts', 'commitlore-run.sh');
+const OWN_VERSION = JSON.parse(
+  execFileSync('node', ['-p', 'JSON.stringify(require("./package.json"))'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  }),
+).version as string;
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const temp = (label: string): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `cl-plug-${label}-`));
+  scratch.push(dir);
+  return dir;
+};
+
+/** The interpreter's directory, so a narrowed PATH can still find node. */
+const nodeDir = dirname(process.execPath);
+
+const run = (path: string): string =>
+  execFileSync('sh', [SCRIPT, '--version'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { PATH: path, CLAUDE_PLUGIN_ROOT: REPO_ROOT, HOME: process.env['HOME'] ?? '' },
+  }).trim();
+
+describe('#483 the plugin entry point', () => {
+  it('answers with the plugin\'s own version when nothing shadows it', () => {
+    // What the release gate meant to check all along.
+    expect(run(`/usr/bin:/bin:${nodeDir}`)).toBe(OWN_VERSION);
+  });
+
+  it('prefers a commitlore on PATH over the plugin root, as documented', () => {
+    // A machine with both runs the CLI install. Asserted rather than assumed,
+    // so that changing the order is a decision rather than a side effect.
+    const shadow = temp('shadow');
+    const fake = join(shadow, 'commitlore');
+    writeFileSync(fake, '#!/bin/sh\necho 0.0.0-shadow\n');
+    chmodSync(fake, 0o755);
+
+    expect(run(`${shadow}:/usr/bin:/bin:${nodeDir}`)).toBe('0.0.0-shadow');
+  });
+});


### PR DESCRIPTION
Closes #483. Found running `RELEASE-GATE.md` §4 against a fresh clone during the 0.7.0 release.

## The gate passed while resolving to the wrong build

```
node dist/commitlore.mjs --version                            → 0.7.0
CLAUDE_PLUGIN_ROOT=$PWD sh scripts/commitlore-run.sh --version → 0.6.0
```

Both exit 0. **The check asked whether *something* resolved, not whether the right thing did** — and it has passed that way for two releases.

## The resolution order stays

`commitlore-run.sh` tries `commitlore` on PATH before `CLAUDE_PLUGIN_ROOT`, deliberately: the installer's wrapper execs node itself, so it works where this script would otherwise have to find node, and **on the hook hot path a missing node means no context at all.**

What changes is the gate. It narrows PATH and **compares the version**.

## Two cases, both halves pinned

| | |
|---|---|
| nothing shadows it | entry point answers the repository's own version |
| a `commitlore` sits ahead on PATH | entry point answers that one |

The second is **not a bug being enshrined**. It is the documented order, asserted so that changing it becomes a decision someone makes rather than a side effect of an unrelated edit.

## Why this option and not the other two

#483 recorded three. This is the smallest and the only one that does not touch the hot path.

- **Making the mismatch loud at runtime** means running `--version` twice on every edit, to report a condition `doctor`'s `inject-version` check already reports.
- **Preferring `CLAUDE_PLUGIN_ROOT`** reopens how ADR-0011's ship-`dist`-in-the-repo interacts with the installer's wrapper — a decision, not a patch.

## Stated limits

The gate catches it at release time and `doctor` catches it for a user, but **nothing tells a user who has never run `doctor`.**

The narrowed PATH includes the interpreter's directory, so **a machine whose node lives beside a commitlore wrapper still shadows the plugin** and the check would pass for the wrong reason.