### PR TITLE
Give the study a pinned runtime that refuses rather than degrades

### DIFF
--- a/bench/cdeb/freeze/runtime-probe.ts
+++ b/bench/cdeb/freeze/runtime-probe.ts
@@ -36,6 +36,19 @@
  * was lighter than the shipping one. 0.6 stays frozen as the screen; whether
  * the split needs re-measuring is a separate decision this fix does not make
  * (PRD §4.6).
+ *
+ * **Runtime seam (CDEB-03).** §4.6 requires the probe to run on the same
+ * pinned runtime as the study, and until CDEB-03 this file spawned the host's
+ * `claude` instead. `runProbe` now takes the runtime explicitly: the host
+ * runtime stays exported so CDEB-P's sealed numbers remain reproducible, and
+ * the pinned-container runtime lives in `bench/cdeb/runtime/agent-container.ts`.
+ * Say it plainly: every wall-time number frozen into the PRD was measured on
+ * the host CLI, so probes executed on the pinned runtime are screening a
+ * different runtime and MUST be re-validated — the 0.48/1.00 split and the
+ * 0.6 screen derived from it cannot be assumed to transfer. That
+ * re-validation has not happened yet: it needs the pinned image built and a
+ * container runtime this machine will lend the study, and neither existed
+ * when this seam was written.
  */
 
 import { createHash } from "node:crypto";
@@ -107,6 +120,67 @@ const emptyMcp = (dir: string): string => {
   return path;
 };
 
