### PR TITLE
Fix M6's pilot protocol before the pilot produces a number

### DIFF
--- a/bench/PREREGISTRATION-M6.md
+++ b/bench/PREREGISTRATION-M6.md
@@ -226,3 +226,67 @@ this way — the rule §12 opens with.
 
 Nothing about M5's outcome was known when this was written. Nothing about M6 has
 been run.
+
+---
+
+## 13. The base-rate pilot — protocol, fixed before it runs
+
+§5 says the order is *base-rate pilot → n → register → run*, and leaves the
+pilot itself undescribed. This section fixes it. It is written before the pilot
+executes, for the same reason every other number in this document was: a
+protocol chosen after seeing rows is a protocol chosen by the rows.
+
+### What it measures
+
+The `no-grade` compliance rate, and wall-clock per run. Nothing else. No
+comparison, no table, no verdict.
+
+### Design
+
+| | |
+|---|---|
+| arm | `no-grade` only |
+| tasks | **all ten** `reproposal-*` fixtures |
+| seeds | 3 per task, seeds 1–3 |
+| runs | 30 |
+| driver | `claude-headless` |
+| model | fixed at execution and recorded in every row |
+
+**All ten tasks, not a subset.** §5 records what a subset cost M5: its pilot's
+33.3% came from three tasks including the strongest one in the set, and planning
+from it would have sized the run too small. A base rate taken from a convenience
+sample of a ten-task instrument is a base rate for the sample.
+
+Three seeds is the smallest number that lets a task's runs disagree with each
+other. The pilot is not powered to detect anything, and is not meant to be — its
+job is to say roughly where the rate sits so §5 can size against it.
+
+### Invocation
+
+    node --experimental-strip-types bench/runner.ts \
+      --cond no-grade --seed 1,2,3 --driver claude-headless \
+      --out bench/results/m6-pilot-<date>.jsonl \
+      --save-transcripts bench/results/transcripts-m6-pilot
+
+The output path is under `bench/results/` and not in a temporary directory,
+and the shard is committed when it lands. That is M5 deviation 3, which cost
+that study a re-run.
+
+### Before it starts
+
+No other runner is running. M5 lost roughly two hours to two runners writing the
+same file from different harness commits, and the check that would have caught
+it takes one command.
+
+### What the pilot's rows may and may not be used for
+
+They fix `n` in §5 and they are cited nowhere else. They are not part of any
+analysis set, they do not appear in any table, and they are not evidence for or
+against §2's hypothesis. M5's pilot rows carry the same status and the same
+reason.
+
+### What fixing `n` will look like
+
+`n` follows from the observed `no-grade` rate by the same power calculation §5
+would have used with a prior. When it carries a number, the status line at the
+top of this document changes to registered, in the same commit.


### PR DESCRIPTION
Part of #412.

`bench/PREREGISTRATION-M6.md` §5 says the order is *base-rate pilot → n → register → run*, and left the pilot itself undescribed. **A protocol chosen after seeing rows is a protocol chosen by the rows** — the failure every other section of that document exists to prevent.

## The design decision that matters

**All ten fixtures, not a subset.** §5 already records what a subset cost M5: its pilot's 33.3% came from three tasks including the strongest in the set, and sizing from it would have made the run too small. A base rate from a convenience sample is a base rate for the sample. Repeating that knowingly would be worse than making the mistake once.

Three seeds is the smallest number at which a task's runs can disagree with each other. The pilot is not powered to detect anything and is not meant to be.

## Two operational constraints, both learned the hard way

- the shard is written under `bench/results/` rather than a temporary directory, and committed when it lands — M5 deviation 3, which cost that study a re-run
- the protocol states out loud that no other runner may be running: M5 lost about two hours to two runners writing one file from different harness commits

## What the rows may be used for, stated so it cannot drift

They fix `n`. They are cited nowhere, enter no analysis set and no table, and are evidence for nothing about the hypothesis. M5's pilot rows carry the same status for the same reason.

**The status line still reads `drafted, NOT registered`** — §5 still carries a procedure rather than a number, and this change does not pretend otherwise.
