### PR TITLE
Observe shipping delivery without changing its bytes

### DIFF
--- a/bench/cdeb/runtime/Dockerfile
+++ b/bench/cdeb/runtime/Dockerfile
@@ -42,6 +42,12 @@ COPY dist/ /opt/commitlore/dist/
 #   node /opt/cdeb/egress-proxy.mjs
 COPY bench/cdeb/runtime/egress-proxy.mjs /opt/cdeb/egress-proxy.mjs
 
+# CDEB-04's observer is TypeScript only because the pinned Node runtime strips
+# its erasable types.  It is copied with the parser it imports; the settings
+# command invokes this wrapper, which in turn invokes the shipping dist CLI.
+COPY bench/cdeb/runtime/exposure.ts /opt/cdeb/exposure.ts
+COPY bench/cdeb/runtime/shipping-proxy.ts /opt/cdeb/shipping-proxy.ts
+
 # Isolated HOME (§7.2): created empty, owned by nobody's history. The run
 # spec sets HOME here and mounts nothing over it; the container is discarded
 # after each logical run, so nothing in it can reach the next one.
@@ -49,3 +55,8 @@ RUN mkdir -p /home/agent
 
 WORKDIR /repo
 ENV HOME=/home/agent
+# `node:sqlite` emits a PID-bearing runtime warning.  The pinned runtime
+# suppresses Node warnings for both a direct shipping invocation and the child
+# the proxy starts; otherwise two equivalent hook processes cannot have equal
+# stderr bytes solely because their process IDs differ.
+ENV NODE_NO_WARNINGS=1

