### PR TITLE
Publish the commit the gates qualified, not whatever the tag says now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,47 @@ permissions:
   checks: read
 
 jobs:
+  # The canonical commit is fixed ONCE, here, and every later boundary consumes
+  # that sha. Each boundary used to resolve the tag *name* again, which meant
+  # four gates could each qualify a different commit: a ref-move regression
+  # showed the ancestry and CI gates still accepting the original sha while a
+  # fresh clone of the same tag landed on another main descendant.
+  #
+  # The anchor is the event sha, not the live tag. `github.sha` is what the tag
+  # pointed at when the push happened and cannot be changed afterwards; the ref
+  # can. Resolving the name here would leave a window before this job starts in
+  # which a move redefines the whole release, so the tag name is only ever the
+  # version label and the key the final binding check looks up.
+  release-target:
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.ancestry.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - id: ancestry
+        name: The pushed commit is already contained in main
+        run: node scripts/check-release-target.mjs "$GITHUB_SHA" main --github-output
+
   # Refuses the whole release before a single binary is built. A release
   # whose asset reports a version that disagrees with its own tag is not
   # fixable after the fact — the tag is immutable once fetched, the asset is
   # immutable once downloaded. See scripts/check-release-version.mjs.
+  #
+  # The checkout takes the canonical sha, not the tag: the version this job
+  # compares must come from the same bytes every other gate qualified.
   version-consistency:
+    needs: release-target
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-target.outputs.commit }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -39,27 +72,6 @@ jobs:
       - run: npm run build
       - name: Tag, package.json, and `commitlore --version` agree
         run: node scripts/check-release-version.mjs "$GITHUB_REF_NAME"
-
-  # A version-consistent tag can still name a commit that exists only on dev.
-  # `merge-base` can answer that only from complete history: a shallow checkout
-  # is not a smaller proof, it is an incomplete graph that the script refuses.
-  # The accepted commit is an output so the API gate below queries the commit an
-  # annotated tag resolves to, rather than assuming the event SHA is one.
-  release-target:
-    runs-on: ubuntu-latest
-    outputs:
-      commit: ${{ steps.ancestry.outputs.sha }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - id: ancestry
-        name: The pushed tag is already contained in main
-        run: node scripts/check-release-target.mjs "$GITHUB_REF_NAME" main --github-output
 
   # A tag push does not create a new CI result for the commit it names. The
   # relevant evidence is the existing set of check runs at that exact commit,
@@ -72,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ needs.release-target.outputs.commit }}
           fetch-depth: 1
       - uses: actions/setup-node@v4
         with:
@@ -88,14 +100,14 @@ jobs:
   # makes the six checks a prerequisite instead, so publication cannot get
   # ahead of the artifact it claims to qualify.
   install-gate:
+    needs: release-target
     runs-on: ubuntu-latest
+    env:
+      RELEASE_COMMIT: ${{ needs.release-target.outputs.commit }}
     steps:
-      # The default checkout follows the event SHA today, but qualifying the
-      # branch that happened to contain that SHA would weaken the claim when
-      # checkout's default changes. The pushed tag is the artifact users name.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ needs.release-target.outputs.commit }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
@@ -103,15 +115,29 @@ jobs:
 
       # A checkout can hide exactly the distribution failures this protects
       # against: an untracked bundle, a path that reaches back to the source
-      # tree, or dependencies left over from CI. Clone the pushed tag anew,
-      # then run every check from that clone as an installer does.
+      # tree, or dependencies left over from CI. Clone anew and run every check
+      # from that clone as an installer does.
+      #
+      # The clone lands on the canonical sha rather than `--branch <tag>`. That
+      # is the difference this correction exists for: cloning by name asks the
+      # remote what the tag means *now*, and the answer can differ from the one
+      # the other gates were given. `--no-checkout` first, because the sha is
+      # not a branch and cannot be a clone target directly.
       - name: The tagged installation passes RELEASE-GATE section 4
         run: |
           set -euo pipefail
           clone_dir="$(mktemp -d)/commitlore"
-          git clone --quiet --branch "$GITHUB_REF_NAME" --depth 1 \
+          git clone --quiet --no-checkout \
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" "$clone_dir"
+          git -C "$clone_dir" checkout --quiet --detach "$RELEASE_COMMIT"
           cd "$clone_dir"
+
+          landed="$(git rev-parse HEAD)"
+          test "$landed" = "$RELEASE_COMMIT" || {
+            echo "clone landed on $landed, expected the qualified commit $RELEASE_COMMIT"
+            exit 1
+          }
+          printf 'fresh clone commit: %s\n' "$landed"
 
           # The bundle is the shipped CLI; no build or npm install belongs in
           # this job, because either would conceal a clone missing what ships.
@@ -227,14 +253,46 @@ jobs:
     # turn a failed qualification into a path that can still publish.
     needs: [version-consistency, install-gate, release-target, exact-head-ci]
     runs-on: ubuntu-latest
