### PR TITLE
Refuse a tag that is not on main or whose CI did not pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,147 @@ jobs:
       - name: Tag, package.json, and `commitlore --version` agree
         run: node scripts/check-release-version.mjs "$GITHUB_REF_NAME"
 
+  # RELEASE-GATE §4 used to be a human checklist run after `gh release create`.
+  # That made a failed row a correction to something already published: the
+  # release existed, but its documented installation did not work. This job
+  # makes the six checks a prerequisite instead, so publication cannot get
+  # ahead of the artifact it claims to qualify.
+  install-gate:
+    runs-on: ubuntu-latest
+    steps:
+      # The default checkout follows the event SHA today, but qualifying the
+      # branch that happened to contain that SHA would weaken the claim when
+      # checkout's default changes. The pushed tag is the artifact users name.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # A checkout can hide exactly the distribution failures this protects
+      # against: an untracked bundle, a path that reaches back to the source
+      # tree, or dependencies left over from CI. Clone the pushed tag anew,
+      # then run every check from that clone as an installer does.
+      - name: The tagged installation passes RELEASE-GATE section 4
+        run: |
+          set -euo pipefail
+          clone_dir="$(mktemp -d)/commitlore"
+          git clone --quiet --branch "$GITHUB_REF_NAME" --depth 1 \
+            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" "$clone_dir"
+          cd "$clone_dir"
+
+          # The bundle is the shipped CLI; no build or npm install belongs in
+          # this job, because either would conceal a clone missing what ships.
+          clone_version="$(node dist/commitlore.mjs --version)"
+          printf 'fresh clone version: %s\n' "$clone_version"
+
+          if validation_output="$(printf 'Subject\n\nBlast: wide\n' | node dist/commitlore.mjs validate 2>&1)"; then
+            echo "expected the invalid message to be rejected"
+            exit 1
+          else
+            validation_exit=$?
+          fi
+          printf '%s\n' "$validation_output"
+          test "$validation_exit" -eq 1 || {
+            echo "validate exited $validation_exit, expected 1"
+            exit 1
+          }
+          case "$validation_output" in
+            *Blast*) ;;
+            *)
+              echo "validate rejected the message without reporting its Blast violation"
+              exit 1
+              ;;
+          esac
+
+          # A fresh clone is allowed to warn about unfetched notes and setup it
+          # has not opted into. `doctor` exits zero exactly when none of those
+          # findings is a fail, which is the RELEASE-GATE row's condition.
+          node dist/commitlore.mjs doctor
+
+          # The installed stub records node's absolute path. This command
+          # removes node from PATH while retaining git, so a rejection proves
+          # the hook used that recorded interpreter rather than ambient PATH.
+          git config user.name "Release gate"
+          git config user.email "release-gate@example.invalid"
+          node dist/commitlore.mjs hooks install
+          if hook_output="$(env -i PATH=/usr/bin:/bin git commit --allow-empty \
+            -m 'Release gate invalid message' -m 'Blast: wide' 2>&1)"; then
+            echo "expected the PATH-less hook to reject the invalid commit"
+            exit 1
+          else
+            hook_exit=$?
+          fi
+          printf '%s\n' "$hook_output"
+          test "$hook_exit" -ne 0 || {
+            echo "the PATH-less hook accepted an invalid commit"
+            exit 1
+          }
+          case "$hook_output" in
+            *Blast*) ;;
+            *)
+              echo "the hook rejected the commit without running validation"
+              exit 1
+              ;;
+          esac
+
+          # This is the earlier, marker-bearing stub body. Installing first
+          # records an otherwise healthy target; replacing only the body makes
+          # a real stale-stub fixture rather than merely testing a missing hook.
+          hook_path="$(git rev-parse --git-path hooks/commit-msg)"
+          printf '%s\n' '#!/bin/sh' '# commitlore:commit-msg:v1' \
+            'exec commitlore validate "$1"' > "$hook_path"
+          chmod +x "$hook_path"
+
+          # Doctor deliberately runs a hook probe with PATH=/usr/bin:/bin.
+          # This historical body therefore also produces the expected separate
+          # hook-runtime fail and doctor exits 1. The row being qualified is
+          # commit-msg-hook, whose required verdict is warn rather than ok, so
+          # read that row instead of mistaking the fixture's other finding for
+          # this row's outcome.
+          if stale_report="$(node dist/commitlore.mjs doctor --json)"; then
+            stale_doctor_exit=0
+          else
+            stale_doctor_exit=$?
+          fi
+          printf '%s\n' "$stale_report"
+          printf 'stale-hook doctor exit: %s\n' "$stale_doctor_exit"
+          printf '%s' "$stale_report" | node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => { input += chunk; });
+            process.stdin.on("end", () => {
+              const report = JSON.parse(input);
+              const hook = report.checks.find((check) => check.id === "commit-msg-hook");
+              if (hook?.status !== "warn") {
+                console.error("expected the stale commit-msg hook to warn, got:", hook);
+                process.exit(1);
+              }
+              console.log("stale commit-msg hook: warn");
+            });
+          '
+
+          # The runner intentionally prefers a CLI on PATH, so keep PATH narrow
+          # and include only the node directory needed for the clone fallback.
+          # Comparing versions catches a different installation that still
+          # answers --version successfully (#483).
+          node_dir="$(dirname "$(command -v node)")"
+          plugin_version="$(env PATH="/usr/bin:/bin:$node_dir" \
+            CLAUDE_PLUGIN_ROOT="$clone_dir" "$clone_dir/scripts/commitlore-run.sh" --version)"
+          printf 'plugin version: %s\n' "$plugin_version"
+          test "$plugin_version" = "$clone_version" || {
+            echo "plugin resolved $plugin_version, expected clone version $clone_version"
+            exit 1
+          }
+
   # Nothing is compiled and nothing is attached. ADR-0026 makes the plugin the
   # canonical install path and `install.sh`/`install.ps1` the secondary one, and
   # both take a pinned source checkout -- so the release itself is the tag, and the
   # tag is what those installers resolve. A release with no assets is the whole
   # artifact set, not an incomplete one.
   publish:
