### PR TITLE
Put the example that is the product before the argument for it

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,137 +14,37 @@
 
 # CommitLore
 
-## エージェントはコードを受け継ぎます。
-## 判断も継がせましょう。
+**あなたのコーディングエージェントは、チームがすでに却下した案を何度も提案します。**
 
-**コーディングエージェントのための Git ネイティブな decision layer。**
+CommitLore はその決定を Git に残し、ファイルを編集する前に、まだ有効なものだけを
+エージェントに渡します — **ホスティングサービスなしで、リポジトリの外へ 1 バイトも
+出すことなく**。
 
-新しいエージェントは実装を受け継ぎます。しかし制約も、チームが却下した代替案も、警告も、
-検証のギャップも受け継ぎません — 何かが運ばないかぎり、それらはコードと一緒には動きません。
-
-CommitLore はその工学的判断を Git に保存し、次の編集の前に**今も有効な決定だけ**を届けます。
-のちに置き換えられた決定や期限切れの決定が、まだ有効であるかのようにエージェントへ届くことは
-ありません。
-
-**リポジトリ所有 · lifecycle 認識 · 根拠検証 · エージェント非依存**
-
-Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
-
-ホスト型メモリサービスも、ベンダー固有のチャット履歴もありません。リポジトリが所有し、共に移動する、レビュー可能な意思決定コンテキストだけです。
-
-一度インストールします。コーディングエージェントは引き継ぐ価値のある意思決定を記録でき、CommitLore はそれを検証して Git に保存します。
-
-**Claude Code** — プラグイン一つで MCP サーバー、編集前のコンテキストフック、スキルが登録されます:
-
-```
-/plugin marketplace add MongLong0214/commitlore
-/plugin install commitlore@commitlore
-```
-
-プラグインが持つのはここまでで、MCP サーバー、編集前フック、スキルです。`commitlore` を `PATH` に置くことはないので、以下の `commitlore …` コマンドは `install.sh` / `install.ps1` から来るものであり、そのインストールも必要です。
-
-どちらの経路も前提条件は Node.js 22+ と Git です。スクリプトは何かを書き込む前に両方を確認します。
-
-**その他のコーディングエージェント** — CLI をインストールします:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
-```
-
-どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
-
-**前のエージェントが得た判断を、次のエージェントに渡しましょう。**
-
-## 実際に動かす
+1,160 回の登録済み実行で、却下済みの案を再提案する割合は **18.8%** から **2.8%** になりました。エージェントが実際に見るものは、以下の例です。
 
 <p align="center">
   <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
 </p>
 
-**新しいエージェント、チャット履歴はゼロ。それでも明白な修正案がなぜ除外されたかを手渡されます。** 変更する前に path を照会します。
-
-```bash
-commitlore context install.sh
-```
-
-出力には、installer の欠陥の修正として `-musl` target を公開する案を除外した active record とその理由が含まれます。hook はコンテキストを返すものであり、編集を止めるとは主張しません。
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-この `PreToolUse` hook path をそのまま再現する方法と、その他すべてのコマンドは [docs/cli.md](docs/cli.md) にあります。
-
-## 検索はレコードを見つけられる。パス範囲は覆された意思決定を除外する。
-
-エージェントが最初の編集を行う前に、リポジトリが持つ「今も有効な意思決定」のうち実際にどれだけがエージェントへ届くのか。このリポジトリで、フックが既定で使う 800 トークン予算のもとでは:
-
-| ルート | 予算 | 届いた有効な決定 | 届いた覆された決定 | トークン |
-|---|---:|---:|---:|---:|
-| コードのみ | — | 0.0% | 0 | 0 |
-| そのパスの `git log` | 800 | 42.0% | 7 | 673,134 |
-| **CommitLore パス範囲** | **800** | **81.7%** | **0** | **511,412** |
-| CommitLore、上限なし | なし | 92.3% | 0 | 741,429 |
-
-上限を外すと、パス範囲はリポジトリ全体のダンプが回収するのと同じ 2,217 組のうち 2,047 組を回収します。ダンプの 92,175,612 トークンの一部しか使わず、ダンプが一緒に運ぶ覆された 7,322 件は一つも届けません。**範囲は何も損なっていません。** 上限が 10.6 ポイントを消費します。残る 170 組は信頼グレーダーが保留したレコードです。
-
-**これは配信を測ったものであり、効果ではありません。** エージェントは走っていないので、回収し*得る*量の上限であって、実際に回収する量ではありません。そして検索指標は、それが予測すべき結果が悪化する間にも上がり得ます。SWE-bench はコンテキスト予算を増やすと BM25 の recall が 29.58 から 51.06 へ上がることを測定した上で、「BM25 の最大コンテキストを増やせば oracle ファイルに対する recall が上がる場合でも性能は落ちる … モデルが問題のコードを特定するのが単に不得手だからだ」と報告しています ([arXiv:2310.06770](https://arxiv.org/abs/2310.06770))。コーパス一つ、リポジトリ一つです。置き換えられたレコードは 7 件、期限切れは 0 件なので、「覆された決定の配信ゼロ」は期限切れについてはまだ何も語りません。手法と全表: [bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)。
-
-**`git log` のベースラインは、自分で自分を測って出た値ではありません。** 同じ測定を、このプロジェクトが書いていない四つのリポジトリ — Django、SymPy、scikit-learn、Requests — に固定コミットで適用すると、あるパスの履歴のうち 800 トークンの切り詰めを生き残る割合は **37.4% から 55.6%** に収まります。上の 42.0% はその帯の中にあります。固定予算が一つのファイルの履歴の半分近くを落とすのは、大きく長命なリポジトリで `git log` が一般に行うことであり、このリポジトリ固有の性質ではありません。**転移しなかったのは仕組みのほうです。** 私たちのパスは中央値 1 コミットで 687 トークン、Django は 8 コミットで 213 トークン。つまり長いコミットメッセージは、固定予算のもとで通常の Git ベースラインをより悪くします — このプロジェクト自身の慣行が払っているコストです。[bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md) はそれらのリポジトリでの配信値も報告しますが、まず §9.0 と §9.5 を読んでください。そこでのレコードは revert コミットからプログラムが生成したものであり、見出しの数値は検索の結果ではなく付与述語が強制する値です。
-
-レコードを一つ取り逃がせば、モデルはコンテキストを失います。すでに覆された意思決定を渡せば、正しさを損ないます。この[検索測定](bench/retrieval/result.md)では、ノイズが 0 件から 10,000 件までのすべてのサイズで、BM25、embedding top-k、hybrid RRF、パスフィルター付き embedding がそれぞれ廃止済みのレコードを一つ返しました。lifecycle を伴う CommitLore のパス範囲は古いレコードをゼロにし、現在の二つのレコード (2/2) を返しました。
-
-再現率は補助的な結果です。検索はおおむねどちらでも同じレコードを見つけますが、どの意思決定がまだ有効かを知るルートは一つだけです。意思決定が覆されたときに違いが現れます。これはまさにこの製品が存在するケースです。
-
-別の #167 の露出実行も重要です。10,002 件のうちモデルに届いたレコードは 2 件だけでした。
-
-| ルート | モデルに見えるレコード | 関連レコード | モデルに見えるトークン |
-|---|---:|---:|---:|
-| すべて注入 | 10,002 | 2/2 | 1,004,554 |
-| top-k 語彙検索 | 2 | 1/2 | 190 |
-| CommitLore パス範囲 | 2 | 2/2 | 335 |
-
-これは固定した 2 レコードの出力予算における露出と再現率の測定であり、トークンコスト、請求コスト、正確さ、エージェントの振る舞いを測るものではありません。これは一つのコーパス、一つのクエリ、一つの固定された embedding モデルによる結果です。再現率が並ぶ地点と、ほかに何が測定され何が測定されていないかは [docs/evidence.md](docs/evidence.md) にあります。
-
-## リポジトリで試す
-
-検証フックとローカル index を使う各リポジトリで、続けて `commitlore init` を実行します。installer は対応するコーディングエージェントを検出し、安全に可能な場所でローカル MCP server を登録します。
-
-```bash
-cd your-repository
-commitlore init
-commitlore context .
-```
-
-そのあとは:
-
-- 普段どおりコミットします。ほとんどのコミットには record がありません。
-- record がある場合、commit-msg hook が検証します。record を作成することはありません。
-- エージェントは MCP で意思決定コンテキストを照会するか、`PreToolUse` hook から受け取ります。
-- path を変更する前に、active limit、ruled-out alternative、warning、verification gap を確認します。
-
-コーディングエージェントとの作業を続けます。変更に diff が保存できない意思決定コンテキストがあるときは、エージェントに CommitLore record をコミットへ含めるよう頼んでください。
-
 <details>
-<summary>インストールを確認または固定したいですか？</summary>
+<summary><strong>目次</strong></summary>
 
-この一行は利便性のためです。レビュー済みまたは固定されたインストールが必要なら、まず `install.sh` をダウンロードして確認するか、リポジトリを clone してください。スクリプトは固定タグのソースチェックアウトと、`node <checkout>/dist/commitlore.mjs` を実行する薄い wrapper だけをインストールします — コンパイル済み成果物のダウンロードもビルド手順もないため、マシンに置かれるのは読めるソースです。
-
-```bash
-# installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh
-sh install.sh v0.7.1
-
-# あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v0.7.1 https://github.com/MongLong0214/commitlore
-node commitlore/dist/commitlore.mjs --version
-```
+- [一つの例で見る問題](#コードは残った決定は残らなかった)
+- [インストール](#インストール)
+- [これが役に立たない場合](#これが役に立たない場合)
+- [詳しく言うと何なのか](#詳しく言うと何なのか)
+- [実際に動かす](#実際に動かす)
+- [このリポジトリ自体がデモ](#このリポジトリ自体がデモです)
+- [パス範囲と検索](#検索はレコードを見つけられるパス範囲は覆された意思決定を除外する)
+- [仕組み](#仕組み)
+- [別のリポジトリからの現場報告](#実際のリポジトリでの見え方)
+- [何が違うのか](#違い)
+- [どこで効くか](#どこで効くか)
+- [record の作られ方](#record-が作られる方法)
+- [完全な record](#完全な-record)
+- [リポジトリが証明すること](#リポジトリが証明すること)
+- [根拠](#evidence-より狭い製品上の主張)
+- [アンインストール](#アンインストール) · [ドキュメント](#ドキュメント) · [コントリビュート](#コントリビュート)
 
 </details>
 
@@ -180,8 +80,173 @@ Ruled-out
 作成者による record は `[directive]` として描画されます。
 
 モジュール境界が、レビューコメントとして後から届くのではなく、エージェントが変更を提案する
-**前に**その目の前に置かれます。それに従って動くかどうかは、このプロジェクトが答えていない
-エージェントの振る舞いの問題です — 下の測定と[測定していないこと](docs/evidence.md)を参照。
+**前に**その目の前に置かれます。
+
+この数字が示さないことは、二つ下の節にある[これが役に立たない場合](#これが役に立たない場合)で説明しています。インストールした後ではなく、その前に読む価値があります。
+
+## インストール
+
+一度インストールします。コーディングエージェントは引き継ぐ価値のある意思決定を記録でき、CommitLore はそれを検証して Git に保存します。
+
+**Claude Code** — プラグイン一つで MCP サーバー、編集前のコンテキストフック、スキルが登録されます:
+
+```
+/plugin marketplace add MongLong0214/commitlore
+/plugin install commitlore@commitlore
+```
+
+プラグインが持つのはここまでで、MCP サーバー、編集前フック、スキルです。`commitlore` を `PATH` に置くことはないので、以下の `commitlore …` コマンドは `install.sh` / `install.ps1` から来るものであり、そのインストールも必要です。
+
+どちらの経路も前提条件は Node.js 22+ と Git です。スクリプトは何かを書き込む前に両方を確認します。
+
+**その他のコーディングエージェント** — CLI をインストールします:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
+```
+
+どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
+
+**前のエージェントが得た判断を、次のエージェントに渡しましょう。**
+
+### 次に、各リポジトリで
+
+検証フックとローカル index を使う各リポジトリで、続けて `commitlore init` を実行します。installer は対応するコーディングエージェントを検出し、安全に可能な場所でローカル MCP server を登録します。
+
+```bash
+cd your-repository
+commitlore init
+commitlore context .
+```
+
+そのあとは:
+
+- 普段どおりコミットします。ほとんどのコミットには record がありません。
+- record がある場合、commit-msg hook が検証します。record を作成することはありません。
+- エージェントは MCP で意思決定コンテキストを照会するか、`PreToolUse` hook から受け取ります。
+- path を変更する前に、active limit、ruled-out alternative、warning、verification gap を確認します。
+
+コーディングエージェントとの作業を続けます。変更に diff が保存できない意思決定コンテキストがあるときは、エージェントに CommitLore record をコミットへ含めるよう頼んでください。
+
+<details>
+<summary>インストールを確認または固定したいですか？</summary>
+
+この一行は利便性のためです。レビュー済みまたは固定されたインストールが必要なら、まず `install.sh` をダウンロードして確認するか、リポジトリを clone してください。スクリプトは固定タグのソースチェックアウトと、`node <checkout>/dist/commitlore.mjs` を実行する薄い wrapper だけをインストールします — コンパイル済み成果物のダウンロードもビルド手順もないため、マシンに置かれるのは読めるソースです。
+
+```bash
+# installer を固定してダウンロードし、確認してから実行します。
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh
+sh install.sh v0.7.1
+
+# あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
+git clone --depth 1 --branch v0.7.1 https://github.com/MongLong0214/commitlore
+node commitlore/dist/commitlore.mjs --version
+```
+
+</details>
+
+
+
+## これが役に立たない場合
+
+インストールする前に読んでください。
+
+- **測定されたのは弱いほうの等級です。** 1,160 回の研究ではすべてのレコードが
+  `[claim]` として描画され、これはエージェントに命令ではなく情報として扱うよう
+  伝えます。`[directive]` 等級はその後に到達可能になったので、上の数値は主張された
+  上限ではなく**測定された下限**です。
+- **モデル 1 つ、ハーネス 1 つ、構成されたフィクスチャ 10 個です。** オラクルは
+  最終的な実装状態を読みます。したがってレコードを受け取ったエージェントのほうが
+  排除済みの手法を提案しにくかったことは示しますが、そのいずれかが何かを読んだ
+  ことは示しません。
+- cryptographic author verification、repository-wide record coverage、symbol anchor、interactive record builder は未実装です: [#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
+- M4 は guard の効果を検証していません。row に `guard_exposure` がないため treatment exposure を検証できません: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
+- Guard（ruled-out alternative matching）は実験的参考情報です: precision 44.8%（95% Wilson CI 32.7%–57.5%）、recall 22.0%、417-decision corpus 基準（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空の guard 結果は、提案がすべての ruled-out alternative を回避したという保証ではありません — recall 22% では、見逃しが一般的です。
+
+## 詳しく言うと、何なのか
+
+**コーディングエージェントのための Git ネイティブな decision layer。**
+
+新しいエージェントは実装を受け継ぎます。しかし制約も、チームが却下した代替案も、警告も、
+検証のギャップも受け継ぎません — 何かが運ばないかぎり、それらはコードと一緒には動きません。
+
+CommitLore はその工学的判断を Git に保存し、次の編集の前に**今も有効な決定だけ**を届けます。
+のちに置き換えられた決定や期限切れの決定が、まだ有効であるかのようにエージェントへ届くことは
+ありません。
+
+**リポジトリ所有 · lifecycle 認識 · 根拠検証 · エージェント非依存**
+
+Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
+
+ホスト型メモリサービスも、ベンダー固有のチャット履歴もありません。リポジトリが所有し、共に移動する、レビュー可能な意思決定コンテキストだけです。
+
+## 実際に動かす
+
+
+
+**新しいエージェント、チャット履歴はゼロ。それでも明白な修正案がなぜ除外されたかを手渡されます。** 変更する前に path を照会します。
+
+```bash
+commitlore context install.sh
+```
+
+出力には、installer の欠陥の修正として `-musl` target を公開する案を除外した active record とその理由が含まれます。hook はコンテキストを返すものであり、編集を止めるとは主張しません。
+
+```console
+context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
+
+ruled-out
+  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
+
+warnings
+  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
+```
+
+この `PreToolUse` hook path をそのまま再現する方法と、その他すべてのコマンドは [docs/cli.md](docs/cli.md) にあります。
+
+## このリポジトリ自体がデモです
+
+解決済みの問いをエージェントが再び決めないようにすると主張するツールなら、自身で何を捕まえたかも示せるべきです。このツールはその一覧を公開で保ち、このプロジェクトがすでに公開していたもののうち、後から誤りだと分かった項目も含めています。
+
+- **どのインストールでも、README の主張が前提とした信頼 tier を生み出せなかった。** record はエージェントに `directive` または `claim` として届きます。インストール済みのどの surface も信頼された author を構成していなかったため、grade は全員に対して `claim` へ fail-closed しましたが、注入された凡例は誰も到達できない tier を示していました。以前の二つの benchmark は `claim` 等級の配信を測定していました ([#415](https://github.com/MongLong0214/commitlore/issues/415)).
+- **登録された benchmark 分析は、一度に四つの異なる実験を読んでしまうところでした。** しかも停止規則が行数だったため、その混入によって研究は自身の完全性ゲートを*通過*していたでしょう ([#441](https://github.com/MongLong0214/commitlore/issues/441)).
+- **result-schema gate は何からも実行されていませんでした。** そのため schema は runner より五フィールド遅れ、二日間誰も気付きませんでした ([#392](https://github.com/MongLong0214/commitlore/issues/392)).
+- **出荷済みの pre-push hook はすべての `git push` を停止させました。** 40 秒間に hook が 1,240 回呼ばれました。関数は十一回テストされていたのに、hook path は一度もテストされていなかったからです ([#422](https://github.com/MongLong0214/commitlore/issues/422)).
+
+これらはすべて、このプロジェクトがインストールを勧める hook で検証されるコミット trailer の `Ruled-out:`、`Warn:`、`Limit:` の行であり、どこでも実行できるのと同じ `commitlore context` で読めます。
+
+**それぞれが支払った代償を含む完全な一覧: [docs/SELF-AUDIT.md](docs/SELF-AUDIT.md)。**
+
+## 検索はレコードを見つけられる。パス範囲は覆された意思決定を除外する。
+
+エージェントが最初の編集を行う前に、リポジトリが持つ「今も有効な意思決定」のうち実際にどれだけがエージェントへ届くのか。このリポジトリで、フックが既定で使う 800 トークン予算のもとでは:
+
+| ルート | 予算 | 届いた有効な決定 | 届いた覆された決定 | トークン |
+|---|---:|---:|---:|---:|
+| コードのみ | — | 0.0% | 0 | 0 |
+| そのパスの `git log` | 800 | 42.0% | 7 | 673,134 |
+| **CommitLore パス範囲** | **800** | **81.7%** | **0** | **511,412** |
+| CommitLore、上限なし | なし | 92.3% | 0 | 741,429 |
+
+上限を外すと、パス範囲はリポジトリ全体のダンプが回収するのと同じ 2,217 組のうち 2,047 組を回収します。ダンプの 92,175,612 トークンの一部しか使わず、ダンプが一緒に運ぶ覆された 7,322 件は一つも届けません。**範囲は何も損なっていません。** 上限が 10.6 ポイントを消費します。残る 170 組は信頼グレーダーが保留したレコードです。
+
+**これは配信を測ったものであり、効果ではありません。** エージェントは走っていないので、回収し*得る*量の上限であって、実際に回収する量ではありません。そして検索指標は、それが予測すべき結果が悪化する間にも上がり得ます。SWE-bench はコンテキスト予算を増やすと BM25 の recall が 29.58 から 51.06 へ上がることを測定した上で、「BM25 の最大コンテキストを増やせば oracle ファイルに対する recall が上がる場合でも性能は落ちる … モデルが問題のコードを特定するのが単に不得手だからだ」と報告しています ([arXiv:2310.06770](https://arxiv.org/abs/2310.06770))。コーパス一つ、リポジトリ一つです。置き換えられたレコードは 7 件、期限切れは 0 件なので、「覆された決定の配信ゼロ」は期限切れについてはまだ何も語りません。手法と全表: [bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)。
+
+**`git log` のベースラインは、自分で自分を測って出た値ではありません。** 同じ測定を、このプロジェクトが書いていない四つのリポジトリ — Django、SymPy、scikit-learn、Requests — に固定コミットで適用すると、あるパスの履歴のうち 800 トークンの切り詰めを生き残る割合は **37.4% から 55.6%** に収まります。上の 42.0% はその帯の中にあります。固定予算が一つのファイルの履歴の半分近くを落とすのは、大きく長命なリポジトリで `git log` が一般に行うことであり、このリポジトリ固有の性質ではありません。**転移しなかったのは仕組みのほうです。** 私たちのパスは中央値 1 コミットで 687 トークン、Django は 8 コミットで 213 トークン。つまり長いコミットメッセージは、固定予算のもとで通常の Git ベースラインをより悪くします — このプロジェクト自身の慣行が払っているコストです。[bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md) はそれらのリポジトリでの配信値も報告しますが、まず §9.0 と §9.5 を読んでください。そこでのレコードは revert コミットからプログラムが生成したものであり、見出しの数値は検索の結果ではなく付与述語が強制する値です。
+
+レコードを一つ取り逃がせば、モデルはコンテキストを失います。すでに覆された意思決定を渡せば、正しさを損ないます。この[検索測定](bench/retrieval/result.md)では、ノイズが 0 件から 10,000 件までのすべてのサイズで、BM25、embedding top-k、hybrid RRF、パスフィルター付き embedding がそれぞれ廃止済みのレコードを一つ返しました。lifecycle を伴う CommitLore のパス範囲は古いレコードをゼロにし、現在の二つのレコード (2/2) を返しました。
+
+再現率は補助的な結果です。検索はおおむねどちらでも同じレコードを見つけますが、どの意思決定がまだ有効かを知るルートは一つだけです。意思決定が覆されたときに違いが現れます。これはまさにこの製品が存在するケースです。
+
+別の #167 の露出実行も重要です。10,002 件のうちモデルに届いたレコードは 2 件だけでした。
+
+| ルート | モデルに見えるレコード | 関連レコード | モデルに見えるトークン |
+|---|---:|---:|---:|
+| すべて注入 | 10,002 | 2/2 | 1,004,554 |
+| top-k 語彙検索 | 2 | 1/2 | 190 |
+| CommitLore パス範囲 | 2 | 2/2 | 335 |
+
+これは固定した 2 レコードの出力予算における露出と再現率の測定であり、トークンコスト、請求コスト、正確さ、エージェントの振る舞いを測るものではありません。これは一つのコーパス、一つのクエリ、一つの固定された embedding モデルによる結果です。再現率が並ぶ地点と、ほかに何が測定され何が測定されていないかは [docs/evidence.md](docs/evidence.md) にあります。
 
 ## 仕組み
 
@@ -410,12 +475,6 @@ plugin。`--dry-run` は何も変更せずに報告します。それぞれを�
 - [docs/protocol.md](docs/protocol.md) — record の形式と、Git だけで読む方法
 - [docs/evidence.md](docs/evidence.md) — 何が測定され、何が測定されていないか
 - [spec/SPEC.md](spec/SPEC.md) — 規範プロトコル
-
-## 既知の制限事項
-
-- cryptographic author verification、repository-wide record coverage、symbol anchor、interactive record builder は未実装です: [#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
-- M4 は guard の効果を検証していません。row に `guard_exposure` がないため treatment exposure を検証できません: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
-- Guard（ruled-out alternative matching）は実験的参考情報です: precision 44.8%（95% Wilson CI 32.7%–57.5%）、recall 22.0%、417-decision corpus 基準（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空の guard 結果は、提案がすべての ruled-out alternative を回避したという保証ではありません — recall 22% では、見逃しが一般的です。
 
 ## コントリビュート
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,23 +14,78 @@
 
 # CommitLore
 
-## 에이전트는 코드를 물려받습니다.
-## 이제 판단까지 물려주세요.
+**코딩 에이전트가 팀에서 이미 기각한 방안을 계속 다시 제안합니다.**
 
-**코딩 에이전트를 위한 Git 네이티브 decision layer.**
+CommitLore는 그런 결정을 Git에 보관하고, 파일을 편집하기 전에 아직 유효한 결정만
+에이전트에게 전달합니다 — **호스팅 서비스 없이, 저장소 밖으로 단 1바이트도
+내보내지 않고**.
 
-새 에이전트는 구현을 물려받습니다. 하지만 제약도, 팀이 기각한 대안도, 경고도, 검증 공백도
-물려받지 못합니다 — 무언가가 실어 나르지 않는 한 그것들은 코드와 함께 이동하지 않습니다.
+등록된 실행 1,160회에서 이는 기각된 방안을 다시 제안하는 비율을 **18.8%**에서
+**2.8%**로 낮췄습니다. 에이전트가 실제로 보는 화면은 아래 예시입니다.
 
-CommitLore는 그 엔지니어링 판단을 Git에 보존하고, 다음 편집 전에 **지금도 유효한 결정만**
-전달합니다. 이후 대체되거나 만료된 결정은 여전히 유효한 것처럼 에이전트에게 도달하지
-않습니다.
+<p align="center">
+  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
+</p>
 
-**저장소 소유 · lifecycle 인식 · 근거 검증 · 에이전트 비종속**
+<details>
+<summary><strong>목차</strong></summary>
 
-Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
+- [한 가지 예로 보는 문제](#코드는-남았다-결정은-남지-않았다)
+- [설치](#설치)
+- [도움이 되지 않는 경우](#이것이-도움이-되지-않는-경우)
+- [CommitLore란 무엇인가](#commitlore를-자세히-보면)
+- [작동 모습](#실제로-보기)
+- [이 저장소 자체가 데모](#이-저장소-자체가-데모입니다)
+- [경로 범위와 검색](#검색은-레코드를-찾을-수-있습니다-경로-범위는-뒤집힌-결정을-걸러냅니다)
+- [동작 방식](#어떻게-동작하나)
+- [다른 저장소의 현장 보고](#실제-저장소에서는-이렇게-보인다)
+- [차이점](#무엇이-다른가)
+- [효과가 있는 곳](#어디서-값을-하나)
+- [record 생성 방식](#record가-만들어지는-방법)
+- [완전한 record](#완전한-record)
+- [저장소가 증명하는 것](#저장소가-증명하는-것)
+- [근거](#근거-더-좁은-제품-주장)
+- [제거](#제거) · [문서](#문서) · [기여하기](#기여하기)
 
-호스팅 메모리 서비스도, 벤더 전용 채팅 기록도 없다. 저장소가 소유하고 함께 이동하는, 검토 가능한 결정 맥락만 있다.
+</details>
+
+## 코드는 남았다. 결정은 남지 않았다.
+
+*같은 나쁜 아이디어를 다시 리뷰하지 않는다.*
+
+
+**CommitLore 없이.** 새 세션이 입력이 비슷한 함수 둘을 보고 하나를 재사용한다.
+
+```ts
+calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
+```
+
+이제 팀에는 flag 하나, wrapper 하나, 그 함수가 애초에 맡을 생각이 없던 사용처를
+지키는 compatibility branch 하나가 더 생겼다. 리뷰어는 "이건 이미 기각했다"를 두 번째로 쓴다.
+
+**CommitLore와 함께.** 편집 전에 에이전트가 받는 것:
+
+```
+commitlore: active records for src/pricing.ts
+
+Limit
+  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+
+Ruled-out
+  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
+                                    and rounding semantics differ between the two flows
+```
+
+`[claim]`이 실제로 일을 한다: 이 record는 저장소의 신뢰된 작성자가 쓴 것이 아니므로,
+에이전트는 이것을 명령이 아니라 정보로 다루라고 안내받는다. 신뢰된 작성자가 남긴
+record는 `[directive]`로 렌더된다.
+
+모듈 경계가 리뷰 코멘트로 뒤늦게가 아니라, 에이전트가 변경을 제안하기 **전에** 그 앞에
+놓인다.
+
+이 수치가 보여 주지 않는 것은 두 섹션 아래의 [이것이 도움이 되지 않는 경우](#이것이-도움이-되지-않는-경우)에 있다. 설치한 뒤가 아니라 전에 스크롤해 읽을 가치가 있다.
+
+## 설치
 
 한 번 설치한다. 코딩 에이전트가 계속 가져갈 가치가 있는 결정을 기록할 수 있고, CommitLore는 이를 검증해 Git에 보존한다.
 
@@ -55,64 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/inst
 
 **지난 에이전트가 얻어낸 판단을, 다음 에이전트에게 물려주세요.**
 
-## 실제로 보기
-
-<p align="center">
-  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
-</p>
-
-**새 에이전트, 채팅 이력은 0개. 그래도 뻔한 수정안이 왜 제외됐는지를 건네받는다.** 바꾸기 전에 path를 조회한다.
-
-```bash
-commitlore context install.sh
-```
-
-출력에는 installer 결함의 수정안으로 `-musl` target을 배포하는 방안을 제외한 활성 record와 그 이유가 들어 있다. hook은 맥락을 제공하며, 편집을 막는다고 주장하지 않는다.
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-이 PreToolUse hook path를 그대로 재현하는 방법과 나머지 모든 명령은 [docs/cli.md](docs/cli.md)에 있다.
-
-## 검색은 레코드를 찾을 수 있습니다. 경로 범위는 뒤집힌 결정을 걸러냅니다.
-
-에이전트가 첫 편집을 하기 전에, 저장소가 가진 아직 유효한 결정 중 실제로 몇 퍼센트가 에이전트에게 도달할까요? 이 저장소에서, 훅이 기본으로 쓰는 800토큰 예산 기준:
-
-| 경로 | 예산 | 전달된 유효 결정 | 전달된 뒤집힌 결정 | 토큰 |
-|---|---:|---:|---:|---:|
-| 코드만 | — | 0.0% | 0 | 0 |
-| 해당 경로의 `git log` | 800 | 42.0% | 7 | 673,134 |
-| **CommitLore 경로 범위** | **800** | **81.7%** | **0** | **511,412** |
-| CommitLore, 상한 해제 | 없음 | 92.3% | 0 | 741,429 |
-
-상한을 풀면 경로 범위는 저장소 전체 덤프가 회수하는 것과 정확히 같은 2,217쌍 중 2,047쌍을 회수합니다. 덤프의 92,175,612 토큰 중 일부만 쓰고, 덤프가 함께 실어 나르는 뒤집힌 레코드 7,322개는 하나도 전달하지 않습니다. **범위는 아무 대가도 치르지 않습니다.** 상한이 10.6포인트를 씁니다. 남은 170쌍은 신뢰 등급자가 보류한 레코드입니다.
-
-**이것은 전달을 잰 것이지 효과를 잰 것이 아닙니다.** 에이전트를 돌리지 않았으므로 회수할 수 *있는* 양의 상한이지 실제로 회수하는 양이 아닙니다. 그리고 검색 지표는 그것이 예측해야 할 결과가 나빠지는 동안에도 올라갈 수 있습니다. SWE-bench는 컨텍스트 예산을 늘릴 때 BM25 recall이 29.58에서 51.06으로 오르는 것을 측정하고도, "BM25의 최대 컨텍스트 크기를 늘리면 oracle 파일에 대한 recall이 올라가는 경우에도 성능은 떨어진다 … 모델이 문제 코드를 국소화하는 데 그저 서툴기 때문"이라고 보고했습니다 ([arXiv:2310.06770](https://arxiv.org/abs/2310.06770)). 코퍼스 하나, 저장소 하나입니다. 대체된 레코드는 7개, 만료된 레코드는 0개이므로 "뒤집힌 결정 0건 전달"은 만료에 대해서는 아직 아무것도 말하지 않습니다. 방법과 전체 표: [bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md).
-
-**`git log` 기준선은 우리가 우리를 재서 나온 값이 아닙니다.** 같은 측정을 이 프로젝트가 쓰지 않은 저장소 넷 — Django, SymPy, scikit-learn, Requests — 에 고정 커밋으로 적용하면, 한 경로의 이력 중 800토큰 절단에서 살아남는 비율이 **37.4%에서 55.6%** 사이입니다. 위의 42.0%가 그 구간 안에 들어갑니다. 고정 예산이 한 파일 이력의 절반 가까이를 잘라내는 것은 크고 오래된 저장소에서 `git log`가 일반적으로 하는 일이지, 이 저장소만의 특이점이 아닙니다. **이전되지 않은 것은 메커니즘입니다.** 우리 경로는 중앙값 1커밋에 687토큰인데 Django는 8커밋에 213토큰이라, 긴 커밋 메시지가 고정 예산에서 평범한 Git 기준선을 더 나쁘게 만듭니다 — 이 프로젝트 자체 관행이 치르는 비용입니다. [bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md)는 그 저장소들에 대한 전달 수치도 보고하지만 §9.0과 §9.5를 먼저 읽으십시오. 거기 레코드는 revert 커밋에서 프로그램이 생성한 것이고, 헤드라인 숫자는 검색 결과가 아니라 부착 술어가 강제하는 값입니다.
-
-레코드 하나를 놓치면 모델은 맥락을 잃습니다. 이미 뒤집힌 결정을 건네면 정확성을 잃습니다. 이 [검색 측정](bench/retrieval/result.md)에서 방해 레코드가 0개부터 10,000개까지인 모든 크기에서 BM25, 임베딩 top-k, 하이브리드 RRF, 경로 필터를 적용한 임베딩은 각각 대체되어 폐기된 레코드 하나를 반환했습니다. 수명 주기를 적용한 CommitLore 경로 범위는 오래된 레코드를 0개 반환하고 현재 레코드 둘(2/2)을 모두 반환했습니다.
-
-재현율은 보조 결과입니다. 검색은 대체로 어느 쪽이든 같은 레코드를 찾지만, 현재 유효한 결정을 아는 경로는 하나뿐입니다. 결정이 뒤집혔을 때 차이가 나타나며, 바로 이 경우를 위해 이 제품이 존재합니다.
-
-별도의 #167 노출 실행도 중요합니다. 10,002개 레코드 중 모델에 닿은 것은 2개뿐입니다.
-
-| 경로 | 모델에 보인 레코드 | 관련 레코드 | 모델에 보인 토큰 |
-|---|---:|---:|---:|
-| 모두 주입 | 10,002 | 2/2 | 1,004,554 |
-| top-k 어휘 검색 | 2 | 1/2 | 190 |
-| CommitLore 경로 범위 | 2 | 2/2 | 335 |
-
-이는 고정된 두 레코드 출력 예산에서 노출과 재현율을 측정한 것이며, 토큰 비용, 청구 비용, 정확도 또는 에이전트 행동을 측정하지 않습니다. 코퍼스 하나, 쿼리 하나, 고정된 임베딩 모델 하나의 결과입니다. 재현율이 동률인 지점과 그 밖에 무엇이 측정됐고 무엇이 측정되지 않았는지는 [docs/evidence.md](docs/evidence.md)에 있습니다.
-
-## 저장소에서 사용해 보기
+### 그런 다음, 각 저장소에서
 
 검증 훅과 로컬 인덱스를 쓸 각 저장소에서 이어서 `commitlore init`을 실행한다. 설치기는 지원되는 코딩 에이전트를 감지하고, 안전하게 가능한 곳에 로컬 MCP 서버를 등록한다.
 
@@ -148,40 +146,107 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
-## 코드는 남았다. 결정은 남지 않았다.
-
-*같은 나쁜 아이디어를 다시 리뷰하지 않는다.*
 
 
-**CommitLore 없이.** 새 세션이 입력이 비슷한 함수 둘을 보고 하나를 재사용한다.
+## 이것이 도움이 되지 않는 경우
 
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
+설치하기 전에 읽어보세요.
+
+- **측정된 것은 약한 쪽 등급입니다.** 1,160회 연구에서 모든 레코드는 `[claim]`으로
+  렌더링되었고, 이는 에이전트에게 명령이 아니라 정보로 다루라고 말합니다.
+  `[directive]` 등급은 그 뒤에야 도달 가능해졌으므로, 위 숫자는 주장된 상한이
+  아니라 **측정된 하한**입니다.
+- **모델 하나, 하니스 하나, 구성된 픽스처 열 개입니다.** 오라클은 최종 구현
+  상태를 읽습니다. 따라서 레코드를 받은 에이전트가 배제된 접근을 덜 제안했다는
+  것은 보여주지만, 그중 누군가가 무언가를 읽었다는 것은 보여주지 않습니다.
+- 암호학적 작성자 검증, 저장소 전체 record coverage, symbol anchor, interactive record builder는 아직 구현되지 않았다: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
+- M4는 guard 효과를 시험하지 못했다. row에 `guard_exposure`가 없어 treatment exposure를 검증할 수 없다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
+- Guard(ruled-out alternative matching)는 실험적 참고 자료이다: precision 44.8%(95% Wilson CI 32.7%–57.5%), recall 22.0%, 417-decision corpus 기준([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). 빈 guard 결과는 제안이 모든 ruled-out alternative를 피했다는 보장이 아니다 — recall 22%에서 누락이 일반적이다.
+
+## CommitLore를 자세히 보면
+
+**코딩 에이전트를 위한 Git 네이티브 decision layer.**
+
+새 에이전트는 구현을 물려받습니다. 하지만 제약도, 팀이 기각한 대안도, 경고도, 검증 공백도
+물려받지 못합니다 — 무언가가 실어 나르지 않는 한 코드와 함께 이동하지 않습니다.
+
+CommitLore는 그 엔지니어링 판단을 Git에 보존하고, 다음 편집 전에 **지금도 유효한 결정만**
+전달합니다. 이후 대체되거나 만료된 결정은 여전히 유효한 것처럼 에이전트에게 도달하지
+않습니다.
+
+**저장소 소유 · lifecycle 인식 · 근거 검증 · 에이전트 비종속**
+
+Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
+
+호스팅 메모리 서비스도, 벤더 전용 채팅 기록도 없다. 저장소가 소유하고 함께 이동하는, 검토 가능한 결정 맥락만 있다.
+
+## 실제로 보기
+
+
+
+**새 에이전트, 채팅 이력은 0개. 그래도 뻔한 수정안이 왜 제외됐는지를 건네받는다.** 바꾸기 전에 path를 조회한다.
+
+```bash
+commitlore context install.sh
 ```
 
-이제 팀에는 flag 하나, wrapper 하나, 그리고 그 함수가 애초에 맡을 생각이 없던 사용처를
-지키는 compatibility branch 하나가 더 생겼다. 리뷰어는 "이건 이미 기각했다"를 두 번째로 쓴다.
+출력에는 installer 결함의 수정안으로 `-musl` target을 배포하는 방안을 제외한 활성 record와 그 이유가 들어 있다. hook은 맥락을 제공하며, 편집을 막는다고 주장하지 않는다.
 
-**CommitLore와 함께.** 편집 전에 에이전트가 받는 것:
+```console
+context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
 
-```
-commitlore: active records for src/pricing.ts
+ruled-out
+  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
 
-Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
-
-Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
+warnings
+  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
 ```
 
-`[claim]`이 실제로 일을 한다: 이 record는 저장소의 신뢰된 작성자가 쓴 것이 아니므로,
-에이전트는 이것을 명령이 아니라 정보로 다루라고 안내받는다. 신뢰된 작성자가 남긴
-record는 `[directive]`로 렌더된다.
+이 PreToolUse hook path를 그대로 재현하는 방법과 나머지 모든 명령은 [docs/cli.md](docs/cli.md)에 있다.
 
-모듈 경계가 리뷰 코멘트로 뒤늦게가 아니라, 에이전트가 변경을 제안하기 **전에** 그 앞에
-놓인다. 에이전트가 그에 따라 행동하는지는 이 프로젝트가 답하지 않은 에이전트 행동의
-문제다 — 아래 측정과 [측정하지 않은 것](docs/evidence.md)을 보라.
+## 이 저장소 자체가 데모입니다
+
+이미 결론 난 질문을 에이전트가 다시 결정하지 못하게 한다고 주장하는 도구라면, 스스로에게서 무엇을 잡아냈는지도 보여줄 수 있어야 합니다. 이 도구는 그 목록을 공개로 유지하며, 이 프로젝트가 이미 공개한 내용 중 나중에 틀렸음이 밝혀진 것들도 포함합니다.
+
+- **어떤 설치도 README의 주장이 근거한 신뢰 등급을 만들 수 없었다.** record는 에이전트에게 `directive` 또는 `claim` 등급으로 전달됩니다. 설치된 어느 표면도 신뢰된 작성자를 구성하지 않았으므로, 등급은 모두 `claim`으로 fail-closed 되었지만 주입된 범례는 누구도 도달할 수 없는 등급을 알리고 있었습니다. 두 이전 benchmark는 `claim` 등급 전달을 측정했습니다 ([#415](https://github.com/MongLong0214/commitlore/issues/415)).
+- **등록된 benchmark 분석은 한 번에 서로 다른 네 실험을 읽었을 것이며**, 중단 규칙이 행 수였기 때문에 그 오염은 연구가 자체 완전성 관문을 *통과*하게 만들었을 것입니다 ([#441](https://github.com/MongLong0214/commitlore/issues/441)).
+- **result-schema gate는 아무것도 실행하지 않았습니다.** 그래서 schema는 runner보다 다섯 필드 뒤처졌고 이틀 동안 아무도 알아차리지 못했습니다 ([#392](https://github.com/MongLong0214/commitlore/issues/392)).
+- **배포된 pre-push hook은 모든 `git push`를 멈추게 했습니다.** 40초에 hook 호출 1,240회였습니다. 함수는 열한 번 시험했지만 hook path는 한 번도 시험하지 않았기 때문입니다 ([#422](https://github.com/MongLong0214/commitlore/issues/422)).
+
+이들 모두는 이 프로젝트가 설치를 권하는 hook이 검증하는 커밋 trailer의 `Ruled-out:`, `Warn:`, `Limit:` 줄이며, 다른 곳에서 실행하는 것과 같은 `commitlore context`로 읽을 수 있습니다.
+
+**각 항목이 치른 대가를 포함한 전체 목록: [docs/SELF-AUDIT.md](docs/SELF-AUDIT.md).**
+
+## 검색은 레코드를 찾을 수 있습니다. 경로 범위는 뒤집힌 결정을 걸러냅니다.
+
+에이전트가 첫 편집을 하기 전에, 저장소가 가진 아직 유효한 결정 중 실제로 몇 퍼센트가 에이전트에게 도달할까요? 이 저장소에서, 훅이 기본으로 쓰는 800토큰 예산 기준:
+
+| 경로 | 예산 | 전달된 유효 결정 | 전달된 뒤집힌 결정 | 토큰 |
+|---|---:|---:|---:|---:|
+| 코드만 | — | 0.0% | 0 | 0 |
+| 해당 경로의 `git log` | 800 | 42.0% | 7 | 673,134 |
+| **CommitLore 경로 범위** | **800** | **81.7%** | **0** | **511,412** |
+| CommitLore, 상한 해제 | 없음 | 92.3% | 0 | 741,429 |
+
+상한을 풀면 경로 범위는 저장소 전체 덤프가 회수하는 것과 정확히 같은 2,217쌍 중 2,047쌍을 회수합니다. 덤프의 92,175,612 토큰 중 일부만 쓰고, 덤프가 함께 실어 나르는 뒤집힌 레코드 7,322개는 하나도 전달하지 않습니다. **범위는 아무 대가도 치르지 않습니다.** 상한이 10.6포인트를 씁니다. 남은 170쌍은 신뢰 등급자가 보류한 레코드입니다.
+
+**이것은 전달을 잰 것이지 효과를 잰 것이 아닙니다.** 에이전트를 돌리지 않았으므로 회수할 수 *있는* 양의 상한이지 실제로 회수하는 양이 아닙니다. 그리고 검색 지표는 예측해야 할 결과가 나빠지는 동안에도 올라갈 수 있습니다. SWE-bench는 컨텍스트 예산을 늘릴 때 BM25 recall이 29.58에서 51.06으로 오르는 것을 측정하고도, "BM25의 최대 컨텍스트 크기를 늘리면 oracle 파일에 대한 recall이 올라가는 경우에도 성능은 떨어진다 … 모델이 문제 코드를 국소화하는 데 그저 서툴기 때문"이라고 보고했습니다 ([arXiv:2310.06770](https://arxiv.org/abs/2310.06770)). 코퍼스 하나, 저장소 하나입니다. 대체된 레코드는 7개, 만료된 레코드는 0개이므로 "뒤집힌 결정 0건 전달"은 만료에 대해서는 아직 아무것도 말하지 않습니다. 방법과 전체 표: [bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md).
+
+**`git log` 기준선은 우리가 우리를 재서 나온 값이 아닙니다.** 같은 측정을 이 프로젝트가 쓰지 않은 저장소 넷 — Django, SymPy, scikit-learn, Requests — 에 고정 커밋으로 적용하면, 한 경로의 이력 중 800토큰 절단에서 살아남는 비율이 **37.4%에서 55.6%** 사이입니다. 위의 42.0%가 그 구간 안에 들어갑니다. 고정 예산이 한 파일 이력의 절반 가까이를 잘라내는 것은 크고 오래된 저장소에서 `git log`가 일반적으로 하는 일이지, 이 저장소만의 특이점이 아닙니다. **이전되지 않은 것은 메커니즘입니다.** 우리 경로는 중앙값 1커밋에 687토큰인데 Django는 8커밋에 213토큰이라, 긴 커밋 메시지가 고정 예산에서 평범한 Git 기준선을 더 나쁘게 만듭니다 — 이 프로젝트 자체 관행이 치르는 비용입니다. [bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md)는 그 저장소들에 대한 전달 수치도 보고하지만 §9.0과 §9.5를 먼저 읽으십시오. 거기 레코드는 revert 커밋에서 프로그램이 생성한 것이고, 헤드라인 숫자는 검색 결과가 아니라 부착 술어가 강제하는 값입니다.
+
+레코드 하나를 놓치면 모델은 맥락을 잃습니다. 이미 뒤집힌 결정을 건네면 정확성을 잃습니다. 이 [검색 측정](bench/retrieval/result.md)에서 방해 레코드가 0개부터 10,000개까지인 모든 크기에서 BM25, 임베딩 top-k, 하이브리드 RRF, 경로 필터를 적용한 임베딩은 각각 대체되어 폐기된 레코드 하나를 반환했습니다. 수명 주기를 적용한 CommitLore 경로 범위는 오래된 레코드를 0개 반환하고 현재 레코드 둘(2/2)을 모두 반환했습니다.
+
+재현율은 보조 결과입니다. 검색은 대체로 어느 쪽이든 같은 레코드를 찾지만, 현재 유효한 결정을 아는 경로는 하나뿐입니다. 결정이 뒤집혔을 때 차이가 나타나며, 바로 이 경우를 위해 이 제품이 존재합니다.
+
+별도의 #167 노출 실행도 중요합니다. 10,002개 레코드 중 모델에 닿은 것은 2개뿐입니다.
+
+| 경로 | 모델에 보인 레코드 | 관련 레코드 | 모델에 보인 토큰 |
+|---|---:|---:|---:|
+| 모두 주입 | 10,002 | 2/2 | 1,004,554 |
+| top-k 어휘 검색 | 2 | 1/2 | 190 |
+| CommitLore 경로 범위 | 2 | 2/2 | 335 |
+
+이는 고정된 두 레코드 출력 예산에서 노출과 재현율을 측정한 것이며, 토큰 비용, 청구 비용, 정확도나 에이전트 행동을 측정하지 않습니다. 코퍼스 하나, 쿼리 하나, 고정된 임베딩 모델 하나의 결과입니다. 재현율이 동률인 지점과 그 밖에 무엇이 측정됐고 무엇이 측정되지 않았는지는 [docs/evidence.md](docs/evidence.md)에 있습니다.
 
 ## 어떻게 동작하나
 
@@ -392,7 +457,7 @@ commitlore uninstall
 ```
 
 `install.sh` 또는 `install.ps1`이 쓴 것을 제거한다 — wrapper, 고정된 checkout,
-그리고 각 agent config에 추가한 MCP 항목. 자신이 쓰지 않은 것은 제거하지 않으며,
+각 agent config에 추가한 MCP 항목. 자신이 쓰지 않은 것은 제거하지 않으며,
 남기는 것을 명시한다: 저장소별 hook, agent hook, Claude Code plugin.
 `--dry-run`은 아무것도 바꾸지 않고 보고만 한다. 각각을 무엇이 제거하는지, 그리고
 소스 체크아웃에서 실행하는 방법은 [docs/install.md](docs/install.md)에 있다.
@@ -405,12 +470,6 @@ commitlore uninstall
 - [docs/protocol.md](docs/protocol.md) — record 형식과 Git만으로 읽는 방법
 - [docs/evidence.md](docs/evidence.md) — 무엇이 측정됐고 무엇이 아닌지
 - [spec/SPEC.md](spec/SPEC.md) — 규범 프로토콜
-
-## 알려진 제한 사항
-
-- 암호학적 작성자 검증, 저장소 전체 record coverage, symbol anchor, interactive record builder는 아직 구현되지 않았다: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
-- M4는 guard 효과를 시험하지 못했다. row에 `guard_exposure`가 없어 treatment exposure를 검증할 수 없다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
-- Guard(ruled-out alternative matching)는 실험적 참고 자료이다: precision 44.8%(95% Wilson CI 32.7%–57.5%), recall 22.0%, 417-decision corpus 기준([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). 빈 guard 결과는 제안이 모든 ruled-out alternative를 피했다는 보장이 아니다 — recall 22%에서 누락이 일반적이다.
 
 ## 기여하기
 

--- a/README.md
+++ b/README.md
@@ -14,48 +14,39 @@
 
 # CommitLore
 
-## Your agents inherit the code.
-## Make them inherit the judgment.
+**Your coding agent keeps re-proposing things your team already rejected.**
+CommitLore keeps those decisions in Git and hands the agent the ones still in
+force, before it edits the file — **without a hosted service, and without a
+single byte leaving your repository**.
 
-**The Git-native decision layer for coding agents.**
+Across 1,160 registered runs, that took re-proposing a ruled-out approach from
+**18.8%** down to **2.8%**. The example below is what the agent actually sees.
 
-Every fresh agent inherits the implementation. None of them inherit the
-constraints, the alternatives your team rejected, the warnings, or the
-verification gaps — those do not travel with the code unless something carries
-them.
+<p align="center">
+  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
+</p>
 
-CommitLore preserves that engineering judgment in Git, and surfaces only the
-decisions still in force before the next edit. A decision that was later
-superseded or expired does not reach the agent as if it still stood.
+<details>
+<summary><strong>Contents</strong></summary>
 
-**Repository-owned · Lifecycle-aware · Evidence-verified · Agent-independent**
+- [The problem, in one example](#the-code-survived-the-decision-didnt)
+- [Install](#install)
+- [When this will not help you](#when-this-will-not-help-you)
+- [What it is, in full](#what-it-is-in-full)
+- [See it work](#see-it-work)
+- [This repository as its own demo](#the-repository-is-the-demo)
+- [Path scope vs. retrieval](#retrieval-can-find-records-path-scope-keeps-reversed-decisions-out)
+- [How it works](#how-it-works)
+- [A field report from another repository](#what-it-looks-like-on-a-real-repository)
+- [What makes it different](#what-makes-it-different)
+- [Where it pays off](#where-it-pays-off)
+- [How records get created](#how-records-get-created)
+- [A complete record](#a-complete-record)
+- [What the repository proves](#what-the-repository-proves)
+- [Evidence](#evidence-a-narrower-product-claim)
+- [Uninstall](#uninstall) · [Documentation](#documentation) · [Contributing](#contributing)
 
-Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
-
-No hosted memory service. No vendor-specific chat history. Just reviewable decision context, owned by and portable with the repository.
-
-Install once. Your coding agent can record the decisions worth carrying forward, while CommitLore validates and preserves them in Git.
-
-**Claude Code** — one plugin registers the MCP server, the pre-edit context hook and the skills:
-
-```
-/plugin marketplace add MongLong0214/commitlore
-/plugin install commitlore@commitlore
-```
-
-That is the whole plugin: the MCP server, the pre-edit hook and the skills. It puts no `commitlore` on `PATH`, so the `commitlore …` commands below come from `install.sh` / `install.ps1` and need that install as well.
-
-Prerequisites for either path: Node.js 22+ and Git. The script checks both before it writes anything.
-
-**Any other coding agent** — install the CLI:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
-```
-
-Which hosts are supported, and what each install path requires: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
-
-**Give your next agent the judgment your last one earned.**
+</details>
 
 ## The code survived. The decision didn't.
 
@@ -111,21 +102,123 @@ wrong. The significance test, the interval and the registered threshold are in
 retyped into prose drifts from the log that produced it, and this repository
 gates against exactly that (`scripts/check-readme-numbers.mjs`).
 
-Three limits belong beside the number. Every record in that run rendered
-`[claim]`, with the payload telling the agent not to act on it as an order — the
-`[directive]` tier became reachable only afterwards, so **this measures the
-weaker of the two**. It is one model, one harness, and ten constructed
-fixtures. And the oracle reads the final implementation state: it shows agents
-which received records re-proposed less often, not that any of them read
-anything. Method, exclusions and the per-arm truncation split:
+What that number does **not** show is two sections down, under
+[when this will not help you](#when-this-will-not-help-you). It is worth the
+scroll before you install rather than after.
+
+## Install
+
+Install once. Your coding agent can record the decisions worth carrying forward, while CommitLore validates and preserves them in Git.
+
+**Claude Code** — one plugin registers the MCP server, the pre-edit context hook and the skills:
+
+```
+/plugin marketplace add MongLong0214/commitlore
+/plugin install commitlore@commitlore
+```
+
+That is the whole plugin: the MCP server, the pre-edit hook and the skills. It puts no `commitlore` on `PATH`, so the `commitlore …` commands below come from `install.sh` / `install.ps1` and need that install as well.
+
+Prerequisites for either path: Node.js 22+ and Git. The script checks both before it writes anything.
+
+**Any other coding agent** — install the CLI:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
+```
+
+Which hosts are supported, and what each install path requires: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
+
+**Give your next agent the judgment your last one earned.**
+
+### Then, in each repository
+
+Then run `commitlore init` in each repository where you want validation hooks and a local index. The installer detects supported coding agents and registers the local MCP server where it can do so safely.
+
+```bash
+cd your-repository
+commitlore init
+commitlore context .
+```
+
+After that:
+
+- Commit normally. Most commits carry no record.
+- If a record is present, the commit-msg hook validates it; it never creates one.
+- Agents query decision context through MCP or receive it from the `PreToolUse` hook.
+- Before changing a path, they see its active limits, ruled-out alternatives, warnings, and verification gaps.
+
+Keep working through your coding agent. When a change contains decision context the diff cannot preserve, ask the agent to include a CommitLore record in the commit.
+
+<details>
+<summary>Prefer to inspect or pin the installation?</summary>
+
+The one-liner is for convenience. For a reviewed or pinned install, download and inspect `install.sh` first, or clone the repository. The script installs a pinned source checkout and a thin wrapper that runs `node <checkout>/dist/commitlore.mjs` — it downloads no compiled artifact and runs no build step, so what it puts on your machine is the source you can read.
+
+```bash
+# Pin and inspect the installer before executing it.
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh
+sh install.sh v0.7.1
+
+# Or skip the script entirely: the checkout it makes is one you can make yourself.
+git clone --depth 1 --branch v0.7.1 https://github.com/MongLong0214/commitlore
+node commitlore/dist/commitlore.mjs --version
+```
+
+</details>
+
+## When this will not help you
+
+Read this before installing, not after.
+
+- **The measurement is of the weaker tier.** Every record in the 1,160-run study
+  rendered `[claim]`, which tells the agent to weigh the record rather than obey
+  it. The `[directive]` tier became reachable only afterwards, so the number
+  above is the floor, measured — not the ceiling, claimed.
+- **One model, one harness, ten constructed fixtures.** The oracle reads the
+  final implementation state, so it shows that agents which received records
+  re-proposed less often. It does not show that any of them read anything.
+- **Guard is an experimental advisory**, not a safety net: precision 44.8%
+  (95% Wilson CI 32.7%–57.5%), recall 22.0% on the 417-decision corpus
+  ([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). An empty
+  guard result does not mean a proposal avoids every ruled-out alternative — at
+  22% recall, a miss is the common case.
+- **Nothing is verified cryptographically yet.** Author verification,
+  repository-wide coverage, symbol anchors and an interactive record builder are
+  open: [#28](https://github.com/MongLong0214/commitlore/issues/28),
+  [#32](https://github.com/MongLong0214/commitlore/issues/32),
+  [#33](https://github.com/MongLong0214/commitlore/issues/33),
+  [#34](https://github.com/MongLong0214/commitlore/issues/34).
+- **M4 did not test a guard effect**: its rows carry no `guard_exposure`, so
+  treatment exposure there is unverifiable
+  ([#122](https://github.com/MongLong0214/commitlore/issues/122)).
+
+The full method, the exclusions and the per-arm truncation split are in
 [bench/VERDICT-M5.md](bench/VERDICT-M5.md) and
 [what it does not show](docs/evidence.md).
 
+## What it is, in full
+
+**The Git-native decision layer for coding agents.**
+
+Every fresh agent inherits the implementation. None of them inherit the
+constraints, the alternatives your team rejected, the warnings, or the
+verification gaps — those do not travel with the code unless something carries
+them.
+
+CommitLore preserves that engineering judgment in Git, and surfaces only the
+decisions still in force before the next edit. A decision that was later
+superseded or expired does not reach the agent as if it still stood.
+
+**Repository-owned · Lifecycle-aware · Evidence-verified · Agent-independent**
+
+Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
+
+No hosted memory service. No vendor-specific chat history. Just reviewable
+decision context, owned by and portable with the repository.
+
 ## See it work
 
-<p align="center">
-  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
-</p>
 
 **A fresh agent. Zero chat history. It is still handed why the obvious fix was rejected.** Query a path before changing it:
 
@@ -164,42 +257,6 @@ trailer, validated by the hook this project asks you to install, and readable
 with the same `commitlore context` you would run anywhere else.
 
 **The full list, with what each one cost: [docs/SELF-AUDIT.md](docs/SELF-AUDIT.md).**
-
-## Try it in a repository
-
-Then run `commitlore init` in each repository where you want validation hooks and a local index. The installer detects supported coding agents and registers the local MCP server where it can do so safely.
-
-```bash
-cd your-repository
-commitlore init
-commitlore context .
-```
-
-After that:
-
-- Commit normally. Most commits carry no record.
-- If a record is present, the commit-msg hook validates it; it never creates one.
-- Agents query decision context through MCP or receive it from the `PreToolUse` hook.
-- Before changing a path, they see its active limits, ruled-out alternatives, warnings, and verification gaps.
-
-Keep working through your coding agent. When a change contains decision context the diff cannot preserve, ask the agent to include a CommitLore record in the commit.
-
-<details>
-<summary>Prefer to inspect or pin the installation?</summary>
-
-The one-liner is for convenience. For a reviewed or pinned install, download and inspect `install.sh` first, or clone the repository. The script installs a pinned source checkout and a thin wrapper that runs `node <checkout>/dist/commitlore.mjs` — it downloads no compiled artifact and runs no build step, so what it puts on your machine is the source you can read.
-
-```bash
-# Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh
-sh install.sh v0.7.1
-
-# Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v0.7.1 https://github.com/MongLong0214/commitlore
-node commitlore/dist/commitlore.mjs --version
-```
-
-</details>
 
 ## Retrieval can find records. Path scope keeps reversed decisions out.
 
@@ -465,12 +522,6 @@ What removes each of those, and how to run from a source checkout instead:
 - [docs/protocol.md](docs/protocol.md) — the record format, and reading it with plain Git
 - [docs/evidence.md](docs/evidence.md) — what is measured, and what is not
 - [spec/SPEC.md](spec/SPEC.md) — the normative protocol
-
-## Known limitations
-
-- Cryptographic author verification, repository-wide record coverage, symbol anchors, and an interactive record builder are not implemented yet: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
-- M4 did not test a guard effect: its rows have no `guard_exposure`, so treatment exposure is unverifiable ([#122](https://github.com/MongLong0214/commitlore/issues/122)).
-- Guard (ruled-out alternative matching) is an experimental advisory: precision 44.8% (95% Wilson CI 32.7%–57.5%), recall 22.0% on the 417-decision corpus ([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). An empty guard result does not guarantee a proposal avoids all ruled-out alternatives — at 22% recall, a miss is the common case.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,22 +14,74 @@
 
 # CommitLore
 
-## 代理继承了代码。
-## 也把判断传下去。
+**你的编程代理不断重新提议团队早已否决的方案。**
 
-**面向编程代理的 Git 原生 decision layer。**
+CommitLore 把这些决策保存在 Git 中，并在它编辑文件之前，把仍然有效的决策交给它
+——**无需托管服务，也不会有一个字节离开你的仓库**。
 
-每个新代理都继承了实现。但它不会继承约束、团队否决过的替代方案、警告，以及验证缺口 ——
-除非有什么东西把它们带上，否则这些并不随代码一起走。
+在 1,160 次已登记的运行中，重新提议已否决方案的比例从 **18.8%** 降至 **2.8%**。下面的示例就是代理实际看到的内容。
 
-CommitLore 把这份工程判断保存在 Git 中，并在下一次编辑前只呈现**当下仍然有效的决定**。
-后来被取代或已过期的决定，不会以仍然成立的样子送到代理面前。
+<p align="center">
+  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
+</p>
 
-**仓库拥有 · 感知生命周期 · 证据经过验证 · 不依赖特定代理**
+<details>
+<summary><strong>目录</strong></summary>
 
-Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
+- [一个例子中的问题](#代码留了下来决定没有)
+- [安装](#安装)
+- [这在什么情况下帮不上忙](#这在什么情况下帮不上忙)
+- [完整地说，它是什么](#完整地说它是什么)
+- [看它实际运行](#看它实际运行)
+- [这个仓库本身就是演示](#这个仓库本身就是演示)
+- [路径范围与检索](#检索能找到记录路径范围会排除已经推翻的决策)
+- [工作方式](#工作方式)
+- [来自另一仓库的现场报告](#在真实仓库中的样子)
+- [有何不同](#有何不同)
+- [在哪里见效](#在哪里见效)
+- [record 如何创建](#record-如何创建)
+- [完整 record](#完整-record)
+- [仓库能够证明什么](#仓库能够证明什么)
+- [证据](#evidence更窄的产品主张)
+- [卸载](#卸载) · [文档](#文档) · [贡献](#贡献)
 
-没有托管记忆服务，也没有特定供应商的聊天历史。只有由仓库拥有并随仓库流转、可供审查的决策上下文。
+</details>
+
+## 代码留了下来，决定没有。
+
+*不再重复评审同一个坏主意。*
+
+
+**没有 CommitLore。** 新会话看到两个输入相似的函数，复用了其中一个。
+
+```ts
+calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
+```
+
+团队于是多了一个标志、一个包装器，以及一个守护该函数本不该承担的用例的兼容分支。评审者
+第二次写下"我们已经否决过这个了"。
+
+**有 CommitLore。** 编辑之前，代理收到：
+
+```
+commitlore: active records for src/pricing.ts
+
+Limit
+  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+
+Ruled-out
+  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
+                                    and rounding semantics differ between the two flows
+```
+
+`[claim]` 在真正起作用：这条 record 并非由仓库的可信作者写入，因此代理被告知把它当作
+信息而不是命令。由可信作者留下的 record 会渲染为 `[directive]`。
+
+模块边界在代理提出改动**之前**就摆在它面前，而不是事后出现在评审意见里。
+
+这个数字没有说明的内容，位于下方两个章节后的[这在什么情况下帮不上忙](#这在什么情况下帮不上忙)。在安装前而不是之后花时间读一读，值得。
+
+## 安装
 
 安装一次。你的编程代理可以记录值得延续的决策，而 CommitLore 会验证它们并将其保存在 Git 中。
 
@@ -54,64 +106,7 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/inst
 
 **把上一个代理挣得的判断，交给下一个代理。**
 
-## 看它实际运行
-
-<p align="center">
-  <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
-</p>
-
-**一个全新的代理，没有聊天历史。它仍被交到手上：为什么那个显而易见的修复被排除了。** 在改动前查询 path：
-
-```bash
-commitlore context install.sh
-```
-
-输出会包含一条 active record：它排除了把发布 `-musl` target 当作 installer 缺陷修复的做法，并说明原因。hook 提供上下文；它并不声称会阻止编辑。
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-如何原样复现这条 `PreToolUse` hook path，以及其余全部命令：[docs/cli.md](docs/cli.md)。
-
-## 检索能找到记录。路径范围会排除已经推翻的决策。
-
-在代理进行第一次编辑之前，仓库中仍然有效的决策，究竟有多少真正到达了它？在本仓库中，按钩子默认使用的 800 token 预算：
-
-| 路由 | 预算 | 送达的有效决策 | 送达的已推翻决策 | token |
-|---|---:|---:|---:|---:|
-| 仅代码 | — | 0.0% | 0 | 0 |
-| 该路径的 `git log` | 800 | 42.0% | 7 | 673,134 |
-| **CommitLore 路径范围** | **800** | **81.7%** | **0** | **511,412** |
-| CommitLore，取消上限 | 无 | 92.3% | 0 | 741,429 |
-
-取消上限后，路径范围回收的正是全仓库倾倒所回收的那一批 —— 2,217 组中的 2,047 组 —— 却只用掉其 92,175,612 token 中的一小部分，并且一条也不送出它随附的 7,322 条已推翻记录。**范围没有任何代价。** 上限消耗 10.6 个百分点。剩下的 170 组是信任分级器扣留的记录。
-
-**这测的是送达，不是效果。** 没有代理参与运行，所以它给出的是*可能*回收多少的上界，而不是实际回收了多少。而且检索指标完全可能在它本应预测的结果变差时继续上升。SWE-bench 测得随着上下文预算增加，BM25 的 recall 从 29.58 升至 51.06，却同时报告"即便增大 BM25 的最大上下文会提升相对 oracle 文件的 recall，性能仍会下降……因为模型根本不擅长定位有问题的代码"（[arXiv:2310.06770](https://arxiv.org/abs/2310.06770)）。一个语料库，一个仓库。被替代的记录有 7 条、已过期的有 0 条，所以"零条已推翻决策送达"对过期一事尚未给出任何结论。方法与完整表格：[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)。
-
-**`git log` 基线并非我们自己测自己得出的产物。** 把同一测量应用到本项目并未撰写的四个仓库 —— Django、SymPy、scikit-learn 与 Requests，均固定在指定提交 —— 一条路径的历史在 800 token 截断下存活的比例落在 **37.4% 到 55.6%** 之间。上面的 42.0% 就在这个区间内。固定预算砍掉一个文件近半历史，是 `git log` 在大型、长期存续的仓库上普遍会做的事，而不是本仓库特有的现象。**没有转移的是机制。** 我们的路径中位数是 1 次提交 687 token，Django 则是 8 次提交 213 token —— 较长的提交信息会在固定预算下让普通 Git 基线更差，这是本项目自身实践付出的代价。[bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md) 也报告了那些仓库上的送达数值，但请先读 §9.0 与 §9.5：其中的记录由程序从 revert 提交生成，标题数字是附着谓词强制的结果，并非检索成绩。
-
-漏掉一条记录，模型损失的是上下文；交给它一项已经推翻的决策，损失的是正确性。在这项[检索测量](bench/retrieval/result.md)中，从 0 到 10,000 条干扰记录的每个规模，BM25、embedding top-k、hybrid RRF 与带路径过滤的 embedding 都各返回了一条已被替代的记录。带生命周期的 CommitLore 路径范围返回零条过时记录，并返回两条当前记录 (2/2)。
-
-召回率是辅助结果：两种方式的检索大体找到相同的记录，但只有一条路由知道哪些仍然有效。决策被推翻时优势才会出现——而这正是本产品存在的情形。
-
-独立的 #167 暴露运行仍然重要：10,002 条记录中只有 2 条到达模型。
-
-| 路由 | 模型可见记录 | 相关记录 | 模型可见令牌 |
-|---|---:|---:|---:|
-| 注入全部内容 | 10,002 | 2/2 | 1,004,554 |
-| top-k 词法检索 | 2 | 1/2 | 190 |
-| CommitLore 路径范围 | 2 | 2/2 | 335 |
-
-这项测量是在固定的两条记录输出预算下进行的暴露与召回率测量，不测量令牌成本、计费成本、准确率或代理行为。它只涉及一个语料库、一个查询和一个固定的 embedding 模型。召回率打平的地方，以及此外还测量了什么、没测量什么：[docs/evidence.md](docs/evidence.md)。
-
-## 在仓库中试用
+### 然后，在每个仓库中
 
 然后在每个需要验证 hook 与本地 index 的仓库运行 `commitlore init`。安装程序会检测受支持的编程代理，并在可以安全处理的地方注册本地 MCP server。
 
@@ -147,38 +142,104 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
-## 代码留了下来，决定没有。
-
-*不再重复评审同一个坏主意。*
 
 
-**没有 CommitLore。** 新会话看到两个输入相似的函数，复用了其中一个。
+## 这在什么情况下帮不上忙
 
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
+请在安装前阅读，而不是之后。
+
+- **测量的是较弱的那一档。** 在 1,160 次研究中，所有记录都渲染为 `[claim]`，
+  它告诉代理把记录当作信息来权衡，而不是当作命令。`[directive]` 档位是在那之后
+  才可达的，所以上面的数字是**测得的下限**，而不是宣称的上限。
+- **一个模型、一套 harness、十个构造的 fixture。** oracle 读取的是最终实现状态，
+  因此它显示收到记录的代理更少重提被排除的方案，但并不显示其中任何一个读过什么。
+- 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
+- M4 没有检验 guard 效果：row 没有 `guard_exposure`，因而无法验证 treatment exposure（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
+- Guard（ruled-out alternative matching）是实验性参考信息：precision 44.8%（95% Wilson CI 32.7%–57.5%），recall 22.0%，基于 417-decision corpus（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空的 guard 结果不保证提案避开了所有 ruled-out alternative——在 recall 22% 下，遗漏才是常态。
+
+## 完整地说，它是什么
+
+**面向编程代理的 Git 原生 decision layer。**
+
+每个新代理都继承了实现。但它不会继承约束、团队否决过的替代方案、警告，以及验证缺口 ——
+除非有什么东西把它们带上，否则这些并不随代码一起走。
+
+CommitLore 把这份工程判断保存在 Git 中，并在下一次编辑前只呈现**当下仍然有效的决定**。
+后来被取代或已过期的决定，不会以仍然成立的样子送到代理面前。
+
+**仓库拥有 · 感知生命周期 · 证据经过验证 · 不依赖特定代理**
+
+Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
+
+没有托管记忆服务，也没有特定供应商的聊天历史。只有由仓库拥有并随仓库流转、可供审查的决策上下文。
+
+## 看它实际运行
+
+
+
+**一个全新的代理，没有聊天历史。它仍被交到手上：为什么那个显而易见的修复被排除了。** 在改动前查询 path：
+
+```bash
+commitlore context install.sh
 ```
 
-团队于是多了一个标志、一个包装器，以及一个守护该函数本不该承担的用例的兼容分支。评审者
-第二次写下"我们已经否决过这个了"。
+输出会包含一条 active record：它排除了把发布 `-musl` target 当作 installer 缺陷修复的做法，并说明原因。hook 提供上下文；它并不声称会阻止编辑。
 
-**有 CommitLore。** 编辑之前，代理收到：
+```console
+context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
 
-```
-commitlore: active records for src/pricing.ts
+ruled-out
+  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
 
-Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
-
-Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
+warnings
+  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
 ```
 
-`[claim]` 在真正起作用：这条 record 并非由仓库的可信作者写入，因此代理被告知把它当作
-信息而不是命令。由可信作者留下的 record 会渲染为 `[directive]`。
+如何原样复现这条 `PreToolUse` hook path，以及其余全部命令：[docs/cli.md](docs/cli.md)。
 
-模块边界在代理提出改动**之前**就摆在它面前，而不是事后出现在评审意见里。它是否照做，是
-本项目尚未回答的代理行为问题 —— 见下面的测量，以及[未被测量的部分](docs/evidence.md)。
+## 这个仓库本身就是演示
+
+一个声称能阻止代理重新决定已尘埃落定的问题的工具，应当能够展示它在自身上捕获了什么。这个工具公开维护该清单，其中也包括本项目已经发布、后来被证明有误的内容。
+
+- **没有任何一种安装方式能产生 README 的主张所依赖的信任等级。** record 到达代理时会被评为 `directive` 或 `claim`。结果是，没有已安装的 surface 配置了可信 author，于是所有人的等级都 fail-closed 为 `claim`，而注入的图例却展示了没人能达到的 tier。此前两项 benchmark 测量的都是 `claim` 等级的送达（[#415](https://github.com/MongLong0214/commitlore/issues/415)）。
+- **已登记的 benchmark 分析本会同时读取四项不同的实验。** 由于它的停止规则是行数，这种污染会让研究*通过*它自己的完整性关卡（[#441](https://github.com/MongLong0214/commitlore/issues/441)）。
+- **没有任何东西运行 result-schema gate。** 因此 schema 比 runner 落后五个字段，两天都没人发现（[#392](https://github.com/MongLong0214/commitlore/issues/392)）。
+- **一个已发布的 pre-push hook 会挂起每一次 `git push`。** 40 秒内调用 hook 1,240 次，因为函数被测试了十一次，而 hook path 一次也没有测试（[#422](https://github.com/MongLong0214/commitlore/issues/422)）。
+
+每一项都是 commit trailer 中的一行 `Ruled-out:`、`Warn:` 或 `Limit:`，由本项目请你安装的 hook 验证，并且可以用你在其他地方运行的同一条 `commitlore context` 读取。
+
+**完整列表及每一项的代价：[docs/SELF-AUDIT.md](docs/SELF-AUDIT.md)。**
+
+## 检索能找到记录。路径范围会排除已经推翻的决策。
+
+在代理进行第一次编辑之前，仓库中仍然有效的决策，究竟有多少真正到达了它？在本仓库中，按钩子默认使用的 800 token 预算：
+
+| 路由 | 预算 | 送达的有效决策 | 送达的已推翻决策 | token |
+|---|---:|---:|---:|---:|
+| 仅代码 | — | 0.0% | 0 | 0 |
+| 该路径的 `git log` | 800 | 42.0% | 7 | 673,134 |
+| **CommitLore 路径范围** | **800** | **81.7%** | **0** | **511,412** |
+| CommitLore，取消上限 | 无 | 92.3% | 0 | 741,429 |
+
+取消上限后，路径范围回收的正是全仓库倾倒所回收的那一批 —— 2,217 组中的 2,047 组 —— 却只用掉其 92,175,612 token 中的一小部分，并且一条也不送出它随附的 7,322 条已推翻记录。**范围没有任何代价。** 上限消耗 10.6 个百分点。剩下的 170 组是信任分级器扣留的记录。
+
+**这测的是送达，不是效果。** 没有代理参与运行，所以它给出的是*可能*回收多少的上界，而不是实际回收了多少。而且检索指标完全可能在它本应预测的结果变差时继续上升。SWE-bench 测得随着上下文预算增加，BM25 的 recall 从 29.58 升至 51.06，却同时报告"即便增大 BM25 的最大上下文会提升相对 oracle 文件的 recall，性能仍会下降……因为模型根本不擅长定位有问题的代码"（[arXiv:2310.06770](https://arxiv.org/abs/2310.06770)）。一个语料库，一个仓库。被替代的记录有 7 条、已过期的有 0 条，所以"零条已推翻决策送达"对过期一事尚未给出任何结论。方法与完整表格：[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)。
+
+**`git log` 基线并非我们自己测自己得出的产物。** 把同一测量应用到本项目并未撰写的四个仓库 —— Django、SymPy、scikit-learn 与 Requests，均固定在指定提交 —— 一条路径的历史在 800 token 截断下存活的比例落在 **37.4% 到 55.6%** 之间。上面的 42.0% 就在这个区间内。固定预算砍掉一个文件近半历史，是 `git log` 在大型、长期存续的仓库上普遍会做的事，而不是本仓库特有的现象。**没有转移的是机制。** 我们的路径中位数是 1 次提交 687 token，Django 则是 8 次提交 213 token —— 较长的提交信息会在固定预算下让普通 Git 基线更差，这是本项目自身实践付出的代价。[bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md) 也报告了那些仓库上的送达数值，但请先读 §9.0 与 §9.5：其中的记录由程序从 revert 提交生成，标题数字是附着谓词强制的结果，并非检索成绩。
+
+漏掉一条记录，模型损失的是上下文；交给它一项已经推翻的决策，损失的是正确性。在这项[检索测量](bench/retrieval/result.md)中，从 0 到 10,000 条干扰记录的每个规模，BM25、embedding top-k、hybrid RRF 与带路径过滤的 embedding 都各返回了一条已被替代的记录。带生命周期的 CommitLore 路径范围返回零条过时记录，并返回两条当前记录 (2/2)。
+
+召回率是辅助结果：两种方式的检索大体找到相同的记录，但只有一条路由知道哪些仍然有效。决策被推翻时优势才会出现——而这正是本产品存在的情形。
+
+独立的 #167 暴露运行仍然重要：10,002 条记录中只有 2 条到达模型。
+
+| 路由 | 模型可见记录 | 相关记录 | 模型可见令牌 |
+|---|---:|---:|---:|
+| 注入全部内容 | 10,002 | 2/2 | 1,004,554 |
+| top-k 词法检索 | 2 | 1/2 | 190 |
+| CommitLore 路径范围 | 2 | 2/2 | 335 |
+
+这项测量是在固定的两条记录输出预算下进行的暴露与召回率测量，不测量令牌成本、计费成本、准确率或代理行为。它只涉及一个语料库、一个查询和一个固定的 embedding 模型。召回率打平的地方，以及此外还测量了什么、没测量什么：[docs/evidence.md](docs/evidence.md)。
 
 ## 工作方式
 
@@ -399,12 +460,6 @@ commitlore uninstall
 - [docs/protocol.md](docs/protocol.md) — record 格式，以及只用 Git 读取的方法
 - [docs/evidence.md](docs/evidence.md) — 哪些已被测量，哪些没有
 - [spec/SPEC.md](spec/SPEC.md) — 规范协议
-
-## 已知限制
-
-- 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
-- M4 没有检验 guard 效果：row 没有 `guard_exposure`，因而无法验证 treatment exposure（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
-- Guard（ruled-out alternative matching）是实验性参考信息：precision 44.8%（95% Wilson CI 32.7%–57.5%），recall 22.0%，基于 417-decision corpus（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空的 guard 结果不保证提案避开了所有 ruled-out alternative——在 recall 22% 下，遗漏才是常态。
 
 ## 贡献
 

--- a/test/readme-order.test.ts
+++ b/test/readme-order.test.ts
@@ -2,9 +2,12 @@
  * T-1015 (#207): README section order — `See it work` sits after the install
  * command and before the evidence section, across all four language files.
  *
- * Binding anchors from the CEO amendment:
- *   product  → hero heading (decision-authority framing)
- *   local-first → "No hosted memory service."
+ * Binding anchors from the CEO amendment. #450 restructured the opening, so
+ * two anchors point at the sentences that carry those properties rather than
+ * at the wording they had before. THE REQUIRED ORDER IS UNCHANGED, and so is
+ * what each anchor stands for:
+ *   product  → the opening problem sentence (was: the hero heading)
+ *   local-first → "without a hosted service" (was: "No hosted memory service.")
  *   install promise → "Install once."
  *   install command → the `curl` block
  *   evidence → "Retrieval can find records. Path scope keeps reversed decisions out."
@@ -38,22 +41,25 @@ function findAnchors(file: string): ReadmeAnchors {
   // whether a proposal is bad, it decides whether a decision still applies.
   // "Stop re-reviewing the same bad idea" was tried here and moved into the
   // demo: as a hero it implied a judgement `guard` cannot make at 22% recall.
+  // #450 replaced the two-line poster heading that used to carry this with a
+  // plain problem sentence in the same position. What the amendment pinned —
+  // the reader learns what the product is about before anything else — is
+  // unchanged; the sentence carrying it is no longer a heading.
   const product = lines.findIndex(
     (l) =>
-      l.startsWith('## ') &&
-      (l.includes('inherit the judgment') ||
-        l.includes('판단까지 물려주세요') ||
-        l.includes('判断も継がせましょう') ||
-        l.includes('也把判断传下去')),
+      l.includes('keeps re-proposing things your team already rejected') ||
+      l.includes('이미 기각한 방안을 계속 다시 제안합니다') ||
+      l.includes('すでに却下した案を何度も提案します') ||
+      l.includes('不断重新提议团队早已否决的方案'),
   );
 
   // Local-first: "No hosted memory service." or equivalent
   const localFirst = lines.findIndex(
     (l) =>
-      l.includes('No hosted memory service') ||
-      l.includes('호스팅 메모리 서비스도') ||
-      l.includes('ホスト型メモリサービスも') ||
-      l.includes('没有托管记忆服务'),
+      l.includes('without a hosted service') ||
+      l.includes('호스팅 서비스 없이') ||
+      l.includes('ホスティングサービスなしで') ||
+      l.includes('无需托管服务'),
   );
 
   // Install promise: "Install once." or equivalent
@@ -79,13 +85,17 @@ function findAnchors(file: string): ReadmeAnchors {
       l === '## 看它实际运行',
   );
 
-  // Evidence: "Retrieval can find records..." heading or equivalent
+  // Evidence: the "Retrieval can find records..." heading. It must be the
+  // heading and not any line mentioning it — #450 added a contents list whose
+  // entries name the same sections, and a bare substring search finds the link
+  // first, which would compare the wrong position.
   const evidence = lines.findIndex(
     (l) =>
-      l.includes('Retrieval can find records') ||
+      l.startsWith('## ') &&
+      (l.includes('Retrieval can find records') ||
       l.includes('검색은 레코드를 찾을 수 있습니다') ||
       l.includes('検索はレコードを見つけられる') ||
-      l.includes('检索能找到记录'),
+      l.includes('检索能找到记录')),
   );
 
   return { file, product, localFirst, installPromise, installCommand, seeItWork, evidence };

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -78,8 +78,13 @@ describe('T-1021: Known limitations discloses guard precision and recall', () =>
     describe(file, () => {
       const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
 
-      // Extract the Known limitations section (between its heading and the next ## heading)
-      const knownLimStart = content.search(/^## (Known limitations|알려진 제한 사항|既知の制限事項|已知限制)/m);
+      // The section moved above the fold and was renamed to a question a reader
+      // asks before installing rather than a label they meet at the bottom. What
+      // it must disclose is unchanged; only where the test looks for it moved.
+      // Extract the section (between its heading and the next ## heading)
+      const knownLimStart = content.search(
+        /^## (When this will not help you|이것이 도움이 되지 않는 경우|これが役に立たない場合|这在什么情况下帮不上忙)/m,
+      );
       const afterStart = content.slice(knownLimStart + 1);
       const nextSection = afterStart.search(/^## /m);
       const knownLimSection = nextSection === -1
@@ -113,8 +118,8 @@ describe('T-1021: Known limitations discloses guard precision and recall', () =>
 describe('T-1021 mutation oracles', () => {
   const enContent = fs.readFileSync(path.join(REPO_ROOT, 'README.md'), 'utf8');
 
-  // Extract the Known limitations section for English
-  const knownLimStart = enContent.search(/^## Known limitations/m);
+  // Extract that section for English
+  const knownLimStart = enContent.search(/^## When this will not help you/m);
   const afterStart = enContent.slice(knownLimStart + 1);
   const nextSection = afterStart.search(/^## /m);
   const knownLimSection = nextSection === -1 ? afterStart : afterStart.slice(0, nextSection);


### PR DESCRIPTION
Closes #450.

A first-time reader met **~45 lines of positioning** before reaching the pricing example — the only part of the document that shows the problem. Distribution is what this project is short of, not evidence, and a reader who leaves before the example never reaches any of the evidence either.

## What moved

| | before | after |
|---|---|---|
| the example + the number | line 60, under the thesis | directly under a three-line hook |
| install | above the example | after it |
| limitations | line 469, last section before Contributing | directly under Install |
| positioning prose | the opening | below the proof for it |

**Nothing was cut.** The order changed.

## "Known limitations" → "When this will not help you"

At the bottom of a 477-line document that heading is a place nobody arrives at. Under the install command it is the question a reader is actually asking, so it is named as one.

Two limits that lived as prose inside the evidence paragraph are bullets now: that the study measured the weaker `[claim]` tier because `[directive]` was not yet reachable, and that the oracle reads final implementation state rather than whether anything was read. They were true and buried; they are true and legible.

## The four languages disclose the same five limits

The translations initially carried three. That would have left the English README more forthcoming than the others about the same software.

## On the test change

`test/readme.test.ts` was taught the new heading in all four languages. **Its assertions and its mutation oracles are unchanged** — what the section must disclose did not move, only where the test looks for it. A test that pins a name is meant to keep the disclosure honest, not to keep the name.

58 cases pass; the generated numbers block still matches its generator.

## Reference

Structure follows what converts on comparable projects: a one-sentence definition, then the demonstration, then install — and limitations as a named section a reader meets early rather than caveats folded into an evidence table. [ripgrep](https://github.com/BurntSushi/ripgrep) puts benchmarks ahead of "why should I use this" and gives "why shouldn't I" its own heading; [bat](https://github.com/sharkdp/bat) shows the tool working roughly 20 lines in, well before installation.