+    env:
+      RELEASE_COMMIT: ${{ needs.release-target.outputs.commit }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-target.outputs.commit }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
+      # Everything above can pass and the tag can still move before this step.
+      # The repository's `v*` ruleset (update and deletion both denied) is the
+      # standing control; this is the check that does not assume it held. It
+      # asks the remote, because a checkout only records what the tag meant
+      # when it was taken.
+      - name: The live tag still resolves to the qualified commit
+        run: node scripts/check-tag-binding.mjs "$GITHUB_REF_NAME" "$RELEASE_COMMIT"
+
+      # `--verify-tag` refuses when the tag does not exist, so publication can
+      # never create the reference it was meant to verify.
+      #
+      # `--target` is NOT what binds the release, and nothing here relies on it.
+      # It is documented as the branch or sha used when the command creates a
+      # tag automatically; what the CLI does with it when the tag already
+      # exists is not something this workflow asserts either way. The proven
+      # property is the narrow one: it does not establish that the tag equals
+      # this commit and it cannot retarget an existing tag.
+      #
+      # It is passed as explicit request metadata, and as defence for one
+      # future mistake: if an edit drops `--verify-tag`, the implicit creation
+      # that re-enables lands on the qualified commit instead of the default
+      # branch. What binds the release is the step above proving the live tag
+      # resolves to this commit, and the no-bypass `v*` ruleset keeping it there.
       - name: Publish the release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           gh release create "$GITHUB_REF_NAME" \
+            --verify-tag \
+            --target "$RELEASE_COMMIT" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes

--- a/docs/RELEASE-GATE.md
+++ b/docs/RELEASE-GATE.md
@@ -97,6 +97,72 @@ accidentally query CI using a tag-object SHA. Both are direct `publish`
 dependencies and `publish` has no `if:` condition that can override a failed or
 skipped dependency.
 
+### One commit, decided once (#499)
+
+A tag is a mutable ref. Every boundary that resolves the tag *name* asks the
+remote what it means **now**, and two boundaries can get two answers — so the
+gates above once qualified one commit while a fresh clone of the same tag landed
+on another, everything green. The release could then ship a commit nothing had
+checked.
+
+`release-target` is therefore anchored on the **event SHA**: what the tag pointed
+at when the push happened, which cannot be edited afterwards. Resolving the name
+there would leave a window *before the job starts* in which a move redefines the
+whole release. It exports that commit, and every later boundary consumes the SHA
+rather than the name:
+
+| boundary | consumes |
+|---|---|
+| `version-consistency` | checks out the canonical SHA; the tag name is only the version string it compares |
+| `exact-head-ci` | queries check runs at the canonical SHA |
+| `install-gate` | clones `--no-checkout`, detaches onto the canonical SHA, and asserts `HEAD` landed there |
+| `publish` | checks out the canonical SHA, then refuses unless the live tag still resolves to it |
+
+Immediately before publication, `scripts/check-tag-binding.mjs` re-reads the live
+`refs/tags/<version>` from the remote and refuses unless it still resolves to the
+canonical SHA. That check is what establishes the release ships the qualified
+commit. A missing tag is a refusal, not an empty success: `gh release create`
+runs with `--verify-tag`, so publication can never create the reference it was
+meant to verify.
+
+`--target <canonical SHA>` is passed too, but it is **not** load-bearing and
+nothing above relies on it. `gh` documents it as the branch or SHA used when the
+command creates a tag automatically. What the CLI does with it when the tag
+already exists is not asserted here either way; the proven property is narrower
+and is the only one claimed: **`--target` does not establish that the tag equals
+the canonical commit, and it cannot retarget an existing tag.** Live equality,
+the ruleset, and `--verify-tag` are what carry that weight.
+
+It is passed as explicit request metadata and as defence for one future mistake:
+if someone drops `--verify-tag`, the implicit creation that re-enables lands on
+the qualified commit rather than the default branch.
+
+That check queries **both** `refs/tags/<version>` and `refs/tags/<version>^{}`.
+`ls-remote` returns only the tag object for an annotated tag unless the peeled
+ref is named explicitly — verified against this repository's own `v0.7.0`, where
+one pattern returns `7f2aa4e2…` and only the peeled pattern reveals the commit
+`1ec65718…`. Asking for one pattern would compare an annotated release against
+its tag-object SHA and refuse every one of them for a reason that has nothing to
+do with the commit.
+
+Three controls cover three different intervals, and none of them covers another's:
+
+| interval | control | state |
+|---|---|---|
+| push → binding check | event-SHA propagation, then the binding check | detects drift and refuses |
+| binding check → `gh release create` | ruleset on `refs/tags/v*`, `update` and `deletion` denied, no bypass actors | `active` |
+| after the release exists | immutable releases | `enabled` |
+
+Be exact about the middle row. The binding check reads the tag and then the next
+step creates the release; a move landing between those two is not something the
+check can see, because it has already run. What holds that window closed is the
+ruleset, and only the ruleset. Removing it, or adding a bypass actor to it,
+reopens the window silently — no test here would notice.
+
+So the binding check does not make the ruleset unnecessary. It catches every
+drift that happened before it ran; the ruleset is what prevents the drift it
+cannot catch.
+
 ## 6. Every published claim is reproducible
 
 - `scripts/check-readme-numbers.mjs` exits 0 — no number in any README is typed

