### PR TITLE
Make CDEB token accounting fail closed

### DIFF
--- a/bench/cdeb/PRD.md
+++ b/bench/cdeb/PRD.md
@@ -1207,6 +1207,8 @@ Behavioral outcome은 유효하지만 terminal provider usage가 복구 불가�
 - token-efficiency claim은 NOT MEASURABLE
 - token을 0으로 두거나 추정하지 않음
 - 해당 run을 token denominator에서 제거하지 않음
+- canonical row의 `usage`는 `availability: "unavailable"`와 gap reason만 기록하며,
+  raw category나 `total_token_volume` field를 함께 기록하지 않음
 
 Graceful timeout path는 terminal usage를 얻도록 구현하고 fault-injection test를 통과해야 한다.
 
@@ -1668,6 +1670,7 @@ runs/<logical-run-id>/
   },
 
   "usage": {
+    "availability": "measured",
     "input_tokens": 12000,
     "output_tokens": 4100,
     "cache_creation_input_tokens": 5000,

--- a/bench/cdeb/runtime/agent-container.ts
+++ b/bench/cdeb/runtime/agent-container.ts
@@ -45,6 +45,7 @@ import {
   toolPolicyDigest,
   verifyStreamIdentity,
 } from "./isolation.ts";
+import { persistRawNdjson, readProviderLedger, type ProviderLedger } from "./provider-ledger.ts";
 import type { ProbeRuntime, ProbeRunParams, ProbeRunResult } from "../freeze/runtime-probe.ts";
 
 // ---------------------------------------------------------------------------
@@ -1035,11 +1036,15 @@ export interface AgentRunParams {
 
 export interface AgentRunOutcome {
   readonly exit_code: number | null;
+  /** Compressed raw NDJSON artifact (`provider.ndjson.zst`), never rewritten. */
   readonly provider_stream_path: string;
+  /** SHA-256 of the uncompressed, byte-exact NDJSON stream. */
   readonly provider_stream_sha256: string;
   readonly stderr: string;
   readonly timed_out: boolean;
   readonly identity: StreamIdentity;
+  /** Complete reconciled usage or an explicit unavailable state (§14.6). */
+  readonly ledger: ProviderLedger;
 }
 
 /**
@@ -1048,9 +1053,12 @@ export interface AgentRunOutcome {
  * authorizes nothing here — and the stream the run produces is identity-
  * checked before anything downstream may read it as measurement.
  *
- * The raw NDJSON lands byte-for-byte in `<outDir>/provider.ndjson`; CDEB-05
- * owns parsing it into a ledger. This function owns that the bytes exist, are
- * hashed, and came from the model that was pinned.
+ * Stdout first lands in a short-lived raw sink so no bytes pass through a
+ * string transform. CDEB-05 then persists it byte-exactly as
+ * `<outDir>/provider.ndjson.zst`, records the raw digest, and returns either a
+ * reconciled ledger or an explicit unavailable state. A timeout is not an
+ * excuse to synthesize a total: when SIGTERM lets the CLI emit terminal usage,
+ * the parser uses it; when it does not, the outcome says unavailable.
  */
 export const executeAgentRun = async (
   docker: ContainerRuntimeCommands,
@@ -1112,11 +1120,14 @@ export const executeAgentRun = async (
     else sink.on("close", () => resolve());
   });
 
-  // The bytes are hashed after the run, exactly as captured: nothing touches
-  // the stream between the container's stdout and this file.
+  // The sink is binary and CDEB-05 persists the exact bytes before any parser
+  // sees text. A malformed stream stays inspectable even if identity checking
+  // subsequently refuses its run.
   const streamBytes = readFileSync(streamPath);
+  const artifact = persistRawNdjson(params.outDir, streamBytes);
+  rmSync(streamPath, { force: true });
+  const ledger = readProviderLedger({ requested_model: pin.requested_model, raw_ndjson: streamBytes });
   const streamText = streamBytes.toString("utf8");
-  const providerStreamSha256 = createHash("sha256").update(streamBytes).digest("hex");
   const identity = verifyStreamIdentity(streamText, {
     expected_observed_model: pin.expected_observed_model ?? "",
     agent_cli_version: pin.agent_cli_version ?? "",
@@ -1126,11 +1137,12 @@ export const executeAgentRun = async (
 
   return {
     exit_code: result.exitCode,
-    provider_stream_path: streamPath,
-    provider_stream_sha256: providerStreamSha256,
+    provider_stream_path: artifact.compressed_path,
+    provider_stream_sha256: artifact.raw_stream_sha256,
     stderr: result.stderr,
     timed_out: result.timedOut,
     identity,
+    ledger,
   };
 };
 
@@ -1218,4 +1230,3 @@ export const pinnedProbeRuntime = (
   };
   return { name: "pinned-container", run };
 };
-

--- a/bench/cdeb/runtime/provider-ledger.ts
+++ b/bench/cdeb/runtime/provider-ledger.ts
@@ -1,0 +1,516 @@
+/**
+ * CDEB-05 provider usage ledger (PRD §14, §19.1).
+ *
+ * The raw provider stream is evidence, not a source from which a convenient
+ * number may be inferred. This module therefore has only two token states:
+ *
+ *   - `measured`: every NDJSON segment parsed, every turn has final usage, the
+ *     terminal usage object exists, and the two totals reconcile exactly.
+ *   - `unavailable`: any one of those facts is missing, malformed, truncated,
+ *     delegated, or inconsistent. It deliberately contains no token total.
+ *
+ * A caller cannot turn an unavailable run into a smaller aggregate by omitting
+ * it: `aggregateTokenVolume` propagates the gap. The exact bytes are stored as
+ * `provider.ndjson.zst` plus the raw-byte digest the canonical row records.
+ */
+
+import { closeSync, existsSync, fsyncSync, openSync, readFileSync, renameSync, unlinkSync, writeSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { TextDecoder } from "node:util";
+import { zstdCompressSync, zstdDecompressSync } from "node:zlib";
+
+export interface TokenUsage {
+  readonly input_tokens: number;
+  readonly output_tokens: number;
+  readonly cache_creation_input_tokens: number;
+  readonly cache_read_input_tokens: number;
+}
+
+export const TOKEN_USAGE_FIELDS = [
+  "input_tokens",
+  "output_tokens",
+  "cache_creation_input_tokens",
+  "cache_read_input_tokens",
+] as const;
+
+export type LedgerGap =
+  | "invalid_utf8"
+  | "unparsed_stream"
+  | "malformed_turn"
+  | "turn_usage_missing"
+  | "incomplete_turn"
+  | "terminal_usage_absent"
+  | "terminal_usage_ambiguous"
+  | "terminal_usage_invalid"
+  | "turn_session_mismatch"
+  | "token_total_overflow"
+  | "model_observation_absent"
+  | "subagent_turn";
+
+export interface MeasuredUsage extends TokenUsage {
+  readonly availability: "measured";
+  readonly total_token_volume: number;
+  readonly reconciled: true;
+  readonly unparsed_lines: 0;
+  readonly raw_stream_sha256: string;
+}
+
+/**
+ * Numeric usage is purposefully absent here. A partial total is a tempting
+ * thing for a future caller to sum, so the type makes that impossible.
+ */
+export interface UnavailableUsage {
+  readonly availability: "unavailable";
+  readonly reasons: readonly LedgerGap[];
+  readonly unparsed_lines: number;
+  readonly raw_stream_sha256: string;
+}
+
+export type ProviderUsage = MeasuredUsage | UnavailableUsage;
+
+export type SingleAgentMeasurement =
+  | { readonly status: "eligible" }
+  | { readonly status: "excluded"; readonly reason: "subagent_turn"; readonly delegated_event_count: number };
+
+export interface ProviderLedger {
+  readonly requested_model: string;
+  /** Exact IDs from `message_start`, never an alias copied from the request. */
+  readonly observed_model_ids: readonly string[];
+  readonly single_agent_measurement: SingleAgentMeasurement;
+  readonly turn_count: number;
+  readonly raw_byte_length: number;
+  readonly usage: ProviderUsage;
+}
+
+export interface ProviderLedgerInput {
+  readonly requested_model: string;
+  /** The preserved stream bytes, or a UTF-8 string only for replay tests. */
+  readonly raw_ndjson: Uint8Array | string;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+const sha256 = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
+const rawBytes = (raw: Uint8Array | string): Buffer =>
+  typeof raw === "string" ? Buffer.from(raw, "utf8") : Buffer.from(raw);
+
+const isTokenCount = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+
+const readUsage = (raw: unknown): TokenUsage | null => {
+  const usage = asRecord(raw);
+  if (usage === null) return null;
+  const values = TOKEN_USAGE_FIELDS.map((field) => usage[field]);
+  if (!values.every(isTokenCount)) return null;
+  return {
+    input_tokens: values[0] as number,
+    output_tokens: values[1] as number,
+    cache_creation_input_tokens: values[2] as number,
+    cache_read_input_tokens: values[3] as number,
+  };
+};
+
+const addUsage = (left: TokenUsage, right: TokenUsage): TokenUsage | null => {
+  const sum = {
+    input_tokens: left.input_tokens + right.input_tokens,
+    output_tokens: left.output_tokens + right.output_tokens,
+    cache_creation_input_tokens: left.cache_creation_input_tokens + right.cache_creation_input_tokens,
+    cache_read_input_tokens: left.cache_read_input_tokens + right.cache_read_input_tokens,
+  };
+  return Object.values(sum).every((value) => Number.isSafeInteger(value)) ? sum : null;
+};
+
+const usageEquals = (left: TokenUsage, right: TokenUsage): boolean =>
+  TOKEN_USAGE_FIELDS.every((field) => left[field] === right[field]);
+
+const totalUsage = (usage: TokenUsage): number | null => {
+  const total =
+    usage.input_tokens +
+    usage.output_tokens +
+    usage.cache_creation_input_tokens +
+    usage.cache_read_input_tokens;
+  return Number.isSafeInteger(total) ? total : null;
+};
+
+interface OpenTurn {
+  readonly model: string | null;
+}
+
+const streamKey = (parentToolUseId: string | null): string => parentToolUseId ?? "<main>";
+
+/**
+ * Parses every line before it permits a measured figure. Assistant content
+ * blocks are intentionally ignored: they duplicate a message's usage, while
+ * `message_delta` is the final per-turn usage event (§24.1).
+ */
+export const readProviderLedger = (input: ProviderLedgerInput): ProviderLedger => {
+  if (input.requested_model === "") throw new Error("provider ledger: requested_model must not be empty");
+
+  const bytes = rawBytes(input.raw_ndjson);
+  const rawStreamSha256 = sha256(bytes);
+  const gaps = new Set<LedgerGap>();
+  const observedModelIds: string[] = [];
+  const openTurns = new Map<string, OpenTurn>();
+  let turnTotal: TokenUsage = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+  };
+  let turnTotalOverflowed = false;
+  let turnCount = 0;
+  let unparsedLines = 0;
+  let delegatedEventCount = 0;
+  let terminalResultCount = 0;
+  let terminalUsage: TokenUsage | null = null;
+
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    gaps.add("invalid_utf8");
+    return unavailableLedger({
+      requestedModel: input.requested_model,
+      observedModelIds,
+      delegatedEventCount,
+      turnCount,
+      rawByteLength: bytes.byteLength,
+      rawStreamSha256,
+      unparsedLines,
+      gaps,
+    });
+  }
+
+  for (const line of text.split("\n")) {
+    // Blank separators do not carry an event; all nonblank segments must be
+    // JSON objects, including status/progress events the ledger does not use.
+    if (line.trim() === "") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      unparsedLines += 1;
+      gaps.add("unparsed_stream");
+      continue;
+    }
+    const envelope = asRecord(parsed);
+    if (envelope === null) {
+      unparsedLines += 1;
+      gaps.add("unparsed_stream");
+      continue;
+    }
+
+    const parentRaw = envelope["parent_tool_use_id"];
+    let parentToolUseId: string | null = null;
+    if (parentRaw !== undefined && parentRaw !== null) {
+      delegatedEventCount += 1;
+      if (typeof parentRaw === "string") parentToolUseId = parentRaw;
+      else {
+        parentToolUseId = "<malformed-parent>";
+        gaps.add("malformed_turn");
+      }
+    }
+
+    if (envelope["type"] === "result") {
+      terminalResultCount += 1;
+      const usage = readUsage(envelope["usage"]);
+      if (usage === null) gaps.add("terminal_usage_invalid");
+      else terminalUsage = usage;
+      continue;
+    }
+    if (envelope["type"] !== "stream_event") continue;
+
+    const event = asRecord(envelope["event"]);
+    if (event === null) {
+      gaps.add("malformed_turn");
+      continue;
+    }
+    const key = streamKey(parentToolUseId);
+
+    if (event["type"] === "message_start") {
+      const message = asRecord(event["message"]);
+      const id = message?.["id"];
+      const model = message?.["model"];
+      if (typeof id !== "string" || id === "" || openTurns.has(key)) gaps.add("malformed_turn");
+      if (typeof model !== "string" || model === "") gaps.add("model_observation_absent");
+      else if (!observedModelIds.includes(model)) observedModelIds.push(model);
+      openTurns.set(key, { model: typeof model === "string" && model !== "" ? model : null });
+      continue;
+    }
+
+    if (event["type"] !== "message_delta") continue;
+
+    const open = openTurns.get(key);
+    if (open === undefined) gaps.add("malformed_turn");
+    else openTurns.delete(key);
+    if (open?.model === null) gaps.add("model_observation_absent");
+
+    const usage = readUsage(event["usage"]);
+    if (usage === null) {
+      gaps.add("turn_usage_missing");
+      continue;
+    }
+    const next = addUsage(turnTotal, usage);
+    if (next === null) {
+      turnTotalOverflowed = true;
+      gaps.add("token_total_overflow");
+      continue;
+    }
+    turnTotal = next;
+    turnCount += 1;
+  }
+
+  if (unparsedLines > 0) gaps.add("unparsed_stream");
+  if (openTurns.size > 0) gaps.add("incomplete_turn");
+  if (terminalResultCount === 0) gaps.add("terminal_usage_absent");
+  if (terminalResultCount > 1) gaps.add("terminal_usage_ambiguous");
+  if (observedModelIds.length === 0) gaps.add("model_observation_absent");
+  if (delegatedEventCount > 0) gaps.add("subagent_turn");
+  if (!turnTotalOverflowed && terminalUsage !== null && !usageEquals(turnTotal, terminalUsage)) {
+    gaps.add("turn_session_mismatch");
+  }
+
+  if (gaps.size > 0 || terminalUsage === null || turnTotalOverflowed) {
+    return unavailableLedger({
+      requestedModel: input.requested_model,
+      observedModelIds,
+      delegatedEventCount,
+      turnCount,
+      rawByteLength: bytes.byteLength,
+      rawStreamSha256,
+      unparsedLines,
+      gaps,
+    });
+  }
+
+  const total = totalUsage(turnTotal);
+  if (total === null) {
+    gaps.add("token_total_overflow");
+    return unavailableLedger({
+      requestedModel: input.requested_model,
+      observedModelIds,
+      delegatedEventCount,
+      turnCount,
+      rawByteLength: bytes.byteLength,
+      rawStreamSha256,
+      unparsedLines,
+      gaps,
+    });
+  }
+
+  return {
+    requested_model: input.requested_model,
+    observed_model_ids: observedModelIds,
+    single_agent_measurement: { status: "eligible" },
+    turn_count: turnCount,
+    raw_byte_length: bytes.byteLength,
+    usage: {
+      availability: "measured",
+      ...turnTotal,
+      total_token_volume: total,
+      reconciled: true,
+      unparsed_lines: 0,
+      raw_stream_sha256: rawStreamSha256,
+    },
+  };
+};
+
+const unavailableLedger = (params: {
+  readonly requestedModel: string;
+  readonly observedModelIds: readonly string[];
+  readonly delegatedEventCount: number;
+  readonly turnCount: number;
+  readonly rawByteLength: number;
+  readonly rawStreamSha256: string;
+  readonly unparsedLines: number;
+  readonly gaps: ReadonlySet<LedgerGap>;
+}): ProviderLedger => ({
+  requested_model: params.requestedModel,
+  observed_model_ids: params.observedModelIds,
+  single_agent_measurement:
+    params.delegatedEventCount > 0
+      ? { status: "excluded", reason: "subagent_turn", delegated_event_count: params.delegatedEventCount }
+      : { status: "eligible" },
+  turn_count: params.turnCount,
+  raw_byte_length: params.rawByteLength,
+  usage: {
+    availability: "unavailable",
+    reasons: [...params.gaps].sort(),
+    unparsed_lines: params.unparsedLines,
+    raw_stream_sha256: params.rawStreamSha256,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Raw artifact persistence (§14.1, §19.1)
+// ---------------------------------------------------------------------------
+
+export const PROVIDER_NDJSON_ARTIFACT = "provider.ndjson.zst";
+export const PROVIDER_NDJSON_CHECKSUM = "provider.ndjson.sha256";
+
+export interface RawNdjsonArtifact {
+  readonly compressed_path: string;
+  readonly checksum_path: string;
+  readonly raw_stream_sha256: string;
+  readonly raw_byte_length: number;
+}
+
+let temporaryFileSequence = 0;
+
+const fsyncDirectory = (directory: string): void => {
+  const descriptor = openSync(directory, "r");
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+};
+
+/** Write once: rerunning a completed logical run must not edit its evidence. */
+const writeNewFileAtomically = (destination: string, bytes: Uint8Array): void => {
+  if (existsSync(destination)) throw new Error(`provider ledger: refusing to overwrite ${destination}`);
+  temporaryFileSequence += 1;
+  const temporary = `${destination}.${String(process.pid)}.${String(temporaryFileSequence)}.partial`;
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(temporary, "wx");
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      offset += writeSync(descriptor, bytes, offset, bytes.byteLength - offset);
+    }
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = null;
+    // The ordinary existence check above is enough for the single-writer run
+    // directory CDEB-07 owns; repeat it before rename so an operator mistake
+    // cannot silently replace an immutable artifact.
+    if (existsSync(destination)) throw new Error(`provider ledger: refusing to overwrite ${destination}`);
+    renameSync(temporary, destination);
+  } catch (error) {
+    if (descriptor !== null) closeSync(descriptor);
+    if (existsSync(temporary)) unlinkSync(temporary);
+    throw error;
+  }
+};
+
+/**
+ * Stores compressed raw bytes and a digest of the *uncompressed* stream.
+ * Compression changes the container, never the NDJSON evidence: the reader
+ * below must return the identical Buffer or rejects the artifact.
+ */
+export const persistRawNdjson = (runDirectory: string, rawNdjson: Uint8Array | string): RawNdjsonArtifact => {
+  if (runDirectory === "") throw new Error("provider ledger: runDirectory must not be empty");
+  const raw = rawBytes(rawNdjson);
+  const digest = sha256(raw);
+  const compressedPath = join(runDirectory, PROVIDER_NDJSON_ARTIFACT);
+  const checksumPath = join(runDirectory, PROVIDER_NDJSON_CHECKSUM);
+  writeNewFileAtomically(compressedPath, zstdCompressSync(raw));
+  try {
+    writeNewFileAtomically(checksumPath, Buffer.from(`${digest}  provider.ndjson\n`, "utf8"));
+    fsyncDirectory(runDirectory);
+  } catch (error) {
+    // Do not claim a partial artifact is durable. The compressed evidence can
+    // be removed safely because its checksum never became authoritative.
+    if (existsSync(compressedPath)) unlinkSync(compressedPath);
+    throw error;
+  }
+  return {
+    compressed_path: compressedPath,
+    checksum_path: checksumPath,
+    raw_stream_sha256: digest,
+    raw_byte_length: raw.byteLength,
+  };
+};
+
+export const readPersistedRawNdjson = (runDirectory: string): Buffer => {
+  const compressedPath = join(runDirectory, PROVIDER_NDJSON_ARTIFACT);
+  const checksumPath = join(runDirectory, PROVIDER_NDJSON_CHECKSUM);
+  const sidecar = readFileSync(checksumPath, "utf8");
+  const match = sidecar.match(/^([0-9a-f]{64})  provider\.ndjson\n$/);
+  if (match?.[1] === undefined) throw new Error("provider ledger: malformed provider.ndjson.sha256");
+  const raw = zstdDecompressSync(readFileSync(compressedPath));
+  if (sha256(raw) !== match[1]) throw new Error("provider ledger: raw NDJSON checksum mismatch");
+  return raw;
+};
+
+// ---------------------------------------------------------------------------
+// Aggregation (§14.6, §15.2, §16.4)
+// ---------------------------------------------------------------------------
+
+export interface TokenAggregateInput {
+  readonly logical_run_id: string;
+  readonly ledger: ProviderLedger;
+}
+
+export interface MeasuredTokenAggregate extends TokenUsage {
+  readonly availability: "measured";
+  readonly total_token_volume: number;
+  readonly run_count: number;
+}
+
+export interface UnavailableTokenAggregate {
+  readonly availability: "unavailable";
+  /** Every row that prevented a total; no incomplete row is silently skipped. */
+  readonly unavailable_runs: readonly {
+    readonly logical_run_id: string;
+    readonly reasons: readonly (LedgerGap | "duplicate_logical_run_id" | "no_runs" | "token_total_overflow")[];
+  }[];
+}
+
+export type TokenAggregate = MeasuredTokenAggregate | UnavailableTokenAggregate;
+
+/**
+ * Sum only an all-complete set. This is intentionally not a filter: one
+ * unavailable row changes the aggregate's type and removes every numeric
+ * total, so a report cannot accidentally describe a partial numerator.
+ */
+export const aggregateTokenVolume = (runs: readonly TokenAggregateInput[]): TokenAggregate => {
+  if (runs.length === 0) {
+    return { availability: "unavailable", unavailable_runs: [{ logical_run_id: "(aggregate)", reasons: ["no_runs"] }] };
+  }
+
+  const seen = new Set<string>();
+  const unavailable: {
+    logical_run_id: string;
+    reasons: readonly (LedgerGap | "duplicate_logical_run_id" | "no_runs" | "token_total_overflow")[];
+  }[] = [];
+  let totals: TokenUsage = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+  };
+
+  for (const run of runs) {
+    if (seen.has(run.logical_run_id)) {
+      unavailable.push({ logical_run_id: run.logical_run_id, reasons: ["duplicate_logical_run_id"] });
+      continue;
+    }
+    seen.add(run.logical_run_id);
+    if (run.ledger.usage.availability === "unavailable") {
+      unavailable.push({ logical_run_id: run.logical_run_id, reasons: run.ledger.usage.reasons });
+      continue;
+    }
+    const next = addUsage(totals, run.ledger.usage);
+    if (next === null) {
+      unavailable.push({ logical_run_id: run.logical_run_id, reasons: ["token_total_overflow"] });
+      continue;
+    }
+    totals = next;
+  }
+
+  if (unavailable.length > 0) return { availability: "unavailable", unavailable_runs: unavailable };
+  const total = totalUsage(totals);
+  if (total === null) {
+    return {
+      availability: "unavailable",
+      unavailable_runs: [{ logical_run_id: "(aggregate)", reasons: ["token_total_overflow"] }],
+    };
+  }
+  return { availability: "measured", ...totals, total_token_volume: total, run_count: runs.length };
+};

--- a/bench/cdeb/schemas/result.schema.json
+++ b/bench/cdeb/schemas/result.schema.json
@@ -90,23 +90,54 @@
     },
 
     "usage": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "input_tokens", "output_tokens", "cache_creation_input_tokens",
-        "cache_read_input_tokens", "total_token_volume", "reconciled",
-        "unparsed_lines", "raw_stream_sha256"
-      ],
-      "properties": {
-        "input_tokens": { "type": "integer", "minimum": 0 },
-        "output_tokens": { "type": "integer", "minimum": 0 },
-        "cache_creation_input_tokens": { "type": "integer", "minimum": 0 },
-        "cache_read_input_tokens": { "type": "integer", "minimum": 0 },
-        "total_token_volume": { "type": "integer", "minimum": 0 },
-        "reconciled": { "const": true },
-        "unparsed_lines": { "const": 0 },
-        "raw_stream_sha256": { "$ref": "#/$defs/sha256" }
-      }
+      "oneOf": [
+        {
+          "title": "Complete, reconciled provider usage",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "availability", "input_tokens", "output_tokens", "cache_creation_input_tokens",
+            "cache_read_input_tokens", "total_token_volume", "reconciled",
+            "unparsed_lines", "raw_stream_sha256"
+          ],
+          "properties": {
+            "availability": { "const": "measured" },
+            "input_tokens": { "type": "integer", "minimum": 0 },
+            "output_tokens": { "type": "integer", "minimum": 0 },
+            "cache_creation_input_tokens": { "type": "integer", "minimum": 0 },
+            "cache_read_input_tokens": { "type": "integer", "minimum": 0 },
+            "total_token_volume": { "type": "integer", "minimum": 0 },
+            "reconciled": { "const": true },
+            "unparsed_lines": { "const": 0 },
+            "raw_stream_sha256": { "$ref": "#/$defs/sha256" }
+          }
+        },
+        {
+          "title": "Unavailable provider usage",
+          "description": "Incomplete usage remains evidence of a run, but carries no numeric field a token aggregate could mistake for data.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["availability", "reasons", "unparsed_lines", "raw_stream_sha256"],
+          "properties": {
+            "availability": { "const": "unavailable" },
+            "reasons": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "invalid_utf8", "unparsed_stream", "malformed_turn", "turn_usage_missing",
+                  "incomplete_turn", "terminal_usage_absent", "terminal_usage_ambiguous",
+                  "terminal_usage_invalid", "turn_session_mismatch", "token_total_overflow",
+                  "model_observation_absent", "subagent_turn"
+                ]
+              }
+            },
+            "unparsed_lines": { "type": "integer", "minimum": 0 },
+            "raw_stream_sha256": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      ]
     },
 
     "final_tree": {

--- a/bench/cdeb/verify.mjs
+++ b/bench/cdeb/verify.mjs
@@ -16,17 +16,20 @@
 //   - an unknown file anywhere in a study is a finding
 //   - a schema-invalid row, attempt, evaluator output or freeze manifest fails
 //   - a derived field that does not equal its recomputation fails
-//     (total_token_volume vs the raw category sum; decision_safe_success vs
-//     stop_reason/functional_pass/rejected_decision_revived — §14.7)
+//     (total_token_volume vs the raw category sum when usage is available;
+//     decision_safe_success vs stop_reason/functional_pass/rejected-decision
+//     revival — §14.7)
 //   - a duplicate logical_run_id fails
 //   - if randomization.json names the expected logical runs, a missing or
 //     extra row fails; RESULT.json with an incomplete matrix fails (§22.6)
 //
 // Exit 0: every study verifies, or there are no studies. Exit 1 otherwise.
 
+import { createHash } from "node:crypto";
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { zstdDecompressSync } from "node:zlib";
 
 // `ajv`'s default export ships the draft-07 meta-schema only; these schemas
 // declare draft 2020-12, which lives in its own entry point.
@@ -128,9 +131,11 @@ const checkExposure = (study, path, row) => {
  */
 const checkDerived = (study, path, row) => {
   const u = row.usage;
-  const sum = u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens;
-  if (u.total_token_volume !== sum) {
-    fail(study, `${path}: total_token_volume ${u.total_token_volume} != raw category sum ${sum}`);
+  if (u.availability === "measured") {
+    const sum = u.input_tokens + u.output_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens;
+    if (u.total_token_volume !== sum) {
+      fail(study, `${path}: total_token_volume ${u.total_token_volume} != raw category sum ${sum}`);
+    }
   }
   const recomputed =
     row.stop_reason === "completed" &&
@@ -138,6 +143,46 @@ const checkDerived = (study, path, row) => {
     row.evaluation.rejected_decision_revived === false;
   if (row.decision_safe_success !== recomputed) {
     fail(study, `${path}: decision_safe_success ${row.decision_safe_success} != recomputed ${recomputed} from stop_reason/evaluation`);
+  }
+};
+
+/**
+ * CDEB-05: the row's digest names the raw, decompressed NDJSON bytes, not a
+ * convenient recompression. A per-run row without those bytes is not evidence
+ * that the provider stream it claims to summarize was retained.
+ */
+const checkProviderArtifact = (study, runDir, row) => {
+  const compressedPath = join(runDir, "provider.ndjson.zst");
+  const checksumPath = join(runDir, "provider.ndjson.sha256");
+  const hasCompressed = existsSync(compressedPath);
+  const hasChecksum = existsSync(checksumPath);
+  if (!hasCompressed && !hasChecksum) {
+    if (row !== null) fail(study, `${runDir}: row.json has no provider NDJSON artifact`);
+    return;
+  }
+  if (!hasCompressed || !hasChecksum) {
+    fail(study, `${runDir}: provider NDJSON artifact and checksum must appear together`);
+    return;
+  }
+  let raw;
+  try {
+    raw = zstdDecompressSync(readFileSync(compressedPath));
+  } catch (error) {
+    fail(study, `${compressedPath}: cannot decompress provider NDJSON: ${error.message}`);
+    return;
+  }
+  const sidecar = readFileSync(checksumPath, "utf8");
+  const sidecarMatch = sidecar.match(/^([0-9a-f]{64})  provider\.ndjson\n$/);
+  if (sidecarMatch?.[1] === undefined) {
+    fail(study, `${checksumPath}: malformed provider NDJSON checksum`);
+    return;
+  }
+  const digest = createHash("sha256").update(raw).digest("hex");
+  if (digest !== sidecarMatch[1]) {
+    fail(study, `${runDir}: provider NDJSON checksum does not match decompressed bytes`);
+  }
+  if (row !== null && digest !== row.usage.raw_stream_sha256) {
+    fail(study, `${runDir}: row usage raw_stream_sha256 does not match provider NDJSON`);
   }
 };
 
@@ -192,7 +237,7 @@ const verifyStudy = (root, studyName) => {
 
   const verifyRow = (path) => {
     const row = readJson(study, path);
-    if (!validateAgainst(study, "result", path, row)) return;
+    if (!validateAgainst(study, "result", path, row)) return null;
     checkDerived(study, path, row);
     checkExposure(study, path, row);
     if (seenIds.has(row.logical_run_id)) {
@@ -219,7 +264,20 @@ const verifyStudy = (root, studyName) => {
       if (row.dist_digest !== freeze.dist_digest) {
         fail(study, `${path}: dist_digest does not match the freeze`);
       }
+      if (row.requested_model !== freeze.requested_model) {
+        fail(study, `${path}: requested_model does not match the freeze`);
+      }
+      if (
+        row.observed_model_ids.length !== 1 ||
+        row.observed_model_ids[0] !== freeze.observed_model_id
+      ) {
+        fail(
+          study,
+          `${path}: observed_model_ids ${JSON.stringify(row.observed_model_ids)} do not exactly match the freeze's observed_model_id`,
+        );
+      }
     }
+    return row;
   };
 
   const rowsDir = join(dir, "rows");
@@ -246,7 +304,8 @@ const verifyStudy = (root, studyName) => {
         if (!RUN_ENTRIES.has(entry)) fail(study, `runs/${runName}/${entry}: unknown entry`);
       }
       const rowPath = join(runDir, "row.json");
-      if (existsSync(rowPath)) verifyRow(rowPath);
+      const row = existsSync(rowPath) ? verifyRow(rowPath) : null;
+      checkProviderArtifact(study, runDir, row);
       const evalPath = join(runDir, "evaluator.json");
       if (existsSync(evalPath)) {
         validateAgainst(study, "evaluator", evalPath, readJson(study, evalPath));

--- a/test/cdeb-provider-ledger.test.ts
+++ b/test/cdeb-provider-ledger.test.ts
@@ -1,0 +1,151 @@
+/**
+ * CDEB-05 acceptance: raw provider bytes are the evidence; no incomplete,
+ * delegated, or guessed usage reaches a token number.
+ *
+ * The control fixture is a recorded stream from the existing CLI capture.
+ * Fault cases mutate only that captured byte stream, so they exercise the
+ * actual event shape without calling a provider.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  aggregateTokenVolume,
+  persistRawNdjson,
+  readPersistedRawNdjson,
+  readProviderLedger,
+} from "../bench/cdeb/runtime/provider-ledger.ts";
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const directory of scratch) rmSync(directory, { recursive: true, force: true });
+});
+
+const temp = (label: string): string => {
+  const directory = mkdtempSync(join(tmpdir(), `cdeb-ledger-${label}-`));
+  scratch.push(directory);
+  return directory;
+};
+
+const recordedBytes = (): Buffer => readFileSync("test/fixtures/claude-stream/partial-messages.jsonl");
+const recordedText = (): string => recordedBytes().toString("utf8");
+
+const withoutTerminalResult = (): string =>
+  recordedText()
+    .split("\n")
+    .filter((line) => {
+      try {
+        return (JSON.parse(line) as { type?: unknown }).type !== "result";
+      } catch {
+        return true;
+      }
+    })
+    .join("\n");
+
+const withoutTerminalUsage = (): string =>
+  recordedText()
+    .split("\n")
+    .filter((line) => line !== "")
+    .map((line) => {
+      const event = JSON.parse(line) as { type?: unknown; usage?: unknown };
+      if (event.type === "result") delete event.usage;
+      return JSON.stringify(event);
+    })
+    .join("\n");
+
+describe("CDEB-05 strict provider usage ledger", () => {
+  it("reconciles the recorded final per-turn usage and records the model actually observed", () => {
+    const ledger = readProviderLedger({
+      requested_model: "requested-alias",
+      raw_ndjson: recordedBytes(),
+    });
+
+    expect(ledger.requested_model).toBe("requested-alias");
+    expect(ledger.observed_model_ids).toEqual(["claude-haiku-4-5-20251001"]);
+    expect(ledger.observed_model_ids[0]).not.toBe(ledger.requested_model);
+    expect(ledger.single_agent_measurement).toEqual({ status: "eligible" });
+    expect(ledger.usage.availability).toBe("measured");
+    if (ledger.usage.availability !== "measured") throw new Error("recorded fixture must reconcile");
+    expect(ledger.usage).toMatchObject({
+      input_tokens: 26,
+      output_tokens: 386,
+      cache_creation_input_tokens: 307,
+      cache_read_input_tokens: 72845,
+      total_token_volume: 73564,
+      reconciled: true,
+      unparsed_lines: 0,
+    });
+  });
+
+  it("does not produce a measured number when any stream segment is unparsed", () => {
+    const ledger = readProviderLedger({
+      requested_model: "requested-alias",
+      raw_ndjson: recordedText().replace("\n", "\nthis-is-not-ndjson\n"),
+    });
+
+    expect(ledger.usage.availability).toBe("unavailable");
+    if (ledger.usage.availability !== "unavailable") throw new Error("unparsed stream must be unavailable");
+    expect(ledger.usage.reasons).toContain("unparsed_stream");
+    expect(ledger.usage.unparsed_lines).toBe(1);
+    expect("total_token_volume" in ledger.usage).toBe(false);
+  });
+
+  it("flags a delegated turn and excludes the run from single-agent token counts", () => {
+    const delegated = recordedText().replaceAll(
+      '"parent_tool_use_id":null',
+      '"parent_tool_use_id":"toolu_delegated"',
+    );
+    const good = readProviderLedger({ requested_model: "requested-alias", raw_ndjson: recordedBytes() });
+    const ledger = readProviderLedger({ requested_model: "requested-alias", raw_ndjson: delegated });
+
+    expect(ledger.single_agent_measurement.status).toBe("excluded");
+    expect(ledger.usage.availability).toBe("unavailable");
+    if (ledger.usage.availability !== "unavailable") throw new Error("delegated stream must be unavailable");
+    expect(ledger.usage.reasons).toContain("subagent_turn");
+
+    const aggregate = aggregateTokenVolume([
+      { logical_run_id: "repo-a__task-a__on__r1", ledger: good },
+      { logical_run_id: "repo-a__task-a__on__r2", ledger },
+    ]);
+    expect(aggregate.availability).toBe("unavailable");
+    expect("total_token_volume" in aggregate).toBe(false);
+  });
+
+  it("marks both truncated and terminal-usage-absent streams unavailable, and propagates either gap", () => {
+    const complete = readProviderLedger({ requested_model: "requested-alias", raw_ndjson: recordedBytes() });
+    const truncated = readProviderLedger({ requested_model: "requested-alias", raw_ndjson: withoutTerminalResult() });
+    const absent = readProviderLedger({ requested_model: "requested-alias", raw_ndjson: withoutTerminalUsage() });
+
+    for (const ledger of [truncated, absent]) {
+      expect(ledger.usage.availability).toBe("unavailable");
+      if (ledger.usage.availability !== "unavailable") throw new Error("missing terminal usage must be unavailable");
+      expect("total_token_volume" in ledger.usage).toBe(false);
+    }
+    if (truncated.usage.availability !== "unavailable") throw new Error("truncated fixture must be unavailable");
+    expect(truncated.usage.reasons).toContain("terminal_usage_absent");
+    if (absent.usage.availability !== "unavailable") throw new Error("terminal usage fixture must be unavailable");
+    expect(absent.usage.reasons).toContain("terminal_usage_invalid");
+
+    const aggregate = aggregateTokenVolume([
+      { logical_run_id: "repo-a__task-a__on__r1", ledger: complete },
+      { logical_run_id: "repo-a__task-a__on__r2", ledger: truncated },
+    ]);
+    expect(aggregate).toMatchObject({ availability: "unavailable" });
+    expect("total_token_volume" in aggregate).toBe(false);
+  });
+
+  it("round-trips recorded raw NDJSON byte-exactly through the persisted zstd artifact", () => {
+    const raw = recordedBytes();
+    const directory = temp("raw-roundtrip");
+    const artifact = persistRawNdjson(directory, raw);
+    const restored = readPersistedRawNdjson(directory);
+
+    expect(restored).toEqual(raw);
+    expect(artifact.raw_stream_sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(artifact.raw_byte_length).toBe(raw.byteLength);
+  });
+});

--- a/test/cdeb-runtime-isolation.test.ts
+++ b/test/cdeb-runtime-isolation.test.ts
@@ -46,6 +46,7 @@ import {
   type CapabilityProbe,
 } from '../bench/cdeb/runtime/isolation.ts';
 import { runProbe } from '../bench/cdeb/freeze/runtime-probe.ts';
+import { readPersistedRawNdjson } from '../bench/cdeb/runtime/provider-ledger.ts';
 // @ts-expect-error -- plain ESM module without type declarations
 import { decideEgress, parseConnectTarget } from '../bench/cdeb/runtime/egress-proxy.mjs';
 import {
@@ -607,7 +608,7 @@ describe('pin manifest and gate token', () => {
     ).rejects.toThrowError(/not frozen/);
   });
 
-  it('executeAgentRun captures the raw stream byte-for-byte and identity-checks it', async () => {
+  it('executeAgentRun captures the raw stream byte-for-byte, persists it, and identity-checks it', async () => {
     const stream = validStream();
     const streamingDocker: ContainerRuntimeCommands = {
       run: () => ({ stdout: '', stderr: '', exitCode: 0, timedOut: false }),
@@ -626,9 +627,10 @@ describe('pin manifest and gate token', () => {
       outDir,
       providerEnv: {},
     });
-    const captured = readFileSync(join(outDir, 'provider.ndjson'), 'utf8');
+    const captured = readPersistedRawNdjson(outDir).toString('utf8');
     expect(captured).toBe(stream);
     expect(outcome.identity.observed_model_ids).toEqual([PIN_MODEL]);
+    expect(outcome.ledger.usage.availability).toBe('measured');
     expect(outcome.exit_code).toBe(0);
     expect(outcome.provider_stream_sha256).toMatch(/^[0-9a-f]{64}$/);
   });

--- a/test/cdeb-verify.test.ts
+++ b/test/cdeb-verify.test.ts
@@ -12,10 +12,12 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { zstdCompressSync } from 'node:zlib';
 
 import { afterAll, describe, expect, it } from 'vitest';
 
@@ -89,6 +91,7 @@ const validRow = (overrides: Record<string, unknown> = {}): Record<string, unkno
     exposure_log_sha256: HEX64,
   },
   usage: {
+    availability: 'measured',
     input_tokens: 1000,
     output_tokens: 200,
     cache_creation_input_tokens: 300,
@@ -199,6 +202,17 @@ const verify = (root: string): { code: number; output: string } => {
   }
 };
 
+const writeRunWithProviderArtifact = (root: string, rawStreamSha256: string): void => {
+  const runDir = join(root, 'cdeb-test-01', 'runs', 'repo-a__task-a__on__r1');
+  mkdirSync(runDir, { recursive: true });
+  const raw = readFileSync('test/fixtures/claude-stream/partial-messages.jsonl');
+  writeFileSync(join(runDir, 'provider.ndjson.zst'), zstdCompressSync(raw));
+  writeFileSync(join(runDir, 'provider.ndjson.sha256'), `${createHash('sha256').update(raw).digest('hex')}  provider.ndjson\n`);
+  const row = validRow();
+  (row.usage as Record<string, unknown>).raw_stream_sha256 = rawStreamSha256;
+  writeFileSync(join(runDir, 'row.json'), `${JSON.stringify(row, null, 2)}\n`);
+};
+
 describe('#443 the CDEB recursive verifier', () => {
   it('passes a clean study — the control every failure case depends on', () => {
     const result = verify(study('clean', [validRow()]));
@@ -247,6 +261,27 @@ describe('#443 the CDEB recursive verifier', () => {
     const result = verify(study('tokensum', [row]));
     expect(result.code).toBe(1);
     expect(result.output).toMatch(/total_token_volume 1999 != raw category sum 2000/);
+  });
+
+  it('fails a per-run row whose raw usage digest does not match its compressed NDJSON artifact', () => {
+    const root = study('artifact-digest', []);
+    writeRunWithProviderArtifact(root, HEX64);
+    const result = verify(root);
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/raw_stream_sha256 does not match provider NDJSON/);
+  });
+
+  it('accepts an unavailable usage row without inventing a numeric total', () => {
+    const row = validRow({
+      usage: {
+        availability: 'unavailable',
+        reasons: ['terminal_usage_absent'],
+        unparsed_lines: 0,
+        raw_stream_sha256: HEX64,
+      },
+    });
+    const result = verify(study('usage-unavailable', [row]));
+    expect(result.code, result.output).toBe(0);
   });
 
   it('fails when decision_safe_success does not match its recomputation', () => {
@@ -313,6 +348,12 @@ describe('#443 the CDEB recursive verifier', () => {
     const result = verify(study('drift', [validRow({ dist_digest: 'c'.repeat(64) })]));
     expect(result.code).toBe(1);
     expect(result.output).toMatch(/dist_digest does not match the freeze/);
+  });
+
+  it('fails a row whose observed answer model differs from the frozen observation', () => {
+    const result = verify(study('model-drift', [validRow({ observed_model_ids: ['claude-other-9'] })]));
+    expect(result.code).toBe(1);
+    expect(result.output).toMatch(/observed_model_ids/);
   });
 
   it('fails a row claiming delivery with nothing having run to deliver it', () => {


### PR DESCRIPTION
CDEB-05. Depends on #520 (merged).

A cost number that looks measured and is not is worse than no number, and the substitution is quiet: a gap filled with a mean, a zero, or a per-token extrapolation reads as diligence. `docs/SELF-AUDIT.md` exists because of exactly that shape.

So usage has **two states and no third**:

| | meaning |
|---|---|
| `measured` | every NDJSON segment parsed, every turn carried final usage, terminal usage existed, and the two totals reconciled exactly |
| `unavailable` | anything else — and the row schema has **no place to put a number**, so a reader cannot mistake a diagnostic for data |

The schema split is a `oneOf` on `availability`. The unavailable branch carries `reasons` and the raw stream digest, and not one token field.

## Dropping the row is the same defect one layer up

Aggregation **propagates** the gap rather than summing what is left. §14.6 already says an unrecoverable run stays in the denominator; a smaller total assembled from the runs that happened to parse describes a different population than the one that ran.

## Observed, not requested

The models recorded are the ones observed answering. Drift between requested and observed is what the pinned runtime (#520) exists to catch, and the ledger is where it becomes evidence rather than an assumption. The verifier now binds a row to the retained raw bytes — decompress, digest, compare against both the sidecar and the row — so a summary whose stream was not kept is a finding, not a claim.

A timeout is not an excuse to synthesize a total. When SIGTERM lets the CLI emit terminal usage the parser uses it; when it does not, the outcome says so.

## Two things worth arguing with

**One unavailable run makes the whole aggregate unavailable.** That is the strict reading of §14.6 and it will feel severe on a long matrix. The reasons are per run, so a report can always say which ones and why — but the headline number refuses rather than shrinks.

**`node:zlib` zstd needs Node 22.15**, above the package floor of 22. This is bench-only; no shipped code imports it. CI runs 22 and 24.

83 cases pass across the ledger, verifier and isolation suites — an unparsed segment, a delegated turn, a truncated stream, an absent terminal usage, and a byte-exact round trip of recorded NDJSON through the persisted artifact. Both typechecks clean, two builds leave `dist` unchanged, both verifiers pass.

Every stream tested here is a recorded fixture; no containerized agent run was performed.