-    needs: version-consistency
+    needs: [version-consistency, install-gate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ permissions:
   contents: write
   id-token: write
   attestations: write
+  # `exact-head-ci` reads the check runs GitHub recorded for the tagged commit.
+  # Reading a branch's green badge would answer a different, weaker question.
+  checks: read
 
 jobs:
   # Refuses the whole release before a single binary is built. A release
@@ -36,6 +39,48 @@ jobs:
       - run: npm run build
       - name: Tag, package.json, and `commitlore --version` agree
         run: node scripts/check-release-version.mjs "$GITHUB_REF_NAME"
+
+  # A version-consistent tag can still name a commit that exists only on dev.
+  # `merge-base` can answer that only from complete history: a shallow checkout
+  # is not a smaller proof, it is an incomplete graph that the script refuses.
+  # The accepted commit is an output so the API gate below queries the commit an
+  # annotated tag resolves to, rather than assuming the event SHA is one.
+  release-target:
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.ancestry.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - id: ancestry
+        name: The pushed tag is already contained in main
+        run: node scripts/check-release-target.mjs "$GITHUB_REF_NAME" main --github-output
+
+  # A tag push does not create a new CI result for the commit it names. The
+  # relevant evidence is the existing set of check runs at that exact commit,
+  # not the last green run on main and not a local suite this release happens
+  # to start. The script has a fixed required list and treats every missing or
+  # non-success result as a block; an empty API response is therefore a failure.
+  exact-head-ci:
+    needs: release-target
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Every required CI check succeeded at the tagged commit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/check-exact-head-ci.mjs "$GITHUB_REPOSITORY_OWNER" "${GITHUB_REPOSITORY#*/}" "${{ needs.release-target.outputs.commit }}"
 
   # RELEASE-GATE §4 used to be a human checklist run after `gh release create`.
   # That made a failed row a correction to something already published: the
@@ -177,7 +222,10 @@ jobs:
   # tag is what those installers resolve. A release with no assets is the whole
   # artifact set, not an incomplete one.
   publish:
-    needs: [version-consistency, install-gate]
+    # A skipped or failed prerequisite skips this job by GitHub's default needs
+    # semantics. Keep it free of `if:`: a condition such as `always()` would
+    # turn a failed qualification into a path that can still publish.
+    needs: [version-consistency, install-gate, release-target, exact-head-ci]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/RELEASE-GATE.md
+++ b/docs/RELEASE-GATE.md
@@ -46,6 +46,10 @@ exclusion, so this table is a spot check of the rule, not the rule itself.
 
 ## 4. The installation the documentation describes actually works
 
+These checks run as the `install-gate` job in the tag-triggered release workflow,
+against a fresh clone of the pushed tag. `publish` depends on that job, so a
+GitHub Release cannot exist until every automated row below has passed.
+
 | check | command | pass |
 |---|---|---|
 | fresh clone runs | `git clone`, then `dist/commitlore.mjs --version` | exit 0 |

--- a/docs/RELEASE-GATE.md
+++ b/docs/RELEASE-GATE.md
@@ -47,8 +47,9 @@ exclusion, so this table is a spot check of the rule, not the rule itself.
 ## 4. The installation the documentation describes actually works
 
 These checks run as the `install-gate` job in the tag-triggered release workflow,
-against a fresh clone of the pushed tag. `publish` depends on that job, so a
-GitHub Release cannot exist until every automated row below has passed.
+against a fresh clone of the pushed tag. `publish` depends on this job as well as
+the version, ancestry, and exact-head-CI gates, so a GitHub Release cannot exist
+until every automated prerequisite has passed.
 
 | check | command | pass |
 |---|---|---|
@@ -68,23 +69,51 @@ whichever the CLI install is**, and the release check passed for two releases
 while reporting the wrong version, because it only asked whether *something*
 resolved (#483). Leaving `PATH` alone here would keep asking that question.
 
-## 5. Every published claim is reproducible
+## 5. The tag is a promoted, exactly green commit
+
+A matching version and a working fresh clone say nothing about *where* a tag was
+cut. A dev-only commit can satisfy both. Nor does a green `main` badge prove the
+tagged SHA passed: it may be a failed, cancelled, skipped, timed-out, still
+running, or entirely untested commit between two green ones.
+
+The tag workflow therefore blocks `publish` on both jobs below.
+
+| check | command | pass |
+|---|---|---|
+| release target | `scripts/check-release-target.mjs <tag> main` from a `fetch-depth: 0` checkout | the tag resolves to a commit contained in `main`; a shallow checkout fails rather than guessing |
+| exact-head CI | `scripts/check-exact-head-ci.mjs <owner> <repo> <resolved-tag-sha>` | all six explicitly named check runs below are present at that SHA, `completed`, and concluded `success` |
+
+The exact-head list is fixed rather than inferred from the API response:
+`check (22)`, `check (24)`, `git-matrix (ubuntu-latest)`, `git-matrix
+(macos-latest)`, `install-script`, and `install-ps1`. Any other conclusion —
+including `failure`, `cancelled`, `timed_out`, `skipped`, `neutral`, `stale`, or
+`action_required` — blocks publication. So do `queued` and `in_progress`, a
+check reported for another SHA, and an absent check; an empty result is six
+absent checks, not a clean result.
+
+`release-target` exports the commit behind the tag only after the ancestry check
+passes. `exact-head-ci` consumes that exact commit, so annotated tags do not
+accidentally query CI using a tag-object SHA. Both are direct `publish`
+dependencies and `publish` has no `if:` condition that can override a failed or
+skipped dependency.
+
+## 6. Every published claim is reproducible
 
 - `scripts/check-readme-numbers.mjs` exits 0 — no number in any README is typed
   by hand.
 - No README asserts something a command in this file contradicts. The three that
   did (green on `main`, a clone carries its dependencies, a clone carries the
   whole memory) are the reason this section exists.
-- CI is green **at the exact commit being released**, checked by looking at CI
-  rather than at a local test run. A local suite passed at every one of the three
-  commits where CI was red.
+- CI is green **at the exact commit being released**, as enforced by section 5's
+  explicit check-run set rather than inferred from a local test run or a branch
+  badge. A local suite passed at every one of the three commits where CI was red.
 
-## 6. The suite proves something
+## 7. The suite proves something
 
 - `npx vitest run` green, and the run reports `Test Files N passed` — a bare test
   count is not evidence. A delegated task once reported 943 of a 1108 baseline
   because another process was writing to the worktree during its run.
-- Each fix in sections 1–4 has a test that fails when that one fix is reverted.
+- Each fix in sections 1–5 has a test that fails when that one fix is reverted.
   Reverting is the evidence; a passing test proves nothing on its own.
 
 ## What this gate deliberately does not require

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Refuses a release unless every named CI check succeeded at its exact commit.
+ *
+ * A green branch, a recent green workflow, or a passing local suite is not a
+ * substitute for a successful check run at the SHA a tag resolves to. This
+ * script names the required check runs up front and treats every other state —
+ * including a missing run — as a blocking failure.
+ *
+ * Usage:
+ *   node scripts/check-exact-head-ci.mjs <owner> <repo> <sha>
+ *   node scripts/check-exact-head-ci.mjs <owner> <repo> <sha> --from-file <check-runs.json>
+ *   node scripts/check-exact-head-ci.mjs <owner> <repo> <sha> --from-stdin
+ *
+ * `--from-file` and `--from-stdin` are test seams. Their JSON is the response
+ * body from GET /repos/{owner}/{repo}/commits/{sha}/check-runs (or a raw array
+ * of its `check_runs` entries). Without either seam the script calls GitHub.
+ *
+ * Exit codes follow SPEC §10:
+ *   0  every explicitly required check completed successfully at `sha`
+ *   1  a required check is absent, belongs to another SHA, or is not success
+ *   2  bad input, unreadable payload, or an API/repository failure
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+// This is intentionally a fixed allowlist, not a list inferred from whatever
+// happened to report at a SHA. A missing check is the failure this gate exists
+// to catch, so presence cannot define the requirement.
+export const REQUIRED_CHECKS = Object.freeze([
+  'check (22)',
+  'check (24)',
+  'git-matrix (ubuntu-latest)',
+  'git-matrix (macos-latest)',
+  'install-script',
+  'install-ps1',
+]);
+
+class GateError extends Error {
+  constructor(message, exitCode = 2) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+const usage = () => {
+  throw new GateError(
+    'usage: node scripts/check-exact-head-ci.mjs <owner> <repo> <sha> [--from-file <check-runs.json> | --from-stdin]',
+  );
+};
+
+const parseArgs = (argv) => {
+  const positional = [];
+  let fromFile = null;
+  let fromStdin = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--from-file') {
+      const path = argv[index + 1];
+      if (!path || fromFile !== null) usage();
+      fromFile = path;
+      index += 1;
+    } else if (arg === '--from-stdin') {
+      if (fromStdin) usage();
+      fromStdin = true;
+    } else if (arg.startsWith('--')) {
+      usage();
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (fromFile !== null && fromStdin) usage();
+  if (positional.length !== 3 || positional.some((value) => value === '')) usage();
+  return { owner: positional[0], repo: positional[1], sha: positional[2], fromFile, fromStdin };
+};
+
+const readStdin = async () => {
+  let body = '';
+  for await (const chunk of process.stdin) body += chunk;
+  return body;
+};
+
+const parsePayload = (text, source) => {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new GateError(`ERROR: ${source} is not valid JSON: ${error.message}`);
+  }
+};
+
+const checkRunsFrom = (payload, source) => {
+  if (Array.isArray(payload)) return payload;
+  if (payload !== null && typeof payload === 'object' && Array.isArray(payload.check_runs)) {
+    return payload.check_runs;
+  }
+  throw new GateError(`ERROR: ${source} does not contain a check_runs array.`);
+};
+
+const networkPayload = async (owner, repo, sha) => {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new GateError('ERROR: GITHUB_TOKEN is required to query the exact-head CI checks.');
+  }
+
+  const apiBase = (process.env.GITHUB_API_URL ?? 'https://api.github.com').replace(/\/$/, '');
+  const path = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodeURIComponent(sha)}/check-runs`;
+  const checkRuns = [];
+  let page = 1;
+  let totalCount = null;
+
+  do {
+    const response = await fetch(`${apiBase}${path}?per_page=100&page=${page}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!response.ok) {
+      throw new GateError(`ERROR: GitHub check-runs API returned ${response.status} ${response.statusText} for ${sha}.`);
+    }
+
+    let payload;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      throw new GateError(`ERROR: GitHub check-runs API returned invalid JSON: ${error.message}`);
+    }
+    const pageRuns = checkRunsFrom(payload, 'GitHub check-runs API response');
+    checkRuns.push(...pageRuns);
+    if (typeof payload.total_count === 'number') totalCount = payload.total_count;
+    if (pageRuns.length === 0) break;
+    page += 1;
+  } while (checkRuns.length < (totalCount ?? Number.POSITIVE_INFINITY));
+
+  return checkRuns;
+};
+
+const checkRequiredRuns = (checkRuns, sha) => {
+  const problems = [];
+
+  for (const required of REQUIRED_CHECKS) {
+    const matching = checkRuns.filter((run) => run !== null && typeof run === 'object' && run.name === required);
+    if (matching.length === 0) {
+      problems.push(`${required}: required check is absent`);
+      continue;
+    }
+
+    for (const run of matching) {
+      if (run.head_sha !== sha) {
+        problems.push(`${required}: reported head SHA "${String(run.head_sha)}", expected "${sha}"`);
+      }
+      if (run.status !== 'completed') {
+        problems.push(`${required}: status "${String(run.status)}", expected "completed"`);
+      }
+      if (run.conclusion !== 'success') {
+        problems.push(`${required}: conclusion "${String(run.conclusion)}", expected "success"`);
+      }
+    }
+  }
+
+  return problems;
+};
+
+const main = async () => {
+  const { owner, repo, sha, fromFile, fromStdin } = parseArgs(process.argv.slice(2));
+  let payload;
+  let source;
+
+  if (fromFile !== null) {
+    source = `payload file ${fromFile}`;
+    try {
+      payload = parsePayload(readFileSync(fromFile, 'utf8'), source);
+    } catch (error) {
+      if (error instanceof GateError) throw error;
+      throw new GateError(`ERROR: could not read ${source}: ${error.message}`);
+    }
+  } else if (fromStdin) {
+    source = 'stdin payload';
+    payload = parsePayload(await readStdin(), source);
+  } else {
+    source = 'GitHub check-runs API response';
+    payload = { check_runs: await networkPayload(owner, repo, sha) };
+  }
+
+  const checkRuns = checkRunsFrom(payload, source);
+  const problems = checkRequiredRuns(checkRuns, sha);
+  if (problems.length > 0) {
+    console.error(`ERROR: exact-head CI did not pass for ${owner}/${repo}@${sha}:`);
+    for (const problem of problems) console.error(`  - ${problem}`);
+    console.error('  Every required check must be present, completed, and concluded success at this exact SHA.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`exact-head CI accepted: all ${REQUIRED_CHECKS.length} required checks succeeded at ${owner}/${repo}@${sha}`);
+};
+
+const invokedAsScript = process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedAsScript) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = error instanceof GateError ? error.exitCode : 2;
+  });
+}