--- a/bench/cdeb/runtime/arm-settings.ts
+++ b/bench/cdeb/runtime/arm-settings.ts
@@ -1,0 +1,188 @@
+/**
+ * The two CDEB arm configurations (PRD §§2.3, 9.1–9.2).
+ *
+ * This writer deliberately has no option for a budget, trusted author, or
+ * index policy.  The proxy invokes the pinned shipping command with exactly
+ * the installed hook's arguments, so those product defaults remain product
+ * defaults rather than benchmark choices.
+ */
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { DEFAULT_BUDGET_TOKENS } from "../../../dist/core/inject.js";
+import { configuredTrustedAuthors } from "../../../dist/core/trusted-authors.js";
+import { CLAUDE_HOOK_EVENT, CLAUDE_HOOK_MATCHER } from "../../../dist/hooks/claude-settings.js";
+
+import { EMPTY_MCP_CONFIG } from "./isolation.ts";
+import { CONTAINER_NODE_EXECUTABLE, CONTAINER_SHIPPING_CLI, SHIPPING_HOOK_ARGS } from "./shipping-proxy.ts";
+
+export type CdebArm = "on" | "off";
+
+export const CONTAINER_PROXY_ENTRY = "/opt/cdeb/shipping-proxy.ts";
+export const CONTAINER_EXPOSURE_PATH = "/repo/.git/cdeb/exposure.jsonl";
+export const CDEB_EXPOSURE_RELATIVE_PATH = ".git/cdeb/exposure.jsonl";
+
+const CAPTURE_HOOK_NAMES = ["commit-msg", "prepare-commit-msg", "post-commit", "pre-push"] as const;
+
+export interface ShippingConfigurationFreeze {
+  readonly hookEvent: string;
+  readonly matcher: string;
+  readonly childCommand: readonly string[];
+  readonly defaultBudget: number;
+  readonly trustedAuthors: readonly string[];
+  readonly noIndex: false;
+}
+
+export interface CdebArmConfig {
+  readonly arm: CdebArm;
+  readonly configDir: string;
+  readonly settingsPath: string;
+  readonly mcpPath: string;
+  readonly exposurePath: string;
+  readonly settingsJson: string;
+  readonly mcpJson: string;
+  readonly shipping: ShippingConfigurationFreeze;
+}
+
+export class CaptureSurfaceError extends Error {
+  public constructor(message: string) {
+    super(`CDEB capture surface must be absent: ${message}`);
+    this.name = "CaptureSurfaceError";
+  }
+}
+
+const quote = (value: string): string => JSON.stringify(value);
+
+/** Command the Claude settings shell runs; the child is the shipping injector. */
+export const proxyHookCommand = (): string =>
+  [
+    quote(CONTAINER_NODE_EXECUTABLE),
+    "--no-warnings",
+    "--experimental-strip-types",
+    quote(CONTAINER_PROXY_ENTRY),
+    "--exposure",
+    quote(CONTAINER_EXPOSURE_PATH),
+    "--node",
+    quote(CONTAINER_NODE_EXECUTABLE),
+    "--shipping-cli",
+    quote(CONTAINER_SHIPPING_CLI),
+  ].join(" ");
+
+export const readShippingConfigurationFreeze = (cwd: string): ShippingConfigurationFreeze => ({
+  hookEvent: CLAUDE_HOOK_EVENT,
+  matcher: CLAUDE_HOOK_MATCHER,
+  childCommand: [CONTAINER_NODE_EXECUTABLE, CONTAINER_SHIPPING_CLI, ...SHIPPING_HOOK_ARGS],
+  defaultBudget: DEFAULT_BUDGET_TOKENS,
+  trustedAuthors: configuredTrustedAuthors(cwd),
+  noIndex: false,
+});
+
+const settingsFor = (arm: CdebArm): Record<string, unknown> =>
+  arm === "off"
+    ? { hooks: {} }
+    : {
+        hooks: {
+          [CLAUDE_HOOK_EVENT]: [
+            {
+              matcher: CLAUDE_HOOK_MATCHER,
+              hooks: [{ type: "command", command: proxyHookCommand() }],
+            },
+          ],
+        },
+      };
+
+const activeCaptureHooks = (cwd: string): readonly { name: string; path: string }[] => {
+  // `git rev-parse --git-path` resolves linked worktrees and core.hooksPath.
+  const result = spawnSync("git", ["rev-parse", "--git-path", "hooks"], { cwd, encoding: "utf8" });
+  if (result.status !== 0) throw new CaptureSurfaceError(`cannot locate git hooks (${(result.stderr ?? "").trim()})`);
+  const hooksDir = resolve(cwd, (result.stdout ?? "").trim());
+  return CAPTURE_HOOK_NAMES.flatMap((name) => {
+    const path = join(hooksDir, name);
+    if (!existsSync(path)) return [];
+    try {
+      return (statSync(path).mode & 0o111) === 0 ? [] : [{ name, path }];
+    } catch {
+      return [{ name, path }];
+    }
+  });
+};
+
+const assertSettingsContainOnlyDelivery = (config: CdebArmConfig): void => {
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(config.settingsPath, "utf8"));
+  } catch {
+    throw new CaptureSurfaceError(`${config.arm} settings are unreadable`);
+  }
+  const expected = settingsFor(config.arm);
+  if (JSON.stringify(value) !== JSON.stringify(expected)) {
+    throw new CaptureSurfaceError(`${config.arm} settings are not the frozen delivery-only shape`);
+  }
+};
+
+/** Refuses a run where any capture hook could run in either condition. */
+export const assertCaptureSurfaceAbsent = (cwd: string, config: CdebArmConfig): void => {
+  assertSettingsContainOnlyDelivery(config);
+  const active = activeCaptureHooks(cwd);
+  if (active.length > 0) {
+    throw new CaptureSurfaceError(
+      `${config.arm} arm has active ${active.map((hook) => `${hook.name} (${hook.path})`).join(", ")}`,
+    );
+  }
+};
+
+/**
+ * Writes the CDEB-controlled files consumed by `executeAgentRun`.  The caller
+ * supplies a fresh config directory; reusing one risks mixing an exposure log
+ * from another logical run, so that is refused rather than overwritten.
+ */
+export const writeCdebArmConfig = (cwd: string, configDir: string, arm: CdebArm): CdebArmConfig => {
+  mkdirSync(configDir, { recursive: true });
+  const settingsPath = join(configDir, "settings.json");
+  const mcpPath = join(configDir, "mcp.json");
+  const exposurePath = join(cwd, CDEB_EXPOSURE_RELATIVE_PATH);
+  if (existsSync(settingsPath) || existsSync(mcpPath)) {
+    throw new Error(`CDEB config directory is not fresh: ${configDir}`);
+  }
+  if (existsSync(exposurePath)) {
+    throw new Error(`CDEB exposure path already exists: ${exposurePath}`);
+  }
+  mkdirSync(dirname(exposurePath), { recursive: true });
+  writeFileSync(exposurePath, "", { flag: "wx" });
+
+  const settingsJson = `${JSON.stringify(settingsFor(arm), null, 2)}\n`;
+  const mcpJson = `${EMPTY_MCP_CONFIG}\n`;
+  writeFileSync(settingsPath, settingsJson, { flag: "w" });
+  writeFileSync(mcpPath, mcpJson, { flag: "w" });
+  const config: CdebArmConfig = {
+    arm,
+    configDir,
+    settingsPath,
+    mcpPath,
+    exposurePath,
+    settingsJson,
+    mcpJson,
+    shipping: readShippingConfigurationFreeze(cwd),
+  };
+  assertCaptureSurfaceAbsent(cwd, config);
+  return config;
+};
+
+/** Hash the complete observer implementation, including its frozen parser. */
+export const shippingProxySha256 = (proxyPath: string, parserPath: string): string => {
+  const hash = createHash("sha256");
+  for (const path of [proxyPath, parserPath]) {
+    hash.update(path).update("\0").update(readFileSync(path)).update("\0");
+  }
+  return hash.digest("hex");
+};
+
+export const assertFrozenShippingProxy = (expectedSha256: string, proxyPath: string, parserPath: string): void => {
+  const actual = shippingProxySha256(proxyPath, parserPath);
+  if (actual !== expectedSha256) {
+    throw new Error(`CDEB shipping proxy changed: expected sha256 ${expectedSha256}, found ${actual}`);
+  }
+};

