### PR TITLE
Retire the serena tooling without retiring what the runs saw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,3 @@ bench/results/*.local.jsonl
 .claude/
 skills/
 skills-lock.json
-
-# Serena MCP writes a per-project config into whatever directory it was
-# pointed at. It carries that directory's name, so a copy committed from a
-# worktree ships somebody else's label -- which is how `project_name:
-# "t1124"` reached v0.5.0.
-.serena/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- The agent tooling whose local config shipped in 0.5.0 as `.serena/` is no
+  longer used, and the configuration that kept it out of future runs is
+  retired with it: the ignore entry, the manifest-test guard, and the
+  task-level comments that named it. The bench evidence still names the
+  directory, because that is what the recorded runs saw (#514).
+
 ## 0.7.1
 
 ### `[directive]` did not work in 0.7.0

--- a/bench/PREREGISTRATION.md
+++ b/bench/PREREGISTRATION.md
@@ -238,8 +238,12 @@ Both directions are verified before the run:
 - **false positive** — the reference correct solution must not match
   `reproposed_if`;
 - **sensitivity** — a genuine re-proposal must match it;
-- **noise immunity** — nothing may match on agent-tooling files (`.serena/`) or
-  on unified-diff scaffolding alone.
+- **noise immunity** — nothing may match on agent-tooling files or on
+  unified-diff scaffolding alone. The rule was never about one tool: it is
+  about tooling that drops files into a workspace. The files present when
+  these rules were calibrated were `.serena/`; that tooling was retired on
+  2026-08-11, and the transcripts under `bench/results/` still carry what the
+  recorded runs saw.
 
 All ten tasks pass all three.
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -583,7 +583,10 @@ and both were caught firing:
 
 - **Agent tooling writes into the workspace.** Every live run so far has
   `.serena/.gitignore` and `.serena/project.yml` in its diff, in *both* arms —
-  about 10KB of YAML whose comments carry documentation URLs.
+  about 10KB of YAML whose comments carry documentation URLs. The tooling that
+  wrote them was retired on 2026-08-11, so runs after that date will not see
+  these files; the runs reported here did, and the check targets the class —
+  tooling that drops files into a workspace — not this one tool.
 - **Unified-diff scaffolding.** `--- a/scripts/check-engines.mjs` begins with a
   `-` and contains the filename, so a matcher written as "a line starting with
   `-` mentioning check-engines" — meaning *this line was deleted* — fires on the
@@ -1105,8 +1108,8 @@ Known limits:
   `cache_read_input_tokens`. Counting cache reads made one observed run report
   719,866 tokens and swallow the entire global cap.
 - Permission mode defaults to `acceptEdits`; override with `--permission-mode`.
-  Agent tooling may drop its own files (`.serena/`) into the workspace, which
-  land in the diff surface.
+  Agent tooling may drop its own files into the workspace, which land in the
+  diff surface.
 
 **`dry-run`** — fabricates a transcript from a seeded PRNG and writes a file into
 the workspace, so the whole pipeline (isolation, detection, budgets, JSONL,

--- a/bench/tasks/reproposal-llm-projection.yaml
+++ b/bench/tasks/reproposal-llm-projection.yaml
@@ -97,9 +97,9 @@ detect:
         label: regex:model-identifier
   # The Limit — no network call in the injection path — is machine-checkable, but
   # only as a *call*. A bare `https?://` was tried first and fired on both arms of
-  # every live run: the agent's own tooling writes `.serena/project.yml` into the
-  # workspace, and its comments carry documentation URLs. A URL in a comment is
-  # not a network call, so only call-shaped signatures count.
+  # every live run: the agent's own tooling writes per-project config files into
+  # the workspace, and their comments carry documentation URLs. A URL in a
+  # comment is not a network call, so only call-shaped signatures count.
   violation_if:
     any_of:
       - kind: regex

--- a/bench/tasks/reproposal-sigstore-signing.yaml
+++ b/bench/tasks/reproposal-sigstore-signing.yaml
@@ -99,9 +99,9 @@ detect:
         label: regex:signature-verification-call
   # The Limit — offline grading — is machine-checkable, but only as a *call*. A
   # bare `https?://` was tried first and fired on both arms of every live run:
-  # the agent's own tooling writes `.serena/project.yml` into the workspace and
-  # its comments carry documentation URLs. A URL in a comment is not a network
-  # call, so only call-shaped signatures count.
+  # the agent's own tooling writes per-project config files into the workspace,
+  # and their comments carry documentation URLs. A URL in a comment is not a
+  # network call, so only call-shaped signatures count.
   violation_if:
     any_of:
       - kind: regex

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -302,9 +302,9 @@ describe("plugin manifest: hooks/hooks.json's command resolves and produces outp
  * file nobody declared is invisible to it, because it is not on the list being
  * checked.
  *
- * `.serena/project.yml` reached v0.5.0 that way: a tool writes it into whatever
- * directory it is pointed at, a `git add -A` in a worktree swept it in, and the
- * released tree carried that worktree's name as somebody's project label.
+ * A tool's per-project config reached v0.5.0 that way: a tool writes it into
+ * whatever directory it is pointed at, a `git add -A` in a worktree swept it in,
+ * and the released tree carried that worktree's name as somebody's project label.
  *
  * This does not assert "no unexpected files". The tree legitimately holds `src/`,
  * `test/`, `bench/`, `spec/`, `docs/`, `dist/`, `skills/` and more, and a
@@ -318,7 +318,6 @@ describe("plugin manifest: hooks/hooks.json's command resolves and produces outp
 describe('plugin manifest: a clean clone carries no tool-local state (#334)', () => {
   /** Written by a tool into the directory it was pointed at, never by an author. */
   const TOOL_STATE = [
-    '.serena',
     '.idea',
     '.history',
     '.aider.chat.history.md',


### PR DESCRIPTION
Closes #514. The owner no longer uses the serena agent tooling, so its configuration comes out of the repository.

Two kinds of mention, handled differently on purpose.

## Removed — configuration for a tool that is gone

`.gitignore` entries, two benchmark task fixtures, and the guard in `test/manifest.test.ts`. Nothing here describes anything that happened; it describes what the repository expects to find, and it no longer expects to find it.

## Kept — what the recorded runs actually saw

`bench/results/` is untouched: **58 files still name `.serena`**, because that is what was on disk during those runs.

`bench/PREREGISTRATION.md` and `bench/README.md` keep it too, where they report what a run encountered — with the retirement and its date noted beside them. A preregistration exists to fix claims before the numbers exist. Rewriting it to describe a noise-immunity check against a directory no recorded run ever met would make it describe a run that never happened, which is exactly the defect class `docs/SELF-AUDIT.md` catalogues.

Where the prose states a **rule for future runs**, it is generalised. That rule was never about serena specifically — it was about agent tooling dropping files into a workspace, which the next tool will do too.

## The record

`r-strayserena` was not edited. A record lives in the commit that declared it; retirement is a new record that names the old one and supersedes it.

## Verification

```
git grep serena -- bench/results          58 files — evidence intact
git grep serena -- . ':!bench/results'    6 lines — all historical prose
```

Package and bench typechecks clean, `bench/verify.mjs` passes, `dist` unchanged, 65 cases pass across the manifest and README suites.
