### PR TITLE
Give the gates a token that cannot publish what they are gating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,19 @@ on:
     tags:
       - "v*"
 
-# `contents: write` is what lets the publish job create the GitHub Release
-# and upload assets to it. `id-token`/`attestations` are what
-# actions/attest-build-provenance needs (Sigstore-backed keyless signing —
-# no secret key for this repo to manage or leak). Nothing here needs to
-# write code, open PRs, or touch anything but this one release.
+# Read for the workflow; the ability to create a release belongs to the one job
+# that creates one. Granting `contents: write` here hands it to the gates too,
+# and the gates run `actions/checkout@v4` and `actions/setup-node@v4` — mutable
+# major tags whose contents can change under the same reference. Anything
+# executing inside a gate with a release-write token could create the release
+# before that gate, or any other, had finished, which would make the ordering
+# these jobs exist to enforce decorative.
+#
+# `id-token` and `attestations` were granted for an attestation action this
+# workflow does not contain. Privilege granted for a step that is not here is
+# privilege available to every step that is.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
   # `exact-head-ci` reads the check runs GitHub recorded for the tagged commit.
   # Reading a branch's green badge would answer a different, weaker question.
   checks: read
@@ -50,10 +54,14 @@ jobs:
         name: The pushed commit is already contained in main
         run: node scripts/check-release-target.mjs "$GITHUB_SHA" main --github-output
 
-  # Refuses the whole release before a single binary is built. A release
-  # whose asset reports a version that disagrees with its own tag is not
-  # fixable after the fact — the tag is immutable once fetched, the asset is
-  # immutable once downloaded. See scripts/check-release-version.mjs.
+  # Refuses the whole release before a single binary is built. A release whose
+  # asset reports a version that disagrees with its own tag is not fixable
+  # after the fact: the asset is immutable once downloaded, and a tag someone
+  # has already fetched cannot be corrected for them by moving it here.
+  #
+  # The tag itself is not immutable — this workflow exists because a ref can
+  # move — which is what the `v*` ruleset and the binding check below are for.
+  # See scripts/check-release-version.mjs.
   #
   # The checkout takes the canonical sha, not the tag: the version this job
   # compares must come from the same bytes every other gate qualified.
@@ -252,6 +260,11 @@ jobs:
     # semantics. Keep it free of `if:`: a condition such as `always()` would
     # turn a failed qualification into a path that can still publish.
     needs: [version-consistency, install-gate, release-target, exact-head-ci]
+    # The only job that may create a release, and it cannot start until all four
+    # gates have passed. Scoping the grant here is what makes that ordering a
+    # constraint rather than a convention.
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     env:
       RELEASE_COMMIT: ${{ needs.release-target.outputs.commit }}

--- a/docs/RELEASE-GATE.md
+++ b/docs/RELEASE-GATE.md
@@ -47,7 +47,8 @@ exclusion, so this table is a spot check of the rule, not the rule itself.
 ## 4. The installation the documentation describes actually works
 
 These checks run as the `install-gate` job in the tag-triggered release workflow,
-against a fresh clone of the pushed tag. `publish` depends on this job as well as
+against a fresh clone landed on the canonical commit — not on the tag name; §5
+explains why that distinction is the point. `publish` depends on this job as well as
 the version, ancestry, and exact-head-CI gates, so a GitHub Release cannot exist
 until every automated prerequisite has passed.
 
@@ -80,7 +81,7 @@ The tag workflow therefore blocks `publish` on both jobs below.
 
 | check | command | pass |
 |---|---|---|
-| release target | `scripts/check-release-target.mjs <tag> main` from a `fetch-depth: 0` checkout | the tag resolves to a commit contained in `main`; a shallow checkout fails rather than guessing |
+| release target | `scripts/check-release-target.mjs "$GITHUB_SHA" main` from a `fetch-depth: 0` checkout | the pushed commit is contained in `main`; a shallow checkout fails rather than guessing |
 | exact-head CI | `scripts/check-exact-head-ci.mjs <owner> <repo> <resolved-tag-sha>` | all six explicitly named check runs below are present at that SHA, `completed`, and concluded `success` |
 
 The exact-head list is fixed rather than inferred from the API response:

--- a/scripts/check-tag-binding.mjs
+++ b/scripts/check-tag-binding.mjs
@@ -154,10 +154,21 @@ const rows = payload
   .split('\n')
   .map((line) => line.trim())
   .filter((line) => line.length > 0)
+  // Split the whole line, not its first two fields. A limit of 2 discards
+  // whatever follows, so a line carrying a second sha and ref would be read as
+  // the first pair and accepted: the payload said two contradictory things and
+  // the check would have reported one of them as verified.
   .map((line) => {
-    const [sha, name] = line.split(/\s+/, 2);
-    return { sha, name };
+    const fields = line.split(/\s+/);
+    return { sha: fields[0], name: fields[1], extra: fields.slice(2) };
   });
