### PR TITLE
Check the manifest the canonical install path actually resolves

### DIFF
--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Release gate (`.github/workflows/release.yml`): the pushed tag, this
- * package's declared version, and the CLI's own `--version` output must all
- * agree before anything is built or attached to a release.
+ * package's declared version, every release manifest's declared version, and
+ * the CLI's own `--version` output must all agree before anything is built or
+ * attached to a release.
  *
  * This matters more than the usual "the numbers should match" check. A tag
  * is immutable the moment someone has fetched it, and a release asset is
@@ -11,11 +12,16 @@
  * with a `v0.1.1` and an explanation. Catching the mismatch before the build
  * matrix runs is the only point where it is still cheap.
  *
- * Compares three sources:
+ * Compares every release-version source:
  *   - the git tag this workflow triggered on (`GITHUB_REF_NAME`, e.g.
  *     `v0.1.0`; a plain argument for local testing), with exactly one
  *     leading `v` stripped
- *   - `package.json`'s `"version"` field
+ *   - `package.json`'s `.version` field
+ *   - `.claude-plugin/plugin.json`'s `.version` field — the manifest Claude
+ *     Code resolves when installing the canonical plugin distribution
+ *   - `package-lock.json`'s `.version` and `.packages[""].version` fields.
+ *     They are independent root-package declarations and must both move with
+ *     the release, while dependency versions in that lockfile do not.
  *   - `node dist/commitlore.mjs --version` — the same value every build of
  *     the CLI reports, script or compiled binary, since both read it from
  *     the same `packageVersion()` (`src/core/paths.ts`) against the same
@@ -37,6 +43,36 @@ import { fileURLToPath } from 'node:url';
 const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const BUNDLE = join(REPO_ROOT, 'dist', 'commitlore.mjs');
 
