### PR TITLE
Put the boundary a reader needs on the first screen

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,10 +17,11 @@
 **あなたのコーディングエージェントは、チームがすでに却下した案を何度も提案します。**
 
 CommitLore はその決定を Git に残し、ファイルを編集する前に、まだ有効なものだけを
-エージェントに渡します — **ホスティングサービスなしで、リポジトリの外へ 1 バイトも
-出すことなく**。
+エージェントに渡します。
 
-1,160 回の登録済み実行で、却下済みの案を再提案する割合は **18.8%** から **2.8%** になりました。エージェントが実際に見るものは、以下の例です。
+CommitLore にホスティングサービスはなく、record は Git に保管します。MCP サーバー
+または hook がコンテキストを返した後は、host が自身のポリシーでそのコンテキストを
+扱います。CommitLore はそのデータフローを制御しません。
 
 <p align="center">
   <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
@@ -29,11 +30,13 @@ CommitLore はその決定を Git に残し、ファイルを編集する前に�
 <details>
 <summary><strong>目次</strong></summary>
 
-- [一つの例で見る問題](#コードは残った決定は残らなかった)
 - [インストール](#インストール)
+- [エージェントが受け取るもの](#実際に動かす)
+- [自動になること、ならないこと](#自動になることならないこと)
 - [これが役に立たない場合](#これが役に立たない場合)
+- [一つの例で見る問題](#コードは残った決定は残らなかった)
 - [詳しく言うと何なのか](#詳しく言うと何なのか)
-- [実際に動かす](#実際に動かす)
+- [パス問い合わせを見る](#パス問い合わせを見る)
 - [このリポジトリ自体がデモ](#このリポジトリ自体がデモです)
 - [パス範囲と検索](#検索はレコードを見つけられるパス範囲は覆された意思決定を除外する)
 - [仕組み](#仕組み)
@@ -48,45 +51,9 @@ CommitLore はその決定を Git に残し、ファイルを編集する前に�
 
 </details>
 
-## コードは残った。決定は残らなかった。
-
-*同じ悪い案を二度レビューしない。*
-
-
-**CommitLore なしの場合。** 新しいセッションが入力の似た2つの関数を見て、一方を再利用します。
-
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
-```
-
-チームにはフラグが1つ、ラッパーが1つ、そしてその関数が担うつもりのなかったユースケースを
-守る互換ブランチが1つ増えます。レビュアーは「それは既に却下した」と2度目を書きます。
-
-**CommitLore ありの場合。** 編集の前に、エージェントはこれを受け取ります:
-
-```
-commitlore: active records for src/pricing.ts
-
-Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
-
-Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
-```
-
-`[claim]` は実際に機能しています: この record はリポジトリの信頼された作成者が書いた
-ものではないため、エージェントは命令ではなく情報として扱うよう伝えられます。信頼された
-作成者による record は `[directive]` として描画されます。
-
-モジュール境界が、レビューコメントとして後から届くのではなく、エージェントが変更を提案する
-**前に**その目の前に置かれます。
-
-この数字が示さないことは、二つ下の節にある[これが役に立たない場合](#これが役に立たない場合)で説明しています。インストールした後ではなく、その前に読む価値があります。
-
 ## インストール
 
-一度インストールします。コーディングエージェントは引き継ぐ価値のある意思決定を記録でき、CommitLore はそれを検証して Git に保存します。
+一度インストールします。host integration を入れ、使うリポジトリを初期化します。
 
 **Claude Code** — プラグイン一つで MCP サーバー、編集前のコンテキストフック、スキルが登録されます:
 
@@ -97,6 +64,10 @@ Ruled-out
 
 プラグインが持つのはここまでで、MCP サーバー、編集前フック、スキルです。`commitlore` を `PATH` に置くことはないので、以下の `commitlore …` コマンドは `install.sh` / `install.ps1` から来るものであり、そのインストールも必要です。
 
+**Codex** — CommitLore plugin をインストールしてから、以下と同じ repository setup を
+行います。plugin が delivery と capture を提供し、下の CLI が repository command を
+提供します。
+
 どちらの経路も前提条件は Node.js 22+ と Git です。スクリプトは何かを書き込む前に両方を確認します。
 
 **その他のコーディングエージェント** — CLI をインストールします:
@@ -105,13 +76,21 @@ Ruled-out
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
 ```
 
+**Hermes** — CLI をインストールした後、host integration を設定します:
+
+```bash
+commitlore hermes install
+```
+
 どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
 
 **前のエージェントが得た判断を、次のエージェントに渡しましょう。**
 
 ### 次に、各リポジトリで
 
-検証フックとローカル index を使う各リポジトリで、続けて `commitlore init` を実行します。installer は対応するコーディングエージェントを検出し、安全に可能な場所でローカル MCP server を登録します。
+検証フック、ローカル index、リポジトリ所有の agent procedure を使う各リポジトリで、
+続けて `commitlore init` を実行します。installer は対応するコーディングエージェントを
+検出し、安全に可能な場所でローカル MCP server を登録します。
 
 ```bash
 cd your-repository
@@ -123,8 +102,7 @@ commitlore context .
 
 - 普段どおりコミットします。ほとんどのコミットには record がありません。
 - record がある場合、commit-msg hook が検証します。record を作成することはありません。
-- エージェントは MCP で意思決定コンテキストを照会するか、`PreToolUse` hook から受け取ります。
-- path を変更する前に、active limit、ruled-out alternative、warning、verification gap を確認します。
+- delivery と capture は別の layer です。次の節で host ごとの二つの layer を正確に説明します。
 
 コーディングエージェントとの作業を続けます。変更に diff が保存できない意思決定コンテキストがあるときは、エージェントに CommitLore record をコミットへ含めるよう頼んでください。
 
@@ -145,7 +123,44 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
+## 実際に動かす
 
+`src/pricing.ts` を編集する前に、エージェントは説明ではなく record そのものである
+この payload を受け取ります:
+
+```
+commitlore: active records for src/pricing.ts
+
+Limit
+  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+
+Ruled-out
+  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
+                                    and rounding semantics differ between the two flows
+```
+
+`[claim]` には意味があります。この record はリポジトリの信頼された作成者が書いた
+ものではないため、エージェントは命令ではなく情報として評価するよう伝えられます。
+信頼された作成者による record は `[directive]` として描画されます。delivery は
+コンテキストを渡すものであり、編集を止めるものではありません。
+
+## 自動になること、ならないこと
+
+**Delivery** は path を編集する前に record がエージェントへ届くことです。
+**Capture** は決定が検証済みの commit-time flow に入れることです。二つは別の layer です:
+
+| Host | Delivery | Capture |
+|---|---|---|
+| Claude Code | **はい — plugin により自動です。** | **はい — plugin により可能です。** |
+| Codex | **はい — plugin により自動です。** | **はい — plugin により可能です。** |
+| Hermes | **はい — `commitlore hermes install`.** | **はい — `commitlore hermes install`.** |
+| その他の `AGENTS.md` convention host | **procedure であり自動ではありません。** `commitlore init` が編集前 delivery instruction を書きます。host が従う場合も従わない場合もあります。 | **procedure であり自動ではありません。** host が従う場合も従わない場合もあります。 |
+
+「はい」は layer がインストールされるという意味であり、すべての commit に record が
+付くという意味ではありません。自動 integration は最初の三行だけです。その他の
+`AGENTS.md` host では二つの手順は hook ではなく instruction です。host が capture を
+開始し、candidate が検証を通ってから commit hook が付加します。commit-msg hook は
+record があれば検証しますが、新しく作ることはありません。
 
 ## これが役に立たない場合
 
@@ -163,6 +178,33 @@ node commitlore/dist/commitlore.mjs --version
 - M4 は guard の効果を検証していません。row に `guard_exposure` がないため treatment exposure を検証できません: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
 - Guard（ruled-out alternative matching）は実験的参考情報です: precision 44.8%（95% Wilson CI 32.7%–57.5%）、recall 22.0%、417-decision corpus 基準（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空の guard 結果は、提案がすべての ruled-out alternative を回避したという保証ではありません — recall 22% では、見逃しが一般的です。
 
+完全な方法、除外、arm ごとの truncation split は [bench/VERDICT-M5.md](bench/VERDICT-M5.md) と
+[示していないこと](docs/evidence.md) にあります。delivery の方法と retrieval の根拠は
+[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md) にあります。
+
+## コードは残った。決定は残らなかった。
+
+*同じ悪い案を二度レビューしない。*
+
+**CommitLore なしの場合。** 新しいセッションが入力の似た2つの関数を見て、一方を再利用します。
+
+```ts
+calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
+```
+
+チームにはフラグが1つ、ラッパーが1つ、そしてその関数が担うつもりのなかったユースケースを
+守る互換ブランチが1つ増えます。レビュアーは「それは既に却下した」と2度目を書きます。
+
+**CommitLore ありの場合。** 編集の前に、エージェントは上で示した active record を
+受け取り、レビューコメントから再構成した指示を受け取るのではありません。
+
+モジュール境界が、レビューコメントとして後から届くのではなく、エージェントが変更を提案する
+**前に**その目の前に置かれます。
+
+1,160 回の登録済み実行で、却下済みの案を再提案する割合は **18.8%** から **2.8%**
+になりました。この数字が示さないことは、上の
+[これが役に立たない場合](#これが役に立たない場合)にあります。
+
 ## 詳しく言うと、何なのか
 
 **コーディングエージェントのための Git ネイティブな decision layer。**
@@ -178,9 +220,12 @@ CommitLore はその工学的判断を Git に保存し、次の編集の前に*
 
 Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 
-ホスト型メモリサービスも、ベンダー固有のチャット履歴もありません。リポジトリが所有し、共に移動する、レビュー可能な意思決定コンテキストだけです。
+ホスト型メモリサービスも、ベンダー固有のチャット履歴もありません。リポジトリが所有する、
+レビュー可能な意思決定コンテキストだけです。commit trailer は commit と共に移動しますが、
+notes-backed record は通常の clone には来ません。Git は既定で `refs/notes/*` を
+fetch しないため、clone の後に notes fetch を構成する必要があります。
 
-## 実際に動かす
+## パス問い合わせを見る
 
 
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,11 +17,11 @@
 **코딩 에이전트가 팀에서 이미 기각한 방안을 계속 다시 제안합니다.**
 
 CommitLore는 그런 결정을 Git에 보관하고, 파일을 편집하기 전에 아직 유효한 결정만
-에이전트에게 전달합니다 — **호스팅 서비스 없이, 저장소 밖으로 단 1바이트도
-내보내지 않고**.
+에이전트에게 전달합니다.
 
-등록된 실행 1,160회에서 이는 기각된 방안을 다시 제안하는 비율을 **18.8%**에서
-**2.8%**로 낮췄습니다. 에이전트가 실제로 보는 화면은 아래 예시입니다.
+CommitLore에는 호스팅 서비스가 없고 record를 Git에 보관합니다. MCP 서버나 hook이
+맥락을 반환한 뒤에는 host가 자신의 정책에 따라 그 맥락을 처리하며, CommitLore는 그
+데이터 흐름을 제어하지 않습니다.
 
 <p align="center">
   <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
@@ -30,11 +30,13 @@ CommitLore는 그런 결정을 Git에 보관하고, 파일을 편집하기 전�
 <details>
 <summary><strong>목차</strong></summary>
 
-- [한 가지 예로 보는 문제](#코드는-남았다-결정은-남지-않았다)
 - [설치](#설치)
+- [에이전트가 받는 것](#실제로-보기)
+- [자동으로 되는 것과 아닌 것](#자동으로-되는-것과-아닌-것)
 - [도움이 되지 않는 경우](#이것이-도움이-되지-않는-경우)
+- [한 가지 예로 보는 문제](#코드는-남았다-결정은-남지-않았다)
 - [CommitLore란 무엇인가](#commitlore를-자세히-보면)
-- [작동 모습](#실제로-보기)
+- [경로 질의 보기](#경로-질의-보기)
 - [이 저장소 자체가 데모](#이-저장소-자체가-데모입니다)
 - [경로 범위와 검색](#검색은-레코드를-찾을-수-있습니다-경로-범위는-뒤집힌-결정을-걸러냅니다)
 - [동작 방식](#어떻게-동작하나)
@@ -49,45 +51,9 @@ CommitLore는 그런 결정을 Git에 보관하고, 파일을 편집하기 전�
 
 </details>
 
-## 코드는 남았다. 결정은 남지 않았다.
-
-*같은 나쁜 아이디어를 다시 리뷰하지 않는다.*
-
-
-**CommitLore 없이.** 새 세션이 입력이 비슷한 함수 둘을 보고 하나를 재사용한다.
-
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
-```
-
-이제 팀에는 flag 하나, wrapper 하나, 그 함수가 애초에 맡을 생각이 없던 사용처를
-지키는 compatibility branch 하나가 더 생겼다. 리뷰어는 "이건 이미 기각했다"를 두 번째로 쓴다.
-
-**CommitLore와 함께.** 편집 전에 에이전트가 받는 것:
-
-```
-commitlore: active records for src/pricing.ts
-
-Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
-
-Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
-```
-
-`[claim]`이 실제로 일을 한다: 이 record는 저장소의 신뢰된 작성자가 쓴 것이 아니므로,
-에이전트는 이것을 명령이 아니라 정보로 다루라고 안내받는다. 신뢰된 작성자가 남긴
-record는 `[directive]`로 렌더된다.
-
-모듈 경계가 리뷰 코멘트로 뒤늦게가 아니라, 에이전트가 변경을 제안하기 **전에** 그 앞에
-놓인다.
-
-이 수치가 보여 주지 않는 것은 두 섹션 아래의 [이것이 도움이 되지 않는 경우](#이것이-도움이-되지-않는-경우)에 있다. 설치한 뒤가 아니라 전에 스크롤해 읽을 가치가 있다.
-
 ## 설치
 
-한 번 설치한다. 코딩 에이전트가 계속 가져갈 가치가 있는 결정을 기록할 수 있고, CommitLore는 이를 검증해 Git에 보존한다.
+한 번 설치한다. host integration을 설치하고, 사용할 저장소를 초기화한다.
 
 **Claude Code** — 플러그인 하나가 MCP 서버, 편집 전 컨텍스트 훅, 스킬을 함께 등록한다:
 
@@ -98,6 +64,9 @@ record는 `[directive]`로 렌더된다.
 
 플러그인이 담는 것은 여기까지다: MCP 서버, 편집 전 훅, 스킬. `commitlore`를 `PATH`에 올리지는 않으므로, 아래의 `commitlore …` 명령은 `install.sh` / `install.ps1`에서 오고 그 설치까지 필요하다.
 
+**Codex** — CommitLore plugin을 설치한 뒤 아래와 같은 repository setup을 한다.
+plugin이 delivery와 capture를 제공하고, 아래 CLI가 repository command를 제공한다.
+
 두 경로 모두의 전제 조건: Node.js 22+ 와 Git. 스크립트는 무엇이든 쓰기 전에 둘을 확인한다.
 
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
@@ -106,13 +75,21 @@ record는 `[directive]`로 렌더된다.
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
 ```
 
+**Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
+
+```bash
+commitlore hermes install
+```
+
 어떤 host를 지원하는지, 각 설치 경로가 무엇을 요구하는지: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
 
 **지난 에이전트가 얻어낸 판단을, 다음 에이전트에게 물려주세요.**
 
 ### 그런 다음, 각 저장소에서
 
-검증 훅과 로컬 인덱스를 쓸 각 저장소에서 이어서 `commitlore init`을 실행한다. 설치기는 지원되는 코딩 에이전트를 감지하고, 안전하게 가능한 곳에 로컬 MCP 서버를 등록한다.
+검증 훅, 로컬 인덱스, 저장소 소유 agent procedure를 쓸 각 저장소에서 이어서
+`commitlore init`을 실행한다. 설치기는 지원되는 코딩 에이전트를 감지하고,
+안전하게 가능한 곳에 로컬 MCP 서버를 등록한다.
 
 ```bash
 cd your-repository
@@ -124,8 +101,7 @@ commitlore context .
 
 - 평소처럼 커밋한다. 대부분의 커밋에는 record가 없다.
 - record가 있으면 commit-msg hook이 검증한다. record를 만들지는 않는다.
-- 에이전트는 MCP로 결정 맥락을 조회하거나 `PreToolUse` hook으로 받는다.
-- path를 바꾸기 전에 active limit, ruled-out alternative, warning, verification gap을 본다.
+- delivery와 capture는 다른 layer다. 다음 섹션에서 host별 두 layer를 정확히 설명한다.
 
 코딩 에이전트와 계속 작업한다. 변경에 diff가 보존할 수 없는 결정 맥락이 있으면, 에이전트에게 커밋에 CommitLore record를 넣어 달라고 요청한다.
 
@@ -146,6 +122,43 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
+## 실제로 보기
+
+`src/pricing.ts`를 편집하기 전에 에이전트는 설명이 아니라 record 자체인 이 payload를 받는다:
+
+```
+commitlore: active records for src/pricing.ts
+
+Limit
+  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+
+Ruled-out
+  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
+                                    and rounding semantics differ between the two flows
+```
+
+`[claim]`에는 의미가 있다. 이 record는 저장소의 신뢰된 작성자가 쓰지 않았으므로,
+에이전트는 명령이 아니라 정보로 평가해야 한다. 신뢰된 작성자가 남긴 record는
+`[directive]`로 렌더된다. delivery는 맥락을 주며, 편집을 막지 않는다.
+
+## 자동으로 되는 것과 아닌 것
+
+**Delivery**는 path를 편집하기 전에 record가 에이전트에 도달한다는 뜻이다.
+**Capture**는 결정이 검증된 commit-time flow에 들어갈 수 있다는 뜻이다. 둘은 다른 layer다:
+
+| Host | Delivery | Capture |
+|---|---|---|
+| Claude Code | **예 — plugin을 통해 자동으로 된다.** | **예 — plugin을 통해 된다.** |
+| Codex | **예 — plugin을 통해 자동으로 된다.** | **예 — plugin을 통해 된다.** |
+| Hermes | **예 — `commitlore hermes install`.** | **예 — `commitlore hermes install`.** |
+| 그 밖의 `AGENTS.md` convention host | **procedure이며 자동이 아니다.** `commitlore init`이 편집 전 delivery instruction을 쓴다. host가 따를 수도, 따르지 않을 수도 있다. | **procedure이며 자동이 아니다.** host가 따를 수도, 따르지 않을 수도 있다. |
+
+“예”는 layer가 설치되었다는 뜻이지 모든 commit에 record가 생긴다는 뜻이 아니다.
+대부분의 commit에는 record가 없어야 한다. 자동 integration은 첫 세 행에만 있다. 다른
+`AGENTS.md` host에서는 두 단계 모두 hook이 아니라 instruction이다. host가 capture를
+시작해야 하고, candidate는 commit hook이 붙이기 전에 검증을 통과해야 한다. commit-msg
+hook은 record가 있으면 검증하지만, 새로 만들지는 않는다.
+
 
 
 ## 이것이 도움이 되지 않는 경우
@@ -163,6 +176,33 @@ node commitlore/dist/commitlore.mjs --version
 - M4는 guard 효과를 시험하지 못했다. row에 `guard_exposure`가 없어 treatment exposure를 검증할 수 없다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
 - Guard(ruled-out alternative matching)는 실험적 참고 자료이다: precision 44.8%(95% Wilson CI 32.7%–57.5%), recall 22.0%, 417-decision corpus 기준([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). 빈 guard 결과는 제안이 모든 ruled-out alternative를 피했다는 보장이 아니다 — recall 22%에서 누락이 일반적이다.
 
+전체 방법, 제외 항목, arm별 truncation split은 [bench/VERDICT-M5.md](bench/VERDICT-M5.md)와
+[보여 주지 않는 것](docs/evidence.md)에 있다. delivery 방법과 retrieval 근거는
+[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)에 있다.
+
+## 코드는 남았다. 결정은 남지 않았다.
+
+*같은 나쁜 아이디어를 다시 리뷰하지 않는다.*
+
+**CommitLore 없이.** 새 세션이 입력이 비슷한 함수 둘을 보고 하나를 재사용한다.
+
+```ts
+calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
+```
+
+이제 팀에는 flag 하나, wrapper 하나, 그 함수가 애초에 맡을 생각이 없던 사용처를
+지키는 compatibility branch 하나가 더 생겼다. 리뷰어는 "이건 이미 기각했다"를 두 번째로 쓴다.
+
+**CommitLore와 함께.** 편집 전에 에이전트는 위에 보인 active record를 받아,
+리뷰 코멘트에서 재구성한 지시를 받지 않는다.
+
+모듈 경계가 리뷰 코멘트로 뒤늦게가 아니라, 에이전트가 변경을 제안하기 **전에** 그 앞에
+놓인다.
+
+등록된 실행 1,160회에서 이는 기각된 방안을 다시 제안하는 비율을 **18.8%**에서
+**2.8%**로 낮췄습니다. 이 수치가 보여 주지 않는 것은 위의
+[이것이 도움이 되지 않는 경우](#이것이-도움이-되지-않는-경우)에 있다.
+
 ## CommitLore를 자세히 보면
 
 **코딩 에이전트를 위한 Git 네이티브 decision layer.**
@@ -178,9 +218,12 @@ CommitLore는 그 엔지니어링 판단을 Git에 보존하고, 다음 편집 �
 
 Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 
-호스팅 메모리 서비스도, 벤더 전용 채팅 기록도 없다. 저장소가 소유하고 함께 이동하는, 검토 가능한 결정 맥락만 있다.
+호스팅 메모리 서비스도, 벤더 전용 채팅 기록도 없다. 저장소가 소유하는, 검토 가능한
+결정 맥락만 있다. commit trailer는 commit과 함께 이동하지만 notes-backed record는
+ordinary clone에 오지 않는다. Git은 기본으로 `refs/notes/*`를 fetch하지 않으므로,
+clone 뒤 notes fetch를 구성해야 한다.
 
-## 실제로 보기
+## 경로 질의 보기
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
 
 **Your coding agent keeps re-proposing things your team already rejected.**
 CommitLore keeps those decisions in Git and hands the agent the ones still in
-force, before it edits the file — **without a hosted service, and without a
-single byte leaving your repository**.
+force, before it edits the file.
 
-Across 1,160 registered runs, that took re-proposing a ruled-out approach from
-**18.8%** down to **2.8%**. The example below is what the agent actually sees.
+CommitLore has no hosted service; it keeps its records in Git. Once its MCP
+server or hook returns context, the host handles that context under its own
+policy; CommitLore does not control that data flow.
 
 <p align="center">
   <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
@@ -29,11 +29,13 @@ Across 1,160 registered runs, that took re-proposing a ruled-out approach from
 <details>
 <summary><strong>Contents</strong></summary>
 
-- [The problem, in one example](#the-code-survived-the-decision-didnt)
 - [Install](#install)
+- [What the agent receives](#see-it-work)
+- [What happens automatically](#what-happens-automatically-and-what-does-not)
 - [When this will not help you](#when-this-will-not-help-you)
+- [The problem, in one example](#the-code-survived-the-decision-didnt)
 - [What it is, in full](#what-it-is-in-full)
-- [See it work](#see-it-work)
+- [A path query](#see-a-path-query)
 - [This repository as its own demo](#the-repository-is-the-demo)
 - [Path scope vs. retrieval](#retrieval-can-find-records-path-scope-keeps-reversed-decisions-out)
 - [How it works](#how-it-works)
@@ -48,67 +50,10 @@ Across 1,160 registered runs, that took re-proposing a ruled-out approach from
 
 </details>
 
-## The code survived. The decision didn't.
-
-*Stop re-reviewing the same bad idea.*
-
-
-**Without CommitLore.** A new session sees two functions with similar inputs and
-reuses one.
-
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
-```
-
-The team now has another flag, another wrapper, and another compatibility branch
-protecting a use case the function was never meant to own. The reviewer writes
-"we already rejected this" for the second time.
-
-**With CommitLore.** Before editing, the agent receives:
-
-```
-commitlore: active records for src/pricing.ts
-
-Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
-
-Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
-```
-
-`[claim]` is doing real work: this record was not written by a trusted author of
-the repository, so the agent is told to treat it as information rather than as an
-order. A record that *was* signed by a trusted author renders as `[directive]`.
-
-The module boundary is in front of the agent before it proposes the change,
-rather than in a review comment after.
-
-**Whether it acts on that is now measured.** Across 1,160 registered runs, an
-agent handed the repository's active records re-proposed a ruled-out approach in
-**2.8%** of them (16/580). Without them: **18.8%** (109/579).
-
-| arm | re-proposed a ruled-out approach |
-|---|---:|
-| the agent alone | **18.8%** (109/579) |
-| **with CommitLore** | **2.8%** (16/580) |
-
-**The threshold was registered before the run**, and the preregistration
-predicted a *smaller* effect than it got — that prediction, with its stated
-probabilities, is in
-[bench/PREREGISTRATION-M5.md](bench/PREREGISTRATION-M5.md) §A.2, and it was
-wrong. The significance test, the interval and the registered threshold are in
-[bench/VERDICT-M5.md](bench/VERDICT-M5.md) rather than here: a statistic
-retyped into prose drifts from the log that produced it, and this repository
-gates against exactly that (`scripts/check-readme-numbers.mjs`).
-
-What that number does **not** show is two sections down, under
-[when this will not help you](#when-this-will-not-help-you). It is worth the
-scroll before you install rather than after.
-
 ## Install
 
-Install once. Your coding agent can record the decisions worth carrying forward, while CommitLore validates and preserves them in Git.
+Install once. Install the host integration and initialise the repository where
+you want it to work.
 
 **Claude Code** — one plugin registers the MCP server, the pre-edit context hook and the skills:
 
@@ -119,6 +64,10 @@ Install once. Your coding agent can record the decisions worth carrying forward,
 
 That is the whole plugin: the MCP server, the pre-edit hook and the skills. It puts no `commitlore` on `PATH`, so the `commitlore …` commands below come from `install.sh` / `install.ps1` and need that install as well.
 
+**Codex** — install the CommitLore plugin, then use the same repository setup
+below. Its plugin supplies both delivery and capture; the CLI below provides
+the repository commands.
+
 Prerequisites for either path: Node.js 22+ and Git. The script checks both before it writes anything.
 
 **Any other coding agent** — install the CLI:
@@ -127,13 +76,22 @@ Prerequisites for either path: Node.js 22+ and Git. The script checks both befor
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
 ```
 
+**Hermes** — after installing the CLI, configure its host integration:
+
+```bash
+commitlore hermes install
+```
+
 Which hosts are supported, and what each install path requires: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
 
 **Give your next agent the judgment your last one earned.**
 
 ### Then, in each repository
 
-Then run `commitlore init` in each repository where you want validation hooks and a local index. The installer detects supported coding agents and registers the local MCP server where it can do so safely.
+Then run `commitlore init` in each repository where you want validation hooks,
+a local index, and the repository-owned agent procedure. The installer detects
+supported coding agents and registers the local MCP server where it can do so
+safely.
 
 ```bash
 cd your-repository
@@ -145,8 +103,8 @@ After that:
 
 - Commit normally. Most commits carry no record.
 - If a record is present, the commit-msg hook validates it; it never creates one.
-- Agents query decision context through MCP or receive it from the `PreToolUse` hook.
-- Before changing a path, they see its active limits, ruled-out alternatives, warnings, and verification gaps.
+- Delivery and capture are different layers; the next section says exactly
+  which hosts have each one.
 
 Keep working through your coding agent. When a change contains decision context the diff cannot preserve, ask the agent to include a CommitLore record in the commit.
 
@@ -166,6 +124,47 @@ node commitlore/dist/commitlore.mjs --version
 ```
 
 </details>
+
+## See it work
+
+Before editing `src/pricing.ts`, the agent receives this payload — the record,
+not a description of one:
+
+```
+commitlore: active records for src/pricing.ts
+
+Limit
+  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+
+Ruled-out
+  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
+                                    and rounding semantics differ between the two flows
+```
+
+`[claim]` matters: the record was not written by a trusted author of the
+repository, so the agent is told to weigh it as information, not obey it as an
+order. A record signed by a trusted author renders as `[directive]`. Delivery
+gives the agent context; it does not block the edit.
+
+## What happens automatically — and what does not
+
+**Delivery** means the record reaches the agent before it edits a path.
+**Capture** means a decision can enter the verified commit-time flow. They are
+separate layers:
+
+| Host | Delivery | Capture |
+|---|---|---|
+| Claude Code | **Yes — automatic through the plugin.** | **Yes — through the plugin.** |
+| Codex | **Yes — automatic through the plugin.** | **Yes — through the plugin.** |
+| Hermes | **Yes — `commitlore hermes install`.** | **Yes — `commitlore hermes install`.** |
+| Other `AGENTS.md`-convention hosts | **Procedure, not automatic.** `commitlore init` writes the pre-edit delivery instruction; the host may or may not follow it. | **Procedure, not automatic.** The host may or may not follow it. |
+
+“Yes” means the layer is installed, not that every commit gains a record.
+Most commits should carry none. Only the first three rows run integrations
+automatically. On other `AGENTS.md` hosts, both steps are instructions, not
+hooks. A host still has to start capture, and the candidate must pass
+verification before the commit hook attaches it. The commit-msg hook validates
+a record when present; it never invents one.
 
 ## When this will not help you
 
@@ -195,7 +194,47 @@ Read this before installing, not after.
 
 The full method, the exclusions and the per-arm truncation split are in
 [bench/VERDICT-M5.md](bench/VERDICT-M5.md) and
-[what it does not show](docs/evidence.md).
+[what it does not show](docs/evidence.md). Delivery methodology and the
+retrieval evidence are in [bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md).
+
+## The code survived. The decision didn't.
+
+*Stop re-reviewing the same bad idea.*
+
+**Without CommitLore.** A new session sees two functions with similar inputs and
+reuses one.
+
+```ts
+calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
+```
+
+The team now has another flag, another wrapper, and another compatibility branch
+protecting a use case the function was never meant to own. The reviewer writes
+"we already rejected this" for the second time.
+
+**With CommitLore.** Before editing, the agent receives the active record shown
+above, rather than an instruction reconstructed from a review comment.
+
+The module boundary is in front of the agent before it proposes the change,
+rather than in a review comment after.
+
+**Whether it acts on that is now measured.** Across 1,160 registered runs, an
+agent handed the repository's active records re-proposed a ruled-out approach in
+**2.8%** of them (16/580). Without them: **18.8%** (109/579).
+
+| arm | re-proposed a ruled-out approach |
+|---|---:|
+| the agent alone | **18.8%** (109/579) |
+| **with CommitLore** | **2.8%** (16/580) |
+
+**The threshold was registered before the run**, and the preregistration
+predicted a *smaller* effect than it got — that prediction, with its stated
+probabilities, is in
+[bench/PREREGISTRATION-M5.md](bench/PREREGISTRATION-M5.md) §A.2, and it was
+wrong. The significance test, the interval and the registered threshold are in
+[bench/VERDICT-M5.md](bench/VERDICT-M5.md) rather than here: a statistic
+retyped into prose drifts from the log that produced it, and this repository
+gates against exactly that (`scripts/check-readme-numbers.mjs`).
 
 ## What it is, in full
 
@@ -215,10 +254,10 @@ superseded or expired does not reach the agent as if it still stood.
 Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 
 No hosted memory service. No vendor-specific chat history. Just reviewable
-decision context, owned by and portable with the repository.
+decision context, owned by the repository. Commit trailers travel with their
+commits; notes-backed records need the notes fetch configured after a clone.
 
-## See it work
-
+## See a path query
 
 **A fresh agent. Zero chat history. It is still handed why the obvious fix was rejected.** Query a path before changing it:
 
@@ -330,8 +369,11 @@ authority is Git rather than a service:
 - **Reviewable.** A decision arrives as a commit trailer in a pull request, where
   it can be argued with before it becomes authority.
 - **Owned by the repository.** No account, no vendor, nothing to lose access to.
-- **Travels with a clone.** A new machine, a new contributor, or a new agent gets
-  the decisions with the code.
+- **Commit trailers travel with a clone.** A record in
+  `refs/notes/commitlore` does not arrive in an ordinary clone: Git does not
+  fetch `refs/notes/*` by default. `commitlore init` configures that mirror;
+  [the sharing documentation](docs/cli.md#sharing-records-with-a-team) explains
+  the remaining fetch and push boundary.
 
 ## What makes it different
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,10 +16,10 @@
 
 **你的编程代理不断重新提议团队早已否决的方案。**
 
-CommitLore 把这些决策保存在 Git 中，并在它编辑文件之前，把仍然有效的决策交给它
-——**无需托管服务，也不会有一个字节离开你的仓库**。
+CommitLore 把这些决策保存在 Git 中，并在它编辑文件之前，把仍然有效的决策交给它。
 
-在 1,160 次已登记的运行中，重新提议已否决方案的比例从 **18.8%** 降至 **2.8%**。下面的示例就是代理实际看到的内容。
+CommitLore 没有托管服务；它把 record 保存在 Git 中。其 MCP 服务器或 hook 返回
+上下文后，host 会按自己的政策处理这些上下文；CommitLore 无法控制那条数据流。
 
 <p align="center">
   <img src="./assets/readme/commitlore-demo.svg" width="100%" alt="commitlore demo: lifecycle filtering shows only active decisions">
@@ -28,11 +28,13 @@ CommitLore 把这些决策保存在 Git 中，并在它编辑文件之前，把�
 <details>
 <summary><strong>目录</strong></summary>
 
-- [一个例子中的问题](#代码留了下来决定没有)
 - [安装](#安装)
+- [代理收到的内容](#看它实际运行)
+- [哪些是自动的，哪些不是](#哪些是自动的哪些不是)
 - [这在什么情况下帮不上忙](#这在什么情况下帮不上忙)
+- [一个例子中的问题](#代码留了下来决定没有)
 - [完整地说，它是什么](#完整地说它是什么)
-- [看它实际运行](#看它实际运行)
+- [查看路径查询](#查看路径查询)
 - [这个仓库本身就是演示](#这个仓库本身就是演示)
 - [路径范围与检索](#检索能找到记录路径范围会排除已经推翻的决策)
 - [工作方式](#工作方式)
@@ -47,43 +49,9 @@ CommitLore 把这些决策保存在 Git 中，并在它编辑文件之前，把�
 
 </details>
 
-## 代码留了下来，决定没有。
-
-*不再重复评审同一个坏主意。*
-
-
-**没有 CommitLore。** 新会话看到两个输入相似的函数，复用了其中一个。
-
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
-```
-
-团队于是多了一个标志、一个包装器，以及一个守护该函数本不该承担的用例的兼容分支。评审者
-第二次写下"我们已经否决过这个了"。
-
-**有 CommitLore。** 编辑之前，代理收到：
-
-```
-commitlore: active records for src/pricing.ts
-
-Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
-
-Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
-```
-
-`[claim]` 在真正起作用：这条 record 并非由仓库的可信作者写入，因此代理被告知把它当作
-信息而不是命令。由可信作者留下的 record 会渲染为 `[directive]`。
-
-模块边界在代理提出改动**之前**就摆在它面前，而不是事后出现在评审意见里。
-
-这个数字没有说明的内容，位于下方两个章节后的[这在什么情况下帮不上忙](#这在什么情况下帮不上忙)。在安装前而不是之后花时间读一读，值得。
-
 ## 安装
 
-安装一次。你的编程代理可以记录值得延续的决策，而 CommitLore 会验证它们并将其保存在 Git 中。
+安装一次。装好 host integration，并初始化要使用的仓库。
 
 **Claude Code** — 一个插件即可注册 MCP 服务器、编辑前上下文钩子与技能:
 
@@ -94,6 +62,9 @@ Ruled-out
 
 插件所含仅此而已：MCP 服务器、编辑前钩子与技能。它不会把 `commitlore` 放到 `PATH` 上，因此下面的 `commitlore …` 命令来自 `install.sh` / `install.ps1`，还需要那一步安装。
 
+**Codex** — 安装 CommitLore plugin，然后运行下方相同的 repository setup。plugin
+提供 delivery 与 capture；下方的 CLI 提供 repository command。
+
 两条路径的前置条件都是 Node.js 22+ 与 Git。脚本在写入任何内容之前会检查这两项。
 
 **其他编程代理** — 安装 CLI:
@@ -102,13 +73,21 @@ Ruled-out
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
 ```
 
+**Hermes** — 安装 CLI 后，配置它的 host integration：
+
+```bash
+commitlore hermes install
+```
+
 支持哪些 host，以及各条安装路径需要什么：[docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
 
 **把上一个代理挣得的判断，交给下一个代理。**
 
 ### 然后，在每个仓库中
 
-然后在每个需要验证 hook 与本地 index 的仓库运行 `commitlore init`。安装程序会检测受支持的编程代理，并在可以安全处理的地方注册本地 MCP server。
+然后在每个需要验证 hook、本地 index 与仓库自有 agent procedure 的仓库运行
+`commitlore init`。安装程序会检测受支持的编程代理，并在可以安全处理的地方注册
+本地 MCP server。
 
 ```bash
 cd your-repository
@@ -120,8 +99,7 @@ commitlore context .
 
 - 照常提交。绝大多数提交没有 record。
 - 如果已有 record，commit-msg hook 会验证它；不会创建 record。
-- 代理通过 MCP 查询决策上下文，或从 `PreToolUse` hook 接收它。
-- 更改 path 前，它们会看到 active limit、ruled-out alternative、warning 和 verification gap。
+- delivery 与 capture 是不同 layer。下一节会准确说明每个 host 具备的两层。
 
 继续通过编程代理工作。若某项更改包含 diff 无法保存的决策上下文，请让代理在提交中加入 CommitLore record。
 
@@ -142,7 +120,41 @@ node commitlore/dist/commitlore.mjs --version
 
 </details>
 
+## 看它实际运行
 
+在编辑 `src/pricing.ts` 前，代理会收到这份 payload——record 本身，而不是对它的描述：
+
+```
+commitlore: active records for src/pricing.ts
+
+Limit
+  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+
+Ruled-out
+  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
+                                    and rounding semantics differ between the two flows
+```
+
+`[claim]` 有实际含义：这条 record 并非由仓库的可信作者写入，所以代理会被告知把它
+当作信息权衡，而不是当作命令服从。可信作者写入的 record 会渲染为 `[directive]`。
+delivery 给代理的是上下文，并不阻止编辑。
+
+## 哪些是自动的，哪些不是
+
+**Delivery** 表示 record 会在代理编辑 path 前到达。**Capture** 表示一项决定可以进入
+经过验证的 commit-time flow。二者是不同的 layer：
+
+| Host | Delivery | Capture |
+|---|---|---|
+| Claude Code | **有——通过 plugin 自动完成。** | **有——通过 plugin 提供。** |
+| Codex | **有——通过 plugin 自动完成。** | **有——通过 plugin 提供。** |
+| Hermes | **有——`commitlore hermes install`。** | **有——`commitlore hermes install`。** |
+| 其他遵循 `AGENTS.md` convention 的 host | **是 procedure，不自动。** `commitlore init` 写入编辑前 delivery instruction；host 可能遵循，也可能不遵循。 | **是 procedure，不自动。** host 可能遵循，也可能不遵循。 |
+
+“有”只表示该 layer 已安装，不表示每次 commit 都会得到 record。绝大多数 commit
+本就不应携带 record。只有前三行会自动运行 integration。在其他 `AGENTS.md` host 上，
+两步都是 instruction，而不是 hook。host 仍须启动 capture，candidate 也必须先通过
+验证，commit hook 才会附加它。commit-msg hook 会验证已有的 record；它从不凭空创建 record。
 
 ## 这在什么情况下帮不上忙
 
@@ -156,6 +168,32 @@ node commitlore/dist/commitlore.mjs --version
 - 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
 - M4 没有检验 guard 效果：row 没有 `guard_exposure`，因而无法验证 treatment exposure（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
 - Guard（ruled-out alternative matching）是实验性参考信息：precision 44.8%（95% Wilson CI 32.7%–57.5%），recall 22.0%，基于 417-decision corpus（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空的 guard 结果不保证提案避开了所有 ruled-out alternative——在 recall 22% 下，遗漏才是常态。
+
+完整方法、排除项与每个 arm 的 truncation split 见 [bench/VERDICT-M5.md](bench/VERDICT-M5.md)
+及[它没有显示什么](docs/evidence.md)。delivery 方法和 retrieval 证据见
+[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)。
+
+## 代码留了下来，决定没有。
+
+*不再重复评审同一个坏主意。*
+
+**没有 CommitLore。** 新会话看到两个输入相似的函数，复用了其中一个。
+
+```ts
+calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
+```
+
+团队于是多了一个标志、一个包装器，以及一个守护该函数本不该承担的用例的兼容分支。评审者
+第二次写下“我们已经否决过这个了”。
+
+**有 CommitLore。** 编辑之前，代理收到的是上方展示的 active record，而不是从评审意见
+重新拼凑出的指令。
+
+模块边界在代理提出改动**之前**就摆在它面前，而不是事后出现在评审意见里。
+
+在 1,160 次已登记的运行中，重新提议已否决方案的比例从 **18.8%** 降至 **2.8%**。
+这个数字没有说明的内容，见上方的
+[这在什么情况下帮不上忙](#这在什么情况下帮不上忙)。
 
 ## 完整地说，它是什么
 
@@ -171,9 +209,11 @@ CommitLore 把这份工程判断保存在 Git 中，并在下一次编辑前只�
 
 Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
 
-没有托管记忆服务，也没有特定供应商的聊天历史。只有由仓库拥有并随仓库流转、可供审查的决策上下文。
+没有托管记忆服务，也没有特定供应商的聊天历史。只有由仓库拥有、可供审查的
+决策上下文。commit trailer 会随 commit 流转；notes-backed record 则需要在 clone
+之后配置 notes fetch。普通 clone 不会获取 `refs/notes/*`，因为 Git 默认不 fetch 它。
 
-## 看它实际运行
+## 查看路径查询
 
 
 

--- a/bench/cdeb/evaluator/runner-oci.ts
+++ b/bench/cdeb/evaluator/runner-oci.ts
@@ -100,22 +100,79 @@ export const buildEvaluatorRunArgs = (request: OciEvaluationRequest): string[] =
   return args;
 };
 
-export const dockerDaemonAvailable = (): boolean => {
+/**
+ * Why the runtime is not usable, when it is not.
+ *
+ * `timed-out` is deliberately not folded into `unreachable`. A probe that ran
+ * out of time did not learn that the daemon is absent; it learned nothing. Both
+ * refuse — refusing on "I do not know" is the whole point — but they are
+ * different facts, and an operator staring at a study that would not start
+ * needs to be told which one happened.
+ */
+export type RuntimeUnavailableReason = "unreachable" | "timed-out" | "not-installed";
+
+export type RuntimeProbe =
+  | { readonly available: true; readonly serverVersion: string }
+  | { readonly available: false; readonly reason: RuntimeUnavailableReason; readonly detail: string };
+
+/** How long the probe waits before it stops knowing anything. */
+const PROBE_TIMEOUT_MS = 20_000;
+
+/**
+ * Asks once whether the pinned runtime can be used, and reports what it found.
+ *
+ * The timeout is generous on purpose. At five seconds a cold or loaded daemon
+ * answered late often enough that one call could time out and the next could
+ * succeed — which is how the same question got two answers inside a single
+ * evaluation, and how a fail-closed guard came to disagree with the code it
+ * guards.
+ */
+export const probeEvaluatorRuntime = (): RuntimeProbe => {
   const result = spawnSync("docker", ["info", "--format", "{{.ServerVersion}}"], {
     encoding: "utf8",
-    timeout: 5_000,
+    timeout: PROBE_TIMEOUT_MS,
   });
-  return result.status === 0;
+  if (result.error !== undefined && (result.error as NodeJS.ErrnoException).code === "ENOENT") {
+    return { available: false, reason: "not-installed", detail: "docker is not on PATH" };
+  }
+  if (result.signal !== null) {
+    return {
+      available: false,
+      reason: "timed-out",
+      detail: `docker info did not answer within ${String(PROBE_TIMEOUT_MS)}ms`,
+    };
+  }
+  if (result.status !== 0) {
+    return { available: false, reason: "unreachable", detail: (result.stderr ?? "").trim() };
+  }
+  return { available: true, serverVersion: (result.stdout ?? "").trim() };
 };
+
+/**
+ * Thin boolean view of the probe, for callers that only branch on it.
+ *
+ * Anything deciding whether the fail-closed path *will* fire must use
+ * `probeEvaluatorRuntime` and pass the result to `runEvaluatorOci`. Calling
+ * this and then calling the runner asks the same question twice, and the two
+ * answers are not guaranteed to match.
+ */
+export const dockerDaemonAvailable = (): boolean => probeEvaluatorRuntime().available;
 
 /**
  * Runs one evaluation in the pinned image. Throws EvaluatorRuntimeUnavailable
  * when the daemon cannot be reached — never falls back to a weaker surface.
+ *
+ * `probe` exists so a caller that has already decided can hand that decision
+ * in rather than have it re-derived here. Re-deriving is what let a guard and
+ * the guarded call observe different runtimes.
  */
-export const runEvaluatorOci = (request: OciEvaluationRequest): { stdout: Buffer; stderr: string; exitCode: number | null } => {
-  if (!dockerDaemonAvailable()) {
+export const runEvaluatorOci = (
+  request: OciEvaluationRequest,
+  probe: RuntimeProbe = probeEvaluatorRuntime(),
+): { stdout: Buffer; stderr: string; exitCode: number | null } => {
+  if (!probe.available) {
     throw new EvaluatorRuntimeUnavailable(
-      "no reachable docker daemon — study evaluation requires the pinned image; refusing to downgrade",
+      `docker runtime ${probe.reason} (${probe.detail}) — study evaluation requires the pinned image; refusing to downgrade`,
     );
   }
   const result = spawnSync("docker", buildEvaluatorRunArgs(request), {

--- a/test/cdeb-evaluator.test.ts
+++ b/test/cdeb-evaluator.test.ts
@@ -30,7 +30,7 @@ import {
   buildEvaluatorRunArgs,
   combineImageIdentity,
   digestRef,
-  dockerDaemonAvailable,
+  probeEvaluatorRuntime,
   ENGINE_CONTEXT_FILES,
   evaluatorImageContextDigest,
   EvaluatorRuntimeUnavailable,
@@ -200,13 +200,19 @@ describe("OCI contract (§12.1/§12.2) — frozen argv, fail-closed absence", ()
   });
 
   it("refuses to evaluate when no daemon is reachable — never downgrades", () => {
-    if (dockerDaemonAvailable()) {
+    // One probe, used for both the decision to assert and the call being
+    // asserted on. Asking twice is what made this intermittent: a five-second
+    // probe could time out on the first call and succeed on the second, so the
+    // guard concluded "no daemon" and the runner then found one and did not
+    // throw. The property is fail-closed behaviour, not the machine's mood.
+    const probe = probeEvaluatorRuntime();
+    if (probe.available) {
       // On a machine with a live daemon this path executes the pinned argv
       // against whatever image is named; the fail-closed property under test
       // only has teeth where the daemon is absent.
       return;
     }
-    expect(() => runEvaluatorOci(request)).toThrow(EvaluatorRuntimeUnavailable);
+    expect(() => runEvaluatorOci(request, probe)).toThrow(EvaluatorRuntimeUnavailable);
   });
 });
 
@@ -308,5 +314,45 @@ describe("entrypoint infrastructure semantics (§10.3)", () => {
     );
     expect(result.status).toBe(2);
     expect(result.stderr).toContain("overlap");
+  });
+});
+
+describe("runtime probe (#553): one question, one answer", () => {
+  const probeRequest = {
+    imageRef: "registry.example/cdeb-eval@sha256:" + "cd".repeat(32),
+    archivePath: "/host/runs/x/final-tree.tar.zst",
+    tasksDir: "/host/sealed",
+    taskId: "smoke-calc-fix",
+    claimedOid: "e".repeat(40),
+    imageDigest: TEST_IMAGE_DIGEST,
+  };
+
+  it("reports why it is unavailable, and never calls a timeout an absence", () => {
+    const probe = probeEvaluatorRuntime();
+    if (probe.available) {
+      expect(typeof probe.serverVersion).toBe("string");
+      return;
+    }
+    expect(["unreachable", "timed-out", "not-installed"]).toContain(probe.reason);
+    expect(probe.detail.length).toBeGreaterThan(0);
+  });
+
+  // The defect this closes: the guard and the guarded call each probed, and a
+  // slow daemon answered differently to each. A caller that has decided must be
+  // able to hand that decision in, or the two can never be made to agree.
+  it("refuses on an injected unavailable probe regardless of the machine", () => {
+    expect(() =>
+      runEvaluatorOci(probeRequest, { available: false, reason: "timed-out", detail: "injected" }),
+    ).toThrow(EvaluatorRuntimeUnavailable);
+  });
+
+  it("names the reason in what it throws, so an operator learns which happened", () => {
+    try {
+      runEvaluatorOci(probeRequest, { available: false, reason: "not-installed", detail: "docker is not on PATH" });
+      expect.unreachable("expected a refusal");
+    } catch (error) {
+      expect(String(error)).toContain("not-installed");
+      expect(String(error)).toContain("docker is not on PATH");
+    }
   });
 });

--- a/test/readme-order.test.ts
+++ b/test/readme-order.test.ts
@@ -1,19 +1,24 @@
 /**
- * T-1015 (#207): README section order — `See it work` sits after the install
- * command and before the evidence section, across all four language files.
+ * T-1015 (#207, #547): README first-screen order. A new reader gets the
+ * recognizable problem, installation, the actual payload, the delivery/capture
+ * boundary, limitations, then evidence — in that order in all four languages.
  *
  * Binding anchors from the CEO amendment. #450 restructured the opening, so
  * two anchors point at the sentences that carry those properties rather than
- * at the wording they had before. THE REQUIRED ORDER IS UNCHANGED, and so is
- * what each anchor stands for:
+ * at the wording they had before. #547 deliberately extends the required
+ * order to make the automatic boundary and limitations visible before the
+ * evidence section. The anchors still stand for:
  *   product  → the opening problem sentence (was: the hero heading)
- *   local-first → "without a hosted service" (was: "No hosted memory service.")
+ *   local-first → the accurate no-hosted-service data-flow sentence
  *   install promise → "Install once."
  *   install command → the `curl` block
+ *   automatic → the heading that distinguishes delivery from capture
+ *   limitations → the heading that says when this will not help
  *   evidence → "Retrieval can find records. Path scope keeps reversed decisions out."
  *
  * The required order is:
- *   product < local-first < install-promise < install-command < see-it-work < evidence
+ *   product < local-first < install-promise < install-command < payload
+ *   < automatic-boundary < limitations < evidence
  */
 
 import { describe, it, expect } from 'vitest';
@@ -29,6 +34,8 @@ interface ReadmeAnchors {
   installPromise: number;
   installCommand: number;
   seeItWork: number;
+  automaticBoundary: number;
+  limitations: number;
   evidence: number;
 }
 
@@ -53,13 +60,14 @@ function findAnchors(file: string): ReadmeAnchors {
       l.includes('不断重新提议团队早已否决的方案'),
   );
 
-  // Local-first: "No hosted memory service." or equivalent
+  // Local-first: the opening states the scope accurately. CommitLore has no
+  // hosted service, but a host can handle returned context under its own policy.
   const localFirst = lines.findIndex(
     (l) =>
-      l.includes('without a hosted service') ||
-      l.includes('호스팅 서비스 없이') ||
-      l.includes('ホスティングサービスなしで') ||
-      l.includes('无需托管服务'),
+      l.includes('CommitLore has no hosted service') ||
+      l.includes('CommitLore에는 호스팅 서비스가 없') ||
+      l.includes('CommitLore にホスティングサービスは') ||
+      l.includes('CommitLore 没有托管服务'),
   );
 
   // Install promise: "Install once." or equivalent
@@ -85,6 +93,25 @@ function findAnchors(file: string): ReadmeAnchors {
       l === '## 看它实际运行',
   );
 
+  // The table heading, rather than an incidental mention of delivery or
+  // capture. A previous anchor regression matched the contents link instead
+  // of a heading; keep every heading lookup exact for the same reason.
+  const automaticBoundary = lines.findIndex(
+    (l) =>
+      l === '## What happens automatically — and what does not' ||
+      l === '## 자동으로 되는 것과 아닌 것' ||
+      l === '## 自動になること、ならないこと' ||
+      l === '## 哪些是自动的，哪些不是',
+  );
+
+  const limitations = lines.findIndex(
+    (l) =>
+      l === '## When this will not help you' ||
+      l === '## 이것이 도움이 되지 않는 경우' ||
+      l === '## これが役に立たない場合' ||
+      l === '## 这在什么情况下帮不上忙',
+  );
+
   // Evidence: the "Retrieval can find records..." heading. It must be the
   // heading and not any line mentioning it — #450 added a contents list whose
   // entries name the same sections, and a bare substring search finds the link
@@ -98,7 +125,17 @@ function findAnchors(file: string): ReadmeAnchors {
       l.includes('检索能找到记录')),
   );
 
-  return { file, product, localFirst, installPromise, installCommand, seeItWork, evidence };
+  return {
+    file,
+    product,
+    localFirst,
+    installPromise,
+    installCommand,
+    seeItWork,
+    automaticBoundary,
+    limitations,
+    evidence,
+  };
 }
 
 const FILES = ['README.md', 'README.ko.md', 'README.ja.md', 'README.zh-CN.md'] as const;
@@ -114,6 +151,8 @@ describe('T-1015: README section order', () => {
         expect(anchors.installPromise).toBeGreaterThanOrEqual(0);
         expect(anchors.installCommand).toBeGreaterThanOrEqual(0);
         expect(anchors.seeItWork).toBeGreaterThanOrEqual(0);
+        expect(anchors.automaticBoundary).toBeGreaterThanOrEqual(0);
+        expect(anchors.limitations).toBeGreaterThanOrEqual(0);
         expect(anchors.evidence).toBeGreaterThanOrEqual(0);
       });
 
@@ -123,9 +162,11 @@ describe('T-1015: README section order', () => {
         expect(anchors.installPromise).toBeLessThan(anchors.installCommand);
       });
 
-      it('See it work sits after install command and before evidence', () => {
+      it('the first screen delivers payload, automation boundary, limits, then evidence', () => {
         expect(anchors.installCommand).toBeLessThan(anchors.seeItWork);
-        expect(anchors.seeItWork).toBeLessThan(anchors.evidence);
+        expect(anchors.seeItWork).toBeLessThan(anchors.automaticBoundary);
+        expect(anchors.automaticBoundary).toBeLessThan(anchors.limitations);
+        expect(anchors.limitations).toBeLessThan(anchors.evidence);
       });
     });
   }
@@ -137,7 +178,9 @@ describe('T-1015: README section order', () => {
       expect(anchors.localFirst).toBeLessThan(anchors.installPromise);
       expect(anchors.installPromise).toBeLessThan(anchors.installCommand);
       expect(anchors.installCommand).toBeLessThan(anchors.seeItWork);
-      expect(anchors.seeItWork).toBeLessThan(anchors.evidence);
+      expect(anchors.seeItWork).toBeLessThan(anchors.automaticBoundary);
+      expect(anchors.automaticBoundary).toBeLessThan(anchors.limitations);
+      expect(anchors.limitations).toBeLessThan(anchors.evidence);
     }
   });
 
@@ -157,6 +200,46 @@ describe('T-1015: README section order', () => {
           content.includes('モデルに見えるレコード') ||
           content.includes('模型可见记录'),
       ).toBe(true);
+    }
+  });
+
+  it('the first screen names delivery and capture for every host class', () => {
+    for (const file of FILES) {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      expect(content).toContain('| Host | Delivery | Capture |');
+      expect(content).toContain('| Claude Code |');
+      expect(content).toContain('| Codex |');
+      expect(content).toContain('| Hermes |');
+      expect(content).toContain('commitlore hermes install');
+      expect(content).toContain('AGENTS.md');
+    }
+  });
+
+  it('distinguishes clone-carried trailers from notes-backed records in every file', () => {
+    for (const file of FILES) {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      expect(content).toContain('refs/notes/*');
+    }
+  });
+
+  it('does not claim that returned context remains inside the repository', () => {
+    const oldClaims = [
+      'single byte leaving your repository',
+      '저장소 밖으로 단 1바이트도',
+      'リポジトリの外へ 1 バイトも',
+      '不会有一个字节离开你的仓库',
+    ];
+    const hostPolicy = [
+      /under its own\s+policy/,
+      /자신의 정책에 따라/,
+      /自身のポリシーで/,
+      /按自己的政策/,
+    ];
+
+    for (const [index, file] of FILES.entries()) {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      expect(content).not.toContain(oldClaims[index]!);
+      expect(content).toMatch(hostPolicy[index]!);
     }
   });
 });


### PR DESCRIPTION
Closes #547 and #544.

The README did four jobs at once — landing page, quick start, protocol specification, audit report — and each was written well enough that together they buried the question a new reader actually has: **after I install this, what happens by itself and what does not.**

## That question now has its own section

Answered per host, split into the two layers that can differ:

- **delivery** — a record reaches the agent before it edits a path
- **capture** — a decision gets recorded at commit time

A host can have one without the other, and until now nothing said so. The `AGENTS.md`-convention hosts get a *procedure*, not a mechanism, and the table says that in those words rather than leaving a reader to discover it when nothing is recorded.

## Two claims corrected, not deleted

**"Not a byte leaves the repository"** is true of CommitLore and not of the data flow. Once the hook or the MCP server returns context, the host forwards it under its own policy — which we do not control.

**"Records travel with the clone"** is true of commit trailers and false of notes-backed records. That is why `doctor` has a notes-refspec check at all, and why #512 existed.

## Nothing was removed

The protocol, threat model and benchmark methodology already have their own documents under `docs/`, so the material **moved** rather than disappeared. Every generated block is still generated from `bench/report.ts` and byte-compared in CI; the four language files stay in step with their version pins.

`Ruled-out:` shortening the page by deleting the evidence and audit material. The willingness to publish unflattering results is this project's strongest asset, and trading it for a faster read would be the worst possible edit.

## The order assertion was extended, not relaxed

`test/readme-order.test.ts` gained anchors for the automatic boundary and the limitations, and its header records that the change was deliberate. A test that quietly loosens is worse than one that fails.

`Limit:` the README still cannot tell a reader whether their particular host will follow a written procedure. Only the hosts with a plugin or an installer have that answered by a mechanism rather than by hope.

45 cases pass across the readme-order, readme and docs suites.