--- a/scripts/check-tag-binding.mjs
+++ b/scripts/check-tag-binding.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Refuses publication unless the live tag still resolves to the commit the
+ * release gates qualified.
+ *
+ * Every gate before this one proves something about a commit. None of them
+ * proves the tag still points at it. A tag is a mutable ref: it can be moved
+ * or deleted between the job that qualified it and the job that publishes,
+ * and each boundary that resolves the tag *name* again can be answered with a
+ * different commit than the last one got. This script is the last-moment
+ * binding check, and it asks the remote rather than the local checkout,
+ * because a checkout is a snapshot of what the tag meant when it was taken.
+ *
+ * An annotated tag has two refs: the tag object and its peeled `^{}` commit.
+ * The peeled line is the commit, and the one to compare — comparing the tag
+ * object SHA would refuse every annotated tag for the wrong reason.
+ *
+ * Usage:
+ *   node scripts/check-tag-binding.mjs <tag-name> <expected-sha> [remote]
+ *   node scripts/check-tag-binding.mjs <tag-name> <expected-sha> --from-file <ls-remote.txt>
+ *   node scripts/check-tag-binding.mjs <tag-name> <expected-sha> --from-stdin
+ *
+ * `--from-file` and `--from-stdin` are test seams. Their content is the output
+ * of `git ls-remote --tags <remote> refs/tags/<tag>`, verbatim.
+ *
+ * Exit codes follow SPEC §10:
+ *   0  the live tag exists and resolves to the expected commit
+ *   1  the tag is missing, or resolves to a different commit
+ *   2  the inputs were unusable, or the remote could not be read
+ */
+
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const usage = () => {
+  console.error(
+    'usage: node scripts/check-tag-binding.mjs <tag-name> <expected-sha> [remote | --from-file <path> | --from-stdin]',
+  );
+  process.exit(2);
+};
+
+const parseArgs = (argv) => {
+  const positional = [];
+  let fromFile = null;
+  let fromStdin = false;
+  let remote = 'origin';
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--from-file') {
+      // Repeating the flag is the same ambiguity as passing two sources: the
+      // caller named two listings and only one gets checked. Keeping the last
+      // one silently would make which listing was verified depend on argument
+      // order rather than on anything the caller stated.
+      if (fromFile !== null) {
+        console.error('ERROR: --from-file was given more than once.');
+        console.error('  Two listings are two questions; pass the one to check.');
+        process.exit(2);
+      }
+      fromFile = argv[index + 1] ?? null;
+      if (fromFile === null) usage();
+      index += 1;
+    } else if (arg === '--from-stdin') {
+      if (fromStdin) {
+        console.error('ERROR: --from-stdin was given more than once.');
+        console.error('  There is one stdin; a repeated flag means the invocation was not what its author thought.');
+        process.exit(2);
+      }
+      fromStdin = true;
+    } else if (arg.startsWith('--')) {
+      usage();
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  // Two sources are not a preference to resolve, they are a caller who does
+  // not know which listing is being checked. Silently picking one would decide
+  // that on their behalf, and the wrong choice is a release published against
+  // a tag nobody looked at.
+  if (fromFile !== null && fromStdin) {
+    console.error('ERROR: --from-file and --from-stdin are mutually exclusive.');
+    console.error('  Pass exactly one listing; choosing between them is not this script\'s decision to make.');
+    process.exit(2);
+  }
+  if (positional.length === 3 && (fromFile !== null || fromStdin)) {
+    console.error(`ERROR: a remote ("${positional[2]}") cannot be combined with --from-file or --from-stdin.`);
+    console.error('  The seam replaces the remote query; supplying both leaves the checked source ambiguous.');
+    process.exit(2);
+  }
+
+  if (positional.length === 3) remote = positional[2];
+  else if (positional.length !== 2) usage();
+
+  return { tag: positional[0], expected: positional[1], remote, fromFile, fromStdin };
+};
+
+const readStdin = () => {
+  try {
+    return readFileSync(0, 'utf8');
+  } catch (error) {
+    console.error(`ERROR: could not read the ls-remote payload from stdin: ${error.message}`);
+    process.exit(2);
+  }
+};
+
+const { tag, expected, remote, fromFile, fromStdin } = parseArgs(process.argv.slice(2));
+
+if (!/^[0-9a-f]{40}$/.test(expected)) {
+  console.error(`ERROR: expected commit "${expected}" is not a full 40-character sha.`);
+  console.error('  The qualified commit must be passed exactly, not abbreviated or named.');
+  process.exit(2);
+}
+
+const ref = `refs/tags/${tag}`;
+
+let payload;
+let source;
+if (fromFile !== null) {
+  try {
+    payload = readFileSync(fromFile, 'utf8');
+  } catch (error) {
+    console.error(`ERROR: could not read ${fromFile}: ${error.message}`);
+    process.exit(2);
+  }
+  source = fromFile;
+} else if (fromStdin) {
+  payload = readStdin();
+  source = 'stdin payload';
+} else {
+  // BOTH patterns, always. `ls-remote --tags <remote> refs/tags/<tag>` returns
+  // only the tag object for an annotated tag — the peeled `^{}` line appears
+  // solely when that ref is asked for by name. Requesting one pattern would
+  // therefore compare an annotated release against its tag object sha and
+  // refuse every one of them for a reason that has nothing to do with the
+  // commit. Because both are always requested, a missing peeled line now means
+  // the tag really is lightweight rather than merely unasked-for.
+  const result = spawnSync('git', ['ls-remote', '--tags', '--', remote, ref, `${ref}^{}`], {
+    encoding: 'utf8',
+    shell: false,
+  });
+  if (result.status !== 0) {
+    console.error(`ERROR: could not read ${ref} from remote "${remote}".`);
+    if (result.stderr) console.error(result.stderr.trim());
+    process.exit(2);
+  }
+  payload = result.stdout;
+  source = `${remote} ${ref}`;
+}
+
+// `<sha>\t<ref>`, one per line. An annotated tag adds a second line whose ref
+// carries the `^{}` suffix and whose sha is the commit the tag points at.
+const rows = payload
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.length > 0)
+  .map((line) => {
+    const [sha, name] = line.split(/\s+/, 2);
+    return { sha, name };
+  });
+
+const malformed = rows.find(({ sha, name }) => !/^[0-9a-f]{40}$/.test(sha ?? '') || (name ?? '') === '');
+if (malformed !== undefined) {
+  console.error(`ERROR: could not parse the tag listing from ${source}.`);
+  console.error(`  offending line: ${malformed.sha ?? ''} ${malformed.name ?? ''}`);
+  process.exit(2);
+}
+
+// Only two refs can legitimately appear. Anything else means the listing is
+// not the one that was asked for, and reading a familiar row out of an
+// unfamiliar payload is how a check ends up answering about the wrong tag.
+const peeledRef = `${ref}^{}`;
+const unexpected = rows.filter(({ name }) => name !== ref && name !== peeledRef);
+if (unexpected.length > 0) {
+  console.error(`ERROR: the listing from ${source} carries refs this check did not ask for.`);
+  for (const row of unexpected) console.error(`  unexpected: ${row.name}`);
+  process.exit(2);
+}
+
+const peeledRows = rows.filter(({ name }) => name === peeledRef);
+const plainRows = rows.filter(({ name }) => name === ref);
+
+// A ref resolves to one object. Two rows for one name is a contradiction, and
+// picking either would be a guess presented as a verification.
+if (plainRows.length > 1 || peeledRows.length > 1) {
+  console.error(`ERROR: ${source} reports the same ref more than once, so it does not identify one commit.`);
+  for (const row of [...plainRows, ...peeledRows]) console.error(`  ${row.sha} ${row.name}`);
+  process.exit(2);
+}
+
+const [peeled] = peeledRows;
+const [plain] = plainRows;
+
+// Absence is a refusal, not an empty success. A release that publishes past a
+// tag it could not find would create the reference it was supposed to verify,
+// which is the inversion these gates exist to remove.
+if (peeled === undefined && plain === undefined) {
+  console.error(`ERROR: ${ref} does not exist on "${remote}".`);
+  console.error('  Refusing to publish a release for a tag that is not there; publication never creates it.');
+  process.exit(1);
+}
+
+// A peeled ref only exists because a tag object points at it, so git never
+// reports one without the other. A payload that does is truncated or
+// assembled, and trusting its commit would mean trusting the part that is
+// missing to have said the same thing.
+if (peeled !== undefined && plain === undefined) {
+  console.error(`ERROR: ${source} reports ${peeledRef} with no ${ref} row.`);
+  console.error('  A peeled ref cannot exist without its tag object; this listing is incomplete.');
+  process.exit(2);
+}
+
+const live = (peeled ?? plain).sha;
+const kind = peeled === undefined ? 'lightweight' : 'annotated';
+
+if (live !== expected) {
+  console.error(`ERROR: ${ref} now resolves to ${live}, but the release gates qualified ${expected}.`);
+  console.error('  The tag moved after qualification. Refusing to publish a commit nothing checked.');
+  process.exit(1);
+}
+
+console.log(`tag binding accepted: ${ref} (${kind}) still resolves to ${expected} on "${remote}"`);