--- a/scripts/check-release-target.mjs
+++ b/scripts/check-release-target.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Refuses a release tag whose commit is not part of the target branch.
+ *
+ * A matching version proves only that a tag and package describe the same
+ * bytes. It does not prove those bytes are the promoted mainline: a dev-only
+ * commit can report exactly the version a release expects. This gate asks git
+ * the stronger question before publication begins.
+ *
+ * Usage:
+ *   node scripts/check-release-target.mjs <tag-or-sha> <target-branch> [--github-output]
+ *
+ * Exit codes follow SPEC §10:
+ *   0  the resolved commit is contained in the target branch
+ *   1  the resolved commit is not contained in the target branch
+ *   2  git could not resolve an input or inspect the repository
+ *   3  the checkout is shallow, so the ancestry answer would be incomplete
+ *
+ * `--github-output` writes the resolved commit as `sha` to GITHUB_OUTPUT after
+ * a passing ancestry check. The following exact-head CI job consumes that
+ * value, so it queries the commit behind an annotated tag rather than relying
+ * on the tag object SHA supplied by an event implementation.
+ */
+
+import { appendFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const usage = () => {
+  console.error('usage: node scripts/check-release-target.mjs <tag-or-sha> <target-branch> [--github-output]');
+  process.exit(2);
+};
+
+const args = process.argv.slice(2);
+const githubOutput = args.at(-1) === '--github-output';
+if (githubOutput) args.pop();
+if (args.length !== 2) usage();
+
+const [releaseRef, targetBranch] = args;
+if (!releaseRef || !targetBranch) usage();
+
+const git = (args) =>
+  spawnSync('git', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    shell: false,
+  });
+
+const resolveCommit = (revision, label) => {
+  const result = git(['rev-parse', '--verify', '--quiet', '--end-of-options', `${revision}^{commit}`]);
+  if (result.status !== 0) {
+    console.error(`ERROR: cannot resolve ${label} "${revision}" to a commit.`);
+    if (result.stderr) console.error(result.stderr.trim());
+    process.exit(2);
+  }
+  return result.stdout.trim();
+};
+
+// A shallow clone can make `merge-base --is-ancestor` answer from an
+// incomplete graph. Equality may happen to be visible, but that is not proof
+// of the requested history relation; fail explicitly rather than treating the
+// partial answer as a pass.
+const shallow = git(['rev-parse', '--is-shallow-repository']);
+if (shallow.status !== 0) {
+  console.error('ERROR: cannot determine whether this checkout has complete history.');
+  if (shallow.stderr) console.error(shallow.stderr.trim());
+  process.exit(2);
+}
+if (shallow.stdout.trim() !== 'false') {
+  console.error('ERROR: cannot establish release ancestry from a shallow repository.');
+  console.error('  The release checkout must use fetch-depth: 0 before checking main ancestry.');
+  process.exit(3);
+}
+
+const releaseCommit = resolveCommit(releaseRef, 'release tag or SHA');
+
+// A tag checkout normally has `origin/main`, not a local `main` branch. A
+// throwaway/local repository normally has the reverse. Prefer the remote
+// tracking ref when both exist: it is the branch the release workflow fetched.
+const targetCandidates = targetBranch.startsWith('refs/')
+  ? [targetBranch]
+  : [`refs/remotes/origin/${targetBranch}`, `refs/heads/${targetBranch}`, targetBranch];
+
+let targetCommit = null;
+let targetRef = null;
+for (const candidate of targetCandidates) {
+  const result = git(['rev-parse', '--verify', '--quiet', '--end-of-options', `${candidate}^{commit}`]);
+  if (result.status === 0) {
+    targetCommit = result.stdout.trim();
+    targetRef = candidate;
+    break;
+  }
+}
+if (targetCommit === null || targetRef === null) {
+  console.error(`ERROR: cannot resolve target branch "${targetBranch}" in this checkout.`);
+  console.error('  Fetch the target branch and its full history before asking the ancestry gate.');
+  process.exit(2);
+}
+
+const ancestry = git(['merge-base', '--is-ancestor', releaseCommit, targetCommit]);
+if (ancestry.status === 1) {
+  console.error(`ERROR: release commit ${releaseCommit} is not contained in target branch "${targetBranch}" (${targetRef}).`);
+  console.error('  Refusing to publish a tag that has not reached the release branch.');
+  process.exit(1);
+}
+if (ancestry.status !== 0) {
+  console.error(`ERROR: git could not determine whether ${releaseCommit} is an ancestor of ${targetRef}.`);
+  if (ancestry.stderr) console.error(ancestry.stderr.trim());
+  process.exit(2);
+}
+
+if (githubOutput) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    console.error('ERROR: --github-output requires the GITHUB_OUTPUT environment variable.');
+    process.exit(2);
+  }
+  try {
+    appendFileSync(outputPath, `sha=${releaseCommit}\n`);
+  } catch (error) {
+    console.error(`ERROR: could not write the resolved release SHA to GITHUB_OUTPUT: ${error.message}`);
+    process.exit(2);
+  }
+}
+
+console.log(`release target accepted: ${releaseRef} resolves to ${releaseCommit} and is contained in target branch "${targetBranch}" (${targetRef})`);

