### PR TITLE
Run the whole chain against itself before trusting any of it

### DIFF
--- a/bench/cdeb/orchestrator.ts
+++ b/bench/cdeb/orchestrator.ts
@@ -16,7 +16,8 @@
 import { createHash } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   executeAgentRun,
@@ -27,7 +28,11 @@ import {
 import type { CapabilityGatePassed } from "./runtime/isolation.ts";
 import { readExposureEvents, exposureLogSha256 } from "./runtime/exposure.ts";
 import { readPersistedRawNdjson, readProviderLedger, type ProviderLedger } from "./runtime/provider-ledger.ts";
-import { assertCaptureSurfaceAbsent, writeCdebArmConfig } from "./runtime/arm-settings.ts";
+import {
+  assertCaptureSurfaceAbsent,
+  assertFrozenShippingProxy,
+  writeCdebArmConfig,
+} from "./runtime/arm-settings.ts";
 import { materializeBundle, type RepositoryBundleIdentity } from "./freeze/repository-bundle.ts";
 import { freezeFinalTree, frozenTreeProvenance } from "./evaluator/freeze-tree.ts";
 import { runEvaluatorOci } from "./evaluator/runner-oci.ts";
@@ -56,6 +61,10 @@ export type LifecycleState =
 
 export const MAX_PRE_AGENT_ATTEMPTS = 3;
 export const MAX_EVALUATOR_ATTEMPTS = 3;
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SHIPPING_PROXY_PATH = join(HERE, "runtime", "shipping-proxy.ts");
+const EXPOSURE_PARSER_PATH = join(HERE, "runtime", "exposure.ts");
 
 const conditionSuffix = (condition: CdebCondition): "on" | "off" =>
   condition === "commitlore-on" ? "on" : "off";
@@ -262,6 +271,8 @@ export interface LogicalRunPlan {
   readonly condition: CdebCondition;
   readonly repeat: 1 | 2 | 3;
   readonly order: number;
+  /** Opaque analyzer input path committed by public-freeze.json. */
+  readonly analysis_row_file: string;
   /** Required to re-parse retained CDEB-05 bytes during evaluator-only resume. */
   readonly requested_model: string;
   readonly prompt: string;
@@ -339,6 +350,11 @@ export const materializedWorkspacePreparer = (
 export interface RunStudyOptions {
   readonly storage: DurableStudyStorage;
   readonly progress?: ProgressReporter;
+  /** Test-only path override for a copied, byte-mutated proxy fixture. */
+  readonly shipping_proxy_paths?: {
+    readonly proxy_path: string;
+    readonly parser_path: string;
+  };
 }
 
 export interface StudyRunResult {
@@ -376,6 +392,59 @@ const requiredRunId = (plan: LogicalRunPlan): void => {
   if (plan.logical_run_id !== expected) {
     throw new Error(`logical run id ${plan.logical_run_id} does not name its repository/task/condition/repeat cell`);
   }
+};
+
+interface FreezeWiring {
+  readonly hook_proxy_sha256: string;
+  readonly analysis_row_files: readonly string[];
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Reads the two freeze commitments this coordinator must enforce itself.
+ * Keeping this narrow avoids turning the runner into a second freeze schema
+ * parser while making it impossible to omit either seam at execution time.
+ */
+const frozenWiring = (freeze: unknown): FreezeWiring => {
+  if (!isRecord(freeze)) throw new Error("CDEB public freeze is not an object with execution wiring");
+  const proxy = freeze["hook_proxy_sha256"];
+  if (typeof proxy !== "string" || !/^[0-9a-f]{64}$/u.test(proxy)) {
+    throw new Error("CDEB public freeze has no valid hook_proxy_sha256");
+  }
+  const analysis = freeze["analysis_inputs"];
+  if (!isRecord(analysis) || !Array.isArray(analysis["row_files"])) {
+    throw new Error("CDEB public freeze has no analysis_inputs.row_files");
+  }
+  const rowFiles = analysis["row_files"];
+  if (rowFiles.some((path) => typeof path !== "string" || !/^rows\/[a-z0-9][a-z0-9._-]*\.json$/u.test(path))) {
+    throw new Error("CDEB public freeze names an unsafe analysis row path");
+  }
+  if (new Set(rowFiles).size !== rowFiles.length) {
+    throw new Error("CDEB public freeze names an analysis row path more than once");
+  }
+  return { hook_proxy_sha256: proxy, analysis_row_files: rowFiles as readonly string[] };
+};
+
+/** The sealed schedule maps every logical observation to one frozen row path. */
+const analysisRowsForPlan = (plan: CdebStudyPlan, wiring: FreezeWiring): ReadonlyMap<string, string> => {
+  const named = new Map<string, string>();
+  for (const logicalRun of plan.logical_runs) {
+    if (named.has(logicalRun.logical_run_id)) {
+      throw new Error(`CDEB logical run schedule has duplicate id ${logicalRun.logical_run_id}`);
+    }
+    if (!wiring.analysis_row_files.includes(logicalRun.analysis_row_file)) {
+      throw new Error(
+        `CDEB ${logicalRun.logical_run_id} writes ${logicalRun.analysis_row_file}, which public-freeze.json does not name`,
+      );
+    }
+    named.set(logicalRun.logical_run_id, logicalRun.analysis_row_file);
+  }
+  if (new Set(named.values()).size !== named.size || named.size !== wiring.analysis_row_files.length) {
+    throw new Error("CDEB sealed schedule and public freeze do not name the same one-to-one analysis row set");
+  }
+  return named;
 };
 
 /** Binds the sealed task mapping to the committed opaque block order. */
@@ -505,7 +574,7 @@ const finalizeMeasuredRow = (
     evaluator,
     evaluator_attempts: evaluatorAttempts,
   });
-  storage.writeRow(plan.logical_run_id, row);
+  storage.writeRow(plan.logical_run_id, plan.analysis_row_file, row);
 };
 
 const evaluateFrozenTree = async (
@@ -770,6 +839,15 @@ export const runStudy = async (
   dependencies: OrchestratorDependencies,
   options: RunStudyOptions,
 ): Promise<StudyRunResult> => {
+  const wiring = frozenWiring(plan.public_freeze);
+  const analysisRows = analysisRowsForPlan(plan, wiring);
+  const shippingPaths = options.shipping_proxy_paths ?? {
+    proxy_path: SHIPPING_PROXY_PATH,
+    parser_path: EXPOSURE_PARSER_PATH,
+  };
+  // The bytes the arm would execute are checked before an attempt checkpoint
+  // exists. A modified observer is a changed experiment, never a row.
+  assertFrozenShippingProxy(wiring.hook_proxy_sha256, shippingPaths.proxy_path, shippingPaths.parser_path);
   if (plan.logical_runs.length === 0) throw new Error("CDEB study has no logical runs");
   if (plan.randomization.block_count * 2 !== plan.logical_runs.length) {
     throw new Error("CDEB randomization block count does not match its logical run schedule");
@@ -785,6 +863,7 @@ export const runStudy = async (
   options.storage.repairBackupMirrors();
   options.storage.ensureCommittedJson("public-freeze.json", plan.public_freeze);
   options.storage.ensureCommittedJson("randomization.json", plan.randomization);
+  options.storage.reconcileNamedRows(analysisRows);
   const completedBefore = options.storage.completedRows(expectedIds);
   let completed = completedBefore.size;
   for (const logicalRun of plan.logical_runs) {

--- a/bench/cdeb/storage.ts
+++ b/bench/cdeb/storage.ts
@@ -143,6 +143,13 @@ const logicalIdPathSafe = (logicalRunId: string): void => {
   }
 };
 
+/** The public freeze may name only opaque, flat analysis rows. */
+const analysisRowPathSafe = (path: string): void => {
+  if (!/^rows\/[a-z0-9][a-z0-9._-]*\.json$/u.test(path)) {
+    throw new ImmutableArtifactError(`invalid freeze-named analysis row path ${JSON.stringify(path)}`);
+  }
+};
+
 const attemptIdPathSafe = (attemptId: string): void => {
   if (!/^[a-z0-9-]+__[a-z0-9-]+__(on|off)__r[1-3]__a[1-9][0-9]*$/u.test(attemptId)) {
     throw new ImmutableArtifactError(`invalid attempt id ${JSON.stringify(attemptId)}`);
@@ -245,6 +252,29 @@ export class DurableStudyStorage {
 
   public writeJsonNew(relativePath: string, value: unknown): void {
     this.writeNew(relativePath, jsonBytes(value));
+  }
+
+  /**
+   * Finish a row publication interrupted between its two immutable views.
+   * Both views carry the same bytes: the per-run `row.json` binds the row to its
+   * evidence, while the freeze-named `rows/*.json` file is the analyzer's
+   * only permitted input.  Either existing copy is evidence; divergent copies
+   * are an integrity failure, never a choice for recovery to make.
+   */
+  private writeOrMatch(relativePath: string, bytes: Buffer): void {
+    const primary = this.absolute(relativePath);
+    const backup = this.absolute(relativePath, this.backupDir);
+    if (existsSync(primary)) {
+      if (!readFileSync(primary).equals(bytes)) {
+        throw new ImmutableArtifactError(`existing artifact differs from immutable row publication ${relativePath}`);
+      }
+      this.mirrorExisting(relativePath);
+      return;
+    }
+    if (existsSync(backup) && !readFileSync(backup).equals(bytes)) {
+      throw new ImmutableArtifactError(`backup artifact differs from immutable row publication ${relativePath}`);
+    }
+    this.writeNew(relativePath, bytes);
   }
 
   public readJson<T>(relativePath: string): T | null {
@@ -438,19 +468,43 @@ export class DurableStudyStorage {
     this.writeJsonNew(this.runRelative(logicalRunId, "evaluator.json"), value);
   }
 
-  /** The row is the final commit record.  It can never be replaced. */
-  public writeRow(logicalRunId: string, row: Record<string, unknown>): void {
+  /**
+   * The row is the final commit record.  The per-run and analysis views are
+   * byte-identical immutable publications of one observation, not two rows.
+   */
+  public writeRow(logicalRunId: string, analysisRowPath: string, row: Record<string, unknown>): void {
     const named = row["logical_run_id"];
     if (named !== logicalRunId) {
       throw new ImmutableArtifactError(`row logical_run_id does not match its directory for ${logicalRunId}`);
     }
-    const mirrorRow = this.absolute(join("rows", `${logicalRunId}.json`));
-    if (existsSync(mirrorRow)) {
-      // `rows/` is a legacy alternative verifier input, not a second output
-      // path. Writing both would look exactly like a duplicate observation.
-      throw new ImmutableArtifactError(`rows/${logicalRunId}.json already exists; refusing a duplicate logical row`);
+    analysisRowPathSafe(analysisRowPath);
+    const bytes = jsonBytes(row);
+    // The analyzer-facing name lands first. A kill before the run-local copy
+    // is recovered by `reconcileNamedRows` before resume decides what is done.
+    this.writeOrMatch(analysisRowPath, bytes);
+    this.writeOrMatch(this.runRelative(logicalRunId, "row.json"), bytes);
+  }
+
+  /** Repairs a killed row publication without re-running its observation. */
+  public reconcileNamedRows(namedRows: ReadonlyMap<string, string>): void {
+    const paths = new Set<string>();
+    for (const [logicalRunId, analysisRowPath] of namedRows) {
+      logicalIdPathSafe(logicalRunId);
+      analysisRowPathSafe(analysisRowPath);
+      if (paths.has(analysisRowPath)) {
+        throw new ImmutableArtifactError(`freeze names ${analysisRowPath} for more than one logical row`);
+      }
+      paths.add(analysisRowPath);
+      const runPath = this.runRelative(logicalRunId, "row.json");
+      const primaryRun = this.absolute(runPath);
+      const primaryAnalysis = this.absolute(analysisRowPath);
+      const hasRun = existsSync(primaryRun);
+      const hasAnalysis = existsSync(primaryAnalysis);
+      if (!hasRun && !hasAnalysis) continue;
+      const bytes = hasRun ? readFileSync(primaryRun) : readFileSync(primaryAnalysis);
+      this.writeOrMatch(runPath, bytes);
+      this.writeOrMatch(analysisRowPath, bytes);
     }
-    this.writeJsonNew(this.runRelative(logicalRunId, "row.json"), row);
   }
 
   public readFinalTree(logicalRunId: string): FinalTreeArtifact | null {
@@ -530,12 +584,6 @@ export class DurableStudyStorage {
         if (rows.has(id)) throw new ImmutableArtifactError(`duplicate logical row ${id}`);
         rows.set(id, row);
       }
-    }
-    const legacyRows = this.absolute("rows");
-    if (existsSync(legacyRows) && readdirSync(legacyRows).length > 0) {
-      // The verifier treats `rows/` and `runs/*/row.json` as alternative input
-      // layouts; accepting both would create an unresolvable duplicate.
-      throw new ImmutableArtifactError("rows/ is populated alongside run directories; refusing duplicate row surfaces");
     }
     return rows;
   }

--- a/bench/cdeb/verify.mjs
+++ b/bench/cdeb/verify.mjs
@@ -27,7 +27,7 @@
 
 import { createHash } from "node:crypto";
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { zstdDecompressSync } from "node:zlib";
 
@@ -273,12 +273,14 @@ const verifyStudy = (root, studyName) => {
   const freezePath = join(dir, "public-freeze.json");
   let expectedRuns = null;
   let freeze = null;
+  let freezeNamedRows = null;
   if (!existsSync(freezePath)) {
     fail(study, "public-freeze.json is missing — rows without a freeze manifest commit to nothing");
   } else {
     freeze = readJson(study, freezePath);
     if (freeze !== null && validateAgainst(study, "study", freezePath, freeze)) {
       expectedRuns = freeze.expected_logical_runs;
+      freezeNamedRows = new Set(freeze.analysis_inputs.row_files);
     }
   }
   if (!existsSync(join(dir, "randomization.json"))) {
@@ -297,17 +299,38 @@ const verifyStudy = (root, studyName) => {
     }
   }
 
-  const seenIds = new Map(); // logical_run_id -> path
+  const seenIds = new Map(); // logical_run_id -> { path, row }
+
+  const isRunRow = (path) => {
+    const normalized = relative(dir, path).split("\\").join("/");
+    return /^runs\/[^/]+\/row\.json$/.test(normalized);
+  };
+
+  const isFreezeNamedRow = (path) => {
+    if (freezeNamedRows === null) return false;
+    const normalized = relative(dir, path).split("\\").join("/");
+    return freezeNamedRows.has(normalized);
+  };
 
   const verifyRow = (path) => {
     const row = readJson(study, path);
     if (!validateAgainst(study, "result", path, row)) return null;
     checkDerived(study, path, row);
     checkExposure(study, path, row);
-    if (seenIds.has(row.logical_run_id)) {
-      fail(study, `duplicate logical_run_id ${row.logical_run_id} in ${path} and ${seenIds.get(row.logical_run_id)}`);
+    const existing = seenIds.get(row.logical_run_id);
+    if (existing !== undefined) {
+      // CDEB-09 publishes a byte-identical per-run audit copy and the opaque,
+      // freeze-named analyzer input. They are one logical observation, not a
+      // duplicate row. Any different bytes, two run rows, or an unregistered
+      // rows/ file remains a duplicate finding.
+      const pairedViews =
+        (isRunRow(path) && isFreezeNamedRow(existing.path)) ||
+        (isRunRow(existing.path) && isFreezeNamedRow(path));
+      if (!pairedViews || JSON.stringify(existing.row) !== JSON.stringify(row)) {
+        fail(study, `duplicate logical_run_id ${row.logical_run_id} in ${path} and ${existing.path}`);
+      }
     } else {
-      seenIds.set(row.logical_run_id, path);
+      seenIds.set(row.logical_run_id, { path, row });
     }
     if (expectedIds !== null && !expectedIds.has(row.logical_run_id)) {
       fail(study, `${path}: logical_run_id ${row.logical_run_id} is not in the randomization's expected set`);

--- a/test/cdeb-orchestrator.test.ts
+++ b/test/cdeb-orchestrator.test.ts
@@ -9,7 +9,7 @@
 import { cpSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { afterAll, describe, expect, it } from "vitest";
 
@@ -30,6 +30,7 @@ import {
   type PreparedWorkspace,
 } from "../bench/cdeb/orchestrator.ts";
 import { readProviderLedger } from "../bench/cdeb/runtime/provider-ledger.ts";
+import { shippingProxySha256 } from "../bench/cdeb/runtime/arm-settings.ts";
 import { DurableStudyStorage, SimulatedProcessKill } from "../bench/cdeb/storage.ts";
 import { FIXTURE_ROOT, SEALED_DIR, TASK_ID, TEST_IMAGE_DIGEST } from "./cdeb-evaluator-helpers.ts";
 
@@ -51,6 +52,8 @@ const HEX = "a".repeat(64);
 const OID = "b".repeat(40);
 const RECORDED_STREAM = (): Buffer => readFileSync("test/fixtures/claude-stream/partial-messages.jsonl");
 const RECORDED_MODEL = "claude-haiku-4-5-20251001";
+const PROXY = resolve("bench/cdeb/runtime/shipping-proxy.ts");
+const PARSER = resolve("bench/cdeb/runtime/exposure.ts");
 
 interface Counters {
   readonly agent: Map<string, number>;
@@ -146,6 +149,7 @@ const makePlan = (condition: CdebCondition, order: number): LogicalRunPlan => {
     condition,
     repeat: 1,
     order,
+    analysis_row_file: `rows/${logical_run_id}.json`,
     requested_model: RECORDED_MODEL,
     prompt: "Fix calc without running external services.",
     expected_record_ids: [],
@@ -210,16 +214,25 @@ const makePlan = (condition: CdebCondition, order: number): LogicalRunPlan => {
   };
 };
 
-const studyPlan = (): CdebStudyPlan => ({
-  public_freeze: { benchmark: "cdeb-v1", study_id: "cdeb-orchestrator-test", freeze: "fixture" },
-  randomization: {
-    schema_version: 1,
-    algorithm: "sha256-key-sort-v1",
-    block_count: 1,
-    blocks: [{ block_index: "block-000", conditions: ["commitlore-on", "commitlore-off"] }],
-  },
-  logical_runs: [makePlan("commitlore-on", 1), makePlan("commitlore-off", 2)],
-});
+const studyPlan = (): CdebStudyPlan => {
+  const logical_runs = [makePlan("commitlore-on", 1), makePlan("commitlore-off", 2)];
+  return {
+    public_freeze: {
+      benchmark: "cdeb-v1",
+      study_id: "cdeb-orchestrator-test",
+      freeze: "fixture",
+      hook_proxy_sha256: shippingProxySha256(PROXY, PARSER),
+      analysis_inputs: { row_files: logical_runs.map((run) => run.analysis_row_file) },
+    },
+    randomization: {
+      schema_version: 1,
+      algorithm: "sha256-key-sort-v1",
+      block_count: 1,
+      blocks: [{ block_index: "block-000", conditions: ["commitlore-on", "commitlore-off"] }],
+    },
+    logical_runs,
+  };
+};
 
 const dependencies = (counts: Counters, options: { failEvaluatorFirst?: boolean; preTurnFailures?: number } = {}): OrchestratorDependencies => ({
   prepare_workspace: async () => workspaceFor(),

--- a/test/cdeb-smoke.test.ts
+++ b/test/cdeb-smoke.test.ts
@@ -1,0 +1,616 @@
+/**
+ * CDEB-09 end-to-end adversarial smoke gate.
+ *
+ * These are disposable repositories and sealed tasks. The agent container is
+ * represented by the CDEB-03 command seam because this checkout has no pinned
+ * runtime image; everything after its byte stream is the production chain:
+ * runtime identity/ledger, shipping proxy, freeze, durable storage, evaluator,
+ * recursive verifier and analyzer. OCI-only containment is intentionally not
+ * credited here; CDEB-06 isolation owns that separate surface.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { cpSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { analysisSourceDigest, analyzeStudy } from "../bench/cdeb/analyze.ts";
+import { normalizedResultSha256 } from "../bench/cdeb/evaluator/engine.ts";
+import { evaluateLocal } from "../bench/cdeb/evaluator/runner-local.ts";
+import {
+  canonicalFinalTreeFreezer,
+  runStudy,
+  runtimeAgentRunner,
+  summarizeExposure,
+  type CdebStudyPlan,
+  type EvaluatorRunner,
+  type LogicalRunPlan,
+  type OrchestratorDependencies,
+  type PreparedWorkspace,
+} from "../bench/cdeb/orchestrator.ts";
+import {
+  runtimePinDigest,
+  type ContainerRuntimeCommands,
+  type RuntimePin,
+} from "../bench/cdeb/runtime/agent-container.ts";
+import { assertRuntimeCapabilities, CAPABILITY_IDS, FROZEN_TOOL_POLICY } from "../bench/cdeb/runtime/isolation.ts";
+import { assertCaptureSurfaceAbsent, shippingProxySha256, writeCdebArmConfig } from "../bench/cdeb/runtime/arm-settings.ts";
+import { runTransparentShippingProxy } from "../bench/cdeb/runtime/shipping-proxy.ts";
+import { DurableStudyStorage } from "../bench/cdeb/storage.ts";
+import {
+  FIXTURE_ROOT,
+  SEALED_DIR,
+  TEST_IMAGE_DIGEST,
+  fixtureFile,
+} from "./cdeb-evaluator-helpers.ts";
+import { CLI_ENTRY } from "../bench/hooks-settings.ts";
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const directory of scratch) rmSync(directory, { recursive: true, force: true });
+});
+
+const temp = (label: string): string => {
+  const directory = mkdtempSync(join(tmpdir(), `cdeb-smoke-${label}-`));
+  scratch.push(directory);
+  return directory;
+};
+
+const git = (cwd: string, args: readonly string[]): string =>
+  execFileSync("git", [...args], { cwd, encoding: "utf8" }).trim();
+
+const sha256 = (value: string | Buffer): string => createHash("sha256").update(value).digest("hex");
+const HEX = "a".repeat(64);
+const OID = "b".repeat(40);
+const RECORD_ID = "r-smokecalc";
+const MODEL_ID = "smoke-pinned-observation";
+const CLI_VERSION = "1.0.0";
+const PROXY = resolve("bench/cdeb/runtime/shipping-proxy.ts");
+const PARSER = resolve("bench/cdeb/runtime/exposure.ts");
+const VERIFY = resolve("bench/cdeb/verify.mjs");
+
+const PIN: RuntimePin = {
+  schema_version: 1,
+  frozen: true,
+  image: { reference: "cdeb-smoke-agent", digest: `sha256:${"c".repeat(64)}` },
+  agent_cli_version: CLI_VERSION,
+  agent_executable: { path: "/cdeb/agent", sha256: "d".repeat(64) },
+  node: { version: process.version, executable_path: process.execPath, executable_sha256: "e".repeat(64) },
+  requested_model: "smoke-request",
+  expected_observed_model: MODEL_ID,
+  permission_mode: "acceptEdits",
+  network_policy: {
+    egress: "provider-only",
+    enforcement: "internal-network+allowlist-proxy",
+    allowed_hosts: ["provider.invalid"],
+    allowed_port: 443,
+  },
+};
+
+const GATE = assertRuntimeCapabilities(
+  CAPABILITY_IDS.map((capability) => ({ capability, ok: true, detail: `fixture observation: ${capability}` })),
+  runtimePinDigest(PIN),
+);
+
+const providerStream = (model: string = MODEL_ID): Buffer => Buffer.from(
+  [
+    JSON.stringify({
+      type: "system",
+      subtype: "init",
+      tools: FROZEN_TOOL_POLICY.allowed,
+      mcp_servers: [],
+      model,
+      permissionMode: PIN.permission_mode,
+      claude_code_version: CLI_VERSION,
+    }),
+    JSON.stringify({
+      type: "stream_event",
+      parent_tool_use_id: null,
+      event: { type: "message_start", message: { id: "smoke-turn", model } },
+    }),
+    JSON.stringify({
+      type: "stream_event",
+      parent_tool_use_id: null,
+      event: {
+        type: "message_delta",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        delta: { stop_reason: "end_turn" },
+      },
+    }),
+    JSON.stringify({
+      type: "result",
+      num_turns: 1,
+      is_error: false,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    }),
+    "",
+  ].join("\n"),
+);
+
+const sourceRepository = (): { readonly directory: string; readonly commit: string; readonly tree: string } => {
+  const directory = join(temp("source"), "repository");
+  cpSync(join(FIXTURE_ROOT, "base"), directory, { recursive: true });
+  git(directory, ["init", "--quiet"]);
+  git(directory, ["config", "user.email", "smoke@example.invalid"]);
+  git(directory, ["config", "user.name", "CDEB smoke"]);
+  git(directory, ["add", "-A"]);
+  git(directory, [
+    "commit", "--quiet", "-m",
+    [
+      "seed disposable task",
+      "",
+      "Ruled-out: recursive clamp | it overflows wide ranges",
+      `Record-Id: ${RECORD_ID}`,
+      "Provenance: authored",
+    ].join("\n"),
+  ]);
+  return {
+    directory,
+    commit: git(directory, ["rev-parse", "HEAD"]),
+    tree: git(directory, ["rev-parse", "HEAD^{tree}"]),
+  };
+};
+
+const prepareWorkspace = (source: string): OrchestratorDependencies["prepare_workspace"] => async (plan): Promise<PreparedWorkspace> => {
+  const root = temp("workspace");
+  const workdir = join(root, "repository");
+  const configDir = join(root, "config");
+  cpSync(source, workdir, { recursive: true });
+  const arm = plan.condition === "commitlore-on" ? "on" : "off";
+  const config = writeCdebArmConfig(workdir, configDir, arm);
+  assertCaptureSurfaceAbsent(workdir, config);
+  return {
+    workdir,
+    config_dir: config.configDir,
+    exposure_path: config.exposurePath,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+};
+
+type CandidateWriter = (workdir: string) => void;
+
+const mountedPath = (args: readonly string[], suffix: string): string => {
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] !== "--volume") continue;
+    const value = args[index + 1];
+    if (value !== undefined && value.endsWith(suffix)) return value.slice(0, -suffix.length);
+  }
+  throw new Error(`smoke runtime did not receive expected mount ${suffix}`);
+};
+
+/**
+ * The injected runtime writes a recorded provider stream, but invokes the
+ * shipping proxy and edits the mounted candidate tree exactly where the agent
+ * image would. It is deliberately not a container-isolation simulation.
+ */
+const fixtureRuntime = (candidate: CandidateWriter, model: string = MODEL_ID): ContainerRuntimeCommands => {
+  // The matrix needs one real shipping invocation, not 90 identical product
+  // executions. Later ON cells still carry their empty observed side channel.
+  let shippingObserved = false;
+  return {
+    run: () => ({ stdout: "", stderr: "not used by the smoke stream fixture", exitCode: 0, timedOut: false }),
+    runToSink: async (args, sink) => {
+      const workdir = mountedPath(args, ":/repo");
+      const configDir = mountedPath(args, ":/cdeb:ro");
+      const settings = JSON.parse(readFileSync(join(configDir, "settings.json"), "utf8")) as { hooks: Record<string, unknown> };
+      if (Object.keys(settings.hooks).length > 0 && !shippingObserved) {
+        shippingObserved = true;
+        await runTransparentShippingProxy({
+          cwd: workdir,
+          exposurePath: join(workdir, ".git", "cdeb", "exposure.jsonl"),
+          nodeExecutable: process.execPath,
+          shippingCli: CLI_ENTRY,
+          input: Buffer.from(JSON.stringify({
+            hook_event_name: "PreToolUse",
+            tool_name: "Read",
+            tool_input: { file_path: "src/calc.js" },
+          }), "utf8"),
+        });
+      }
+      candidate(workdir);
+      sink.write(providerStream(model));
+      sink.end();
+      return { exitCode: 0, stderr: "", timedOut: false };
+    },
+  };
+};
+
+const categoryFor = (cell: number): string => {
+  if (cell < 12) return "rejected-architecture";
+  if (cell < 20) return "rejected-workaround";
+  if (cell < 25) return "compatibility-constraint";
+  if (cell < 28) return "security-operational";
+  return "superseded-lifecycle";
+};
+
+const sealedTaskSource = (taskId: string): string => [
+  "const task = {",
+  `  task_id: ${JSON.stringify(taskId)},`,
+  "  record_ids: [],",
+  "  functional_checks(tree) {",
+  "    const source = tree.read('src/calc.js') ?? '';",
+  "    return [{ name: 'direct-clamp', passed: source.includes('export const clamp') && !source.includes('recursiveClamp') }];",
+  "  },",
+  "  decision_oracle(tree) {",
+  "    const source = tree.read('src/calc.js') ?? '';",
+  "    return source.includes('recursiveClamp') ? 'REVIVED' : 'SAFE';",
+  "  },",
+  "};",
+  "export default task;",
+  "",
+].join("\n");
+
+const writeSealedTasks = (taskIds: readonly string[]): string => {
+  const directory = temp("sealed");
+  for (const taskId of taskIds) writeFileSync(join(directory, `${taskId}.task.ts`), sealedTaskSource(taskId));
+  return directory;
+};
+
+interface PlanOptions {
+  readonly source: { readonly commit: string; readonly tree: string };
+  readonly cells: readonly { readonly repository: number; readonly task: number; readonly repeat: 1 | 2 | 3 }[];
+  readonly task_id?: string;
+}
+
+const smokePlan = ({ source, cells, task_id: fixedTaskId }: PlanOptions): CdebStudyPlan => {
+  const descriptors = cells.flatMap((cell, block) => {
+    const repository_id = `repo-${String(cell.repository)}`;
+    const task_id = fixedTaskId ?? `task-${String(cell.task).padStart(2, "0")}`;
+    const category = categoryFor(cell.task + cell.repository * 6);
+    return (["commitlore-on", "commitlore-off"] as const).map((condition, arm) => ({
+      ...cell,
+      repository_id,
+      task_id,
+      category,
+      condition,
+      order: block * 2 + arm + 1,
+      analysis_row_file: `rows/block-${String(block).padStart(3, "0")}-${arm === 0 ? "on" : "off"}.json`,
+    }));
+  });
+  const rows = descriptors.map((descriptor) => descriptor.analysis_row_file);
+  const repository_bundles = Array.from({ length: 5 }, (_unused, repository) => ({
+    repository_id: `repo-${String(repository)}`,
+    bundle_sha256: HEX,
+    snapshot_commit: source.commit,
+    snapshot_tree_oid: source.tree,
+    refs_digest: HEX,
+    notes_ref_digest: HEX,
+    source_authorization_id: `smoke-source-${String(repository)}`,
+  }));
+  const public_freeze = {
+    schema_version: 1,
+    benchmark: "cdeb-v1",
+    protocol_version: "1.3.0",
+    study_id: "cdeb-smoke-disposable",
+    protocol_digest: HEX,
+    candidate_registry_commitment: HEX,
+    sealed_task_bundle_sha256: HEX,
+    repository_bundles,
+    agent_runtime_image_digest: PIN.image.digest!,
+    requested_model: PIN.requested_model,
+    observed_model_id: MODEL_ID,
+    agent_cli_version: CLI_VERSION,
+    agent_executable_sha256: PIN.agent_executable.sha256!,
+    product_commit: OID,
+    dist_digest: HEX,
+    hook_proxy_sha256: shippingProxySha256(PROXY, PARSER),
+    byte_identity_verified: true,
+    evaluator_image_digests: [TEST_IMAGE_DIGEST],
+    analysis_source_digest: analysisSourceDigest(),
+    bootstrap_seed: "cdeb-smoke-seed",
+    calibrated_overhead: 0,
+    qualification_manifest_sha256: HEX,
+    runtime_qualification_summary: { tasks_probed: 30, tasks_qualified: 30 },
+    delivery_qualification_summary: { tasks_verified: 30 },
+    claim_thresholds: {
+      safe_success_lift_pp: 10,
+      token_volume_reduction: 0.15,
+      revival_reduction: 0.3,
+      min_off_revivals: 10,
+      min_safe_successes_per_arm: 10,
+      min_finite_replicates: 9900,
+    },
+    expected_logical_runs: descriptors.length,
+    analysis_inputs: { row_files: rows },
+  };
+  const freezeSha = sha256(`${JSON.stringify(public_freeze, null, 2)}\n`);
+  const logical_runs: LogicalRunPlan[] = descriptors.map((descriptor) => {
+    const logical_run_id = `${descriptor.repository_id}__${descriptor.task_id}__${
+      descriptor.condition === "commitlore-on" ? "on" : "off"
+    }__r${String(descriptor.repeat)}`;
+    return {
+      logical_run_id,
+      repository_id: descriptor.repository_id,
+      task_id: descriptor.task_id,
+      category: descriptor.category,
+      condition: descriptor.condition,
+      repeat: descriptor.repeat,
+      order: descriptor.order,
+      analysis_row_file: descriptor.analysis_row_file,
+      requested_model: PIN.requested_model,
+      prompt: "Apply the direct clamp implementation.",
+      // OFF must name the record too so its absent delivery is an observed
+      // false, not summarizeExposure's vacuous truth for an empty expectation.
+      expected_record_ids: [RECORD_ID],
+      make_row: ({ agent, exposure, final_tree, evaluator, evaluator_attempts }) => ({
+        schema_version: 1,
+        benchmark: "cdeb-v1",
+        protocol_version: "1.3.0",
+        study_id: public_freeze.study_id,
+        logical_run_id,
+        repository_id: descriptor.repository_id,
+        task_id: descriptor.task_id,
+        category: descriptor.category,
+        condition: descriptor.condition,
+        repeat: descriptor.repeat,
+        order: descriptor.order,
+        freeze_manifest_sha256: freezeSha,
+        sealed_task_bundle_sha256: HEX,
+        repository_bundle_sha256: HEX,
+        repository_snapshot: source.commit,
+        base_tree_oid: final_tree.base_tree_oid,
+        refs_digest: HEX,
+        notes_ref_digest: HEX,
+        requested_model: PIN.requested_model,
+        observed_model_ids: agent.provider_ledger.observed_model_ids,
+        agent_cli_version: CLI_VERSION,
+        agent_executable_sha256: PIN.agent_executable.sha256,
+        node_version: PIN.node.version,
+        node_executable_sha256: PIN.node.executable_sha256,
+        agent_runtime_image_digest: PIN.image.digest,
+        tool_policy_digest: HEX,
+        network_policy_digest: HEX,
+        settings_digest: HEX,
+        mcp_config_digest: HEX,
+        harness_commit: OID,
+        product_commit: OID,
+        dist_digest: HEX,
+        hook_proxy_sha256: public_freeze.hook_proxy_sha256,
+        started_at: agent.started_at,
+        finished_at: agent.finished_at,
+        stop_reason: agent.stop_reason,
+        first_model_turn_observed: true,
+        wall_ms: 1,
+        exposure,
+        usage: agent.provider_ledger.usage,
+        final_tree: {
+          final_tree_oid: final_tree.final_tree_oid,
+          canonical_diff_sha256: final_tree.canonical_diff_sha256,
+          archive_sha256: final_tree.archive_sha256,
+          workspace_status_digest: final_tree.workspace_status_digest,
+        },
+        evaluation: {
+          evaluator_image_digest: evaluator.evaluator_image_digest,
+          evaluator_attempts,
+          functional_pass: evaluator.functional_pass,
+          rejected_decision_revived: evaluator.rejected_decision_revived,
+          normalized_result_sha256: normalizedResultSha256(evaluator),
+        },
+        decision_safe_success: agent.stop_reason === "completed" && evaluator.functional_pass && !evaluator.rejected_decision_revived,
+        simulated: false,
+      }),
+    };
+  });
+  return {
+    public_freeze,
+    randomization: {
+      schema_version: 1,
+      algorithm: "sha256-key-sort-v1",
+      block_count: cells.length,
+      blocks: cells.map((_cell, block) => ({
+        block_index: `block-${String(block).padStart(3, "0")}`,
+        conditions: ["commitlore-on", "commitlore-off"] as const,
+      })),
+    },
+    logical_runs,
+  };
+};
+
+const matrixCells = (): PlanOptions["cells"] =>
+  Array.from({ length: 5 }, (_unused, repository) =>
+    Array.from({ length: 6 }, (_task, task) =>
+      ([1, 2, 3] as const).map((repeat) => ({ repository, task, repeat })),
+    ).flat(),
+  ).flat();
+
+const pairCells = (): PlanOptions["cells"] => [{ repository: 0, task: 0, repeat: 1 }];
+
+const evaluator = (tasksDir: string, retryFirst: boolean = false, cacheIdenticalTaskTrees: boolean = false): {
+  readonly runner: EvaluatorRunner;
+  readonly calls: { readonly logical_run_id: string; readonly oid: string; readonly archive: string }[];
+} => {
+  const calls: { logical_run_id: string; oid: string; archive: string }[] = [];
+  let failedFirst = false;
+  const cached = new Map<string, { readonly oid: string; readonly verdict: ReturnType<typeof evaluateLocal>["verdict"] }>();
+  return {
+    calls,
+    runner: {
+      evaluate: async ({ plan, archive_path, final_tree }) => {
+        calls.push({ logical_run_id: plan.logical_run_id, oid: final_tree.final_tree_oid, archive: sha256(readFileSync(archive_path)) });
+        if (retryFirst && !failedFirst) {
+          failedFirst = true;
+          return { kind: "infrastructure-failure", failure_detail: "injected evaluator transport interruption" };
+        }
+        const previous = cached.get(plan.task_id);
+        if (cacheIdenticalTaskTrees && previous !== undefined) {
+          if (previous.oid !== final_tree.final_tree_oid || previous.verdict === null) {
+            return { kind: "infrastructure-failure", failure_detail: "smoke evaluator cache observed a different candidate tree" };
+          }
+          return { kind: "verdict", verdict: previous.verdict };
+        }
+        const local = evaluateLocal({
+          tasksDir,
+          taskId: plan.task_id,
+          archivePath: archive_path,
+          claimedOid: final_tree.final_tree_oid,
+          imageDigest: TEST_IMAGE_DIGEST,
+        });
+        if (local.verdict === null) {
+          return { kind: "infrastructure-failure", failure_detail: local.stderr || "evaluator emitted no verdict" };
+        }
+        if (cacheIdenticalTaskTrees) cached.set(plan.task_id, { oid: final_tree.final_tree_oid, verdict: local.verdict });
+        return { kind: "verdict", verdict: local.verdict };
+      },
+    },
+  };
+};
+
+const dependencies = (
+  source: string,
+  candidate: CandidateWriter,
+  evaluatorRunner: EvaluatorRunner,
+  model: string = MODEL_ID,
+): OrchestratorDependencies => ({
+  prepare_workspace: prepareWorkspace(source),
+  agent: runtimeAgentRunner({ docker: fixtureRuntime(candidate, model), pin: PIN, gate: GATE, provider_env: {} }),
+  freeze_tree: canonicalFinalTreeFreezer,
+  collect_exposure: (workspace, plan) =>
+    summarizeExposure(workspace.exposure_path, plan.expected_record_ids, false),
+  evaluator: evaluatorRunner,
+});
+
+const goodCandidate: CandidateWriter = (workdir) => {
+  writeFileSync(join(workdir, "src", "calc.js"), fixtureFile("patches", "good", "calc.js"));
+};
+
+const attacks: readonly { readonly name: string; readonly candidate: CandidateWriter }[] = [
+  {
+    name: "evaluator tamper",
+    candidate: (workdir) => {
+      const files: Record<string, string> = {
+        "src/calc.js": fixtureFile("attacks", "forge-scripts", "calc.js"),
+        "package.json": fixtureFile("attacks", "forge-scripts", "package.json"),
+        "forge-pass.js": fixtureFile("attacks", "forge-scripts", "forge-pass.js"),
+        "evaluator.json": fixtureFile("attacks", "forge-scripts", "forged-evaluator.json"),
+        ".cdeb/oracles/verdict.json": fixtureFile("attacks", "forge-scripts", ".cdeb", "oracles", "verdict.json"),
+      };
+      for (const [relative, contents] of Object.entries(files)) {
+        const path = join(workdir, relative);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, contents);
+      }
+    },
+  },
+  {
+    name: "secret attempt",
+    candidate: (workdir) => writeFileSync(join(workdir, "src", "calc.js"), fixtureFile("attacks", "secret-env-calc.js")),
+  },
+  {
+    name: "network attempt",
+    candidate: (workdir) => writeFileSync(join(workdir, "src", "calc.js"), fixtureFile("attacks", "network-calc.js")),
+  },
+];
+
+describe("CDEB-09 composed disposable smoke", () => {
+  it(
+    "publishes freeze-named rows through analysis, proves a frozen evaluator retry, and catches a nested invalid result",
+    { timeout: 180_000 },
+    async () => {
+      const source = sourceRepository();
+      const plan = smokePlan({ source, cells: matrixCells() });
+      const sealed = writeSealedTasks([...new Set(plan.logical_runs.map((run) => run.task_id))]);
+      const resultRoot = temp("results");
+      const study = join(resultRoot, "disposable");
+      const storage = new DurableStudyStorage({ studyDir: study, backupDir: temp("backup") });
+      const localEvaluator = evaluator(sealed, true, true);
+
+      await runStudy(plan, dependencies(source.directory, goodCandidate, localEvaluator.runner), { storage });
+
+      const firstId = plan.logical_runs[0]!.logical_run_id;
+      const firstCalls = localEvaluator.calls.filter((call) => call.logical_run_id === firstId);
+      expect(firstCalls).toHaveLength(2);
+      expect(new Set(firstCalls.map((call) => call.oid))).toEqual(new Set([firstCalls[0]!.oid]));
+      expect(new Set(firstCalls.map((call) => call.archive))).toEqual(new Set([firstCalls[0]!.archive]));
+      const firstRow = storage.readRunState(firstId).row;
+      expect(firstRow?.["evaluation"]).toMatchObject({ evaluator_attempts: 2, functional_pass: true });
+      expect(firstRow?.["exposure"]).toMatchObject({
+        hook_opportunities: 1,
+        proxy_executions: 1,
+        expected_record_delivered: true,
+        delivered_record_ids: [RECORD_ID],
+      });
+
+      // The only analysis inputs are the rows the freeze names. This is the
+      // CDEB-07/08 wiring assertion, not a disk discovery convenience.
+      const analysis = analyzeStudy(study);
+      expect(analysis.matrix.rows).toBe(180);
+      expect(analysis.source.row_files).toEqual((plan.public_freeze as { analysis_inputs: { row_files: string[] } }).analysis_inputs.row_files);
+
+      const verified = spawnSync(process.execPath, [VERIFY, resultRoot], { encoding: "utf8" });
+      expect(verified.status, `${verified.stdout}${verified.stderr}`).toBe(0);
+
+      // The fault lands below the study root, where a non-recursive verifier
+      // would miss it. The real recursive verifier must name this exact copy.
+      writeFileSync(join(study, "runs", firstId, "row.json"), "{\"nested\":true}\n");
+      const rejected = spawnSync(process.execPath, [VERIFY, resultRoot], { encoding: "utf8" });
+      expect(rejected.status).toBe(1);
+      expect(`${rejected.stdout}${rejected.stderr}`).toContain(`runs/${firstId}/row.json`);
+    },
+  );
+
+  it("stops before launch when the frozen shipping proxy bytes were mutated", async () => {
+    const source = sourceRepository();
+    const plan = smokePlan({ source, cells: pairCells() });
+    const changedProxy = join(temp("changed-proxy"), "shipping-proxy.ts");
+    writeFileSync(changedProxy, `${readFileSync(PROXY, "utf8")}\n`);
+    const storage = new DurableStudyStorage({ studyDir: temp("proxy-study"), backupDir: temp("proxy-backup") });
+    const localEvaluator = evaluator(SEALED_DIR);
+
+    await expect(runStudy(plan, dependencies(source.directory, goodCandidate, localEvaluator.runner), {
+      storage,
+      shipping_proxy_paths: { proxy_path: changedProxy, parser_path: PARSER },
+    })).rejects.toThrow(/shipping proxy changed/);
+    expect(storage.readRunState(plan.logical_runs[0]!.logical_run_id).launched_attempt_ids).toEqual([]);
+  });
+
+  it("stops the real runtime-to-orchestrator path on model drift", async () => {
+    const source = sourceRepository();
+    const plan = smokePlan({ source, cells: pairCells() });
+    const storage = new DurableStudyStorage({ studyDir: temp("drift-study"), backupDir: temp("drift-backup") });
+    const localEvaluator = evaluator(SEALED_DIR);
+    const firstId = plan.logical_runs[0]!.logical_run_id;
+
+    await expect(runStudy(
+      plan,
+      dependencies(source.directory, goodCandidate, localEvaluator.runner, "unfrozen-observation"),
+      { storage },
+    )).rejects.toThrow(/model identity hard stop/);
+    const state = storage.readRunState(firstId);
+    expect(state.row).toBeNull();
+    expect(state.final_tree).toBeNull();
+    expect(state.agent_attempts).toMatchObject([{ terminal_state: "MEASUREMENT_INTEGRITY_FAILURE", first_model_turn_observed: true }]);
+  });
+
+  it.each(attacks)("has the sealed evaluator refuse a running-pipeline $name", async ({ candidate }) => {
+    const source = sourceRepository();
+    const plan = smokePlan({ source, cells: pairCells(), task_id: "smoke-calc-fix" });
+    const storage = new DurableStudyStorage({ studyDir: temp("attack-study"), backupDir: temp("attack-backup") });
+    const localEvaluator = evaluator(SEALED_DIR);
+    const previousSecret = process.env.CDEB_STUDY_SECRET;
+    process.env.CDEB_STUDY_SECRET = "fixture-only-secret";
+    try {
+      await runStudy(plan, dependencies(source.directory, candidate, localEvaluator.runner), { storage });
+    } finally {
+      if (previousSecret === undefined) delete process.env.CDEB_STUDY_SECRET;
+      else process.env.CDEB_STUDY_SECRET = previousSecret;
+    }
+    for (const run of plan.logical_runs) {
+      const row = storage.readRunState(run.logical_run_id).row;
+      expect(row?.["evaluation"]).toMatchObject({ functional_pass: false });
+      expect(row?.["decision_safe_success"]).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
CDEB-09. Depends on #529 and #528 (both merged). Closes the wiring gap #529 flagged.

Every earlier ticket tested its own component with its own fixtures. Components that each refuse correctly still compose into a pipeline that does not — a guarantee enforced in one module is worth nothing if the module that should invoke it never does, and no unit test can see that gap because it lives exactly between the things being tested.

This is the only place the composed path runs: **freeze → orchestrate → evaluate → ledger → analyze → verify**, with each attack injected into the running pipeline rather than into a stand-in for it.

## The gap was real

#529's `Warn:` said the analyzer reads only row files the freeze names, the orchestrator writes by its own convention, and nothing checked the pairing. A full run produced rows the analyzer would have refused to read.

**The writer moved, not the reader.** The orchestrator now writes at the paths the freeze publishes. Relaxing the analyzer to accept rows discovered on disk would have closed the gap by deleting the guarantee that exists because of #441.

## Every case names its refusal

A run that fails proves nothing on its own — it can fail for the wrong reason and look identical from outside. That is how a control that never fires passes for one that does. So the assertions name where the pipeline stopped:

| attack | what is asserted |
|---|---|
| model drift | hard stop, **no row and no final tree**, while recording that a first turn was observed |
| evaluator tamper / network / secret | a **failing evaluation for every cell** — not an error that could pass for infrastructure trouble |
| shipping proxy mutation | caught |
| nested invalid result | refused |
| evaluator retry | bound to the patch-frozen tree |

## Stated

`Limit:` this exercises the attacks the design anticipated. An adversary who reads it will look for the ones it does not attempt — notably collusion between a candidate and an evaluator image, and any attack on the freeze itself before a run starts.

`Warn:` the container runtime was unavailable here, so network isolation, host secret and mount isolation, and resource limits are proven only against the local sealed evaluator. The OCI enforcement path needs a machine with a working daemon before the freeze may treat it as tested.

43 cases pass across the smoke, orchestrator, analyzer and verifier suites; both typechecks clean; two builds leave `dist` unchanged; both verifiers pass. No live provider or container ran.