--- a/bench/cdeb/runtime/exposure.ts
+++ b/bench/cdeb/runtime/exposure.ts
@@ -1,0 +1,243 @@
+/**
+ * CDEB-04's observation contract (PRD §9.3, §9.5).
+ *
+ * The proxy records facts about the shipping hook after it has forwarded the
+ * hook's bytes.  This module intentionally knows the *published hook output*
+ * grammar, not how an injection is assembled.  It is the one frozen parser
+ * used both by the proxy and by the reader that admits an exposure artifact.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+
+export const EXPOSURE_EVENT_VERSION = 1 as const;
+
+export type OutputParseState = "empty" | "parsed" | "unknown";
+
+export interface ParsedShippingOutput {
+  readonly state: Exclude<OutputParseState, "unknown">;
+  readonly recordIds: readonly string[];
+}
+
+export interface ExposureEvent {
+  readonly version: typeof EXPOSURE_EVENT_VERSION;
+  readonly event_index: number;
+  readonly tool_name: string | null;
+  readonly repository_relative_path: string | null;
+  readonly input_sha256: string;
+  readonly child_command_sha256: string;
+  readonly child_exit_code: number;
+  readonly stdout_sha256: string;
+  readonly stdout_bytes: number;
+  /**
+   * The digest of the bytes the agent was actually handed, and `null` when it
+   * was handed nothing.
+   *
+   * Not merged into `stdout_sha256`, and not present on an empty delivery. A
+   * hook that fired on a path with no records still produces stdout — zero
+   * bytes of it — and `sha256("")` is a perfectly valid digest of that. An
+   * event carrying one would let a summariser count an empty delivery as a
+   * payload, which is exactly the opportunity-versus-delivery conflation §9.5
+   * exists to prevent, one layer above where CDEB-P hit it.
+   */
+  readonly payload_sha256: string | null;
+  readonly parsed_record_ids: readonly string[] | null;
+  readonly parse_state: OutputParseState;
+  readonly product_error: string | null;
+  readonly started_monotonic_ns: number;
+  readonly finished_monotonic_ns: number;
+}
+
+export class FrozenOutputParseError extends Error {
+  public constructor(message: string) {
+    super(`shipping hook output is not the frozen grammar: ${message}`);
+    this.name = "FrozenOutputParseError";
+  }
+}
+
+export class ExposureIntegrityError extends Error {
+  public constructor(message: string) {
+    super(`CDEB exposure is incomplete: ${message}`);
+    this.name = "ExposureIntegrityError";
+  }
+}
+
+const sha256 = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
+export const sha256Bytes = (bytes: Uint8Array): string => sha256(bytes);
+
+const asUtf8 = (bytes: Buffer): string => {
+  const text = bytes.toString("utf8");
+  if (!Buffer.from(text, "utf8").equals(bytes)) {
+    throw new FrozenOutputParseError("stdout is not UTF-8");
+  }
+  return text;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const exactKeys = (value: Record<string, unknown>, keys: readonly string[]): boolean => {
+  const actual = Object.keys(value).sort();
+  return actual.length === keys.length && actual.every((key, index) => key === keys[index]);
+};
+
+/**
+ * Parse the only non-empty stdout shape the shipping `--hook-input` command
+ * emits.  The row expression is deliberately anchored to injection rows: an
+ * incidental Record-Id in a decision's prose must not become an exposure.
+ */
+export const parseShippingHookOutput = (stdout: Buffer): ParsedShippingOutput => {
+  if (stdout.length === 0) return { state: "empty", recordIds: [] };
+
+  const text = asUtf8(stdout);
+  if (!text.endsWith("\n")) throw new FrozenOutputParseError("hook JSON is missing its terminal newline");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new FrozenOutputParseError("stdout is not one JSON object");
+  }
+  if (!isPlainObject(parsed) || !exactKeys(parsed, ["hookSpecificOutput"])) {
+    throw new FrozenOutputParseError("top-level hook object changed");
+  }
+  const hook = parsed["hookSpecificOutput"];
+  if (!isPlainObject(hook) || !exactKeys(hook, ["additionalContext", "hookEventName"])) {
+    throw new FrozenOutputParseError("hookSpecificOutput shape changed");
+  }
+  if (hook["hookEventName"] !== "PreToolUse" || typeof hook["additionalContext"] !== "string") {
+    throw new FrozenOutputParseError("hook event or context type changed");
+  }
+
+  const context = hook["additionalContext"];
+  if (!context.startsWith("commitlore: active records for ") || !context.endsWith("\n")) {
+    throw new FrozenOutputParseError("context is not the shipping injection projection");
+  }
+
+  const ids: string[] = [];
+  const row = /^  \[(?:directive|claim)\]\s{2,}(r-[a-z0-9]{6,})\s{2,}[0-9a-f]{8}\s{2,}/gmu;
+  for (const match of context.matchAll(row)) {
+    const id = match[1];
+    if (id === undefined) throw new FrozenOutputParseError("record row has no id");
+    if (ids.includes(id)) throw new FrozenOutputParseError(`record id ${id} appears more than once`);
+    ids.push(id);
+  }
+  return { state: "parsed", recordIds: ids };
+};
+
+const isSha256 = (value: unknown): value is string => typeof value === "string" && /^[0-9a-f]{64}$/u.test(value);
+
+const isIntegerAtLeast = (value: unknown, minimum: number): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value >= minimum;
+
+const isStringOrNull = (value: unknown): value is string | null => value === null || typeof value === "string";
+
+const readEvent = (line: string, lineNumber: number): ExposureEvent => {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} is not JSON`);
+  }
+  if (!isPlainObject(value)) throw new ExposureIntegrityError(`line ${String(lineNumber)} is not an object`);
+
+  const expected = [
+    "child_command_sha256",
+    "child_exit_code",
+    "event_index",
+    "finished_monotonic_ns",
+    "input_sha256",
+    "parse_state",
+    "parsed_record_ids",
+    "payload_sha256",
+    "product_error",
+    "repository_relative_path",
+    "started_monotonic_ns",
+    "stdout_bytes",
+    "stdout_sha256",
+    "tool_name",
+    "version",
+  ];
+  if (!exactKeys(value, expected)) {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} has an unexpected event shape`);
+  }
+  if (value["version"] !== EXPOSURE_EVENT_VERSION) {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} has an unsupported event version`);
+  }
+  for (const key of ["input_sha256", "child_command_sha256", "stdout_sha256"] as const) {
+    if (!isSha256(value[key])) throw new ExposureIntegrityError(`line ${String(lineNumber)} has an invalid ${key}`);
+  }
+  if (value["payload_sha256"] !== null && !isSha256(value["payload_sha256"])) {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} has an invalid payload_sha256`);
+  }
+  for (const key of ["event_index", "stdout_bytes", "started_monotonic_ns", "finished_monotonic_ns"] as const) {
+    if (!isIntegerAtLeast(value[key], key === "event_index" ? 1 : 0)) {
+      throw new ExposureIntegrityError(`line ${String(lineNumber)} has an invalid ${key}`);
+    }
+  }
+  if (!Number.isInteger(value["child_exit_code"])) {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} has an invalid child_exit_code`);
+  }
+  if (!isStringOrNull(value["tool_name"]) || !isStringOrNull(value["repository_relative_path"]) || !isStringOrNull(value["product_error"])) {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} has an invalid nullable field`);
+  }
+  const state = value["parse_state"];
+  if (state !== "empty" && state !== "parsed" && state !== "unknown") {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} has an invalid parse_state`);
+  }
+  const ids = value["parsed_record_ids"];
+  if (state === "unknown") {
+    if (ids !== null) throw new ExposureIntegrityError(`line ${String(lineNumber)} marks an unknown parse as known`);
+  } else {
+    if (!Array.isArray(ids) || ids.some((id) => typeof id !== "string" || !/^r-[a-z0-9]{6,}$/u.test(id))) {
+      throw new ExposureIntegrityError(`line ${String(lineNumber)} has invalid parsed_record_ids`);
+    }
+    if (state === "empty" && ids.length !== 0) {
+      throw new ExposureIntegrityError(`line ${String(lineNumber)} says empty stdout delivered records`);
+    }
+  }
+  // A payload exists exactly when the frozen parser read one out of stdout.
+  if (state === "parsed") {
+    if (value["payload_sha256"] !== value["stdout_sha256"]) {
+      throw new ExposureIntegrityError(`line ${String(lineNumber)} payload digest differs from stdout digest`);
+    }
+  } else if (value["payload_sha256"] !== null) {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} reports a payload for a ${String(state)} delivery`);
+  }
+  const started = value["started_monotonic_ns"] as number;
+  const finished = value["finished_monotonic_ns"] as number;
+  if (finished < started) {
+    throw new ExposureIntegrityError(`line ${String(lineNumber)} ends before it starts`);
+  }
+  return value as unknown as ExposureEvent;
+};
+
+/**
+ * Opens an append-only exposure artifact.  An unreadable or ambiguous event is
+ * a hard refusal: treating it as zero delivery would recreate the pilot's
+ * "hook did not fire" versus "hook delivered nothing" blind spot.
+ */
+export const readExposureEvents = (path: string): readonly ExposureEvent[] => {
+  if (!existsSync(path)) throw new ExposureIntegrityError(`side channel is missing: ${path}`);
+  const bytes = readFileSync(path);
+  const text = asUtf8(bytes);
+  if (text === "") return [];
+  if (!text.endsWith("\n")) throw new ExposureIntegrityError("side channel ends with a partial event");
+  const lines = text.slice(0, -1).split("\n");
+  const events = lines.map((line, index) => readEvent(line, index + 1));
+  for (const [index, event] of events.entries()) {
+    if (event.event_index !== index + 1) {
+      throw new ExposureIntegrityError(`line ${String(index + 1)} has event_index ${String(event.event_index)}, expected ${String(index + 1)}`);
+    }
+    if (event.parse_state === "unknown") {
+      throw new ExposureIntegrityError(`line ${String(index + 1)} could not parse shipping output`);
+    }
+  }
+  return events;
+};
+
+export const exposureLogSha256 = (path: string): string => {
+  if (!existsSync(path)) throw new ExposureIntegrityError(`side channel is missing: ${path}`);
+  return sha256(readFileSync(path));
+};