--- a/test/release-publish-prerequisites.test.ts
+++ b/test/release-publish-prerequisites.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Release publication is deliberately tested outside Actions. A tag can be
+ * syntactically valid while naming a dev-only commit, and a local test run can
+ * be green while the CI record for that exact commit is absent or failed. Both
+ * are facts GitHub's YAML cannot safely infer with an `if:` expression.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { load } from 'js-yaml';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { REQUIRED_CHECKS } from '../scripts/check-exact-head-ci.mjs';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const RELEASE_TARGET = join(REPO_ROOT, 'scripts', 'check-release-target.mjs');
+const EXACT_HEAD_CI = join(REPO_ROOT, 'scripts', 'check-exact-head-ci.mjs');
+const RELEASE_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'release.yml');
+
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const tempDir = (label: string): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `commitlore-release-${label}-`));
+  scratch.push(dir);
+  return dir;
+};
+
+const git = (cwd: string, args: string[]): string => {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', shell: false });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed (exit ${result.status}): ${result.stderr}`);
+  }
+  return result.stdout;
+};
+
+const commit = (repo: string, path: string, contents: string, message: string): string => {
+  writeFileSync(join(repo, path), contents);
+  git(repo, ['add', path]);
+  git(repo, ['-c', 'user.name=Release gate', '-c', 'user.email=release-gate@example.invalid', 'commit', '--quiet', '-m', message]);
+  return git(repo, ['rev-parse', 'HEAD']).trim();
+};
+
+interface RunResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+const run = (script: string, args: string[], cwd = REPO_ROOT): RunResult => {
+  const result = spawnSync(process.execPath, [script, ...args], { cwd, encoding: 'utf8', shell: false });
+  return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+};
+
+let repo: string;
+let remote: string;
+let mainSha: string;
+let sideSha: string;
+
+beforeAll(() => {
+  repo = tempDir('source');
+  remote = tempDir('remote.git');
+  git(REPO_ROOT, ['init', '--quiet', '--initial-branch=main', repo]);
+  mainSha = commit(repo, 'main.txt', 'on main\n', 'main commit');
+
+  git(repo, ['checkout', '--quiet', '-b', 'dev']);
+  sideSha = commit(repo, 'dev.txt', 'dev only\n', 'dev commit');
+  git(repo, ['tag', 'v9.9.9']);
+
+  git(repo, ['checkout', '--quiet', 'main']);
+  git(repo, ['init', '--quiet', '--bare', remote]);
+  git(repo, ['remote', 'add', 'origin', remote]);
+  git(repo, ['push', '--quiet', '--all', 'origin']);
+  git(repo, ['push', '--quiet', '--tags', 'origin']);
+});
+
+describe('the tagged commit is in main history', () => {
+  it('accepts a commit that is on the target branch', () => {
+    const result = run(RELEASE_TARGET, [mainSha, 'main'], repo);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('release target accepted');
+  });
+
+  it('refuses a commit that is only on a side branch', () => {
+    const result = run(RELEASE_TARGET, [sideSha, 'main'], repo);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('is not contained in target branch');
+  });
+
+  it('refuses a tag that points only at dev', () => {
+    const result = run(RELEASE_TARGET, ['v9.9.9', 'main'], repo);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('is not contained in target branch');
+  });
+
+  it('refuses a shallow clone rather than guessing from its truncated history', () => {
+    const shallow = join(tempDir('shallow-parent'), 'clone');
+    git(REPO_ROOT, ['clone', '--quiet', '--depth', '1', '--branch', 'main', `file://${remote}`, shallow]);
+
+    const result = run(RELEASE_TARGET, ['HEAD', 'main'], shallow);
+    expect(result.status).toBe(3);
+    expect(result.stderr).toContain('shallow repository');
+  });
+});
+
+const RELEASE_SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+
+interface CheckRun {
+  name: string;
+  head_sha: string;
+  status: string;
+  conclusion: string | null;
+}
+
+const successfulPayload = (): { check_runs: CheckRun[] } => ({
+  check_runs: REQUIRED_CHECKS.map((name) => ({
+    name,
+    head_sha: RELEASE_SHA,
+    status: 'completed',
+    conclusion: 'success',
+  })),
+});
+
+const runPayload = (payload: unknown): RunResult => {
+  const path = join(tempDir('payload'), 'check-runs.json');
+  writeFileSync(path, JSON.stringify(payload));
+  return run(EXACT_HEAD_CI, ['MongLong0214', 'commitlore', RELEASE_SHA, '--from-file', path]);
+};
+
+const rejectedPayload = (payload: unknown, detail: string): void => {
+  const result = runPayload(payload);
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain(detail);
+};
+
+describe('the required CI checks passed at the exact tagged SHA', () => {
+  it('accepts only a complete set of successful required checks', () => {
+    const result = runPayload(successfulPayload());
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('exact-head CI accepted');
+  });
+
+  it('refuses a required check that failed', () => {
+    const payload = successfulPayload();
+    payload.check_runs[0]!.conclusion = 'failure';
+    rejectedPayload(payload, 'conclusion "failure"');
+  });
+
+  it('refuses a required check that was cancelled', () => {
+    const payload = successfulPayload();
+    payload.check_runs[0]!.conclusion = 'cancelled';
+    rejectedPayload(payload, 'conclusion "cancelled"');
+  });
+
+  it('refuses a required check that timed out', () => {
+    const payload = successfulPayload();
+    payload.check_runs[0]!.conclusion = 'timed_out';
+    rejectedPayload(payload, 'conclusion "timed_out"');
+  });
+
+  it('refuses a required check that was skipped', () => {
+    const payload = successfulPayload();
+    payload.check_runs[0]!.conclusion = 'skipped';
+    rejectedPayload(payload, 'conclusion "skipped"');
+  });
+
+  it('refuses a required check that is still in progress', () => {
+    const payload = successfulPayload();
+    payload.check_runs[0]!.status = 'in_progress';
+    payload.check_runs[0]!.conclusion = null;
+    rejectedPayload(payload, 'status "in_progress"');
+  });
+
+  it('refuses a payload that omits one required check entirely', () => {
+    const payload = successfulPayload();
+    payload.check_runs = payload.check_runs.slice(1);
+    rejectedPayload(payload, 'required check is absent');
+  });
+
+  it('refuses an empty payload', () => {
+    rejectedPayload({ check_runs: [] }, 'required check is absent');
+  });
+
+  it('refuses successes reported for a different SHA', () => {
+    const payload = successfulPayload();
+    for (const check of payload.check_runs) check.head_sha = OTHER_SHA;
+    rejectedPayload(payload, 'head SHA');
+  });
+});
+
+describe('publication has no path around a failed prerequisite', () => {
+  const publish = () => {
+    const workflow = load(readFileSync(RELEASE_WORKFLOW, 'utf8')) as {
+      jobs: Record<string, { needs?: string[]; if?: string }>;
+    };
+    return workflow.jobs.publish;
+  };
+
+  it('needs all four release prerequisites', () => {
+    expect(publish().needs).toEqual([
+      'version-consistency',
+      'install-gate',
+      'release-target',
+      'exact-head-ci',
+    ]);
+  });
+
+  it('has no if condition that bypasses any of the four prerequisite failures', () => {
+    const job = publish();
+    // An omitted need is itself a bypass: GitHub cannot withhold publication
+    // for a job it was never asked to wait for. Assert the complete dependency
+    // set here as well as the absence of an `always()`-style escape hatch.
+    expect(job.needs).toEqual([
+      'version-consistency',
+      'install-gate',
+      'release-target',
+      'exact-head-ci',
+    ]);
+    expect(job.if).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Correction lane for the v0.7.1 promotion FAIL. Stacked on #495.

The section-4 job (#495) made the installation a prerequisite. The review found the gap that left: **the workflow accepts every `v*` tag.** Nothing asked whether the tagged commit is on the release branch, and nothing asked whether CI passed at that exact commit. Tagging any dev commit published it; tagging a commit whose CI failed published that.

Two scripts rather than two `if:` expressions, because a condition in YAML cannot be tested and these are the conditions that decide whether a wrong artefact reaches users.

**The CI gate asks whether the required checks passed, not whether any failure is visible.** Everything that is not a success refuses — failure, cancelled, timed out, skipped, queued, still running, and a required check absent from the response entirely. An empty result set is a refusal rather than a quiet pass; that inversion is the defect this repository has now published twice.

The ancestry gate refuses when it cannot see enough history to answer, so a shallow checkout produces a refusal rather than an accident.

`publish` waits on all four jobs and has no `if:`. An omitted dependency is itself a bypass — nothing can withhold a release for a job it was never asked to wait for — so the test asserts the complete set, not just the absence of an escape hatch.

## Evidence

Both scripts were driven directly, not only through the suite:

| case | result |
|---|---|
| six required checks all success | accept |
| failure / cancelled / timed_out / skipped / in_progress | refuse |
| a required check absent, and an empty payload | refuse |
| successes recorded for a **different commit** | refuse |
| tag on `main` / tag on a side branch | accept / refuse |
| shallow clone that cannot answer | refuse |

15 cases pass. The six required check names were also compared against a real CI run on `main`: exact match, so the gate cannot deadlock the release it guards.