+
+const overfull = rows.find(({ extra }) => extra.length > 0);
+if (overfull !== undefined) {
+  console.error(`ERROR: a line in the listing from ${source} carries more than one sha and ref.`);
+  console.error(`  offending line: ${overfull.sha} ${overfull.name} ${overfull.extra.join(' ')}`);
+  process.exit(2);
+}
 
 const malformed = rows.find(({ sha, name }) => !/^[0-9a-f]{40}$/.test(sha ?? '') || (name ?? '') === '');
 if (malformed !== undefined) {

--- a/test/release-tag-binding.test.ts
+++ b/test/release-tag-binding.test.ts
@@ -344,6 +344,17 @@ describe('#499 the published tag is the commit the gates qualified', () => {
       expect(result.stderr).toContain('cannot exist without its tag object');
     });
 
+    it('refuses a line carrying more than one sha and ref', () => {
+      // `split(/\s+/, 2)` discarded everything past the first pair, so a line
+      // saying two contradictory things was read as the first and accepted.
+      const file = listing(`${SHA_A}\t${REF} ${SHA_B}\t${REF}\n`);
+
+      const result = run(TAG_BINDING, [TAG, SHA_A, '--from-file', file], REPO_ROOT);
+
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('more than one sha and ref');
+    });
+
     it('refuses a listing carrying refs that were never requested', () => {
       const file = listing(`${SHA_A}\t${REF}\n${SHA_B}\trefs/tags/v0.0.1\n`);
 
@@ -460,6 +471,39 @@ describe('#499 every release boundary consumes one canonical sha', () => {
     const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
 
     expect(raw).toContain('--target "$RELEASE_COMMIT"');
+  });
+
+  // The gates run mutable `@v4` actions. A workflow-global `contents: write`
+  // would give every one of them a token that can create the release, and an
+  // action whose contents changed under the same reference could publish
+  // before any gate finished — the ordering below would still be declared and
+  // would no longer be a constraint.
+  it('grants release-write to the publishing job alone', () => {
+    const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
+    const parsed = load(raw) as {
+      permissions?: Record<string, string>;
+      jobs: Record<string, { permissions?: Record<string, string> }>;
+    };
+
+    expect(parsed.permissions?.['contents']).toBe('read');
+
+    for (const [name, job] of Object.entries(parsed.jobs)) {
+      if (name === 'publish') continue;
+      expect(job.permissions?.['contents'] ?? 'read').toBe('read');
+    }
+
+    expect(parsed.jobs['publish']?.permissions?.['contents']).toBe('write');
+  });
+
+  it('grants no privilege for an action the workflow does not contain', () => {
+    const raw = readFileSync(RELEASE_WORKFLOW, 'utf8');
+    const parsed = load(raw) as { permissions?: Record<string, string> };
+
+    // `id-token` and `attestations` were granted for an attestation action that
+    // is not here. Unused privilege is still available to every step present.
+    expect(raw).not.toContain('attest-build-provenance');
+    expect(parsed.permissions?.['id-token']).toBeUndefined();
+    expect(parsed.permissions?.['attestations']).toBeUndefined();
   });
 
   it('orders the binding check before the release is created', () => {


### PR DESCRIPTION
Release blocker found by adversarial review of `46ab6569`. Base `18fc7b3b` (current `main`). **No `v0.7.1` tag exists; the tag waits for this.**

## The gates were decorative against a supply-chain path

`contents: write` was declared for the **whole workflow**, so all five jobs held a token that can create a release — including the four whose only purpose is to decide whether one should exist. Those four run `actions/checkout@v4` and `actions/setup-node@v4`: mutable major tags whose contents can change under the same reference.

So anything executing inside a gate could have created the release **before that gate, or any other, had finished**. The ordering was declared, and enforced by nothing.

The grant now belongs to `publish` alone, which cannot start until all four gates pass. That is what turns the ordering from a convention into a constraint.

`id-token` and `attestations` were granted for an attestation action this workflow does not contain and never did. Privilege granted for a step that is not here is privilege available to every step that is.

## The parser accepted a payload saying two contradictory things

Demonstrated, then reproduced:

```
aaaa…  refs/tags/v9.9.9  bbbb…  refs/tags/v9.9.9   →  exit 0
```

`split(/\s+/, 2)` discarded everything past the first pair, so a line carrying a second sha and ref was read as the first and **accepted** — the opposite of what a verification is for. The claim that only git's actual shape is accepted was false. The whole line is parsed now; anything beyond one sha and one ref exits 2.

## Two documentation claims that would undo the previous fix

- §4 still described a clone of the **pushed tag** when the previous change deliberately stopped cloning by name
- the §5 table still showed `check-release-target.mjs <tag> main` where the workflow passes `$GITHUB_SHA`

A reader following either would have reintroduced exactly the live-name resolution that was removed. The workflow also called a tag "immutable once fetched" while existing entirely because a ref can move.

## Evidence

The three new cases **fail against the shipping workflow and parser** and pass here. Restoring `main`'s two files turns the suite red at exactly 3, and putting them back turns it green — the reverting is the evidence.

```
release-gate suites   48 pass
typecheck             clean
dist                  rebuilds byte-identical
workflow              loads as YAML
```

## Stated limit

Gate jobs still run mutable `@v4` action references. A changed action can still read this repository's source and its own job's token; what it can no longer do is create a release. Pinning those actions by digest is the right move and is a separate decision with its own upgrade cost — bundling it inside a release blocker would be the wrong place for it.