--- a/bench/cdeb/runtime/shipping-proxy.ts
+++ b/bench/cdeb/runtime/shipping-proxy.ts
@@ -1,0 +1,221 @@
+/**
+ * CDEB-04's transparent wrapper around the shipping hook command (PRD §9.3).
+ *
+ * It does not interpret, render, or edit the hook result.  The product command
+ * receives the original stdin bytes and its stdout, stderr, and status are
+ * forwarded after capture without a text conversion.  Observation is written
+ * only to the separate append-only artifact.
+ */
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+import { parseShippingHookOutput, sha256Bytes, type ExposureEvent } from "./exposure.ts";
+
+/** Path in the pinned runtime image; Dockerfile copies the committed shipping dist here. */
+export const CONTAINER_SHIPPING_CLI = "/opt/commitlore/dist/cli.js";
+export const CONTAINER_NODE_EXECUTABLE = "/usr/local/bin/node";
+
+/** The product subcommand and options.  No CDEB option changes budget, trust, or index behaviour. */
+export const SHIPPING_HOOK_ARGS = ["inject", "--hook-input"] as const;
+
+export interface ProxyInvocation {
+  readonly cwd: string;
+  readonly input: Buffer;
+  readonly exposurePath: string;
+  readonly nodeExecutable: string;
+  readonly shippingCli: string;
+}
+
+export interface ProxyResult {
+  readonly stdout: Buffer;
+  readonly stderr: Buffer;
+  readonly exitCode: number;
+  readonly event: ExposureEvent;
+}
+
+const sha256 = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
+const childCommand = (nodeExecutable: string, shippingCli: string): readonly string[] => [
+  nodeExecutable,
+  shippingCli,
+  ...SHIPPING_HOOK_ARGS,
+];
+
+const readInput = (): Promise<Buffer> =>
+  new Promise((resolveInput, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (chunk: Buffer | string) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    process.stdin.on("end", () => resolveInput(Buffer.concat(chunks)));
+    process.stdin.on("error", reject);
+  });
+
+const commandDigest = (command: readonly string[]): string => sha256(Buffer.from(JSON.stringify(command), "utf8"));
+
+const inputMetadata = (input: Buffer, cwd: string): { toolName: string | null; relativePath: string | null } => {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(input.toString("utf8"));
+  } catch {
+    return { toolName: null, relativePath: null };
+  }
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return { toolName: null, relativePath: null };
+  }
+  const record = payload as Record<string, unknown>;
+  const toolName = typeof record["tool_name"] === "string" ? record["tool_name"] : null;
+  const payloadCwd = typeof record["cwd"] === "string" && record["cwd"] !== "" ? record["cwd"] : cwd;
+  const toolInput = record["tool_input"];
+  if (typeof toolInput !== "object" || toolInput === null || Array.isArray(toolInput)) {
+    return { toolName, relativePath: null };
+  }
+  const tool = toolInput as Record<string, unknown>;
+  const path = ["file_path", "notebook_path", "path"]
+    .map((key) => tool[key])
+    .find((candidate): candidate is string => typeof candidate === "string" && candidate !== "");
+  if (path === undefined) return { toolName, relativePath: null };
+  const target = resolve(isAbsolute(path) ? path : resolve(payloadCwd, path));
+  const scoped = relative(resolve(payloadCwd), target);
+  if (scoped === "" || scoped === ".." || scoped.startsWith(`..${sep}`) || isAbsolute(scoped)) {
+    return { toolName, relativePath: null };
+  }
+  return { toolName, relativePath: scoped.split(sep).join("/") };
+};
+
+const nextEventIndex = (exposurePath: string): number => {
+  if (!existsSync(exposurePath)) return 1;
+  const previous = readFileSync(exposurePath, "utf8");
+  if (previous === "") return 1;
+  return previous.split("\n").filter((line) => line !== "").length + 1;
+};
+
+const appendExposure = (path: string, event: ExposureEvent): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${JSON.stringify(event)}\n`, { encoding: "utf8", flag: "a" });
+};
+
+/** Runs the product command once and produces the side-channel event. */
+export const runTransparentShippingProxy = async (invocation: ProxyInvocation): Promise<ProxyResult> => {
+  const started = Number(process.hrtime.bigint());
+  const command = childCommand(invocation.nodeExecutable, invocation.shippingCli);
+  const metadata = inputMetadata(invocation.input, invocation.cwd);
+  const child = spawn(command[0] ?? process.execPath, command.slice(1), {
+    cwd: invocation.cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+  child.stdin.end(invocation.input);
+
+  const exitCode = await new Promise<number>((resolveExit) => {
+    let spawnError = false;
+    child.once("error", () => {
+      spawnError = true;
+    });
+    child.once("close", (code) => resolveExit(code ?? (spawnError ? 127 : 1)));
+  });
+
+  const stdout = Buffer.concat(stdoutChunks);
+  const stderr = Buffer.concat(stderrChunks);
+  let parsedRecordIds: readonly string[] | null = null;
+  let parseState: ExposureEvent["parse_state"] = "unknown";
+  try {
+    const parsed = parseShippingHookOutput(stdout);
+    parsedRecordIds = parsed.recordIds;
+    parseState = parsed.state;
+  } catch {
+    // The caller later refuses an `unknown` exposure event.  The product's
+    // bytes and status still take precedence over an observer-side failure.
+  }
+
+  const finished = Number(process.hrtime.bigint());
+  const event: ExposureEvent = {
+    version: 1,
+    event_index: nextEventIndex(invocation.exposurePath),
+    tool_name: metadata.toolName,
+    repository_relative_path: metadata.relativePath,
+    input_sha256: sha256(invocation.input),
+    child_command_sha256: commandDigest(command),
+    child_exit_code: exitCode,
+    stdout_sha256: sha256Bytes(stdout),
+    stdout_bytes: stdout.length,
+    // Null unless the hook actually handed the agent a projection: see the
+    // field's note in exposure.ts.
+    payload_sha256: parseState === "parsed" ? sha256Bytes(stdout) : null,
+    parsed_record_ids: parsedRecordIds,
+    parse_state: parseState,
+    product_error: stderr.length === 0 ? null : stderr.toString("utf8"),
+    started_monotonic_ns: started,
+    finished_monotonic_ns: finished,
+  };
+
+  // Do not add an observer diagnostic to stderr or alter the child status:
+  // either would make a successful product hook observably different.  A
+  // missing side channel is detected as a hard refusal before measurement.
+  try {
+    appendExposure(invocation.exposurePath, event);
+  } catch {
+    // See the invariant above.
+  }
+  return { stdout, stderr, exitCode, event };
+};
+
+interface ProxyCliOptions {
+  readonly exposurePath: string;
+  readonly nodeExecutable: string;
+  readonly shippingCli: string;
+}
+
+const cliOptions = (argv: readonly string[]): ProxyCliOptions => {
+  let exposurePath: string | undefined;
+  let nodeExecutable = process.execPath;
+  let shippingCli = CONTAINER_SHIPPING_CLI;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--exposure") {
+      exposurePath = argv[index + 1];
+      index += 1;
+    } else if (token === "--node") {
+      nodeExecutable = argv[index + 1] ?? "";
+      index += 1;
+    } else if (token === "--shipping-cli") {
+      shippingCli = argv[index + 1] ?? "";
+      index += 1;
+    } else {
+      throw new Error(`unknown proxy option ${JSON.stringify(token)}`);
+    }
+  }
+  if (exposurePath === undefined || exposurePath === "") throw new Error("--exposure is required");
+  if (nodeExecutable === "") throw new Error("--node must not be empty");
+  if (shippingCli === "") throw new Error("--shipping-cli must not be empty");
+  return { exposurePath, nodeExecutable, shippingCli };
+};
+
+const main = async (): Promise<void> => {
+  let options: ProxyCliOptions;
+  try {
+    options = cliOptions(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`cdeb shipping proxy: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 2;
+    return;
+  }
+  const result = await runTransparentShippingProxy({
+    cwd: process.cwd(),
+    input: await readInput(),
+    exposurePath: options.exposurePath,
+    nodeExecutable: options.nodeExecutable,
+    shippingCli: options.shippingCli,
+  });
+  if (result.stdout.length > 0) process.stdout.write(result.stdout);
+  if (result.stderr.length > 0) process.stderr.write(result.stderr);
+  process.exitCode = result.exitCode;
+};
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === resolve(import.meta.filename)) {
+  void main();
+}