+/**
+ * A missing or malformed manifest is an inability to run this gate (exit 2),
+ * not a version disagreement (exit 1). Name every field it would have
+ * supplied so the release operator knows exactly what to restore or repair.
+ */
+const readManifest = (relativePath, fields) => {
+  const path = join(REPO_ROOT, relativePath);
+  const sources = fields.map((field) => `${relativePath} ${field}`).join(' and ');
+  if (!existsSync(path)) {
+    console.error(`ERROR: ${sources} cannot be checked: required manifest is missing`);
+    process.exit(2);
+  }
+
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.error(`ERROR: ${sources} cannot be checked: invalid JSON (${reason})`);
+    process.exit(2);
+  }
+};
+
+const requiredVersion = (value, source) => {
+  if (typeof value !== 'string' || value === '') {
+    console.error(`ERROR: ${source} must be a non-empty version string`);
+    process.exit(2);
+  }
+  return value;
+};
+
 const tagArg = process.argv[2] ?? process.env.GITHUB_REF_NAME;
 if (!tagArg) {
   console.error('ERROR: no tag given — pass one as an argument or set GITHUB_REF_NAME');
@@ -54,31 +90,44 @@ if (!existsSync(BUNDLE)) {
   process.exit(2);
 }
 
-const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
-const pkgVersion = pkg.version;
-if (typeof pkgVersion !== 'string' || pkgVersion === '') {
-  console.error('ERROR: package.json has no "version" string');
-  process.exit(2);
-}
+const pkg = readManifest('package.json', ['.version']);
+const plugin = readManifest('.claude-plugin/plugin.json', ['.version']);
+const packageLock = readManifest('package-lock.json', ['.version', '.packages[""].version']);
+
+const pkgVersion = requiredVersion(pkg.version, 'package.json .version');
+const pluginVersion = requiredVersion(plugin.version, '.claude-plugin/plugin.json .version');
+const packageLockVersion = requiredVersion(packageLock.version, 'package-lock.json .version');
+const packageLockRootVersion = requiredVersion(
+  packageLock.packages?.['']?.version,
+  'package-lock.json .packages[""].version',
+);
 
 const cliVersion = execFileSync(process.execPath, [BUNDLE, '--version'], { encoding: 'utf8' }).trim();
 
 const mismatches = [];
-if (tagVersion !== pkgVersion) {
-  mismatches.push(`tag "${tagArg}" (${tagVersion}) != package.json "version" (${pkgVersion})`);
-}
-if (pkgVersion !== cliVersion) {
-  mismatches.push(`package.json "version" (${pkgVersion}) != \`commitlore --version\` (${cliVersion})`);
-}
-if (tagVersion !== cliVersion) {
-  mismatches.push(`tag "${tagArg}" (${tagVersion}) != \`commitlore --version\` (${cliVersion})`);
+const versionSources = [
+  ['package.json .version', pkgVersion],
+  ['.claude-plugin/plugin.json .version', pluginVersion],
+  ['package-lock.json .version', packageLockVersion],
+  ['package-lock.json .packages[""].version', packageLockRootVersion],
+  ['dist/commitlore.mjs --version', cliVersion],
+];
+for (const [source, version] of versionSources) {
+  if (tagVersion !== version) {
+    mismatches.push(`tag "${tagArg}" (${tagVersion}) != ${source} (${version})`);
+  }
 }
 
 if (mismatches.length > 0) {
   console.error(`ERROR: version mismatch — refusing to release (${mismatches.length} disagreement(s)):`);
   for (const m of mismatches) console.error(`  - ${m}`);
-  console.error('  Delete the tag, fix package.json (and rebuild), and push a corrected tag.');
+  console.error('  Delete the tag, fix every named manifest (and rebuild), and push a corrected tag.');
   process.exit(1);
 }
 
-console.log(`version consistent: tag ${tagArg} == package.json ${pkgVersion} == commitlore --version ${cliVersion}`);
+console.log(
+  `version consistent: tag ${tagArg} == package.json .version ${pkgVersion} == ` +
+    `.claude-plugin/plugin.json .version ${pluginVersion} == package-lock.json .version ` +
+    `${packageLockVersion} == package-lock.json .packages[""].version ${packageLockRootVersion} == ` +
+    `dist/commitlore.mjs --version ${cliVersion}`,
+);

--- a/test/check-release-version.test.ts
+++ b/test/check-release-version.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #492: release versions were compared only between the tag, package.json,
+ * and the built CLI. The plugin manifest Claude Code installs and both
+ * root-package fields npm records in package-lock.json could drift unnoticed.
+ *
+ * Each fixture is an isolated miniature checkout because the gate derives its
+ * repository root from its own path. That makes these real process tests of
+ * the release script without mutating this checkout's manifests.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const GATE = join(REPO_ROOT, 'scripts', 'check-release-version.mjs');
+const VERSION = '0.7.1';
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+interface FixtureVersions {
+  package?: string;
+  plugin?: string;
+  packageLock?: string;
+  packageLockRoot?: string;
+  cli?: string;
+  pluginManifest?: boolean;
+}
+
+const fixture = (versions: FixtureVersions = {}): string => {
+  const root = mkdtempSync(join(tmpdir(), 'commitlore-release-version-'));
+  scratch.push(root);
+
+  mkdirSync(join(root, 'scripts'));
+  mkdirSync(join(root, 'dist'));
+  copyFileSync(GATE, join(root, 'scripts', 'check-release-version.mjs'));
+
+  writeFileSync(
+    join(root, 'package.json'),
+    `${JSON.stringify({ name: 'commitlore', version: versions.package ?? VERSION }, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(root, 'package-lock.json'),
+    `${JSON.stringify(
+      {
+        name: 'commitlore',
+        lockfileVersion: 3,
+        version: versions.packageLock ?? VERSION,
+        packages: { '': { name: 'commitlore', version: versions.packageLockRoot ?? VERSION } },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  if (versions.pluginManifest !== false) {
+    mkdirSync(join(root, '.claude-plugin'));
+    writeFileSync(
+      join(root, '.claude-plugin', 'plugin.json'),
+      `${JSON.stringify({ name: 'commitlore', version: versions.plugin ?? VERSION }, null, 2)}\n`,
+    );
+  }
+  writeFileSync(
+    join(root, 'dist', 'commitlore.mjs'),
+    `#!/usr/bin/env node\nif (process.argv[2] === '--version') console.log(${JSON.stringify(versions.cli ?? VERSION)});\n`,
+  );
+
+  return root;
+};
+
+const run = (root: string) =>
+  spawnSync(process.execPath, [join(root, 'scripts', 'check-release-version.mjs'), `v${VERSION}`], {
+    encoding: 'utf8',
+  });
+
+describe('#492 check-release-version', () => {
+  it('passes when the tag, every manifest field, and the CLI agree', () => {
+    const result = run(fixture());
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('version consistent');
+  });
+
+  it.each([
+    ['the plugin manifest', { plugin: '0.7.0' }, '.claude-plugin/plugin.json .version'],
+    ['the package-lock root version', { packageLock: '0.7.0' }, 'package-lock.json .version'],
+    [
+      'the package-lock root package version',
+      { packageLockRoot: '0.7.0' },
+      'package-lock.json .packages[""].version',
+    ],
+  ] satisfies [string, FixtureVersions, string][])('%s disagreement fails and names its field', (_, versions, source) => {
+    const result = run(fixture(versions));
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(source);
+  });
+
+  it('reports every disagreement instead of stopping at the first one', () => {
+    const result = run(
+      fixture({ plugin: '0.7.0', packageLock: '0.7.0', packageLockRoot: '0.6.0' }),
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('.claude-plugin/plugin.json .version');
+    expect(result.stderr).toContain('package-lock.json .version');
+    expect(result.stderr).toContain('package-lock.json .packages[""].version');
+  });
+
+  it('fails when the required plugin manifest is missing', () => {
+    const result = run(fixture({ pluginManifest: false }));
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('.claude-plugin/plugin.json .version');
+    expect(result.stderr).toContain('required manifest is missing');
+  });
+});


### PR DESCRIPTION
Closes #492.

**Held: `dev` is frozen for the v0.7.1 promotion. This is opened for CI evidence, not to merge.**

The release gate compared the tag, `package.json` and `commitlore --version`, and never opened `.claude-plugin/plugin.json` or `package-lock.json`. ADR-0026 makes the plugin the canonical install path, so the one manifest a plugin user's install resolves was the one the gate did not look at.

That is not hypothetical: `package-lock.json` declared `0.1.0` from the first release through 0.7.0 while both manifests moved, and this gate passed every time, because it does not look there. A human found it by reading.

The two lock fields are checked separately because they went stale separately. A missing manifest is a failure rather than a skip — the defect being repaired is a gate that stayed quiet about a file it did not read.

**Evidence.** Five of the six new cases fail against the previous script and all six pass against this one. That is the property that makes them worth having.