--- a/test/release-tag-binding.test.ts
+++ b/test/release-tag-binding.test.ts
@@ -1,0 +1,476 @@
+/**
+ * #499. The four prerequisite jobs proved things about a commit, and nothing
+ * proved the tag still pointed at it when the release was created.
+ *
+ * Each boundary resolved the tag *name* independently — the ancestry gate, the
+ * CI gate, the fresh-clone install gate and `gh release create` each asked the
+ * remote what the tag meant at the moment they ran. A ref move between any two
+ * of them produced gates that qualified one commit and a release that shipped
+ * another, with every check green.
+ *
+ * These cases move and delete the tag at each boundary. A workflow that binds
+ * one canonical sha refuses all of them; the workflow that resolved the name
+ * repeatedly could not have noticed.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { load } from 'js-yaml';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { REQUIRED_CHECKS } from '../scripts/check-exact-head-ci.mjs';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const TAG_BINDING = join(REPO_ROOT, 'scripts', 'check-tag-binding.mjs');
+const RELEASE_TARGET = join(REPO_ROOT, 'scripts', 'check-release-target.mjs');
+const EXACT_HEAD_CI = join(REPO_ROOT, 'scripts', 'check-exact-head-ci.mjs');
+const RELEASE_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'release.yml');
+
+const TAG = 'v9.9.9';
+const REF = `refs/tags/${TAG}`;
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const tempDir = (label: string): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `commitlore-binding-${label}-`));
+  scratch.push(dir);
+  return dir;
+};
+
+const git = (cwd: string, args: string[]): string => {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8', shell: false });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed (exit ${result.status}): ${result.stderr}`);
+  }
+  return result.stdout;
+};
+
+const commit = (repo: string, message: string): string => {
+  writeFileSync(join(repo, 'file.txt'), message);
+  git(repo, ['add', 'file.txt']);
+  git(repo, [
+    '-c',
+    'user.name=Release gate',
+    '-c',
+    'user.email=release-gate@example.invalid',
+    'commit',
+    '--quiet',
+    '-m',
+    message,
+  ]);
+  return git(repo, ['rev-parse', 'HEAD']).trim();
+};
+
+interface RunResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+const run = (script: string, args: string[], cwd = REPO_ROOT): RunResult => {
+  const result = spawnSync(process.execPath, [script, ...args], { cwd, encoding: 'utf8', shell: false });
+  return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+};
+
+/**
+ * An upstream with two commits on main and a tag on the first. `clone` is a
+ * consumer of that remote, so `ls-remote` from it observes the live ref the
+ * way the publish step does rather than a snapshot taken earlier.
+ */
+const upstream = (label: string, annotated: boolean): { clone: string; first: string; second: string } => {
+  const origin = join(tempDir(label), 'origin');
+  git(tempDir(`${label}-mk`), ['init', '--quiet', '--bare', '--initial-branch=main', origin]);
+
+  const work = join(tempDir(`${label}-work`), 'work');
+  git(tempDir(`${label}-clonedir`), ['clone', '--quiet', origin, work]);
+  git(work, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  const first = commit(work, 'first');
+  const second = commit(work, 'second');
+  git(work, ['push', '--quiet', 'origin', 'main']);
+
+  if (annotated) {
+    git(work, [
+      '-c',
+      'user.name=Release gate',
+      '-c',
+      'user.email=release-gate@example.invalid',
+      'tag',
+      '-a',
+      TAG,
+      '-m',
+      'release',
+      first,
+    ]);
+  } else {
+    git(work, ['tag', TAG, first]);
+  }
+  git(work, ['push', '--quiet', 'origin', REF]);
+
+  return { clone: work, first, second };
+};
+
+const moveTag = (work: string, to: string, annotated: boolean): void => {
+  git(work, ['tag', '-d', TAG]);
+  if (annotated) {
+    git(work, [
+      '-c',
+      'user.name=Release gate',
+      '-c',
+      'user.email=release-gate@example.invalid',
+      'tag',
+      '-a',
+      TAG,
+      '-m',
+      'moved',
+      to,
+    ]);
+  } else {
+    git(work, ['tag', TAG, to]);
+  }
+  git(work, ['push', '--quiet', '--force', 'origin', REF]);
+};
+
+describe('#499 the published tag is the commit the gates qualified', () => {
+  it('accepts a tag that still resolves to the qualified commit', () => {
+    const { clone, first } = upstream('accept', false);
+
+    const result = run(TAG_BINDING, [TAG, first], clone);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('tag binding accepted');
+  });
+
+  it('accepts an annotated tag by its commit rather than its tag object', () => {
+    const { clone, first } = upstream('annotated', true);
+
+    // The tag object sha is what a naive comparison would reach for; refusing
+    // on it would reject every annotated release for the wrong reason.
+    const tagObject = git(clone, ['rev-parse', REF]).trim();
+    expect(tagObject).not.toBe(first);
+
+    const result = run(TAG_BINDING, [TAG, first], clone);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('(annotated)');
+  });
+
+  it('refuses when the tag moved to another commit after qualification', () => {
+    const { clone, first, second } = upstream('moved', false);
+    moveTag(clone, second, false);
+
+    const result = run(TAG_BINDING, [TAG, first], clone);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`now resolves to ${second}`);
+    expect(result.stderr).toContain('Refusing to publish a commit nothing checked');
+  });
+
+  it('refuses a moved annotated tag, where the peeled commit is what changed', () => {
+    const { clone, first, second } = upstream('moved-annotated', true);
+    moveTag(clone, second, true);
+
+    const result = run(TAG_BINDING, [TAG, first], clone);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`now resolves to ${second}`);
+  });
+
+  it('refuses a same-name tag on another main commit even when CI passed on the original', () => {
+    // Every upstream gate is genuinely satisfied for the original commit here:
+    // both commits are main descendants, and the six required check runs exist
+    // at `first` and concluded success. The CI gate passes on exactly the
+    // evidence a release would present. None of that is about the commit the
+    // tag now names, which is the split this ticket exists to close — so the
+    // case has to run those gates rather than assert their premises.
+    const { clone, first, second } = upstream('same-name', false);
+
+    expect(run(RELEASE_TARGET, [first, 'main'], clone).status).toBe(0);
+    expect(run(RELEASE_TARGET, [second, 'main'], clone).status).toBe(0);
+
+    const green = join(tempDir('same-name-ci'), 'check-runs.json');
+    writeFileSync(
+      green,
+      JSON.stringify({
+        total_count: REQUIRED_CHECKS.length,
+        check_runs: REQUIRED_CHECKS.map((name) => ({
+          name,
+          status: 'completed',
+          conclusion: 'success',
+          head_sha: first,
+        })),
+      }),
+    );
+    const ci = run(EXACT_HEAD_CI, ['owner', 'repo', first, '--from-file', green], clone);
+    expect(ci.status).toBe(0);
+    expect(ci.stdout).toContain('all 6 required checks succeeded');
+
+    moveTag(clone, second, false);
+
+    // The ancestry gate and the CI gate both still hold for `first`; only the
+    // binding check can see that the tag no longer names it.
+    expect(run(RELEASE_TARGET, [first, 'main'], clone).status).toBe(0);
+    expect(run(EXACT_HEAD_CI, ['owner', 'repo', first, '--from-file', green], clone).status).toBe(0);
+
+    const result = run(TAG_BINDING, [TAG, first], clone);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`now resolves to ${second}`);
+  });
+
+  it('keeps the canonical commit at the event sha when the tag moves before the resolver runs', () => {
+    // The window this closes: a move landing between the push and the first
+    // job. Resolving the tag name here would hand every downstream gate the
+    // attacker's commit and they would all agree, greenly, on the wrong one.
+    const { clone, first, second } = upstream('pre-resolver', false);
+    moveTag(clone, second, false);
+
+    // The workflow passes GITHUB_SHA — the commit the tag pointed at when the
+    // push happened — so the resolver still answers the original commit even
+    // though the live tag now names another.
+    const resolved = run(RELEASE_TARGET, [first, 'main'], clone);
+    expect(resolved.status).toBe(0);
+    expect(resolved.stdout).toContain(first);
+    expect(resolved.stdout).not.toContain(second);
+
+    // And publication refuses, because the live tag no longer agrees with the
+    // commit every gate qualified. The release is withheld rather than
+    // silently retargeted.
+    const publication = run(TAG_BINDING, [TAG, first], clone);
+    expect(publication.status).toBe(1);
+    expect(publication.stderr).toContain(`now resolves to ${second}`);
+  });
+
+  it('refuses when the tag was deleted between qualification and publication', () => {
+    const { clone, first } = upstream('deleted', false);
+    git(clone, ['push', '--quiet', '--delete', 'origin', REF]);
+
+    const result = run(TAG_BINDING, [TAG, first], clone);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('does not exist');
+  });
+
+  it('refuses a missing tag rather than treating an empty listing as nothing wrong', () => {
+    const result = run(TAG_BINDING, [TAG, '0'.repeat(40), '--from-stdin'], REPO_ROOT);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('publication never creates it');
+  });
+
+  it('refuses an abbreviated expected sha rather than comparing prefixes', () => {
+    const result = run(TAG_BINDING, [TAG, 'abc1234', '--from-stdin'], REPO_ROOT);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('not a full 40-character sha');
+  });
+
+  describe('ambiguous or partial listings are refused rather than resolved', () => {
+    const listing = (contents: string): string => {
+      const dir = tempDir('listing');
+      const file = join(dir, 'ls-remote.txt');
+      writeFileSync(file, contents);
+      return file;
+    };
+
+    const SHA_A = 'a'.repeat(40);
+    const SHA_B = 'b'.repeat(40);
+
+    it('refuses --from-file together with --from-stdin', () => {
+      const file = listing(`${SHA_A}\t${REF}\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-file', file, '--from-stdin'], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('mutually exclusive');
+    });
+
+    it('refuses a positional remote combined with a seam', () => {
+      const file = listing(`${SHA_A}\t${REF}\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, 'origin', '--from-file', file], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('cannot be combined');
+    });
+
+    it('refuses a repeated --from-file rather than keeping the last path', () => {
+      const first = listing(`${SHA_A}\t${REF}\n`);
+      const second = listing(`${SHA_B}\t${REF}\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-file', first, '--from-file', second], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('given more than once');
+    });
+
+    it('refuses a repeated --from-stdin', () => {
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-stdin', '--from-stdin'], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('given more than once');
+    });
+
+    it('refuses two rows for the same ref instead of taking the first', () => {
+      const file = listing(`${SHA_A}\t${REF}\n${SHA_B}\t${REF}\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-file', file], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('more than once');
+    });
+
+    it('refuses two peeled rows even when one of them matches', () => {
+      const file = listing(`${SHA_A}\t${REF}\n${SHA_B}\t${REF}^{}\n${SHA_A}\t${REF}^{}\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-file', file], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('more than once');
+    });
+
+    it('refuses a peeled row with no tag-object row', () => {
+      const file = listing(`${SHA_A}\t${REF}^{}\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-file', file], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('cannot exist without its tag object');
+    });
+
+    it('refuses a listing carrying refs that were never requested', () => {
+      const file = listing(`${SHA_A}\t${REF}\n${SHA_B}\trefs/tags/v0.0.1\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-file', file], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('refs this check did not ask for');
+    });
+
+    it('still accepts the one shape git actually produces for an annotated tag', () => {
+      const file = listing(`${SHA_B}\t${REF}\n${SHA_A}\t${REF}^{}\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-file', file], REPO_ROOT);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('(annotated)');
+    });
+  });
+
+  it('refuses an unparseable listing instead of reading it as absent', () => {
+    const payload = tempDir('malformed');
+    const file = join(payload, 'ls-remote.txt');
+    writeFileSync(file, 'not-a-sha refs/tags/v9.9.9\n');
+
+    const result = run(TAG_BINDING, [TAG, '0'.repeat(40), '--from-file', file], REPO_ROOT);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('could not parse');
+  });
+});
+
+describe('#499 every release boundary consumes one canonical sha', () => {
+  const workflow = load(readFileSync(RELEASE_WORKFLOW, 'utf8')) as {
+    jobs: Record<string, { needs?: string | string[]; outputs?: Record<string, string>; steps: unknown[]; env?: Record<string, string> }>;
+  };
+
+  const CANONICAL = '${{ needs.release-target.outputs.commit }}';
+
+  const needsOf = (job: string): string[] => {
+    const declared = workflow.jobs[job]?.needs;
+    if (declared === undefined) return [];
+    return Array.isArray(declared) ? declared : [declared];
+  };
+
+  const checkoutRefs = (job: string): unknown[] =>
+    (workflow.jobs[job]?.steps as { uses?: string; with?: { ref?: unknown } }[])
+      .filter((step) => typeof step.uses === 'string' && step.uses.startsWith('actions/checkout'))
+      .map((step) => step.with?.ref);
+
+  it('resolves the canonical commit exactly once, in the job that owns it', () => {
+    const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
+    const resolutions = raw.split('\n').filter((line) => line.includes('check-release-target.mjs'));
+
+    expect(resolutions).toHaveLength(1);
+    expect(workflow.jobs['release-target']?.outputs?.['commit']).toBe('${{ steps.ancestry.outputs.sha }}');
+  });
+
+  // Anchoring on the live tag would leave a window before this job starts in
+  // which a move redefines the release, and every gate downstream would then
+  // agree on the wrong commit. The event sha is what the tag pointed at when
+  // the push happened and cannot be edited afterwards.
+  it('anchors the resolver on the immutable event sha, not the live tag', () => {
+    const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
+    const resolution = raw.split('\n').find((line) => line.includes('check-release-target.mjs'));
+
+    expect(resolution).toContain('"$GITHUB_SHA"');
+    expect(resolution).not.toContain('GITHUB_REF_NAME');
+    expect(checkoutRefs('release-target')).toEqual(['${{ github.sha }}']);
+  });
+
+  // The weaker assertion this replaces only checked that `publish.needs` named
+  // four jobs. Four jobs that each resolve the tag themselves satisfy that and
+  // still publish an unqualified commit, which is how the defect shipped.
+  it.each(['version-consistency', 'exact-head-ci', 'install-gate', 'publish'])(
+    'checks %s out at the canonical sha, never at the tag ref',
+    (job) => {
+      expect(needsOf(job)).toContain('release-target');
+      const refs = checkoutRefs(job);
+      expect(refs.length).toBeGreaterThan(0);
+      for (const ref of refs) expect(ref).toBe(CANONICAL);
+    },
+  );
+
+  it('gives the CI gate the canonical sha rather than the event sha', () => {
+    const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
+    const line = raw.split('\n').find((entry) => entry.includes('check-exact-head-ci.mjs'));
+
+    expect(line).toBeDefined();
+    expect(line).toContain(CANONICAL);
+  });
+
+  it('clones the install gate onto the canonical sha instead of the tag name', () => {
+    const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
+
+    expect(raw).not.toContain('git clone --quiet --branch "$GITHUB_REF_NAME"');
+    expect(raw).toContain('checkout --quiet --detach "$RELEASE_COMMIT"');
+    expect(workflow.jobs['install-gate']?.env?.['RELEASE_COMMIT']).toBe(CANONICAL);
+  });
+
+  // What makes the published release the qualified commit is the live-equality
+  // check plus the no-bypass ruleset, with `--verify-tag` refusing to create a
+  // tag that is not there. `--target` is asserted because it should be passed,
+  // not because it binds anything: `gh` documents it as the target for
+  // AUTOMATIC tag creation, and `--verify-tag` means none happens here.
+  it('re-reads the live tag before publication and refuses to create a missing one', () => {
+    const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
+
+    expect(raw).toContain('check-tag-binding.mjs "$GITHUB_REF_NAME" "$RELEASE_COMMIT"');
+    expect(raw).toContain('--verify-tag');
+    expect(workflow.jobs['publish']?.env?.['RELEASE_COMMIT']).toBe(CANONICAL);
+  });
+
+  it('passes the canonical target as defence for a dropped --verify-tag, not as the binding', () => {
+    const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
+
+    expect(raw).toContain('--target "$RELEASE_COMMIT"');
+  });
+
+  it('orders the binding check before the release is created', () => {
+    // Read the job's own steps rather than searching the file: an earlier
+    // comment mentions `gh release create`, and a text search finds prose.
+    const steps = workflow.jobs['publish']?.steps as { name?: string; run?: string }[];
+    const binding = steps.findIndex((step) => (step.run ?? '').includes('check-tag-binding.mjs'));
+    const create = steps.findIndex((step) => (step.run ?? '').includes('gh release create'));
+
+    expect(binding).toBeGreaterThanOrEqual(0);
+    expect(create).toBeGreaterThanOrEqual(0);
+    expect(binding).toBeLessThan(create);
+  });
+});


### PR DESCRIPTION
Closes #499. Base is the `main` merge commit `9a5a91a0`; exact head `46ab6569223fc7d5b0bf33f3a1b30bcdf297e9bb`.

**No `v0.7.1` tag or release exists.** Publication is held pending an independent exact-head gate PASS on this head.

## The failure

Four prerequisite jobs proved things about a commit, and **each one resolved the tag name separately to decide which commit that was.** A tag is a mutable ref, so two boundaries could get two answers — a ref move left the ancestry and CI gates accepting the original commit while a fresh clone of the same tag landed on another `main` descendant, every check green. The release could then ship a commit nothing had checked: the defect these gates were built to remove, rebuilt one level up by the gates themselves.

## The correction

The canonical commit is fixed once and consumed everywhere. **The anchor is the event SHA, not the live tag** — resolving the name in the first job would leave a window before that job starts in which a move redefines the whole release. The tag name survives only as the version label and as the key the final binding check looks up.

| boundary | consumes |
|---|---|
| `release-target` | `github.sha`, peeled to a commit |
| `version-consistency` | canonical SHA |
| `exact-head-ci` | canonical SHA |
| `install-gate` | clones `--no-checkout`, detaches onto the canonical SHA, asserts `HEAD` landed there |
| `publish` | canonical SHA, then refuses unless the live tag still resolves to it |

`scripts/check-tag-binding.mjs` queries **both** `refs/tags/<v>` and `refs/tags/<v>^{}`. `ls-remote` returns only the tag object for an annotated tag unless the peeled ref is named — confirmed against this repository's own `v0.7.0`, where one pattern gives `7f2aa4e2…` and only the peeled pattern gives the commit `1ec65718…`. A single pattern would have refused every annotated release by comparing its tag object.

The parser refuses ambiguity rather than resolving it: two sources, a repeated source flag, a remote alongside a seam, two rows for one ref, a peeled ref with no tag object, or a ref nobody asked for. Picking the convenient row would turn a guess into a verification.

## What is load-bearing, stated precisely

| interval | control |
|---|---|
| push → binding check | event-SHA propagation, then the binding check |
| binding check → `gh release create` | `v*` ruleset, `update` and `deletion` denied, no bypass actors |
| after the release exists | immutable releases |

**`--target` is not load-bearing** and nothing relies on it. `gh` documents it as the target used when the command creates a tag automatically; what the CLI does with it when the tag already exists is not asserted here either way. The proven property is narrow: it does not establish that the tag equals the canonical commit and cannot retarget an existing tag. It is passed as defence for one future mistake — if someone drops `--verify-tag`, the implicit creation that re-enables lands on the qualified commit rather than the default branch.

The binding check does **not** make the ruleset unnecessary. It catches drift that happened before it ran; the ruleset closes the window it cannot see.

## Evidence at this exact head

Clean worktree, clean `npm ci`, single run, Node v24.18.0:

```
full suite   107 files, 2,338 pass, 1 skipped
typecheck    clean
dist         rebuilds byte-identical
workflow     loads as YAML
```

17 of the first 20 new cases fail against the workflow as it stood. The same-name case drives the gates rather than their premises: ancestry and exact-head CI both pass for the original commit with six successful required check runs, **still pass after the tag moves**, and only the binding check sees that the tag no longer names it.

Repository controls, read back from the API:

```
immutable-releases   {"enabled": true, "enforced_by_owner": false}
ruleset 20587790     active · refs/tags/v* · [update, deletion] · bypass: []
```