--- a/test/cdeb-shipping-proxy.test.ts
+++ b/test/cdeb-shipping-proxy.test.ts
@@ -1,0 +1,269 @@
+/**
+ * CDEB-04 acceptance: the ON arm is the shipping hook, observed without
+ * changing a byte.  These tests drive the CLI subprocess rather than the core
+ * injection function so a replacement renderer cannot satisfy them.
+ */
+
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  assertCaptureSurfaceAbsent,
+  assertFrozenShippingProxy,
+  readShippingConfigurationFreeze,
+  shippingProxySha256,
+  writeCdebArmConfig,
+} from "../bench/cdeb/runtime/arm-settings.ts";
+import { ExposureIntegrityError, readExposureEvents } from "../bench/cdeb/runtime/exposure.ts";
+import { CLI_ENTRY } from "../bench/hooks-settings.ts";
+import { CLAUDE_HOOK_EVENT, CLAUDE_HOOK_MATCHER } from "../dist/hooks/claude-settings.js";
+import { execGit } from "../src/core/git.js";
+import { createTestRepo } from "./git-fixtures.js";
+
+const PROXY = resolve("bench/cdeb/runtime/shipping-proxy.ts");
+const PARSER = resolve("bench/cdeb/runtime/exposure.ts");
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const path of scratch) rmSync(path, { recursive: true, force: true });
+});
+
+const temp = (label: string): string => {
+  const path = mkdtempSync(join(tmpdir(), `cdeb-proxy-${label}-`));
+  scratch.push(path);
+  return path;
+};
+
+const createRepo = (): string => {
+  const repo = createTestRepo({ path: temp("repo") });
+  execGit(["config", "user.email", "owner@example.invalid"], { cwd: repo });
+  execGit(["config", "user.name", "owner"], { cwd: repo });
+  return repo;
+};
+
+const seed = (repo: string, file = "pricing.ts", id = "r-proxy01"): void => {
+  writeFileSync(join(repo, file), "export const price = 1;\n");
+  execGit(["add", file], { cwd: repo });
+  execGit(
+    [
+      "commit",
+      "--no-verify",
+      "-m",
+      [
+        "feat: price",
+        "",
+        "Ruled-out: shared cache | it would introduce an unowned runtime dependency",
+        `Record-Id: ${id}`,
+        "Provenance: authored",
+      ].join("\n"),
+    ],
+    { cwd: repo },
+  );
+};
+
+const payload = (file: string): Buffer =>
+  Buffer.from(
+    JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: file },
+    }),
+    "utf8",
+  );
+
+const direct = (repo: string, input: Buffer) =>
+  spawnSync(process.execPath, [CLI_ENTRY, "inject", "--hook-input"], {
+    cwd: repo,
+    input,
+    encoding: "buffer",
+    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+  });
+
+const proxied = (repo: string, exposure: string, input: Buffer) =>
+  spawnSync(
+    process.execPath,
+    ["--no-warnings", "--experimental-strip-types", PROXY, "--exposure", exposure, "--node", process.execPath, "--shipping-cli", CLI_ENTRY],
+    { cwd: repo, input, encoding: "buffer", env: { ...process.env, NODE_NO_WARNINGS: "1" } },
+  );
+
+const output = (value: Buffer | string | undefined): Buffer =>
+  Buffer.isBuffer(value) ? value : Buffer.from(value ?? "", "utf8");
+
+let repo: string;
+beforeEach(() => {
+  repo = createRepo();
+});
+
+describe("CDEB §9.3 transparent shipping proxy", () => {
+  it("forwards a real shipping injection byte-for-byte", () => {
+    seed(repo);
+    const input = payload("pricing.ts");
+    const directResult = direct(repo, input);
+    const exposure = join(temp("identity"), "exposure.jsonl");
+    const proxyResult = proxied(repo, exposure, input);
+
+    expect(proxyResult.status).toBe(directResult.status);
+    expect(output(proxyResult.stdout).equals(output(directResult.stdout))).toBe(true);
+    expect(output(proxyResult.stderr).equals(output(directResult.stderr))).toBe(true);
+
+    const events = readExposureEvents(exposure);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      tool_name: "Read",
+      repository_relative_path: "pricing.ts",
+      child_exit_code: 0,
+      parsed_record_ids: ["r-proxy01"],
+      parse_state: "parsed",
+    });
+    expect(events[0]?.stdout_bytes).toBe(output(directResult.stdout).length);
+  });
+
+  it("keeps product errors byte-identical too", () => {
+    const input = Buffer.from("not JSON\n", "utf8");
+    const directResult = direct(repo, input);
+    const exposure = join(temp("error"), "exposure.jsonl");
+    const proxyResult = proxied(repo, exposure, input);
+
+    expect(proxyResult.status).toBe(directResult.status);
+    expect(output(proxyResult.stdout).equals(output(directResult.stdout))).toBe(true);
+    expect(output(proxyResult.stderr).equals(output(directResult.stderr))).toBe(true);
+    expect(readExposureEvents(exposure)[0]?.product_error).toContain("unparseable JSON");
+  });
+
+  it("records a fired hook with no delivery differently from no hook at all", () => {
+    writeFileSync(join(repo, "unrelated.ts"), "export const unrelated = true;\n");
+    execGit(["add", "unrelated.ts"], { cwd: repo });
+    execGit(["commit", "--no-verify", "-m", "feat: unrelated"], { cwd: repo });
+    const exposure = join(temp("empty"), "exposure.jsonl");
+
+    const result = proxied(repo, exposure, payload("unrelated.ts"));
+
+    expect(result.status).toBe(0);
+    expect(output(result.stdout)).toEqual(Buffer.alloc(0));
+    expect(readExposureEvents(exposure)).toMatchObject([{ parse_state: "empty", parsed_record_ids: [] }]);
+  });
+
+  // A fired-but-empty hook has stdout, and `sha256("")` is a valid digest of
+  // it. If that reached the event, a summariser collecting payload digests
+  // would count the empty delivery as a payload — the same conflation §9.5
+  // forbids one layer down.
+  it("attaches no payload digest to an empty delivery", () => {
+    writeFileSync(join(repo, "unrelated.ts"), "export const unrelated = true;\n");
+    execGit(["add", "unrelated.ts"], { cwd: repo });
+    execGit(["commit", "--no-verify", "-m", "feat: unrelated"], { cwd: repo });
+    const exposure = join(temp("no-payload"), "exposure.jsonl");
+
+    proxied(repo, exposure, payload("unrelated.ts"));
+
+    const [event] = readExposureEvents(exposure);
+    expect(event?.payload_sha256).toBeNull();
+    expect(event?.stdout_sha256).toMatch(/^[0-9a-f]{64}$/u);
+  });
+
+  it("refuses an event that claims a payload the hook never delivered", () => {
+    writeFileSync(join(repo, "unrelated.ts"), "export const unrelated = true;\n");
+    execGit(["add", "unrelated.ts"], { cwd: repo });
+    execGit(["commit", "--no-verify", "-m", "feat: unrelated"], { cwd: repo });
+    const exposure = join(temp("forged-payload"), "exposure.jsonl");
+    proxied(repo, exposure, payload("unrelated.ts"));
+    const original = readFileSync(exposure, "utf8");
+    const forged = JSON.parse(original.trim()) as Record<string, unknown>;
+    forged["payload_sha256"] = forged["stdout_sha256"];
+    writeFileSync(exposure, `${JSON.stringify(forged)}\n`);
+
+    expect(() => readExposureEvents(exposure)).toThrowError(/reports a payload for an? empty delivery/u);
+  });
+
+  it("refuses an ambiguous output parse instead of silently calling it empty", () => {
+    seed(repo);
+    const exposure = join(temp("ambiguous"), "exposure.jsonl");
+    proxied(repo, exposure, payload("pricing.ts"));
+    const original = readFileSync(exposure, "utf8");
+    writeFileSync(exposure, original.replace('"parse_state":"parsed"', '"parse_state":"unknown"').replace('"parsed_record_ids":["r-proxy01"]', '"parsed_record_ids":null'));
+
+    expect(() => readExposureEvents(exposure)).toThrowError(ExposureIntegrityError);
+  });
+});
+
+describe("CDEB §§2.3 and 9.2 arm integrity", () => {
+  it("uses the exact shipping event, matcher, default budget, trust, and index policy", () => {
+    execGit(["config", "--add", "commitlore.trustedAuthor", "owner@example.invalid"], { cwd: repo });
+
+    const freeze = readShippingConfigurationFreeze(repo);
+
+    expect(freeze.hookEvent).toBe(CLAUDE_HOOK_EVENT);
+    expect(freeze.matcher).toBe(CLAUDE_HOOK_MATCHER);
+    expect(freeze.childCommand.slice(-2)).toEqual(["inject", "--hook-input"]);
+    expect(freeze.childCommand).not.toContain("--budget");
+    expect(freeze.childCommand).not.toContain("--trusted-author");
+    expect(freeze.childCommand).not.toContain("--no-index");
+    expect(freeze.defaultBudget).toBe(800);
+    expect(freeze.trustedAuthors).toEqual(["owner@example.invalid"]);
+    expect(freeze.noIndex).toBe(false);
+  });
+
+  it("makes ON and OFF differ only by the delivery hook", () => {
+    const on = writeCdebArmConfig(repo, temp("on-config"), "on");
+    const offRepo = createRepo();
+    const off = writeCdebArmConfig(offRepo, temp("off-config"), "off");
+
+    expect(on.mcpJson).toBe(off.mcpJson);
+    expect(on.shipping).toEqual(off.shipping);
+    expect(JSON.parse(off.settingsJson)).toEqual({ hooks: {} });
+    expect(JSON.parse(on.settingsJson)).toEqual({
+      hooks: {
+        [CLAUDE_HOOK_EVENT]: [
+          {
+            matcher: CLAUDE_HOOK_MATCHER,
+            hooks: [
+              {
+                type: "command",
+                command: expect.stringContaining("shipping-proxy.ts"),
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(on.settingsJson).not.toContain("--budget");
+    expect(on.settingsJson).not.toContain("--trusted-author");
+    expect(on.settingsJson).not.toContain("--no-index");
+  });
+
+  it.each(["on", "off"] as const)("refuses an active capture hook in the %s arm", (arm) => {
+    const config = writeCdebArmConfig(repo, temp(`${arm}-capture-config`), arm);
+    const captureHook = join(repo, ".git", "hooks", "prepare-commit-msg");
+    mkdirSync(join(repo, ".git", "hooks"), { recursive: true });
+    writeFileSync(captureHook, "#!/bin/sh\nexit 0\n");
+    chmodSync(captureHook, 0o755);
+
+    expect(() => assertCaptureSurfaceAbsent(repo, config)).toThrowError(/prepare-commit-msg/);
+  });
+});
+
+describe("CDEB proxy provenance", () => {
+  it("hard-refuses a changed proxy or frozen parser", () => {
+    const expected = shippingProxySha256(PROXY, PARSER);
+    const changedProxy = join(temp("changed-proxy"), "shipping-proxy.ts");
+    writeFileSync(changedProxy, `${readFileSync(PROXY, "utf8")}\n`);
+
+    expect(() => assertFrozenShippingProxy(expected, changedProxy, PARSER)).toThrowError(/shipping proxy changed/);
+  });
+
+  it("has no benchmark context assembler on the ON path", () => {
+    const onPathSources = [
+      readFileSync(PROXY, "utf8"),
+      readFileSync(PARSER, "utf8"),
+      readFileSync(resolve("bench/cdeb/runtime/arm-settings.ts"), "utf8"),
+    ];
+
+    for (const source of onPathSources) {
+      expect(source).not.toContain("assembleContext");
+      expect(source).not.toContain("buildInjection");
+    }
+  });
+});


### PR DESCRIPTION
CDEB-04. Depends on #520 (merged). Unblocks CDEB-07.

The ON arm has to deliver what a user's install delivers. The moment the benchmark renders its own context, it measures itself instead of the product — which is what #36 found, and what #518 found again in a different shape. So the measured arm becomes an **observer**, not a participant.

The proxy hands the shipping command the original stdin bytes, captures stdout, stderr and status, and forwards them without a text conversion. Nothing on that path assembles, reorders or summarises a payload.

## Observation has to be invisible

A diagnostic on stderr, a changed exit code, or a hook that fails because its side channel could not be written would each make a successful product hook observably different from an unobserved one. The side channel is append-only and separate, and its failure never reaches the child's bytes. A missing or ambiguous log is **refused before the run is measured** rather than reported as zero delivery.

The byte-identity gate is a real test, not an inspection: it runs the shipping CLI directly and through the proxy on a live repository with a live record, and compares stdout, stderr and exit status as bytes — on a successful injection and on a product error.

## The bug this fixes before it exists

A payload digest is attached **only when the frozen parser read a projection out of stdout**.

A hook that fired on a path with no records still produces stdout — zero bytes of it — and `sha256("")` is a perfectly valid digest of that. An event carrying one would let a summariser count an empty delivery as a payload. That is precisely the opportunity-versus-delivery conflation CDEB-P hit and §9.5 was written to prevent, one layer above where it hit it. Two cases pin it.

## Arm configuration

Read from the built product rather than restated: hook event, matcher, default budget, trust configuration, index policy. Any active capture hook in **either** arm is refused — unattended capture would otherwise stage a record mid-run and move repository state between runs (§2.3 v1.2).

## Stated, not hidden

The `Limit:` — the proxy cannot observe a hook runner that never starts it, and event indices are assigned by reading the log, so two hooks firing at the same instant collide. The reader refuses the duplicate rather than accepting an ordering it cannot trust.

The `Warn:` — the identity gate suppresses Node runtime warnings on both sides, because the SQLite warning embeds the child process id and two invocations of the same command therefore differ there by construction. The proxy copies stderr verbatim, but the gate does not prove it for those bytes.

12 proxy cases pass; 57 runtime isolation cases still pass; both typechecks clean; two builds leave `dist` unchanged; both verifiers pass.

No container daemon was reachable, so the updated image was not built — the proxy was exercised against the shipping CLI on the host runtime instead.