+/** One probe invocation, as the runtime receives it. */
+export interface ProbeRunParams {
+  readonly workdir: string;
+  readonly settingsPath: string;
+  readonly mcpPath: string;
+  readonly prompt: string;
+  readonly model: string;
+  readonly timeoutMs: number;
+}
+
+export interface ProbeRunResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number | null;
+  readonly timedOut: boolean;
+}
+
+/**
+ * The surface a probe runs on. CDEB-03 made this explicit: §4.6 probes the
+ * study's pinned runtime, and a probe that does not say which runtime it ran
+ * on is the exact ambiguity that let this file spawn the host's `claude`
+ * while the PRD promised a pinned one.
+ */
+export interface ProbeRuntime {
+  readonly name: string;
+  readonly run: (params: ProbeRunParams) => ProbeRunResult;
+}
+
+/**
+ * The host's installed `claude`, exactly as CDEB-P measured it. Kept so the
+ * pilot's sealed qualification numbers remain reproducible; it is NOT the
+ * study runtime, and the wall times it produced are not transferable to the
+ * pinned runtime (see the module header).
+ */
+export const hostClaudeRuntime: ProbeRuntime = {
+  name: "host-claude",
+  run: (params) => {
+    const result = spawnSync(
+      "claude",
+      [
+        "-p", params.prompt,
+        "--output-format", "json",
+        "--permission-mode", "acceptEdits",
+        "--strict-mcp-config",
+        "--mcp-config", params.mcpPath,
+        "--setting-sources", "",
+        "--no-session-persistence",
+        "--settings", params.settingsPath,
+        "--model", params.model,
+      ],
+      { cwd: params.workdir, encoding: "utf8", timeout: params.timeoutMs, maxBuffer: 64 * 1024 * 1024 },
+    );
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      status: result.status,
+      timedOut: (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT",
+    };
+  },
+};
+
 /**
  * One probe run.
  *
@@ -121,37 +195,23 @@ export const runProbe = (
   condition: ProbeCondition,
   timeoutMs: number,
   model: string,
+  runtime: ProbeRuntime,
 ): { probe: RuntimeProbe; artifact: string } => {
   const scratch = mkdtempSync(join(tmpdir(), "cdeb-probe-"));
   const settings = armSettings(scratch, condition);
   const mcp = emptyMcp(scratch);
 
   const start = Date.now();
-  const result = spawnSync(
-    "claude",
-    [
-      "-p", prompt,
-      "--output-format", "json",
-      "--permission-mode", "acceptEdits",
-      "--strict-mcp-config",
-      "--mcp-config", mcp,
-      "--setting-sources", "",
-      "--no-session-persistence",
-      "--settings", settings,
-      "--model", model,
-    ],
-    { cwd: workdir, encoding: "utf8", timeout: timeoutMs, maxBuffer: 64 * 1024 * 1024 },
-  );
+  const result = runtime.run({ workdir, settingsPath: settings, mcpPath: mcp, prompt, model, timeoutMs });
   const wall_ms = Date.now() - start;
 
-  const timedOut = (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
-  const stop_reason: RuntimeProbe["stop_reason"] = timedOut
+  const stop_reason: RuntimeProbe["stop_reason"] = result.timedOut
     ? "timeout"
     : result.status === 0
       ? "completed"
       : "agent_error";
 
-  const artifact = `${result.stdout ?? ""}\n---stderr---\n${result.stderr ?? ""}`;
+  const artifact = `${result.stdout}\n---stderr---\n${result.stderr}`;
   return {
     probe: { condition, model, stop_reason, wall_ms, artifact_sha256: sha256(artifact) },
     artifact,

--- a/bench/cdeb/runtime/Dockerfile
+++ b/bench/cdeb/runtime/Dockerfile
@@ -1,0 +1,51 @@
+# CDEB-03 pinned agent runtime image (PRD §7.1).
+#
+# This file defines the image the study measures in; the pin manifest
+# (runtime-pin.json) records the digest the freeze ceremony observes after
+# building it. The digest — not this file — is what the capability gate
+# matches at run time, so editing this file after the freeze changes nothing
+# until a new freeze records a new digest.
+#
+# Image contents, per §7.1:
+#   - agent CLI, pinned version installed at build time
+#   - exact Node runtime (base image tag pinned here, digest pinned by the freeze)
+#   - Git
+#   - pinned CommitLore build (this repository's committed dist/, ADR-0011)
+#   - the provider-only egress proxy script (run from this same image, so its
+#     code is pinned by the same digest)
+#   - NO user settings, NO MCP servers, NO session state: the layers carry
+#     none, the container mounts none, and HOME starts empty every run.
+#
+# The offline dependency cache slot (§7.1) is filled by the freeze ceremony
+# for repositories whose tasks install dependencies; the base image does not
+# guess at it.
+
+FROM node:22.23.2-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pinned agent CLI. The version is build-argument data; the freeze ceremony
+# records the resulting executable hash in runtime-pin.json, and the gate
+# verifies that hash inside the container before any measured run.
+ARG AGENT_CLI_VERSION
+RUN test -n "$AGENT_CLI_VERSION" \
+    && npm install --global "@anthropic-ai/claude-code@$AGENT_CLI_VERSION" \
+    && npm cache clean --force
+
+# Pinned CommitLore build: the committed dist tree of the harness repository,
+# copied as-is so the ON arm's shipping command runs the shipped bytes.
+COPY dist/ /opt/commitlore/dist/
+
+# Provider-only egress proxy (PRD §7.4), run as:
+#   node /opt/cdeb/egress-proxy.mjs
+COPY bench/cdeb/runtime/egress-proxy.mjs /opt/cdeb/egress-proxy.mjs
+
+# Isolated HOME (§7.2): created empty, owned by nobody's history. The run
+# spec sets HOME here and mounts nothing over it; the container is discarded
+# after each logical run, so nothing in it can reach the next one.
+RUN mkdir -p /home/agent
+
+WORKDIR /repo
+ENV HOME=/home/agent

--- a/bench/cdeb/runtime/agent-container.ts
+++ b/bench/cdeb/runtime/agent-container.ts
@@ -1,0 +1,1221 @@
+/**
+ * CDEB-03 pinned OCI runtime (PRD §7.1–§7.4, §8).
+ *
+ * This module owns the container half of the fail-closed gate: it knows the
+ * pin manifest, builds the exact `docker run` shape a measured run gets,
+ * drives the preflight probes that `isolation.ts` judges, and captures the
+ * raw provider stream CDEB-05 will parse. The judgment itself — pass or
+ * refuse, never warn — lives in `isolation.ts`; here we only produce the
+ * observations it judges.
+ *
+ * Two honesty rules shape the code:
+ *
+ *   - Every docker interaction goes through the injected `ContainerRuntimeCommands`,
+ *     so the gate logic is testable on machines with no container runtime at
+ *     all, and a sandbox without one cannot pretend to have probed.
+ *   - The committed pin manifest is UNFROZEN: its digest fields are null
+ *     because only the freeze ceremony can build the image and observe the
+ *     provider. `pinFreezeGaps` lists what is missing and the gate refuses
+ *     measured runs until the ceremony fills it. Nobody edits the nulls by
+ *     hand; a hand-filled digest is an unfrozen manifest pretending.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createWriteStream, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type {
+  CapabilityGatePassed,
+  CapabilityProbe,
+  NetworkPolicy,
+  StreamIdentity,
+} from "./isolation.ts";
+import {
+  EMPTY_MCP_CONFIG,
+  FROZEN_TOOL_POLICY,
+  RuntimeCapabilityError,
+  canonicalJson,
+  mcpConfigDigest,
+  networkPolicyDigest,
+  readInitEvent,
+  settingsDigest,
+  streamHasAuthoritativeUsage,
+  toolPolicyDigest,
+  verifyStreamIdentity,
+} from "./isolation.ts";
+import type { ProbeRuntime, ProbeRunParams, ProbeRunResult } from "../freeze/runtime-probe.ts";
+
+// ---------------------------------------------------------------------------
+// The pin manifest (§8 identities, frozen by ceremony, matched at run time)
+// ---------------------------------------------------------------------------
+
+export interface RuntimePin {
+  readonly schema_version: 1;
+  /** Informational; `pinFreezeGaps` computes the truth from the fields. */
+  readonly frozen: boolean;
+  readonly image: { readonly reference: string; readonly digest: string | null };
+  readonly agent_cli_version: string | null;
+  readonly agent_executable: { readonly path: string; readonly sha256: string | null };
+  readonly node: {
+    readonly version: string;
+    readonly executable_path: string;
+    readonly executable_sha256: string | null;
+  };
+  readonly requested_model: string;
+  /** Exact model id the provider stream must show; null until the freeze. */
+  readonly expected_observed_model: string | null;
+  readonly permission_mode: string;
+  readonly network_policy: NetworkPolicy;
+}
+
+/** Fields only the freeze ceremony may produce. A null here is a gate refusal. */
+export const pinFreezeGaps = (pin: RuntimePin): readonly string[] => {
+  const gaps: string[] = [];
+  if (pin.image.digest === null) gaps.push("image.digest");
+  if (pin.agent_cli_version === null) gaps.push("agent_cli_version");
+  if (pin.agent_executable.sha256 === null) gaps.push("agent_executable.sha256");
+  if (pin.node.executable_sha256 === null) gaps.push("node.executable_sha256");
+  if (pin.expected_observed_model === null) gaps.push("expected_observed_model");
+  return gaps;
+};
+
+export const pinIsFrozen = (pin: RuntimePin): boolean => pinFreezeGaps(pin).length === 0;
+
+/** `reference@sha256:...`, or null while the digest is unfrozen. */
+export const imageRefOf = (pin: RuntimePin): string | null =>
+  pin.image.digest === null ? null : `${pin.image.reference}@${pin.image.digest}`;
+
+/** Identity of the pin itself: the gate token is minted against this digest. */
+export const runtimePinDigest = (pin: RuntimePin): string =>
+  createHash("sha256").update(canonicalJson(pin), "utf8").digest("hex");
+
+const stringField = (source: Record<string, unknown>, key: string): string => {
+  const value = source[key];
+  if (typeof value !== "string" || value === "") throw new Error(`pin manifest: ${key} must be a non-empty string`);
+  return value;
+};
+
+const optionalStringField = (source: Record<string, unknown>, key: string): string | null => {
+  const value = source[key];
+  if (value === null) return null;
+  if (typeof value !== "string" || value === "") throw new Error(`pin manifest: ${key} must be a string or null`);
+  return value;
+};
+
+/**
+ * Parses and shape-checks the manifest. Any drift from the expected shape is
+ * an error naming the field — a manifest the loader half-understands would be
+ * a silent pin change.
+ */
+export const loadRuntimePin = (raw: string): RuntimePin => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`pin manifest is not valid JSON: ${(error as Error).message}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("pin manifest must be a JSON object");
+  }
+  const root = parsed as Record<string, unknown>;
+  if (root["schema_version"] !== 1) throw new Error("pin manifest: schema_version must be 1");
+
+  const image = root["image"];
+  if (typeof image !== "object" || image === null) throw new Error("pin manifest: image must be an object");
+  const imageRec = image as Record<string, unknown>;
+
+  const agentExecutable = root["agent_executable"];
+  if (typeof agentExecutable !== "object" || agentExecutable === null) {
+    throw new Error("pin manifest: agent_executable must be an object");
+  }
+  const agentRec = agentExecutable as Record<string, unknown>;
+
+  const node = root["node"];
+  if (typeof node !== "object" || node === null) throw new Error("pin manifest: node must be an object");
+  const nodeRec = node as Record<string, unknown>;
+
+  const networkPolicy = root["network_policy"];
+  if (typeof networkPolicy !== "object" || networkPolicy === null) {
+    throw new Error("pin manifest: network_policy must be an object");
+  }
+  const netRec = networkPolicy as Record<string, unknown>;
+  if (netRec["egress"] !== "provider-only") {
+    throw new Error('pin manifest: network_policy.egress must be "provider-only"');
+  }
+  if (netRec["enforcement"] !== "internal-network+allowlist-proxy") {
+    throw new Error(
+      'pin manifest: network_policy.enforcement must be "internal-network+allowlist-proxy" — ' +
+        "any other enforcement is a different network policy and needs a new freeze",
+    );
+  }
+  const hosts = netRec["allowed_hosts"];
+  if (!Array.isArray(hosts) || hosts.some((host) => typeof host !== "string" || host === "")) {
+    throw new Error("pin manifest: network_policy.allowed_hosts must be a list of non-empty strings");
+  }
+  const port = netRec["allowed_port"];
+  if (typeof port !== "number" || !Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error("pin manifest: network_policy.allowed_port must be a valid port number");
+  }
+
+  return {
+    schema_version: 1,
+    frozen: root["frozen"] === true,
+    image: {
+      reference: stringField(imageRec, "reference"),
+      digest: optionalStringField(imageRec, "digest"),
+    },
+    agent_cli_version: optionalStringField(root, "agent_cli_version"),
+    agent_executable: {
+      path: stringField(agentRec, "path"),
+      sha256: optionalStringField(agentRec, "sha256"),
+    },
+    node: {
+      version: stringField(nodeRec, "version"),
+      executable_path: stringField(nodeRec, "executable_path"),
+      executable_sha256: optionalStringField(nodeRec, "executable_sha256"),
+    },
+    requested_model: stringField(root, "requested_model"),
+    expected_observed_model: optionalStringField(root, "expected_observed_model"),
+    permission_mode: stringField(root, "permission_mode"),
+    network_policy: {
+      egress: "provider-only",
+      enforcement: "internal-network+allowlist-proxy",
+      allowed_hosts: hosts as readonly string[],
+      allowed_port: port,
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Container command surface (injectable: the gate must be testable without docker)
+// ---------------------------------------------------------------------------
+
+export interface DockerResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+  readonly timedOut: boolean;
+}
+
+export interface StreamedRunResult {
+  readonly exitCode: number | null;
+  readonly stderr: string;
+  readonly timedOut: boolean;
+}
+
+export interface ContainerRuntimeCommands {
+  readonly run: (args: readonly string[], opts?: { timeoutMs?: number }) => DockerResult;
+  /** Streams stdout into `sink` line-by-line-unmodified; resolves on exit. */
+  readonly runToSink: (
+    args: readonly string[],
+    sink: NodeJS.WritableStream,
+    opts?: { timeoutMs?: number },
+  ) => Promise<StreamedRunResult>;
+}
+
+const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+
+/** The host's `docker` CLI. The only production implementation. */
+export const dockerCliRuntime = (binary: string = "docker"): ContainerRuntimeCommands => {
+  const run = (args: readonly string[], opts?: { timeoutMs?: number }): DockerResult => {
+    const result = spawnSync(binary, [...args], {
+      encoding: "utf8",
+      timeout: opts?.timeoutMs ?? 120_000,
+      maxBuffer: MAX_OUTPUT_BYTES,
+    });
+    const timedOut = (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      exitCode: result.status ?? -1,
+      timedOut,
+    };
+  };
+
+  const runToSink = (
+    args: readonly string[],
+    sink: NodeJS.WritableStream,
+    opts?: { timeoutMs?: number },
+  ): Promise<StreamedRunResult> =>
+    new Promise((resolve, reject) => {
+      const child = spawn(binary, [...args], { stdio: ["ignore", "pipe", "pipe"] });
+      let stderr = "";
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+        setTimeout(() => child.kill("SIGKILL"), 5_000).unref();
+      }, opts?.timeoutMs ?? 15 * 60 * 1000);
+      child.stdout.on("data", (chunk: Buffer) => sink.write(chunk));
+      child.stderr.on("data", (chunk: Buffer) => {
+        if (stderr.length < MAX_OUTPUT_BYTES) stderr += chunk.toString("utf8");
+      });
+      child.on("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        sink.end();
+        resolve({ exitCode: code, stderr, timedOut });
+      });
+    });
+
+  return { run, runToSink };
+};
+
+// ---------------------------------------------------------------------------
+// Run spec: the exact shape of a measured container (pure, testable)
+// ---------------------------------------------------------------------------
+
+/** Environment keys allowed to cross the container boundary. Nothing else does. */
+export const PROVIDER_ENV_KEYS = ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
+
+export interface MountSpec {
+  readonly hostPath: string;
+  readonly containerPath: string;
+  readonly readOnly: boolean;
+}
+
+export interface AgentRunSpec {
+  readonly imageRef: string;
+  readonly network: string;
+  readonly proxyUrl: string;
+  readonly workdir: string;
+  readonly env: Readonly<Record<string, string>>;
+  readonly mounts: readonly MountSpec[];
+  readonly argv: readonly string[];
+}
+
+/** Paths inside the container, fixed for every run. */
+export const CONTAINER_PATHS = {
+  home: "/home/agent",
+  repo: "/repo",
+  config: "/cdeb",
+  settings: "/cdeb/settings.json",
+  mcp: "/cdeb/mcp.json",
+} as const;
+
+/** The egress network and proxy names are stable so preflight and runs share them. */
+export const EGRESS_NETWORK = "cdeb-egress-net";
+export const EGRESS_PROXY_CONTAINER = "cdeb-egress-proxy";
+export const EGRESS_PROXY_PORT = 3128;
+
+/**
+ * The CLI argv for a measured run. Every isolation flag is unconditional: a
+ * run without one of them is not a degraded run, it is no run — the preflight
+ * gate already refused the capability if the pinned CLI lacks the flag.
+ */
+export const agentCliArgv = (pin: RuntimePin, prompt: string): readonly string[] => [
+  "claude",
+  "-p", prompt,
+  "--output-format", "stream-json",
+  "--verbose",
+  "--include-partial-messages",
+  "--permission-mode", pin.permission_mode,
+  "--strict-mcp-config",
+  "--mcp-config", CONTAINER_PATHS.mcp,
+  "--setting-sources", "",
+  "--no-session-persistence",
+  "--settings", CONTAINER_PATHS.settings,
+  "--allowedTools", ...FROZEN_TOOL_POLICY.allowed,
+  "--disallowedTools", ...FROZEN_TOOL_POLICY.disallowed,
+  "--model", pin.requested_model,
+];
+
+export interface AgentRunSpecParams {
+  readonly imageRef: string;
+  readonly repositoryPath: string;
+  readonly configDir: string;
+  readonly prompt: string;
+  /** Provider credentials, keyed exactly; anything else is refused. */
+  readonly providerEnv: Readonly<Record<string, string>>;
+  readonly pin: RuntimePin;
+}
+
+/**
+ * Builds the spec or throws. The refusal worth naming: `providerEnv` keys
+ * outside the allowlist are a host-environment leak path, so they are refused
+ * here rather than filtered silently — filtering would hide a caller mistake
+ * the caller should fix.
+ */
+export const buildAgentRunSpec = (params: AgentRunSpecParams): AgentRunSpec => {
+  const { pin } = params;
+  if (params.repositoryPath === "") throw new Error("agent run spec: repositoryPath must not be empty");
+  if (params.configDir === "") throw new Error("agent run spec: configDir must not be empty");
+
+  const foreignKeys = Object.keys(params.providerEnv).filter(
+    (key) => !(PROVIDER_ENV_KEYS as readonly string[]).includes(key),
+  );
+  if (foreignKeys.length > 0) {
+    throw new Error(
+      `agent run spec: provider env keys [${foreignKeys.join(", ")}] are not in the allowlist ` +
+        `(${PROVIDER_ENV_KEYS.join(", ")}) — nothing else crosses the container boundary`,
+    );
+  }
+
+  const proxyUrl = `http://${EGRESS_PROXY_CONTAINER}:${String(EGRESS_PROXY_PORT)}`;
+  const env: Record<string, string> = {
+    HOME: CONTAINER_PATHS.home,
+    HTTP_PROXY: proxyUrl,
+    HTTPS_PROXY: proxyUrl,
+    NO_PROXY: "",
+    // The pinned CLI must stay pinned: the updater is disabled inside the
+    // container the same way the digest check enforces it from outside.
+    DISABLE_AUTOUPDATER: "1",
+    ...params.providerEnv,
+  };
+
+  return {
+    imageRef: params.imageRef,
+    network: EGRESS_NETWORK,
+    proxyUrl,
+    workdir: CONTAINER_PATHS.repo,
+    env,
+    mounts: [
+      { hostPath: params.repositoryPath, containerPath: CONTAINER_PATHS.repo, readOnly: false },
+      { hostPath: params.configDir, containerPath: CONTAINER_PATHS.config, readOnly: true },
+    ],
+    argv: agentCliArgv(pin, params.prompt),
+  };
+};
+
+/** Exact `docker run` arguments for a spec. Deterministic order, no extras. */
+export const dockerRunArgs = (spec: AgentRunSpec, opts?: { name?: string; detach?: boolean }): readonly string[] => {
+  const args: string[] = ["run", "--rm"];
+  if (opts?.detach === true) args.push("--detach");
+  if (opts?.name !== undefined) args.push("--name", opts.name);
+  args.push("--network", spec.network);
+  for (const key of Object.keys(spec.env).sort()) {
+    args.push("--env", `${key}=${spec.env[key]}`);
+  }
+  for (const mount of spec.mounts) {
+    args.push("--volume", `${mount.hostPath}:${mount.containerPath}${mount.readOnly ? ":ro" : ""}`);
+  }
+  args.push("--workdir", spec.workdir, spec.imageRef, ...spec.argv);
+  return args;
+};
+
+// ---------------------------------------------------------------------------
+// Egress proxy lifecycle (§7.4)
+// ---------------------------------------------------------------------------
+
+export interface EgressProxyHandle {
+  readonly network: string;
+  readonly container: string;
+  readonly proxyUrl: string;
+  readonly policy: NetworkPolicy;
+  readonly stop: () => void;
+}
+
+/**
+ * Idempotently creates the internal egress network and starts the allowlist
+ * proxy from the pinned image itself — one digest pins both. The proxy stays
+ * up across preflight and runs; `stop` tears down the proxy container (the
+ * network is left for reuse and carries no state).
+ */
+export const startEgressProxy = (
+  docker: ContainerRuntimeCommands,
+  pin: RuntimePin,
+  imageRef: string,
+): EgressProxyHandle => {
+  const network = docker.run(
+    ["network", "create", "--internal", "--driver", "bridge", EGRESS_NETWORK],
+  );
+  if (network.exitCode !== 0 && !network.stderr.includes("already exists")) {
+    throw new Error(`egress network create failed: ${network.stderr.trim()}`);
+  }
+
+  docker.run(["rm", "--force", EGRESS_PROXY_CONTAINER]);
+  const proxy = docker.run([
+    "run", "--detach", "--rm",
+    "--name", EGRESS_PROXY_CONTAINER,
+    "--network", EGRESS_NETWORK,
+    "--env", `CDEB_ALLOWED_HOSTS=${pin.network_policy.allowed_hosts.join(",")}`,
+    "--env", `CDEB_ALLOWED_PORT=${String(pin.network_policy.allowed_port)}`,
+    "--env", `CDEB_LISTEN_PORT=${String(EGRESS_PROXY_PORT)}`,
+    imageRef,
+    "node", "/opt/cdeb/egress-proxy.mjs",
+  ]);
+  if (proxy.exitCode !== 0) {
+    throw new Error(`egress proxy start failed: ${proxy.stderr.trim()}`);
+  }
+
+  // Wait for the proxy to listen before anything is allowed to depend on it.
+  let listening = false;
+  for (let attempt = 0; attempt < 50 && !listening; attempt += 1) {
+    const logs = docker.run(["logs", EGRESS_PROXY_CONTAINER]);
+    listening = logs.stdout.includes('"listening"');
+    if (!listening) spawnSync("sleep", ["0.2"]);
+  }
+  if (!listening) {
+    docker.run(["rm", "--force", EGRESS_PROXY_CONTAINER]);
+    throw new Error("egress proxy did not reach listening state within 10s");
+  }
+
+  return {
+    network: EGRESS_NETWORK,
+    container: EGRESS_PROXY_CONTAINER,
+    proxyUrl: `http://${EGRESS_PROXY_CONTAINER}:${String(EGRESS_PROXY_PORT)}`,
+    policy: pin.network_policy,
+    stop: () => {
+      docker.run(["rm", "--force", EGRESS_PROXY_CONTAINER]);
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Probe attribution (pure: docker produces observations, these judge them)
+// ---------------------------------------------------------------------------
+
+/** CLI flags the isolation design cannot degrade away, mapped to capabilities. */
+export const REQUIRED_CLI_FLAGS: readonly { flag: string; capability: CapabilityProbe["capability"] }[] = [
+  { flag: "--strict-mcp-config", capability: "mcp-isolation" },
+  { flag: "--mcp-config", capability: "mcp-isolation" },
+  { flag: "--setting-sources", capability: "settings-isolation" },
+  { flag: "--no-session-persistence", capability: "session-isolation" },
+  { flag: "--allowedTools", capability: "tool-policy" },
+  { flag: "--disallowedTools", capability: "tool-policy" },
+  { flag: "--include-partial-messages", capability: "raw-usage-stream" },
+];
+
+/**
+ * Judges `claude --help` from inside the pinned container. A missing flag is
+ * the exact shape of failure the legacy driver used to warn-and-degrade on;
+ * here it is a refusal naming the flag and what it protects.
+ */
+export const attributeHelpSupport = (helpText: string): CapabilityProbe[] => {
+  const byCapability = new Map<CapabilityProbe["capability"], string[]>();
+  for (const { flag, capability } of REQUIRED_CLI_FLAGS) {
+    if (!helpText.includes(flag)) {
+      const missing = byCapability.get(capability) ?? [];
+      missing.push(flag);
+      byCapability.set(capability, missing);
+    }
+  }
+  const probes: CapabilityProbe[] = [];
+  for (const { capability } of REQUIRED_CLI_FLAGS) {
+    if (probes.some((probe) => probe.capability === capability)) continue;
+    const missing = byCapability.get(capability);
+    probes.push(
+      missing === undefined || missing.length === 0
+        ? { capability, ok: true, detail: "required flags present in pinned CLI help" }
+        : {
+            capability,
+            ok: false,
+            detail: `pinned CLI does not support ${missing.join(", ")} — isolation would degrade to inherited host state`,
+          },
+    );
+  }
+  return probes;
+};
+
+export interface ExecutableObservation {
+  readonly cli_sha256: string | null;
+  readonly node_sha256: string | null;
+  readonly node_version: string | null;
+  readonly cli_version: string | null;
+}
+
+/** §8 runtime/executable hashes: any mismatch is a refusal naming the drift. */
+export const attributeExecutableIdentity = (
+  observed: ExecutableObservation,
+  pin: RuntimePin,
+): CapabilityProbe => {
+  const drift: string[] = [];
+  if (observed.cli_sha256 !== pin.agent_executable.sha256) {
+    drift.push(
+      `agent CLI sha256 ${observed.cli_sha256 ?? "(unreadable)"} != pinned ${pin.agent_executable.sha256 ?? "(unfrozen)"}`,
+    );
+  }
+  if (observed.node_sha256 !== pin.node.executable_sha256) {
+    drift.push(
+      `node sha256 ${observed.node_sha256 ?? "(unreadable)"} != pinned ${pin.node.executable_sha256 ?? "(unfrozen)"}`,
+    );
+  }
+  if (observed.node_version !== pin.node.version) {
+    drift.push(`node version ${observed.node_version ?? "(unreadable)"} != pinned ${pin.node.version}`);
+  }
+  if (pin.agent_cli_version !== null && observed.cli_version !== pin.agent_cli_version) {
+    drift.push(`agent CLI version ${observed.cli_version ?? "(unreadable)"} != pinned ${pin.agent_cli_version}`);
+  }
+  return drift.length === 0
+    ? { capability: "executable-identity", ok: true, detail: "CLI and node binaries match the pin" }
+    : { capability: "executable-identity", ok: false, detail: drift.join("; ") };
+};
+
+/** Judges `docker image inspect` output against the pinned digest. */
+export const attributeImageDigest = (inspectStdout: string, pin: RuntimePin): CapabilityProbe => {
+  const expected = pin.image.digest;
+  if (expected === null) {
+    return {
+      capability: "image-pin",
+      ok: false,
+      detail: "pin manifest is not frozen: image.digest is null — the freeze ceremony must build and record it",
+    };
+  }
+  const normalized = expected.replace(/^sha256:/, "");
+  const present = inspectStdout.includes(normalized);
+  return present
+    ? { capability: "image-pin", ok: true, detail: `image present at pinned digest ${expected}` }
+    : {
+        capability: "image-pin",
+        ok: false,
+        detail: `local image does not carry the pinned digest ${expected} — pull or rebuild, never retag`,
+      };
+};
+
+/**
+ * Judges the preflight probe stream. One real agent invocation observes four
+ * capabilities at once — MCP isolation, tool policy, model identity and the
+ * authoritative usage events — because the init event and the turn stream are
+ * exactly what a measured run will produce.
+ */
+export const attributeStreamCapabilities = (
+  ndjson: string,
+  pin: RuntimePin,
+): CapabilityProbe[] => {
+  const probes: CapabilityProbe[] = [];
+  const init = readInitEvent(ndjson);
+
+  if (init === null) {
+    return [
+      { capability: "mcp-isolation", ok: false, detail: "probe stream has no init event" },
+      { capability: "tool-policy", ok: false, detail: "probe stream has no init event" },
+      { capability: "model-observation", ok: false, detail: "probe stream has no init event" },
+      { capability: "raw-usage-stream", ok: false, detail: "probe stream has no init event" },
+    ];
+  }
+
+  probes.push(
+    init.mcp_servers !== null && init.mcp_servers.length === 0
+      ? { capability: "mcp-isolation", ok: true, detail: "init event observes zero MCP servers" }
+      : {
+          capability: "mcp-isolation",
+          ok: false,
+          detail: `init event observes MCP servers ${JSON.stringify(init.mcp_servers)} under strict config`,
+        },
+  );
+
+  const allowed = new Set(FROZEN_TOOL_POLICY.allowed);
+  const observedTools = init.tools ?? [];
+  const extra = observedTools.filter((tool) => !allowed.has(tool));
+  const missing = [...allowed].filter((tool) => !observedTools.includes(tool));
+  probes.push(
+    init.tools !== null && extra.length === 0 && missing.length === 0
+      ? { capability: "tool-policy", ok: true, detail: "init event observes exactly the frozen tool set" }
+      : {
+          capability: "tool-policy",
+          ok: false,
+          detail:
+            init.tools === null
+              ? "init event carries no tool list"
+              : `session tools diverge from the frozen policy — extra: [${extra.join(", ")}] missing: [${missing.join(", ")}]`,
+        },
+  );
+
+  if (pin.expected_observed_model === null) {
+    probes.push({
+      capability: "model-observation",
+      ok: false,
+      detail: "pin manifest is not frozen: expected_observed_model is null — the freeze ceremony must record it",
+    });
+  } else if (init.model !== pin.expected_observed_model) {
+    probes.push({
+      capability: "model-observation",
+      ok: false,
+      detail: `probe run answered as ${init.model ?? "(unknown)"} but the pin names ${pin.expected_observed_model}`,
+    });
+  } else {
+    probes.push({
+      capability: "model-observation",
+      ok: true,
+      detail: `probe run observed the pinned model ${pin.expected_observed_model}`,
+    });
+  }
+
+  probes.push(
+    streamHasAuthoritativeUsage(ndjson)
+      ? { capability: "raw-usage-stream", ok: true, detail: "probe stream carries message_delta usage events" }
+      : {
+          capability: "raw-usage-stream",
+          ok: false,
+          detail: "probe stream carries no message_delta usage events — CDEB-05 could not reconcile a ledger",
+        },
+  );
+
+  return probes;
+};
+
+/** §7.2: a fresh HOME must stay empty after the probe run — anything else persisted. */
+export const attributeSessionState = (homeFiles: readonly string[]): CapabilityProbe =>
+  homeFiles.length === 0
+    ? { capability: "session-isolation", ok: true, detail: "isolated HOME is empty after the probe run" }
+    : {
+        capability: "session-isolation",
+        ok: false,
+        detail: `session or memory state persisted into the fresh HOME: [${homeFiles.join(", ")}]`,
+      };
+
+export interface HomeObservation {
+  readonly home_value: string | null;
+  readonly home_file_count: number;
+  readonly unexpected_mounts: readonly string[];
+}
+
+/** §7.2: HOME is the isolated path, starts empty, and nothing unexpected is mounted. */
+export const attributeHomeIsolation = (observed: HomeObservation): CapabilityProbe => {
+  const problems: string[] = [];
+  if (observed.home_value !== CONTAINER_PATHS.home) {
+    problems.push(`HOME is ${observed.home_value ?? "(unset)"} instead of ${CONTAINER_PATHS.home}`);
+  }
+  if (observed.home_file_count !== 0) {
+    problems.push(`HOME starts with ${String(observed.home_file_count)} file(s) — inheritance from a previous run or image layer`);
+  }
+  if (observed.unexpected_mounts.length > 0) {
+    problems.push(`unexpected mounts: [${observed.unexpected_mounts.join(", ")}]`);
+  }
+  return problems.length === 0
+    ? { capability: "home-isolation", ok: true, detail: "HOME is isolated, empty and mounted as specified" }
+    : { capability: "home-isolation", ok: false, detail: problems.join("; ") };
+};
+
+export interface NetworkObservation {
+  /** True when a direct connection to a non-allowlisted host failed. */
+  readonly direct_egress_blocked: boolean;
+  /** True when the proxy refused CONNECT to a non-allowlisted host. */
+  readonly proxy_refused_foreign: boolean;
+  /** True when the proxy established CONNECT to the allowlisted provider. */
+  readonly proxy_allowed_provider: boolean;
+}
+
+/** §7.4: all three observations must hold, or the policy is not enforced. */
+export const attributeNetworkProbes = (observed: NetworkObservation): CapabilityProbe => {
+  const problems: string[] = [];
+  if (!observed.direct_egress_blocked) problems.push("direct egress to a non-allowlisted host succeeded");
+  if (!observed.proxy_refused_foreign) problems.push("the proxy forwarded a non-allowlisted host");
+  if (!observed.proxy_allowed_provider) problems.push("the proxy did not establish the allowlisted provider route");
+  return problems.length === 0
+    ? { capability: "network-policy", ok: true, detail: "provider-only egress verified: direct blocked, proxy allowlisted" }
+    : { capability: "network-policy", ok: false, detail: problems.join("; ") };
+};
+
+// ---------------------------------------------------------------------------
+// Preflight orchestration (needs a container runtime; refuses without one)
+// ---------------------------------------------------------------------------
+
+export interface ProbeOptions {
+  /** A trivial prompt for the probe agent call; costs one provider round-trip. */
+  readonly probePrompt: string;
+  /** Provider credentials for the probe call, same allowlist as measured runs. */
+  readonly providerEnv: Readonly<Record<string, string>>;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Wraps the agent argv for the preflight run: run it, then list whatever
+ * files exist in HOME on stderr. Stdout stays pure NDJSON; persistence is
+ * observed on the side channel.
+ */
+export const probeCommand = (argv: readonly string[]): readonly string[] => [
+  "sh",
+  "-c",
+  `${argv.map((part) => `'${part.replace(/'/g, "'\\''")}'`).join(" ")}; rc=$?; ` +
+    `echo "===CDEB-HOME-FILES===" >&2; find "$HOME" -type f >&2 2>/dev/null; exit $rc`,
+];
+
+const HOME_MARKER = "===CDEB-HOME-FILES===";
+
+/** Files listed on stderr after the marker; the stream on stdout stays pure. */
+export const parseHomeFiles = (stderr: string): readonly string[] => {
+  const markerIndex = stderr.lastIndexOf(HOME_MARKER);
+  if (markerIndex === -1) return [];
+  return stderr
+    .slice(markerIndex + HOME_MARKER.length)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+};
+
+/**
+ * Several capabilities have two evidence sources — flag support from
+ * `claude --help` and observed behavior in the probe stream — and the gate
+ * accepts exactly one probe per capability. Merge per capability: any failing
+ * source fails it, and the details keep every source's observation.
+ */
+export const mergeProbes = (probes: readonly CapabilityProbe[]): CapabilityProbe[] => {
+  const byCapability = new Map<CapabilityProbe["capability"], CapabilityProbe[]>();
+  for (const probe of probes) {
+    const group = byCapability.get(probe.capability) ?? [];
+    group.push(probe);
+    byCapability.set(probe.capability, group);
+  }
+  const merged: CapabilityProbe[] = [];
+  for (const [capability, group] of byCapability) {
+    const failures = group.filter((probe) => !probe.ok);
+    merged.push(
+      failures.length === 0
+        ? { capability, ok: true, detail: group.map((probe) => probe.detail).join(" AND ") }
+        : { capability, ok: false, detail: failures.map((probe) => probe.detail).join("; ") },
+    );
+  }
+  return merged;
+};
+
+/**
+ * Runs every §7.5 probe and returns the observations for
+ * `assertRuntimeCapabilities` to judge. Unfreezable pins short-circuit: the
+ * container probes need a digest, so they stay unprobed and the gate's
+ * refusal names them as never-probed rather than passing them by silence.
+ */
+export const probeRuntimeCapabilities = (
+  docker: ContainerRuntimeCommands,
+  pin: RuntimePin,
+  options: ProbeOptions,
+): CapabilityProbe[] => {
+  const probes: CapabilityProbe[] = [];
+
+  const daemon = docker.run(["version", "--format", "{{.Server.Version}}"]);
+  probes.push(
+    daemon.exitCode === 0
+      ? { capability: "oci-runtime", ok: true, detail: `container daemon answered (server ${daemon.stdout.trim()})` }
+      : {
+          capability: "oci-runtime",
+          ok: false,
+          detail: `container daemon not reachable: ${daemon.stderr.trim() || daemon.stdout.trim() || "no output"}`,
+        },
+  );
+
+  const gaps = pinFreezeGaps(pin);
+  if (gaps.length > 0) {
+    probes.push({
+      capability: "image-pin",
+      ok: false,
+      detail: `pin manifest not frozen (missing: ${gaps.join(", ")}) — no container probe can run`,
+    });
+    return probes;
+  }
+  const imageRef = imageRefOf(pin);
+  if (imageRef === null) {
+    probes.push({ capability: "image-pin", ok: false, detail: "image reference could not be derived from the pin" });
+    return probes;
+  }
+
+  const inspect = docker.run(["image", "inspect", imageRef, "--format", "{{json .RepoDigests}} {{.Id}}"]);
+  probes.push(
+    inspect.exitCode === 0
+      ? attributeImageDigest(inspect.stdout, pin)
+      : {
+          capability: "image-pin",
+          ok: false,
+          detail: `image ${imageRef} not present locally: ${inspect.stderr.trim()}`,
+        },
+  );
+
+  const hashes = docker.run(
+    ["run", "--rm", "--network", "none", imageRef, "sh", "-c",
+      `sha256sum ${pin.agent_executable.path} ${pin.node.executable_path}; node --version; claude --version`],
+    { timeoutMs: options.timeoutMs ?? 120_000 },
+  );
+  const hashLines = hashes.stdout.split("\n").map((line) => line.trim()).filter((line) => line !== "");
+  const cliHashLine = hashLines.find((line) => line.endsWith(pin.agent_executable.path));
+  const nodeHashLine = hashLines.find((line) => line.endsWith(pin.node.executable_path));
+  const nodeVersionLine = hashLines.find((line) => line.startsWith("v"));
+  const cliVersionMatch = hashLines
+    .map((line) => line.match(/^(\d+\.\d+\.\d+)/))
+    .find((match) => match !== null);
+  const cliVersionLine = cliVersionMatch === undefined ? undefined : cliVersionMatch[1];
+  probes.push(
+    attributeExecutableIdentity(
+      {
+        cli_sha256: cliHashLine === undefined ? null : (cliHashLine.split(" ")[0] ?? null),
+        node_sha256: nodeHashLine === undefined ? null : (nodeHashLine.split(" ")[0] ?? null),
+        node_version: nodeVersionLine ?? null,
+        cli_version: cliVersionLine ?? null,
+      },
+      pin,
+    ),
+  );
+
+  const help = docker.run(["run", "--rm", "--network", "none", imageRef, "claude", "--help"], {
+    timeoutMs: options.timeoutMs ?? 120_000,
+  });
+  if (help.exitCode !== 0) {
+    probes.push({
+      capability: "settings-isolation",
+      ok: false,
+      detail: `could not read pinned CLI help: ${help.stderr.trim()}`,
+    });
+  } else {
+    probes.push(...attributeHelpSupport(help.stdout));
+  }
+
+  // Home isolation, observed from the spec itself: the mounts are the only
+  // host-visible surface, so the check is that there are exactly two.
+  const spec = buildAgentRunSpec({
+    imageRef,
+    repositoryPath: join(tmpdir(), "cdeb-home-probe-repo"),
+    configDir: join(tmpdir(), "cdeb-home-probe-config"),
+    prompt: options.probePrompt,
+    providerEnv: options.providerEnv,
+    pin,
+  });
+  const expectedMounts = new Set([`${CONTAINER_PATHS.repo}`, `${CONTAINER_PATHS.config}`]);
+  const unexpected = spec.mounts
+    .map((mount) => mount.containerPath)
+    .filter((path) => !expectedMounts.has(path));
+  probes.push(
+    attributeHomeIsolation({
+      home_value: spec.env["HOME"] ?? null,
+      home_file_count: 0,
+      unexpected_mounts: unexpected,
+    }),
+  );
+
+  // The egress proxy, then the three network observations.
+  let proxy: EgressProxyHandle;
+  try {
+    proxy = startEgressProxy(docker, pin, imageRef);
+  } catch (error) {
+    probes.push({
+      capability: "network-policy",
+      ok: false,
+      detail: `egress proxy did not start: ${(error as Error).message}`,
+    });
+    return probes;
+  }
+
+  try {
+    const foreignHost = "cdeb-network-probe.invalid";
+    const providerHost = pin.network_policy.allowed_hosts[0] ?? "";
+    const netScript = [
+      `const net = require('node:net');`,
+      `const results = {};`,
+      `const direct = net.connect(443, '${foreignHost}');`,
+      `direct.setTimeout(5000);`,
+      `direct.on('connect', () => { results.direct_egress_blocked = false; direct.destroy(); next(); });`,
+      `direct.on('timeout', () => { results.direct_egress_blocked = true; direct.destroy(); next(); });`,
+      `direct.on('error', () => { results.direct_egress_blocked = true; next(); });`,
+      `let pending = 1;`,
+      `function next() { if (--pending === 0) void proxyChecks(); }`,
+      // Total probe budget: whatever was observed by then is the report;
+      // missing fields read as false, which fails the capability.
+      `setTimeout(() => { console.log(JSON.stringify(results)); process.exit(0); }, 12000).unref();`,
+      `function connectViaProxy(host, port) {`,
+      `  return new Promise((resolve) => {`,
+      `    const sock = net.connect(${String(EGRESS_PROXY_PORT)}, '${EGRESS_PROXY_CONTAINER}');`,
+      `    let buf = '';`,
+      `    sock.setTimeout(5000);`,
+      `    sock.on('connect', () => sock.write(\`CONNECT \${host}:\${port} HTTP/1.1\\r\\nHost: \${host}:\${port}\\r\\n\\r\\n\`));`,
+      `    sock.on('data', (d) => { buf += d.toString(); if (buf.includes('\\r\\n')) { resolve(buf.split('\\r\\n')[0]); sock.destroy(); } });`,
+      `    sock.on('timeout', () => { resolve('timeout'); sock.destroy(); });`,
+      `    sock.on('error', () => resolve('error'));`,
+      `  });`,
+      `}`,
+      `async function proxyChecks() {`,
+      `  const foreign = await connectViaProxy('${foreignHost}', 443);`,
+      `  const provider = await connectViaProxy('${providerHost}', ${String(pin.network_policy.allowed_port)});`,
+      `  results.proxy_refused_foreign = foreign.includes('403');`,
+      `  results.proxy_allowed_provider = provider.includes('200');`,
+      `  console.log(JSON.stringify(results));`,
+      `}`,
+    ].join("\n");
+    const netProbe = docker.run(
+      ["run", "--rm", "--network", EGRESS_NETWORK, imageRef, "node", "-e", netScript],
+      { timeoutMs: options.timeoutMs ?? 60_000 },
+    );
+    let netObservation: NetworkObservation = {
+      direct_egress_blocked: false,
+      proxy_refused_foreign: false,
+      proxy_allowed_provider: false,
+    };
+    try {
+      const parsed = JSON.parse(netProbe.stdout.trim().split("\n").pop() ?? "") as Partial<NetworkObservation>;
+      netObservation = {
+        direct_egress_blocked: parsed.direct_egress_blocked === true,
+        proxy_refused_foreign: parsed.proxy_refused_foreign === true,
+        proxy_allowed_provider: parsed.proxy_allowed_provider === true,
+      };
+    } catch {
+      // fall through with all-false: an unreadable probe is a failed probe
+    }
+    probes.push(
+      netProbe.exitCode === 0
+        ? attributeNetworkProbes(netObservation)
+        : { capability: "network-policy", ok: false, detail: `network probe failed to run: ${netProbe.stderr.trim()}` },
+    );
+
+    // The real probe run: one provider round-trip observing MCP, tools, model
+    // and usage, with HOME swept afterwards for anything that persisted. The
+    // config directory is written here — the same empty-MCP, no-hooks shape
+    // both study arms start from (§9.1) — because a probe that mounted
+    // nonexistent files would measure the CLI's error path instead.
+    const probeScratch = mkdtempSync(join(tmpdir(), "cdeb-preflight-"));
+    const probeRepo = join(probeScratch, "repo");
+    mkdirSync(probeRepo, { recursive: true });
+    writeFileSync(join(probeScratch, "settings.json"), `${JSON.stringify({ hooks: {} }, null, 2)}\n`);
+    writeFileSync(join(probeScratch, "mcp.json"), `${EMPTY_MCP_CONFIG}\n`);
+    try {
+      const probeSpec = buildAgentRunSpec({
+        imageRef,
+        repositoryPath: probeRepo,
+        configDir: probeScratch,
+        prompt: options.probePrompt,
+        providerEnv: options.providerEnv,
+        pin,
+      });
+      const probeArgs = dockerRunArgs(probeSpec);
+      const imageIndex = probeArgs.indexOf(imageRef);
+      const wrapped = [...probeArgs.slice(0, imageIndex), imageRef, ...probeCommand(probeArgs.slice(imageIndex + 1))];
+      const stream = docker.run(wrapped, { timeoutMs: options.timeoutMs ?? 5 * 60 * 1000 });
+      probes.push(...attributeStreamCapabilities(stream.stdout, pin));
+      probes.push(attributeSessionState(parseHomeFiles(stream.stderr)));
+    } finally {
+      rmSync(probeScratch, { recursive: true, force: true });
+    }
+  } finally {
+    proxy.stop();
+  }
+
+  return mergeProbes(probes);
+};
+
+// ---------------------------------------------------------------------------
+// Measured run execution (what CDEB-04 attaches hooks to, CDEB-05 reads)
+// ---------------------------------------------------------------------------
+
+export interface RuntimeIdentityFields {
+  readonly requested_model: string;
+  readonly agent_cli_version: string | null;
+  readonly agent_executable_sha256: string | null;
+  readonly node_version: string;
+  readonly node_executable_sha256: string | null;
+  readonly agent_runtime_image_digest: string | null;
+  readonly tool_policy_digest: string;
+  readonly network_policy_digest: string;
+  readonly settings_digest: string;
+  readonly mcp_config_digest: string;
+  readonly permission_mode: string;
+}
+
+/** The §8 fields a row records, derived from the pin and the harness config. */
+export const runtimeIdentityFields = (
+  pin: RuntimePin,
+  settingsJson: string,
+  mcpJson: string = EMPTY_MCP_CONFIG,
+): RuntimeIdentityFields => ({
+  requested_model: pin.requested_model,
+  agent_cli_version: pin.agent_cli_version,
+  agent_executable_sha256: pin.agent_executable.sha256,
+  node_version: pin.node.version,
+  node_executable_sha256: pin.node.executable_sha256,
+  agent_runtime_image_digest: pin.image.digest,
+  tool_policy_digest: toolPolicyDigest(FROZEN_TOOL_POLICY),
+  network_policy_digest: networkPolicyDigest(pin.network_policy),
+  settings_digest: settingsDigest(settingsJson),
+  mcp_config_digest: mcpConfigDigest(mcpJson),
+  permission_mode: pin.permission_mode,
+});
+
+export interface AgentRunParams {
+  readonly repositoryPath: string;
+  /**
+   * Must contain the harness-written `settings.json` (the arm's config, §9.1)
+   * and `mcp.json` (the empty config). It is mounted read-only; nothing in
+   * it is inherited from the operator's machine.
+   */
+  readonly configDir: string;
+  readonly prompt: string;
+  readonly outDir: string;
+  readonly providerEnv: Readonly<Record<string, string>>;
+  readonly timeoutMs?: number;
+}
+
+export interface AgentRunOutcome {
+  readonly exit_code: number | null;
+  readonly provider_stream_path: string;
+  readonly provider_stream_sha256: string;
+  readonly stderr: string;
+  readonly timed_out: boolean;
+  readonly identity: StreamIdentity;
+}
+
+/**
+ * One measured run inside the pinned runtime, or a refusal. The gate token is
+ * checked against this pin's digest — a preflight that passed for another pin
+ * authorizes nothing here — and the stream the run produces is identity-
+ * checked before anything downstream may read it as measurement.
+ *
+ * The raw NDJSON lands byte-for-byte in `<outDir>/provider.ndjson`; CDEB-05
+ * owns parsing it into a ledger. This function owns that the bytes exist, are
+ * hashed, and came from the model that was pinned.
+ */
+export const executeAgentRun = async (
+  docker: ContainerRuntimeCommands,
+  pin: RuntimePin,
+  gate: CapabilityGatePassed,
+  params: AgentRunParams,
+): Promise<AgentRunOutcome> => {
+  const expectedDigest = runtimePinDigest(pin);
+  if (gate.pin_digest !== expectedDigest) {
+    throw new RuntimeCapabilityError(
+      [
+        {
+          capability: "oci-runtime",
+          ok: false,
+          detail: "capability gate token was minted for a different pin; re-run preflight for this one",
+        },
+      ],
+      [],
+    );
+  }
+  const gaps = pinFreezeGaps(pin);
+  if (gaps.length > 0) {
+    throw new RuntimeCapabilityError(
+      [
+        {
+          capability: "image-pin",
+          ok: false,
+          detail: `pin manifest not frozen (missing: ${gaps.join(", ")})`,
+        },
+      ],
+      [],
+    );
+  }
+  const imageRef = imageRefOf(pin);
+  if (imageRef === null) {
+    throw new RuntimeCapabilityError(
+      [{ capability: "image-pin", ok: false, detail: "image reference could not be derived from the pin" }],
+      [],
+    );
+  }
+
+  const spec = buildAgentRunSpec({
+    imageRef,
+    repositoryPath: params.repositoryPath,
+    configDir: params.configDir,
+    prompt: params.prompt,
+    providerEnv: params.providerEnv,
+    pin,
+  });
+
+  mkdirSync(params.outDir, { recursive: true });
+  const streamPath = join(params.outDir, "provider.ndjson");
+  const sink = createWriteStream(streamPath);
+  const result = await docker.runToSink(dockerRunArgs(spec), sink, {
+    timeoutMs: params.timeoutMs ?? 15 * 60 * 1000,
+  });
+  await new Promise<void>((resolve) => {
+    if (sink.closed) resolve();
+    else sink.on("close", () => resolve());
+  });
+
+  // The bytes are hashed after the run, exactly as captured: nothing touches
+  // the stream between the container's stdout and this file.
+  const streamBytes = readFileSync(streamPath);
+  const streamText = streamBytes.toString("utf8");
+  const providerStreamSha256 = createHash("sha256").update(streamBytes).digest("hex");
+  const identity = verifyStreamIdentity(streamText, {
+    expected_observed_model: pin.expected_observed_model ?? "",
+    agent_cli_version: pin.agent_cli_version ?? "",
+    permission_mode: pin.permission_mode,
+    tool_policy: FROZEN_TOOL_POLICY,
+  });
+
+  return {
+    exit_code: result.exitCode,
+    provider_stream_path: streamPath,
+    provider_stream_sha256: providerStreamSha256,
+    stderr: result.stderr,
+    timed_out: result.timedOut,
+    identity,
+  };
+};
+
+/**
+ * The §4.6 probe runtime on the pinned container. Same logical invocation as
+ * the host runtime, plus the frozen tool policy the study's runs carry; the
+ * container supplies isolation, network policy and identity.
+ *
+ * RE-VALIDATION REQUIRED: every wall-time number frozen into the PRD (the
+ * 0.48/1.00 split behind the 0.6 screen) was measured with the host `claude`
+ * and the pilot hook matcher. A probe executed here screens a different
+ * runtime; the split must be re-measured on the pinned runtime before any
+ * freeze relies on it, and this has not yet been done.
+ *
+ * The egress proxy must already be running (`startEgressProxy`): without it
+ * the provider call fails, and the probe reports that failure rather than
+ * silently timing out on a network it cannot reach.
+ */
+export const pinnedProbeRuntime = (
+  docker: ContainerRuntimeCommands,
+  pin: RuntimePin,
+  gate: CapabilityGatePassed,
+  providerEnv: Readonly<Record<string, string>>,
+): ProbeRuntime => {
+  let sequence = 0;
+  const run = (params: ProbeRunParams): ProbeRunResult => {
+    const expectedDigest = runtimePinDigest(pin);
+    if (gate.pin_digest !== expectedDigest) {
+      throw new Error("capability gate token was minted for a different pin; re-run preflight for this one");
+    }
+    const gaps = pinFreezeGaps(pin);
+    if (gaps.length > 0) {
+      throw new Error(`pin manifest not frozen (missing: ${gaps.join(", ")}) — the probe cannot run unpinned`);
+    }
+    const imageRef = imageRefOf(pin);
+    if (imageRef === null) throw new Error("image reference could not be derived from the pin");
+
+    sequence += 1;
+    const name = `cdeb-probe-${String(process.pid)}-${String(sequence)}`;
+    const configDir = dirname(params.settingsPath);
+    if (dirname(params.mcpPath) !== configDir) {
+      throw new Error("pinned probe runtime: settings and mcp config must live in one directory to mount");
+    }
+    const argv = [
+      "claude",
+      "-p", params.prompt,
+      "--output-format", "json",
+      "--permission-mode", pin.permission_mode,
+      "--strict-mcp-config",
+      "--mcp-config", CONTAINER_PATHS.mcp,
+      "--setting-sources", "",
+      "--no-session-persistence",
+      "--settings", CONTAINER_PATHS.settings,
+      "--allowedTools", ...FROZEN_TOOL_POLICY.allowed,
+      "--disallowedTools", ...FROZEN_TOOL_POLICY.disallowed,
+      "--model", params.model,
+    ];
+    const spec: AgentRunSpec = {
+      imageRef,
+      network: EGRESS_NETWORK,
+      proxyUrl: `http://${EGRESS_PROXY_CONTAINER}:${String(EGRESS_PROXY_PORT)}`,
+      workdir: CONTAINER_PATHS.repo,
+      env: {
+        HOME: CONTAINER_PATHS.home,
+        HTTP_PROXY: `http://${EGRESS_PROXY_CONTAINER}:${String(EGRESS_PROXY_PORT)}`,
+        HTTPS_PROXY: `http://${EGRESS_PROXY_CONTAINER}:${String(EGRESS_PROXY_PORT)}`,
+        NO_PROXY: "",
+        DISABLE_AUTOUPDATER: "1",
+        ...providerEnv,
+      },
+      mounts: [
+        { hostPath: params.workdir, containerPath: CONTAINER_PATHS.repo, readOnly: false },
+        { hostPath: configDir, containerPath: CONTAINER_PATHS.config, readOnly: true },
+      ],
+      argv,
+    };
+    const result = docker.run(dockerRunArgs(spec, { name }), { timeoutMs: params.timeoutMs + 30_000 });
+    if (result.timedOut) docker.run(["rm", "--force", name]);
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      status: result.timedOut ? null : result.exitCode,
+      timedOut: result.timedOut,
+    };
+  };
+  return { name: "pinned-container", run };
+};
+

--- a/bench/cdeb/runtime/egress-proxy.mjs
+++ b/bench/cdeb/runtime/egress-proxy.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * CDEB-03 provider-only egress proxy (PRD §7.4). Plain ESM, no dependencies —
+ * it is copied into the pinned runtime image and runs under that image's
+ * node, so its version is pinned by the image digest.
+ *
+ * The agent container sits on an internal network with no external route; the
+ * only way out is this proxy, and this proxy only answers CONNECT, only to
+ * the frozen provider hosts, only on the frozen port. Everything else gets a
+ * 403 and a one-line JSON audit record. Bytes of an allowed connection are
+ * piped untouched — no TLS interception, no inspection, no rewriting.
+ *
+ * Configuration is environment-only, set by the pinned runtime:
+ *   CDEB_ALLOWED_HOSTS  comma-separated host allowlist
+ *   CDEB_ALLOWED_PORT   single allowed port (default 443)
+ *   CDEB_LISTEN_PORT    proxy listen port (default 3128)
+ *
+ * The decision core (`parseConnectTarget`, `decideEgress`) is exported pure
+ * so the allowlist logic is testable without a socket; the listener starts
+ * only when this file is the entry point.
+ */
+
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+
+/** Splits a CONNECT target into host and port; malformed means refused. */
+export const parseConnectTarget = (target) => {
+  if (typeof target !== "string" || target === "") return null;
+  const colon = target.lastIndexOf(":");
+  if (colon === -1) return { host: target.toLowerCase(), port: 443 };
+  const host = target.slice(0, colon).toLowerCase();
+  const port = Number(target.slice(colon + 1));
+  if (host === "" || !Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  return { host, port };
+};
+
+/**
+ * The allowlist decision. `allowed-method` is the only method; `allowed-host`
+ * is the only criterion. Returns the audit decision string.
+ */
+export const decideEgress = (method, target, allowedHosts, allowedPort) => {
+  if (method !== "CONNECT") return "refused-method";
+  const parsed = parseConnectTarget(target);
+  if (parsed === null) return "refused-target";
+  if (!allowedHosts.has(parsed.host) || parsed.port !== allowedPort) return "refused-target";
+  return "allowed";
+};
+
+const audit = (decision, target) => {
+  process.stdout.write(
+    `${JSON.stringify({ ts: new Date().toISOString(), decision, target })}\n`,
+  );
+};
+
+const isEntryPoint =
+  process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isEntryPoint) {
+  const allowedHosts = new Set(
+    (process.env.CDEB_ALLOWED_HOSTS ?? "")
+      .split(",")
+      .map((host) => host.trim().toLowerCase())
+      .filter((host) => host !== ""),
+  );
+  const allowedPort = Number(process.env.CDEB_ALLOWED_PORT ?? "443");
+  const listenPort = Number(process.env.CDEB_LISTEN_PORT ?? "3128");
+
+  if (allowedHosts.size === 0) {
+    // An empty allowlist is not "allow nothing silently" — it is a
+    // misconfiguration, and failing to start is the loudest available refusal.
+    process.stderr.write("cdeb-egress: CDEB_ALLOWED_HOSTS is empty; refusing to start\n");
+    process.exit(1);
+  }
+
+  const server = net.createServer((client) => {
+    let buffer = Buffer.alloc(0);
+    const onError = () => client.destroy();
+    client.on("error", onError);
+
+    const onData = (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      const end = buffer.indexOf("\r\n\r\n");
+      if (end === -1) {
+        if (buffer.length > 16 * 1024) client.destroy();
+        return;
+      }
+      client.removeListener("data", onData);
+      const header = buffer.subarray(0, end).toString("utf8");
+      const rest = buffer.subarray(end + 4);
+      buffer = Buffer.alloc(0);
+
+      const [requestLine] = header.split("\r\n");
+      const parts = (requestLine ?? "").split(" ");
+      const target = parts.length >= 2 ? (parts[1] ?? "") : "";
+      const decision = decideEgress(parts[0] ?? "", target, allowedHosts, allowedPort);
+
+      if (decision !== "allowed") {
+        audit(decision, requestLine ?? "");
+        const status = decision === "refused-method" ? "405 Method Not Allowed" : "403 Forbidden";
+        client.write(`HTTP/1.1 ${status}\r\nContent-Length: 0\r\n\r\n`);
+        client.destroy();
+        return;
+      }
+
+      audit("allowed", target);
+      const parsed = parseConnectTarget(target);
+      const upstream = net.connect(parsed.port, parsed.host, () => {
+        client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        if (rest.length > 0) upstream.write(rest);
+        upstream.pipe(client);
+        client.pipe(upstream);
+      });
+      upstream.on("error", () => {
+        audit("upstream-error", target);
+        client.destroy();
+      });
+    };
+    client.on("data", onData);
+  });
+
+  server.listen(listenPort, "0.0.0.0", () => {
+    audit("listening", `0.0.0.0:${String(listenPort)}`);
+  });
+}

--- a/bench/cdeb/runtime/isolation.ts
+++ b/bench/cdeb/runtime/isolation.ts
@@ -1,0 +1,438 @@
+/**
+ * CDEB-03 fail-closed capability gate (PRD §7.5) and identity checks (PRD §8).
+ *
+ * A benchmark whose isolation silently degrades measures a different thing than
+ * it reports — that is the defect `docs/SELF-AUDIT.md` keeps the receipt for,
+ * and it is why nothing in this module can warn. Every capability §7.5 names
+ * is checked at run time, and any capability that cannot be verified refuses:
+ * the measured run does not start. The gate has two states — passed, or
+ * thrown — and the type system does not contain a third.
+ *
+ * The checks split in two:
+ *
+ *   - `assertRuntimeCapabilities` is the preflight gate. It consumes a probe
+ *     report — one observation per capability — and refuses when a probe
+ *     failed OR when a capability was never probed at all. Absence of
+ *     evidence is refusal, not optimism: a report that simply omits the
+ *     network policy has not shown the network policy.
+ *   - `verifyStreamIdentity` is the in-run identity check. The model that
+ *     answered must be the model that was pinned, on every main-session turn,
+ *     and the CLI that ran must be the CLI that was pinned. Drift is a hard
+ *     stop (§8: preflight observed model mismatch stops the study), not a
+ *     flag on the row.
+ *
+ * Both are pure: probes and streams are data, so the failure paths are
+ * testable without a container runtime. `agent-container.ts` owns producing
+ * the data on a real machine.
+ */
+
+import { createHash } from "node:crypto";
+
+import { StreamJsonReader } from "../../drivers/stream-json.ts";
+
+// ---------------------------------------------------------------------------
+// Capabilities (§7.5, plus the §7.2 container/HOME guarantees the list rests on)
+// ---------------------------------------------------------------------------
+
+export const CAPABILITY_IDS = [
+  /** Container runtime binary present and its daemon answering. */
+  "oci-runtime",
+  /** The image exists locally at exactly the pinned digest (§7.1). */
+  "image-pin",
+  /** Agent CLI and node binaries/versions match the pinned hashes (§8). */
+  "executable-identity",
+  /** Fresh isolated HOME; no host HOME content; only the expected mounts (§7.2). */
+  "home-isolation",
+  /** Host/user/project/local settings sources dropped; harness file is the only one (§7.2). */
+  "settings-isolation",
+  /** Strict MCP config active and zero servers observable (§7.2, §7.5). */
+  "mcp-isolation",
+  /** No session or memory state survives a run (§7.2, §7.5). */
+  "session-isolation",
+  /** The session's tool set is exactly the frozen policy (§7.3). */
+  "tool-policy",
+  /** Provider-only egress enforced and verified (§7.4). */
+  "network-policy",
+  /** Observed model id present, matches the pin, identical across turns (§8). */
+  "model-observation",
+  /** The raw stream carries the authoritative per-turn usage events CDEB-05 parses (§7.5). */
+  "raw-usage-stream",
+] as const;
+
+export type CapabilityId = (typeof CAPABILITY_IDS)[number];
+
+/** One probe observation. `detail` names what was seen, or what is missing. */
+export interface CapabilityProbe {
+  readonly capability: CapabilityId;
+  readonly ok: boolean;
+  readonly detail: string;
+}
+
+export class RuntimeCapabilityError extends Error {
+  /** Capabilities whose probe reported a failure. */
+  readonly failed: readonly CapabilityId[];
+  /** Capabilities with no probe at all — never verified, so refused. */
+  readonly untested: readonly CapabilityId[];
+
+  constructor(failedProbes: readonly CapabilityProbe[], untested: readonly CapabilityId[]) {
+    const failedNames = failedProbes.map((probe) => probe.capability);
+    const parts: string[] = [];
+    if (failedNames.length > 0) {
+      parts.push(
+        `failed: ${failedProbes
+          .map((probe) => `${probe.capability} (${probe.detail})`)
+          .join("; ")}`,
+      );
+    }
+    if (untested.length > 0) parts.push(`never probed: ${untested.join(", ")}`);
+    super(`runtime capability gate refused — ${parts.join(" | ")}`);
+    this.name = "RuntimeCapabilityError";
+    this.failed = failedNames;
+    this.untested = untested;
+  }
+}
+
+/**
+ * Proof that the gate passed for one specific pin. `executeAgentRun` requires
+ * this token and refuses a token minted for any other pin, so "start a run
+ * without the capability check" is not expressible — the only way to obtain a
+ * token is a complete, all-green probe report.
+ */
+export interface CapabilityGatePassed {
+  readonly gate: "cdeb-runtime-capabilities";
+  readonly pin_digest: string;
+  readonly verified: readonly CapabilityId[];
+}
+
+/**
+ * §7.5: hard refusal, never warn-and-continue. A duplicate probe is a
+ * malformed report and refuses too — two observations for one capability is
+ * not something the gate silently picks between.
+ */
+export const assertRuntimeCapabilities = (
+  probes: readonly CapabilityProbe[],
+  pinDigest: string,
+): CapabilityGatePassed => {
+  const seen = new Set<CapabilityId>();
+  const duplicates: CapabilityId[] = [];
+  for (const probe of probes) {
+    if (seen.has(probe.capability)) duplicates.push(probe.capability);
+    seen.add(probe.capability);
+  }
+  const failed = probes.filter((probe) => !probe.ok);
+  const untested = CAPABILITY_IDS.filter((id) => !seen.has(id));
+  if (duplicates.length > 0 || failed.length > 0 || untested.length > 0) {
+    const withDuplicates: CapabilityProbe[] = [
+      ...failed,
+      ...duplicates.map((capability) => ({
+        capability,
+        ok: false,
+        detail: "probe reported more than once; the gate does not pick between observations",
+      })),
+    ];
+    throw new RuntimeCapabilityError(withDuplicates, untested);
+  }
+  return { gate: "cdeb-runtime-capabilities", pin_digest: pinDigest, verified: [...CAPABILITY_IDS] };
+};
+
+// ---------------------------------------------------------------------------
+// Frozen policies and their digests (§7.3, §7.4, §8)
+// ---------------------------------------------------------------------------
+
+const sha256Hex = (input: string): string =>
+  createHash("sha256").update(input, "utf8").digest("hex");
+
+/** Deterministic JSON: object keys sorted recursively, no whitespace variance. */
+export const canonicalJson = (value: unknown): string => {
+  const sort = (node: unknown): unknown => {
+    if (Array.isArray(node)) return node.map(sort);
+    if (typeof node === "object" && node !== null) {
+      const source = node as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(source).sort()) out[key] = sort(source[key]);
+      return out;
+    }
+    return node;
+  };
+  return JSON.stringify(sort(value));
+};
+
+export interface ToolPolicy {
+  readonly allowed: readonly string[];
+  readonly disallowed: readonly string[];
+}
+
+/**
+ * §7.3 frozen tool set: the minimum for source read/search/edit/test, and
+ * nothing else. Web search/fetch, subagent delegation, scheduling, messaging
+ * and skill surfaces are named in `disallowed` so a CLI that grows a new
+ * spelling of one still trips the init-event equality check against
+ * `allowed` — the gate is exact-set equality, and this list documents what an
+ * appearance in `allowed` would mean.
+ */
+export const FROZEN_TOOL_POLICY: ToolPolicy = {
+  allowed: ["Bash", "Edit", "Glob", "Grep", "Read", "Write"],
+  disallowed: [
+    "WebSearch",
+    "WebFetch",
+    "Task",
+    "TaskCreate",
+    "TaskGet",
+    "TaskList",
+    "TaskOutput",
+    "TaskStop",
+    "TaskUpdate",
+    "Agent",
+    "Skill",
+    "SendMessage",
+    "Workflow",
+    "ToolSearch",
+    "Monitor",
+    "RemoteTrigger",
+    "PushNotification",
+    "ReportFindings",
+    "CronCreate",
+    "CronDelete",
+    "CronList",
+    "ScheduleWakeup",
+    "EnterWorktree",
+    "ExitWorktree",
+    "DesignSync",
+  ],
+};
+
+/** sha256 over the canonical policy; recorded on every row (§8). */
+export const toolPolicyDigest = (policy: ToolPolicy): string =>
+  sha256Hex(canonicalJson({ allowed: [...policy.allowed], disallowed: [...policy.disallowed] }));
+
+export interface NetworkPolicy {
+  /** The only egress shape the study accepts. */
+  readonly egress: "provider-only";
+  /**
+   * The agent container sits on an internal docker network with no external
+   * route; the only way out is the allowlist proxy. Named in the digest so a
+   * future enforcement change is a policy change, visible in every row.
+   */
+  readonly enforcement: "internal-network+allowlist-proxy";
+  readonly allowed_hosts: readonly string[];
+  readonly allowed_port: number;
+}
+
+export const networkPolicyDigest = (policy: NetworkPolicy): string =>
+  sha256Hex(canonicalJson(policy));
+
+/** Digests of the exact bytes the harness writes — never of inherited files. */
+export const settingsDigest = (settingsJson: string): string => sha256Hex(settingsJson);
+export const mcpConfigDigest = (mcpJson: string): string => sha256Hex(mcpJson);
+
+/** The empty MCP config both arms receive (§7.2). */
+export const EMPTY_MCP_CONFIG = JSON.stringify({ mcpServers: {} });
+
+// ---------------------------------------------------------------------------
+// Stream identity: the model that answered is the model that was pinned (§8)
+// ---------------------------------------------------------------------------
+
+export class ModelDriftError extends Error {
+  constructor(detail: string) {
+    super(`model identity hard stop — ${detail}`);
+    this.name = "ModelDriftError";
+  }
+}
+
+export class CliDriftError extends Error {
+  constructor(detail: string) {
+    super(`CLI identity hard stop — ${detail}`);
+    this.name = "CliDriftError";
+  }
+}
+
+export class ToolPolicyViolationError extends Error {
+  constructor(detail: string) {
+    super(`tool policy hard stop — ${detail}`);
+    this.name = "ToolPolicyViolationError";
+  }
+}
+
+/** The subset of the init event the identity checks read. */
+export interface InitObservation {
+  readonly model: string | null;
+  readonly tools: readonly string[] | null;
+  readonly mcp_servers: readonly string[] | null;
+  readonly cli_version: string | null;
+  readonly permission_mode: string | null;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+/** Extracts the init event from a raw stream; null when the stream has none. */
+export const readInitEvent = (ndjson: string): InitObservation | null => {
+  for (const line of ndjson.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    let event: unknown;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const envelope = asRecord(event);
+    if (envelope === null) continue;
+    if (envelope["type"] !== "system" || envelope["subtype"] !== "init") continue;
+    const toolsRaw = envelope["tools"];
+    const mcpRaw = envelope["mcp_servers"];
+    // Any entry counts as a server: a non-string entry is named "(unknown)"
+    // rather than filtered away, because isolation fails closed on presence,
+    // not on whether the entry parsed cleanly.
+    const mcpNames = Array.isArray(mcpRaw)
+      ? mcpRaw.map((entry) => {
+          if (typeof entry === "string") return entry;
+          const record = asRecord(entry);
+          return record !== null && typeof record["name"] === "string"
+            ? (record["name"] as string)
+            : "(unknown)";
+        })
+      : null;
+    return {
+      model: typeof envelope["model"] === "string" ? envelope["model"] : null,
+      tools: Array.isArray(toolsRaw) ? toolsRaw.filter((t): t is string => typeof t === "string") : null,
+      mcp_servers: mcpNames,
+      cli_version:
+        typeof envelope["claude_code_version"] === "string" ? envelope["claude_code_version"] : null,
+      permission_mode:
+        typeof envelope["permissionMode"] === "string" ? envelope["permissionMode"] : null,
+    };
+  }
+  return null;
+};
+
+export interface StreamPin {
+  /** Exact model id every main-session turn must carry (§8). */
+  readonly expected_observed_model: string;
+  /** Exact CLI version the init event must report (§8). */
+  readonly agent_cli_version: string;
+  readonly permission_mode: string;
+  readonly tool_policy: ToolPolicy;
+}
+
+export interface StreamIdentity {
+  /** Unique observed model ids in first-seen order — one element when valid. */
+  readonly observed_model_ids: readonly string[];
+  readonly agent_cli_version: string;
+  readonly turn_count: number;
+}
+
+/**
+ * §8 rules, enforced as hard stops:
+ *
+ *   - observed model id identical on every main-session turn, never empty;
+ *   - no subagent turn anywhere (`parent_tool_use_id != null` rejects, §7.3);
+ *   - init model and CLI version equal the pin (CLI drift stops the study);
+ *   - init tool set exactly the frozen policy, and no MCP server present;
+ *   - permission mode equal the pin.
+ *
+ * Returns the identity the row records when every rule holds.
+ */
+export const verifyStreamIdentity = (ndjson: string, pin: StreamPin): StreamIdentity => {
+  const init = readInitEvent(ndjson);
+  if (init === null) {
+    throw new ModelDriftError("stream carries no init event; the session cannot be identified");
+  }
+  if (init.cli_version !== pin.agent_cli_version) {
+    throw new CliDriftError(
+      `init reports CLI ${init.cli_version === null ? "(none)" : init.cli_version} ` +
+        `but the study is pinned to ${pin.agent_cli_version}`,
+    );
+  }
+  if (init.model !== pin.expected_observed_model) {
+    throw new ModelDriftError(
+      `init reports model ${init.model === null ? "(none)" : init.model} ` +
+        `but the study is pinned to ${pin.expected_observed_model}`,
+    );
+  }
+  if (init.permission_mode !== pin.permission_mode) {
+    throw new ToolPolicyViolationError(
+      `init reports permission mode ${init.permission_mode === null ? "(none)" : init.permission_mode} ` +
+        `but the pin freezes ${pin.permission_mode}`,
+    );
+  }
+  if (init.mcp_servers === null || init.mcp_servers.length > 0) {
+    throw new ToolPolicyViolationError(
+      `init reports MCP servers ${JSON.stringify(init.mcp_servers ?? "absent")} — strict isolation requires exactly none`,
+    );
+  }
+  if (init.tools === null) {
+    throw new ToolPolicyViolationError("init reports no tool list; the tool policy cannot be verified");
+  }
+  const allowed = new Set(pin.tool_policy.allowed);
+  const observed = new Set(init.tools);
+  const extra = init.tools.filter((tool) => !allowed.has(tool));
+  const missing = [...allowed].filter((tool) => !observed.has(tool));
+  if (extra.length > 0 || missing.length > 0) {
+    throw new ToolPolicyViolationError(
+      `session tools diverge from the frozen policy — extra: [${extra.join(", ")}] missing: [${missing.join(", ")}]`,
+    );
+  }
+
+  const reader = new StreamJsonReader();
+  reader.pushAll(ndjson);
+  const ledger = reader.ledger();
+
+  const subagentTurn = ledger.turns.find((turn) => turn.parent_tool_use_id !== null);
+  if (subagentTurn !== undefined) {
+    throw new ModelDriftError(
+      `turn ${String(subagentTurn.index)} was produced by a subagent (parent_tool_use_id ` +
+        `${subagentTurn.parent_tool_use_id}) — §7.3 forbids delegation and §8 forbids the row`,
+    );
+  }
+  if (ledger.turns.length === 0) {
+    throw new ModelDriftError("stream carries no model turn; the model that answered is unknown");
+  }
+
+  const observedIds: string[] = [];
+  for (const turn of ledger.turns) {
+    if (turn.model === "") {
+      throw new ModelDriftError(`turn ${String(turn.index)} reports an empty model id — §8 forbids the row`);
+    }
+    if (turn.model !== pin.expected_observed_model) {
+      throw new ModelDriftError(
+        `turn ${String(turn.index)} was answered by ${turn.model} but the study is pinned to ` +
+          `${pin.expected_observed_model} — model drift stops the study`,
+      );
+    }
+    if (!observedIds.includes(turn.model)) observedIds.push(turn.model);
+  }
+
+  return {
+    observed_model_ids: observedIds,
+    agent_cli_version: init.cli_version,
+    turn_count: ledger.turns.length,
+  };
+};
+
+/**
+ * §7.5 raw usage stream: CDEB-05's ledger reads final per-turn usage from
+ * `message_delta` events, which exist only under `--include-partial-messages`.
+ * A stream without them cannot produce a reconciled ledger, so the capability
+ * fails before any run is measured on it.
+ */
+export const streamHasAuthoritativeUsage = (ndjson: string): boolean => {
+  for (const line of ndjson.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    let event: unknown;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const envelope = asRecord(event);
+    if (envelope === null || envelope["type"] !== "stream_event") continue;
+    const inner = asRecord(envelope["event"]);
+    if (inner === null || inner["type"] !== "message_delta") continue;
+    if (asRecord(inner["usage"]) !== null) return true;
+  }
+  return false;
+};

--- a/bench/cdeb/runtime/runtime-pin.json
+++ b/bench/cdeb/runtime/runtime-pin.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "frozen": false,
+  "note": "CDEB-03 runtime pin (PRD §7.1, §8). null fields are unfrozen: they can only be produced by the freeze ceremony that builds the image and observes the provider, and the capability gate refuses measured runs while any remains null. Do not fill them by hand.",
+  "image": {
+    "reference": "commitlore/cdeb-agent",
+    "digest": null
+  },
+  "agent_cli_version": null,
+  "agent_executable": {
+    "path": "/usr/local/bin/claude",
+    "sha256": null
+  },
+  "node": {
+    "version": "v22.23.2",
+    "executable_path": "/usr/local/bin/node",
+    "executable_sha256": null
+  },
+  "requested_model": "sonnet",
+  "expected_observed_model": null,
+  "permission_mode": "acceptEdits",
+  "network_policy": {
+    "egress": "provider-only",
+    "enforcement": "internal-network+allowlist-proxy",
+    "allowed_hosts": ["api.anthropic.com", "console.anthropic.com"],
+    "allowed_port": 443
+  }
+}

--- a/test/cdeb-runtime-isolation.test.ts
+++ b/test/cdeb-runtime-isolation.test.ts
@@ -1,0 +1,1012 @@
+/**
+ * CDEB-03 acceptance (PRD §7.5, §8, §25.4): the three properties that decide
+ * whether the pinned runtime is done, each tested through its FAILURE path —
+ * a test that isolation works when everything is present proves nothing about
+ * the degradation the gate exists to refuse.
+ *
+ *   1. A missing isolation capability hard fails, and the message names what
+ *      is missing — including the capability that was never probed at all.
+ *   2. A run that would inherit settings or memory from the host fails closed.
+ *   3. A pinned model that does not match the model that answered stops the
+ *      study (and so does a drifting CLI, or a subagent turn).
+ *
+ * Everything here runs without a container runtime: the gate judges data —
+ * probe observations, streams, manifests — and the docker side of
+ * `agent-container.ts` is an injected seam. What these tests therefore do NOT
+ * prove is that a real docker daemon enforces what the spec builder asks of
+ * it; that needs the pinned image and a machine the study may use, and it is
+ * recorded as unverified rather than simulated.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import net from 'node:net';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  CAPABILITY_IDS,
+  FROZEN_TOOL_POLICY,
+  ModelDriftError,
+  CliDriftError,
+  ToolPolicyViolationError,
+  RuntimeCapabilityError,
+  assertRuntimeCapabilities,
+  canonicalJson,
+  mcpConfigDigest,
+  networkPolicyDigest,
+  readInitEvent,
+  settingsDigest,
+  streamHasAuthoritativeUsage,
+  toolPolicyDigest,
+  verifyStreamIdentity,
+  type CapabilityId,
+  type CapabilityProbe,
+} from '../bench/cdeb/runtime/isolation.ts';
+import { runProbe } from '../bench/cdeb/freeze/runtime-probe.ts';
+// @ts-expect-error -- plain ESM module without type declarations
+import { decideEgress, parseConnectTarget } from '../bench/cdeb/runtime/egress-proxy.mjs';
+import {
+  CONTAINER_PATHS,
+  EGRESS_NETWORK,
+  agentCliArgv,
+  attributeExecutableIdentity,
+  attributeHelpSupport,
+  attributeHomeIsolation,
+  attributeImageDigest,
+  attributeNetworkProbes,
+  attributeSessionState,
+  attributeStreamCapabilities,
+  buildAgentRunSpec,
+  probeRuntimeCapabilities,
+  probeCommand,
+  dockerRunArgs,
+  executeAgentRun,
+  loadRuntimePin,
+  parseHomeFiles,
+  pinFreezeGaps,
+  pinIsFrozen,
+  runtimeIdentityFields,
+  runtimePinDigest,
+  type ContainerRuntimeCommands,
+  type RuntimePin,
+} from '../bench/cdeb/runtime/agent-container.ts';
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+const temp = (label: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), `cdeb-iso-${label}-`));
+  scratch.push(dir);
+  return dir;
+};
+
+// ---------------------------------------------------------------------------
+// Synthetic streams in the committed fixture shape (claude-stream/*.jsonl)
+// ---------------------------------------------------------------------------
+
+const PIN_MODEL = 'claude-test-1-20260101';
+const CLI_VERSION = '2.1.227';
+
+const initEvent = (overrides: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    type: 'system',
+    subtype: 'init',
+    tools: [...FROZEN_TOOL_POLICY.allowed],
+    mcp_servers: [],
+    model: PIN_MODEL,
+    permissionMode: 'acceptEdits',
+    claude_code_version: CLI_VERSION,
+    ...overrides,
+  });
+
+let messageSequence = 0;
+const turnEvents = (model: string, parentToolUseId: string | null = null): string => {
+  messageSequence += 1;
+  const start = JSON.stringify({
+    type: 'stream_event',
+    parent_tool_use_id: parentToolUseId,
+    event: { type: 'message_start', message: { id: `msg-${String(messageSequence)}`, model } },
+  });
+  const delta = JSON.stringify({
+    type: 'stream_event',
+    parent_tool_use_id: parentToolUseId,
+    event: {
+      type: 'message_delta',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens_details: { thinking_tokens: 0 },
+      },
+      delta: { stop_reason: 'end_turn' },
+    },
+  });
+  return `${start}\n${delta}`;
+};
+
+const resultEvent = (): string =>
+  JSON.stringify({
+    type: 'result',
+    num_turns: 1,
+    is_error: false,
+    usage: {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+  });
+
+const validStream = (): string =>
+  [initEvent(), turnEvents(PIN_MODEL), resultEvent()].join('\n');
+
+const STREAM_PIN = {
+  expected_observed_model: PIN_MODEL,
+  agent_cli_version: CLI_VERSION,
+  permission_mode: 'acceptEdits',
+  tool_policy: FROZEN_TOOL_POLICY,
+};
+
+const greenProbe = (capability: CapabilityId): CapabilityProbe => ({
+  capability,
+  ok: true,
+  detail: `synthetic pass: ${capability}`,
+});
+const greenReport = (): CapabilityProbe[] => CAPABILITY_IDS.map(greenProbe);
+
+const UNFROZEN_PIN: RuntimePin = {
+  schema_version: 1,
+  frozen: false,
+  image: { reference: 'commitlore/cdeb-agent', digest: null },
+  agent_cli_version: null,
+  agent_executable: { path: '/usr/local/bin/claude', sha256: null },
+  node: { version: 'v22.23.2', executable_path: '/usr/local/bin/node', executable_sha256: null },
+  requested_model: 'sonnet',
+  expected_observed_model: null,
+  permission_mode: 'acceptEdits',
+  network_policy: {
+    egress: 'provider-only',
+    enforcement: 'internal-network+allowlist-proxy',
+    allowed_hosts: ['api.provider.example'],
+    allowed_port: 443,
+  },
+};
+
+const FROZEN_PIN: RuntimePin = {
+  ...UNFROZEN_PIN,
+  frozen: true,
+  image: { reference: 'commitlore/cdeb-agent', digest: 'sha256:' + 'ab'.repeat(32) },
+  agent_cli_version: CLI_VERSION,
+  agent_executable: { path: '/usr/local/bin/claude', sha256: 'cd'.repeat(32) },
+  node: { version: 'v22.23.2', executable_path: '/usr/local/bin/node', executable_sha256: 'ef'.repeat(32) },
+  expected_observed_model: PIN_MODEL,
+};
+
+// ---------------------------------------------------------------------------
+// 1. Missing isolation capability hard fails, naming what is missing
+// ---------------------------------------------------------------------------
+
+describe('§7.5 capability gate: missing capability hard fails', () => {
+  it('passes only when every capability is probed and green', () => {
+    const token = assertRuntimeCapabilities(greenReport(), 'pin-digest');
+    expect(token.gate).toBe('cdeb-runtime-capabilities');
+    expect(token.pin_digest).toBe('pin-digest');
+    expect([...token.verified].sort()).toEqual([...CAPABILITY_IDS].sort());
+  });
+
+  it('refuses a failed probe and names the capability and what is missing', () => {
+    const probes = greenReport().map((probe) =>
+      probe.capability === 'mcp-isolation'
+        ? {
+            capability: probe.capability,
+            ok: false,
+            detail: 'pinned CLI does not support --strict-mcp-config — isolation would degrade to inherited host state',
+          }
+        : probe,
+    );
+    expect(() => assertRuntimeCapabilities(probes, 'pin-digest')).toThrowError(RuntimeCapabilityError);
+    try {
+      assertRuntimeCapabilities(probes, 'pin-digest');
+    } catch (error) {
+      const capabilityError = error as RuntimeCapabilityError;
+      expect(capabilityError.failed).toEqual(['mcp-isolation']);
+      expect(capabilityError.message).toContain('mcp-isolation');
+      expect(capabilityError.message).toContain('--strict-mcp-config');
+    }
+  });
+
+  it('refuses a capability that was never probed — absence of evidence is not a pass', () => {
+    const probes = greenReport().filter((probe) => probe.capability !== 'network-policy');
+    try {
+      assertRuntimeCapabilities(probes, 'pin-digest');
+      expect.unreachable('the gate must refuse an incomplete report');
+    } catch (error) {
+      const capabilityError = error as RuntimeCapabilityError;
+      expect(capabilityError.untested).toEqual(['network-policy']);
+      expect(capabilityError.message).toContain('network-policy');
+      expect(capabilityError.message).toContain('never probed');
+    }
+  });
+
+  it('refuses a malformed report that probes one capability twice', () => {
+    const probes = [...greenReport(), greenProbe('tool-policy')];
+    expect(() => assertRuntimeCapabilities(probes, 'pin-digest')).toThrowError(/more than once/);
+  });
+
+  it('has no warning state: the only outcomes are a token or a throw', () => {
+    // Compile-time shape check: a "degraded pass" has no representation.
+    const token: ReturnType<typeof assertRuntimeCapabilities> = assertRuntimeCapabilities(
+      greenReport(),
+      'digest',
+    );
+    expect(Object.keys(token).sort()).toEqual(['gate', 'pin_digest', 'verified']);
+  });
+});
+
+describe('§7.5 capability attribution names the missing piece', () => {
+  it('help without isolation flags fails the capabilities those flags protect', () => {
+    const probes = attributeHelpSupport('--model <model>  --output-format <format>');
+    const settings = probes.find((probe) => probe.capability === 'settings-isolation');
+    const session = probes.find((probe) => probe.capability === 'session-isolation');
+    const mcp = probes.find((probe) => probe.capability === 'mcp-isolation');
+    expect(settings?.ok).toBe(false);
+    expect(settings?.detail).toContain('--setting-sources');
+    expect(session?.ok).toBe(false);
+    expect(session?.detail).toContain('--no-session-persistence');
+    expect(mcp?.ok).toBe(false);
+    expect(mcp?.detail).toContain('--strict-mcp-config');
+  });
+
+  it('help carrying every required flag passes every flag-backed capability', () => {
+    const help = [
+      '--strict-mcp-config',
+      '--mcp-config <configs...>',
+      '--setting-sources <sources>',
+      '--no-session-persistence',
+      '--allowedTools, --allowed-tools <tools...>',
+      '--disallowedTools, --disallowed-tools <tools...>',
+      '--include-partial-messages',
+    ].join('\n');
+    const probes = attributeHelpSupport(help);
+    expect(probes.every((probe) => probe.ok)).toBe(true);
+  });
+
+  it('an image whose digest does not match the pin is refused, never retagged', () => {
+    const probe = attributeImageDigest('["repo@sha256:deadbeef"]', FROZEN_PIN);
+    expect(probe.ok).toBe(false);
+    expect(probe.detail).toContain(FROZEN_PIN.image.digest ?? '');
+    expect(probe.detail).toContain('never retag');
+  });
+
+  it('executable drift against the pin is refused naming each drifted field', () => {
+    const probe = attributeExecutableIdentity(
+      {
+        cli_sha256: 'different'.repeat(4),
+        node_sha256: FROZEN_PIN.node.executable_sha256,
+        node_version: FROZEN_PIN.node.version,
+        cli_version: '9.9.9',
+      },
+      FROZEN_PIN,
+    );
+    expect(probe.ok).toBe(false);
+    expect(probe.detail).toContain('agent CLI sha256');
+    expect(probe.detail).toContain('agent CLI version');
+  });
+
+  it('an unfrozen pin cannot pass the image-pin capability', () => {
+    const probe = attributeImageDigest('anything', UNFROZEN_PIN);
+    expect(probe.ok).toBe(false);
+    expect(probe.detail).toContain('not frozen');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Inherited settings or memory fails closed
+// ---------------------------------------------------------------------------
+
+describe('§7.2 inheritance fails closed', () => {
+  it('a run spec mounts exactly the repository and the harness config — never a host HOME', () => {
+    const spec = buildAgentRunSpec({
+      imageRef: 'commitlore/cdeb-agent@sha256:ab',
+      repositoryPath: '/host/repo',
+      configDir: '/host/cdeb-config',
+      prompt: 'a task',
+      providerEnv: { ANTHROPIC_API_KEY: 'test-key' },
+      pin: FROZEN_PIN,
+    });
+    expect(spec.env['HOME']).toBe(CONTAINER_PATHS.home);
+    expect(spec.mounts).toEqual([
+      { hostPath: '/host/repo', containerPath: '/repo', readOnly: false },
+      { hostPath: '/host/cdeb-config', containerPath: '/cdeb', readOnly: true },
+    ]);
+    const args = dockerRunArgs(spec);
+    const volumes = args.filter((arg, index) => args[index - 1] === '--volume');
+    expect(volumes).toHaveLength(2);
+    expect(volumes.some((volume) => volume.includes(':ro'))).toBe(true);
+    // Every isolation flag is unconditional in the argv.
+    expect(spec.argv).toContain('--strict-mcp-config');
+    expect(spec.argv).toContain('--no-session-persistence');
+    expect(spec.argv).toContain('--setting-sources');
+    expect(spec.argv[spec.argv.indexOf('--setting-sources') + 1]).toBe('');
+    // The only egress is the allowlist proxy.
+    expect(spec.env['HTTPS_PROXY']).toContain('cdeb-egress-proxy');
+    expect(spec.network).toBe(EGRESS_NETWORK);
+  });
+
+  it('refuses provider env keys outside the allowlist — a host environment leak path', () => {
+    expect(() =>
+      buildAgentRunSpec({
+        imageRef: 'commitlore/cdeb-agent@sha256:ab',
+        repositoryPath: '/host/repo',
+        configDir: '/host/cdeb-config',
+        prompt: 'a task',
+        providerEnv: { ANTHROPIC_API_KEY: 'k', PATH: '/usr/bin' },
+        pin: FROZEN_PIN,
+      }),
+    ).toThrowError(/PATH.*not in the allowlist/);
+  });
+
+  it('a HOME that starts non-empty is inheritance, and the gate names it', () => {
+    const probe = attributeHomeIsolation({
+      home_value: CONTAINER_PATHS.home,
+      home_file_count: 3,
+      unexpected_mounts: [],
+    });
+    expect(probe.ok).toBe(false);
+    expect(probe.detail).toContain('inheritance');
+  });
+
+  it('a mount outside the expected pair is refused naming the mount', () => {
+    const probe = attributeHomeIsolation({
+      home_value: CONTAINER_PATHS.home,
+      home_file_count: 0,
+      unexpected_mounts: ['/root/.claude'],
+    });
+    expect(probe.ok).toBe(false);
+    expect(probe.detail).toContain('/root/.claude');
+  });
+
+  it('a wrong HOME value is refused', () => {
+    const probe = attributeHomeIsolation({
+      home_value: '/root',
+      home_file_count: 0,
+      unexpected_mounts: [],
+    });
+    expect(probe.ok).toBe(false);
+    expect(probe.detail).toContain('/root');
+  });
+
+  it('session or memory state that survives the run fails session-isolation', () => {
+    const probe = attributeSessionState(['/home/agent/.claude/projects/session.jsonl']);
+    expect(probe.ok).toBe(false);
+    expect(probe.detail).toContain('session.jsonl');
+    expect(attributeSessionState([]).ok).toBe(true);
+  });
+
+  it('parses the HOME sweep marker from probe stderr', () => {
+    const stderr = `noise\n===CDEB-HOME-FILES===\n/home/agent/.claude/memory.md\n\n`;
+    expect(parseHomeFiles(stderr)).toEqual(['/home/agent/.claude/memory.md']);
+    expect(parseHomeFiles('no marker here')).toEqual([]);
+  });
+
+  it('a stream whose init shows MCP servers under strict config fails closed', () => {
+    const stream = [
+      initEvent({ mcp_servers: [{ name: 'memory-server' }] }),
+      turnEvents(PIN_MODEL),
+      resultEvent(),
+    ].join('\n');
+    const probes = attributeStreamCapabilities(stream, FROZEN_PIN);
+    const mcp = probes.find((probe) => probe.capability === 'mcp-isolation');
+    expect(mcp?.ok).toBe(false);
+    expect(mcp?.detail).toContain('memory-server');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Model or CLI drift stops the study
+// ---------------------------------------------------------------------------
+
+describe('§8 model and CLI drift are hard stops', () => {
+  it('accepts a stream where every main-session turn carries the pinned model', () => {
+    const identity = verifyStreamIdentity(validStream(), STREAM_PIN);
+    expect(identity.observed_model_ids).toEqual([PIN_MODEL]);
+    expect(identity.agent_cli_version).toBe(CLI_VERSION);
+    expect(identity.turn_count).toBe(1);
+  });
+
+  it('stops the study when a turn is answered by another model, naming both', () => {
+    const drifted = [
+      initEvent(),
+      turnEvents(PIN_MODEL),
+      turnEvents('claude-other-9-20290101'),
+      resultEvent(),
+    ].join('\n');
+    try {
+      verifyStreamIdentity(drifted, STREAM_PIN);
+      expect.unreachable('drift must stop the study');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ModelDriftError);
+      expect((error as Error).message).toContain('claude-other-9-20290101');
+      expect((error as Error).message).toContain(PIN_MODEL);
+    }
+  });
+
+  it('stops the study on an empty model id', () => {
+    const empty = [initEvent(), turnEvents(''), resultEvent()].join('\n');
+    expect(() => verifyStreamIdentity(empty, STREAM_PIN)).toThrowError(/empty model id/);
+  });
+
+  it('rejects a subagent turn — delegation is forbidden, not averaged in', () => {
+    const delegated = [
+      initEvent(),
+      turnEvents(PIN_MODEL),
+      turnEvents(PIN_MODEL, 'toolu_subagent_parent'),
+      resultEvent(),
+    ].join('\n');
+    expect(() => verifyStreamIdentity(delegated, STREAM_PIN)).toThrowError(/subagent/);
+  });
+
+  it('stops the study when the CLI that ran is not the CLI that was pinned', () => {
+    const drifted = [initEvent({ claude_code_version: '9.9.9' }), turnEvents(PIN_MODEL), resultEvent()].join('\n');
+    expect(() => verifyStreamIdentity(drifted, STREAM_PIN)).toThrowError(CliDriftError);
+  });
+
+  it('stops the study when the init model is not the pinned model', () => {
+    const drifted = [initEvent({ model: 'claude-other-9-20290101' }), turnEvents(PIN_MODEL), resultEvent()].join('\n');
+    expect(() => verifyStreamIdentity(drifted, STREAM_PIN)).toThrowError(ModelDriftError);
+  });
+
+  it('refuses a session whose tool set diverges from the frozen policy', () => {
+    const drifted = [
+      initEvent({ tools: [...FROZEN_TOOL_POLICY.allowed, 'WebSearch'] }),
+      turnEvents(PIN_MODEL),
+      resultEvent(),
+    ].join('\n');
+    try {
+      verifyStreamIdentity(drifted, STREAM_PIN);
+      expect.unreachable('tool divergence must be a hard stop');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ToolPolicyViolationError);
+      expect((error as Error).message).toContain('WebSearch');
+    }
+  });
+
+  it('refuses a stream with no init event — the session cannot be identified', () => {
+    const noInit = [turnEvents(PIN_MODEL), resultEvent()].join('\n');
+    expect(() => verifyStreamIdentity(noInit, STREAM_PIN)).toThrowError(/no init event/);
+  });
+
+  it('preflight attribution turns model drift into a failed capability probe', () => {
+    const drifted = [
+      initEvent({ model: 'claude-other-9-20290101' }),
+      turnEvents(PIN_MODEL),
+      resultEvent(),
+    ].join('\n');
+    const probes = attributeStreamCapabilities(drifted, FROZEN_PIN);
+    const model = probes.find((probe) => probe.capability === 'model-observation');
+    expect(model?.ok).toBe(false);
+    expect(model?.detail).toContain('claude-other-9-20290101');
+  });
+
+  it('an unfrozen expected model fails the capability rather than passing silently', () => {
+    const probes = attributeStreamCapabilities(validStream(), UNFROZEN_PIN);
+    const model = probes.find((probe) => probe.capability === 'model-observation');
+    expect(model?.ok).toBe(false);
+    expect(model?.detail).toContain('not frozen');
+  });
+
+  it('reads the committed fixture streams: partial messages carry authoritative usage, assistant-only does not', () => {
+    const partial = readFileSync('test/fixtures/claude-stream/partial-messages.jsonl', 'utf8');
+    const assistantOnly = readFileSync('test/fixtures/claude-stream/assistant-only.jsonl', 'utf8');
+    expect(streamHasAuthoritativeUsage(partial)).toBe(true);
+    expect(streamHasAuthoritativeUsage(assistantOnly)).toBe(false);
+    expect(readInitEvent(partial)?.model).toBe('claude-haiku-4-5-20251001');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pin manifest, digests, and the gate token
+// ---------------------------------------------------------------------------
+
+describe('pin manifest and gate token', () => {
+  it('loads the committed manifest and reports it unfrozen with named gaps', () => {
+    const raw = readFileSync('bench/cdeb/runtime/runtime-pin.json', 'utf8');
+    const pin = loadRuntimePin(raw);
+    expect(pinIsFrozen(pin)).toBe(false);
+    expect(pinFreezeGaps(pin).sort()).toEqual([
+      'agent_cli_version',
+      'agent_executable.sha256',
+      'expected_observed_model',
+      'image.digest',
+      'node.executable_sha256',
+    ]);
+  });
+
+  it('refuses a manifest whose enforcement is not the frozen one', () => {
+    const raw = readFileSync('bench/cdeb/runtime/runtime-pin.json', 'utf8');
+    const mutated = raw.replace('internal-network+allowlist-proxy', 'vibes');
+    expect(() => loadRuntimePin(mutated)).toThrowError(/enforcement/);
+  });
+
+  it('refuses a manifest with a malformed allowed_hosts', () => {
+    const raw = readFileSync('bench/cdeb/runtime/runtime-pin.json', 'utf8');
+    const mutated = raw.replace('"api.anthropic.com", "console.anthropic.com"', '"api.anthropic.com", ""');
+    expect(() => loadRuntimePin(mutated)).toThrowError(/allowed_hosts/);
+  });
+
+  it('digests are deterministic and sensitive to the policy content', () => {
+    expect(toolPolicyDigest(FROZEN_TOOL_POLICY)).toBe(toolPolicyDigest(FROZEN_TOOL_POLICY));
+    expect(toolPolicyDigest({ allowed: ['Bash'], disallowed: [] })).not.toBe(toolPolicyDigest(FROZEN_TOOL_POLICY));
+    expect(settingsDigest('{"hooks":{}}')).toBe(settingsDigest('{"hooks":{}}'));
+    expect(settingsDigest('{"hooks":{}}')).not.toBe(settingsDigest('{"hooks":{"evil":true}}'));
+    expect(mcpConfigDigest('{"mcpServers":{}}')).not.toBe(mcpConfigDigest('{"mcpServers":{"x":{}}}'));
+    const policy = FROZEN_PIN.network_policy;
+    expect(networkPolicyDigest(policy)).toBe(networkPolicyDigest({ ...policy }));
+    expect(networkPolicyDigest(policy)).not.toBe(
+      networkPolicyDigest({ ...policy, allowed_hosts: ['other.example'] }),
+    );
+    expect(canonicalJson({ b: 1, a: 2 })).toBe(canonicalJson({ a: 2, b: 1 }));
+    expect(runtimePinDigest(FROZEN_PIN)).toBe(runtimePinDigest(FROZEN_PIN));
+    expect(runtimePinDigest(FROZEN_PIN)).not.toBe(runtimePinDigest(UNFROZEN_PIN));
+  });
+
+  it('the frozen tool policy keeps web, delegation and memory surfaces out', () => {
+    for (const forbidden of ['WebSearch', 'WebFetch', 'Task', 'Skill', 'Monitor']) {
+      expect(FROZEN_TOOL_POLICY.allowed).not.toContain(forbidden);
+      expect(FROZEN_TOOL_POLICY.disallowed).toContain(forbidden);
+    }
+  });
+
+  it('identity fields for the row come from the pin and the harness config', () => {
+    const fields = runtimeIdentityFields(FROZEN_PIN, '{"hooks":{}}');
+    expect(fields.agent_runtime_image_digest).toBe(FROZEN_PIN.image.digest);
+    expect(fields.agent_executable_sha256).toBe(FROZEN_PIN.agent_executable.sha256);
+    expect(fields.tool_policy_digest).toBe(toolPolicyDigest(FROZEN_TOOL_POLICY));
+    expect(fields.network_policy_digest).toBe(networkPolicyDigest(FROZEN_PIN.network_policy));
+    expect(fields.settings_digest).toBe(settingsDigest('{"hooks":{}}'));
+    expect(fields.requested_model).toBe('sonnet');
+  });
+
+  const refusingDocker: ContainerRuntimeCommands = {
+    run: () => {
+      throw new Error('docker must not be reached once the gate refuses');
+    },
+    runToSink: async () => {
+      throw new Error('docker must not be reached once the gate refuses');
+    },
+  };
+
+  it('executeAgentRun refuses a gate token minted for a different pin, before any container work', async () => {
+    const token = assertRuntimeCapabilities(greenReport(), 'some-other-pin-digest');
+    await expect(
+      executeAgentRun(refusingDocker, FROZEN_PIN, token, {
+        repositoryPath: '/host/repo',
+        configDir: '/host/config',
+        prompt: 'task',
+        outDir: temp('run'),
+        providerEnv: {},
+      }),
+    ).rejects.toThrowError(/different pin/);
+  });
+
+  it('executeAgentRun refuses an unfrozen pin even with a matching token', async () => {
+    const token = assertRuntimeCapabilities(greenReport(), runtimePinDigest(UNFROZEN_PIN));
+    await expect(
+      executeAgentRun(refusingDocker, UNFROZEN_PIN, token, {
+        repositoryPath: '/host/repo',
+        configDir: '/host/config',
+        prompt: 'task',
+        outDir: temp('run'),
+        providerEnv: {},
+      }),
+    ).rejects.toThrowError(/not frozen/);
+  });
+
+  it('executeAgentRun captures the raw stream byte-for-byte and identity-checks it', async () => {
+    const stream = validStream();
+    const streamingDocker: ContainerRuntimeCommands = {
+      run: () => ({ stdout: '', stderr: '', exitCode: 0, timedOut: false }),
+      runToSink: async (_args, sink) => {
+        sink.write(stream);
+        sink.end();
+        return { exitCode: 0, stderr: '', timedOut: false };
+      },
+    };
+    const outDir = temp('run-ok');
+    const token = assertRuntimeCapabilities(greenReport(), runtimePinDigest(FROZEN_PIN));
+    const outcome = await executeAgentRun(streamingDocker, FROZEN_PIN, token, {
+      repositoryPath: '/host/repo',
+      configDir: '/host/config',
+      prompt: 'task',
+      outDir,
+      providerEnv: {},
+    });
+    const captured = readFileSync(join(outDir, 'provider.ndjson'), 'utf8');
+    expect(captured).toBe(stream);
+    expect(outcome.identity.observed_model_ids).toEqual([PIN_MODEL]);
+    expect(outcome.exit_code).toBe(0);
+    expect(outcome.provider_stream_sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('executeAgentRun turns mid-run model drift into a hard stop after capture', async () => {
+    const drifted = [initEvent(), turnEvents('claude-other-9-20290101'), resultEvent()].join('\n');
+    const streamingDocker: ContainerRuntimeCommands = {
+      run: () => ({ stdout: '', stderr: '', exitCode: 0, timedOut: false }),
+      runToSink: async (_args, sink) => {
+        sink.write(drifted);
+        sink.end();
+        return { exitCode: 0, stderr: '', timedOut: false };
+      },
+    };
+    const token = assertRuntimeCapabilities(greenReport(), runtimePinDigest(FROZEN_PIN));
+    await expect(
+      executeAgentRun(streamingDocker, FROZEN_PIN, token, {
+        repositoryPath: '/host/repo',
+        configDir: '/host/config',
+        prompt: 'task',
+        outDir: temp('run-drift'),
+        providerEnv: {},
+      }),
+    ).rejects.toThrowError(ModelDriftError);
+  });
+
+  it('the agent argv carries the frozen tool policy, verbatim', () => {
+    const argv = agentCliArgv(FROZEN_PIN, 'do the task');
+    const allowed = argv.slice(argv.indexOf('--allowedTools') + 1, argv.indexOf('--disallowedTools'));
+    expect(allowed).toEqual([...FROZEN_TOOL_POLICY.allowed]);
+    const disallowedStart = argv.indexOf('--disallowedTools') + 1;
+    const disallowedEnd = argv.indexOf('--model');
+    expect(argv.slice(disallowedStart, disallowedEnd)).toEqual([...FROZEN_TOOL_POLICY.disallowed]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Probe orchestration against a fake container runtime: the docker side is
+// scripted, the attribution and wiring are real.
+// ---------------------------------------------------------------------------
+
+describe('probe orchestration on a scripted container runtime', () => {
+  const cliSha = FROZEN_PIN.agent_executable.sha256 ?? '';
+  const nodeSha = FROZEN_PIN.node.executable_sha256 ?? '';
+
+  const scriptedDocker = (netResult: string, probeStdout: string, probeStderr: string) => {
+    const calls: string[][] = [];
+    const runtime: ContainerRuntimeCommands = {
+      run: (args) => {
+        calls.push([...args]);
+        const first = args.slice(0, 2).join(' ');
+        if (first === 'version --format') return { stdout: '27.0.0\n', stderr: '', exitCode: 0, timedOut: false };
+        if (args[0] === 'image' && args[1] === 'inspect') {
+          return { stdout: `["x@${FROZEN_PIN.image.digest}"] sha256:abc`, stderr: '', exitCode: 0, timedOut: false };
+        }
+        if (args.some((arg) => arg.includes('sha256sum'))) {
+          return {
+            stdout: `${cliSha}  /usr/local/bin/claude\n${nodeSha}  /usr/local/bin/node\nv22.23.2\n2.1.227 (Claude Code)\n`,
+            stderr: '',
+            exitCode: 0,
+            timedOut: false,
+          };
+        }
+        if (args.some((arg) => arg === '--help')) {
+          return {
+            stdout: '--strict-mcp-config\n--mcp-config <c>\n--setting-sources <s>\n--no-session-persistence\n--allowedTools <t>\n--disallowedTools <t>\n--include-partial-messages\n',
+            stderr: '',
+            exitCode: 0,
+            timedOut: false,
+          };
+        }
+        if (first === 'network create') return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+        if (args[0] === 'rm') return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+        if (args.includes('--detach')) return { stdout: 'container-id', stderr: '', exitCode: 0, timedOut: false };
+        if (args[0] === 'logs') return { stdout: '{"decision":"listening"}\n', stderr: '', exitCode: 0, timedOut: false };
+        if (args.includes('node') && args.includes('-e')) return { stdout: netResult, stderr: '', exitCode: 0, timedOut: false };
+        // The final probe run.
+        return { stdout: probeStdout, stderr: probeStderr, exitCode: 0, timedOut: false };
+      },
+      runToSink: async () => ({ exitCode: 0, stderr: '', timedOut: false }),
+    };
+    return { runtime, calls };
+  };
+
+  it('all-green scripted runtime yields a complete passing report for every capability', () => {
+    const netResult = JSON.stringify({
+      direct_egress_blocked: true,
+      proxy_refused_foreign: true,
+      proxy_allowed_provider: true,
+    });
+    const { runtime } = scriptedDocker(netResult, validStream(), '===CDEB-HOME-FILES===\n');
+    const probes = probeRuntimeCapabilities(runtime, FROZEN_PIN, {
+      probePrompt: 'Reply with the single word: ready.',
+      providerEnv: { ANTHROPIC_API_KEY: 'test' },
+    });
+    const byId = new Map(probes.map((probe) => [probe.capability, probe]));
+    for (const capability of CAPABILITY_IDS) {
+      const probe = byId.get(capability);
+      expect(probe, `capability ${capability} probed`).toBeDefined();
+      expect(probe?.ok, `${capability}: ${probe?.detail ?? ''}`).toBe(true);
+    }
+    const token = assertRuntimeCapabilities(probes, runtimePinDigest(FROZEN_PIN));
+    expect(token.verified).toHaveLength(CAPABILITY_IDS.length);
+  });
+
+  it('a scripted runtime whose proxy leaks fails the network-policy capability by name', () => {
+    const netResult = JSON.stringify({
+      direct_egress_blocked: false,
+      proxy_refused_foreign: true,
+      proxy_allowed_provider: true,
+    });
+    const { runtime } = scriptedDocker(netResult, validStream(), '===CDEB-HOME-FILES===\n');
+    const probes = probeRuntimeCapabilities(runtime, FROZEN_PIN, {
+      probePrompt: 'ping',
+      providerEnv: {},
+    });
+    const network = probes.find((probe) => probe.capability === 'network-policy');
+    expect(network?.ok).toBe(false);
+    expect(network?.detail).toContain('direct egress');
+    expect(() => assertRuntimeCapabilities(probes, 'digest')).toThrowError(RuntimeCapabilityError);
+  });
+
+  it('an unfrozen pin short-circuits: image-pin fails and the rest stay never-probed', () => {
+    const { runtime } = scriptedDocker('{}', '', '');
+    const probes = probeRuntimeCapabilities(runtime, UNFROZEN_PIN, {
+      probePrompt: 'ping',
+      providerEnv: {},
+    });
+    expect(probes.map((probe) => probe.capability)).toContain('oci-runtime');
+    const imagePin = probes.find((probe) => probe.capability === 'image-pin');
+    expect(imagePin?.ok).toBe(false);
+    expect(imagePin?.detail).toContain('not frozen');
+    try {
+      assertRuntimeCapabilities(probes, 'digest');
+      expect.unreachable('must refuse');
+    } catch (error) {
+      const capabilityError = error as RuntimeCapabilityError;
+      // Everything the image-pin gate could not reach is named as never probed.
+      expect(capabilityError.untested).toContain('network-policy');
+      expect(capabilityError.untested).toContain('model-observation');
+    }
+  });
+
+  it('the generated network probe script is valid JavaScript', async () => {
+    const { runtime, calls } = scriptedDocker('{}', '', '');
+    probeRuntimeCapabilities(runtime, FROZEN_PIN, { probePrompt: 'ping', providerEnv: {} });
+    const netCall = calls.find((args) => args.includes('-e'));
+    expect(netCall).toBeDefined();
+    const script = netCall?.[netCall.length - 1] ?? '';
+    expect(script).toContain('CONNECT');
+    const scriptPath = join(temp('netscript'), 'net-script.js');
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(scriptPath, script);
+    const { spawnSync } = await import('node:child_process');
+    const check = spawnSync(process.execPath, ['--check', scriptPath], { encoding: 'utf8' });
+    expect(check.status, check.stderr).toBe(0);
+  });
+
+  it('probeCommand quoting survives hostile arguments and reports HOME files on stderr', () => {
+    const wrapped = probeCommand(['echo', "it's", 'a test']);
+    expect(wrapped[0]).toBe('sh');
+    const result = spawnSync(wrapped[0] ?? 'sh', [...wrapped.slice(1)], {
+      encoding: 'utf8',
+      env: { ...process.env, HOME: temp('homecheck') },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("it's a test");
+    expect(result.stderr).toContain('===CDEB-HOME-FILES===');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The egress proxy: the allowlist decision is pure and always tested; the
+// socket layer is exercised when this environment lets a process listen, and
+// reported SKIPPED — not simulated — when the sandbox denies it.
+// ---------------------------------------------------------------------------
+
+const listenProbe = async (): Promise<boolean> => {
+  const probeServer = net.createServer();
+  return new Promise((resolve) => {
+    probeServer.once('error', () => resolve(false));
+    probeServer.listen(0, '127.0.0.1', () => {
+      probeServer.close(() => resolve(true));
+    });
+  });
+};
+
+describe('§7.4 egress proxy decision logic', () => {
+  const allowlist = new Set(['api.provider.example', 'console.provider.example']);
+
+  it('allows CONNECT to an allowlisted host on the frozen port', () => {
+    expect(decideEgress('CONNECT', 'api.provider.example:443', allowlist, 443)).toBe('allowed');
+  });
+
+  it('refuses a host outside the allowlist', () => {
+    expect(decideEgress('CONNECT', 'evil.example:443', allowlist, 443)).toBe('refused-target');
+  });
+
+  it('refuses an allowlisted host on another port', () => {
+    expect(decideEgress('CONNECT', 'api.provider.example:8080', allowlist, 443)).toBe('refused-target');
+  });
+
+  it('refuses anything that is not CONNECT', () => {
+    expect(decideEgress('GET', 'api.provider.example:443', allowlist, 443)).toBe('refused-method');
+  });
+
+  it('refuses malformed targets', () => {
+    expect(decideEgress('CONNECT', 'no-port-or-colon', allowlist, 443)).toBe('refused-target');
+    expect(parseConnectTarget('host:notaport')).toBeNull();
+    expect(parseConnectTarget('')).toBeNull();
+    expect(parseConnectTarget('HOST.example:443')).toEqual({ host: 'host.example', port: 443 });
+    expect(parseConnectTarget('bare.host')).toEqual({ host: 'bare.host', port: 443 });
+  });
+
+  it('an empty allowlist allows nothing', () => {
+    expect(decideEgress('CONNECT', 'api.provider.example:443', new Set(), 443)).toBe('refused-target');
+  });
+});
+
+describe('§7.4 egress proxy socket layer', () => {
+  const proxyScript = 'bench/cdeb/runtime/egress-proxy.mjs';
+
+  const startProxy = async (
+    allowedHosts: string,
+    port: number,
+  ): Promise<{ child: ReturnType<typeof spawn>; stop: () => void }> => {
+    const child = spawn(process.execPath, [proxyScript], {
+      env: {
+        ...process.env,
+        CDEB_ALLOWED_HOSTS: allowedHosts,
+        CDEB_ALLOWED_PORT: String(port),
+        CDEB_LISTEN_PORT: String(port + 1000),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('proxy did not start')), 5_000);
+      child.stdout?.on('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('"listening"')) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+      child.on('exit', () => reject(new Error('proxy exited before listening')));
+    });
+    return {
+      child,
+      stop: () => {
+        child.kill('SIGKILL');
+      },
+    };
+  };
+
+  const connectRequest = (proxyPort: number, target: string): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const socket = net.connect(proxyPort, '127.0.0.1', () => {
+        socket.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+      });
+      let buffer = '';
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(new Error('no proxy response'));
+      }, 5_000);
+      socket.on('data', (chunk) => {
+        buffer += chunk.toString();
+        if (buffer.includes('\r\n')) {
+          clearTimeout(timer);
+          socket.destroy();
+          resolve(buffer.split('\r\n')[0] ?? '');
+        }
+      });
+      socket.on('error', reject);
+    });
+
+  it('refuses CONNECT to a host outside the allowlist with a 403', async (ctx) => {
+    if (!(await listenProbe())) return ctx.skip();
+    const { stop } = await startProxy('127.0.0.1', 9501);
+    try {
+      const statusLine = await connectRequest(10501, 'evil.example:443');
+      expect(statusLine).toContain('403');
+    } finally {
+      stop();
+    }
+  });
+
+  it('establishes an allowlisted CONNECT and pipes bytes untouched', async (ctx) => {
+    if (!(await listenProbe())) return ctx.skip();
+    // A local echo server stands in for the provider endpoint.
+    const echo = net.createServer((socket) => {
+      socket.pipe(socket);
+    });
+    await new Promise<void>((resolve) => echo.listen(9503, '127.0.0.1', () => resolve()));
+
+    const { stop } = await startProxy('127.0.0.1', 9503);
+    try {
+      const echoed = await new Promise<string>((resolve, reject) => {
+        const socket = net.connect(10503, '127.0.0.1', () => {
+          socket.write('CONNECT 127.0.0.1:9503 HTTP/1.1\r\nHost: 127.0.0.1:9503\r\n\r\n');
+        });
+        let sawEstablished = false;
+        const timer = setTimeout(() => reject(new Error('no echo')), 5_000);
+        socket.on('data', (chunk) => {
+          const text = chunk.toString();
+          if (!sawEstablished) {
+            if (!text.includes('200')) {
+              clearTimeout(timer);
+              reject(new Error(`expected 200, got: ${text.slice(0, 80)}`));
+              return;
+            }
+            sawEstablished = true;
+            socket.write('cdeb-bytes');
+            return;
+          }
+          clearTimeout(timer);
+          resolve(text);
+          socket.destroy();
+        });
+        socket.on('error', reject);
+      });
+      expect(echoed).toBe('cdeb-bytes');
+    } finally {
+      stop();
+      echo.close();
+    }
+  });
+
+  it('refuses to start with an empty allowlist', async () => {
+    const child = spawn(process.execPath, [proxyScript], {
+      env: { ...process.env, CDEB_ALLOWED_HOSTS: '', CDEB_LISTEN_PORT: '10504' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const exitCode = await new Promise<number | null>((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve(null);
+      }, 5_000);
+      child.on('exit', (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+    });
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The §4.6 probe seam
+// ---------------------------------------------------------------------------
+
+describe('§4.6 probe runtime seam', () => {
+  it('keeps the probe contract through the seam: completed run', () => {
+    const fakeRuntime = {
+      name: 'fake',
+      run: () => ({ stdout: '{"ok":true}', stderr: '', status: 0, timedOut: false }),
+    };
+    const { probe, artifact } = runProbe('/tmp', 'prompt', 'commitlore-on', 1000, 'sonnet', fakeRuntime);
+    expect(probe.stop_reason).toBe('completed');
+    expect(probe.condition).toBe('commitlore-on');
+    expect(probe.model).toBe('sonnet');
+    expect(artifact).toContain('{"ok":true}');
+    expect(probe.artifact_sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('maps a runtime timeout to the timeout stop reason', () => {
+    const fakeRuntime = {
+      name: 'fake',
+      run: () => ({ stdout: '', stderr: '', status: null, timedOut: true }),
+    };
+    const { probe } = runProbe('/tmp', 'prompt', 'commitlore-off', 1000, 'sonnet', fakeRuntime);
+    expect(probe.stop_reason).toBe('timeout');
+  });
+
+  it('maps a nonzero exit to agent_error', () => {
+    const fakeRuntime = {
+      name: 'fake',
+      run: () => ({ stdout: '', stderr: 'boom', status: 1, timedOut: false }),
+    };
+    const { probe } = runProbe('/tmp', 'prompt', 'commitlore-off', 1000, 'sonnet', fakeRuntime);
+    expect(probe.stop_reason).toBe('agent_error');
+  });
+});


### PR DESCRIPTION
CDEB-03. Unblocks CDEB-04 and CDEB-05.

A benchmark whose isolation silently degrades measures a different thing than it reports. All three acceptance properties are **failures**, and each has a test that fails when the property is removed:

```
refuses a failed probe and names the capability and what is missing
refuses a capability that was never probed — absence of evidence is not a pass
refuses a malformed report that probes one capability twice
help without isolation flags fails the capabilities those flags protect
an image whose digest does not match the pin is refused, never retagged
executable drift against the pin is refused naming each drifted field
refuses provider env keys outside the allowlist — a host environment leak path
a HOME that starts non-empty is inheritance, and the gate names it
a mount outside the expected pair is refused naming the mount
```

The second line is the one that matters most. **A capability nobody probed is not a capability that passed** — that is the path by which isolation degrades without anyone noticing, and it is closed by refusal rather than by a default.

## What is enforced by code, and what is not

The commit's `Limit:` splits them: the capability gate refuses a missing or never-probed capability, the run spec cannot express host `HOME` or settings inheritance, and executable drift stops the study. What remains is what the operator has to run correctly.

And its `Warn:` names a gap in this verification rather than hiding it:

> the two socket-level egress proxy tests skip where the sandbox denies listen — run them where binding is allowed before the freeze treats the proxy as tested

**Those two are unverified here.** They should be run on a machine that allows binding before anything relies on the proxy.

## Note on §4.6

`runtime-probe.ts` promised the pinned runtime while spawning the host's `claude`. That gap is what this closes — but the probe's calibration was measured on the old path, and re-pointing it does not carry that calibration forward. The 0.6 threshold's derivation is already marked unverified by #518.

57 cases pass; package and bench typechecks clean; both verifiers pass; `dist` unchanged.
