### PR TITLE
Release 0.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,100 @@
 
 ## Unreleased
 
-- The agent tooling whose local config shipped in 0.5.0 as `.serena/` is no
-  longer used, and the configuration that kept it out of future runs is
-  retired with it: the ignore entry, the manifest-test guard, and the
-  task-level comments that named it. The bench evidence still names the
-  directory, because that is what the recorded runs saw (#514).
+## 0.8.0
+
+Everything 0.7.1 promised about unattended capture is in a release for the
+first time. 0.7.1 was published on 2026-08-09; the work it was credited with
+merged on 2026-08-11, so the published artefact never carried `commitlore auto`
+or `capture --unattended` at all (#525, #511). It does now.
+
+### One command sets a repository up
+
+`commitlore init` grew the step that had been missing: it registers this
+repository's MCP server, so the tools that *start* a capture reach a host that
+loads `.mcp.json`.
+
+Without it the install was half a product and did not say so. The git hooks can
+apply and finalise a record that something else already staged; they cannot
+begin one, because a hook has a diff and a capture needs a transcript. Four
+repositories ran with `unattended: true` and produced no records between them
+until this was wired by hand.
+
+`init` also writes the `AGENTS.md` capture procedure into the repository, so
+the instruction travels with the work rather than with the machine. An
+`AGENTS.md` that already exists keeps every line it had.
+
+### Records get their own identity
+
+A capture with no `Record-Id` in its draft used to land on the commit anonymous,
+and nothing reported it. Supersession then had nothing to name, collision
+detection had no key, and the injected payload rendered `-` where the id
+belongs — so an agent could not cite the constraint it was about to follow.
+
+The pipeline now mints one from the record's own content: stable if a capture
+is retried, never replacing an id the draft supplied, and never minted for a
+draft that was rejected.
+
+### Hosts, and what each of them actually does
+
+| Host | Delivery | Capture |
+|---|---|---|
+| Claude Code | plugin | plugin |
+| Codex | plugin — `commitlore plugin install-codex` | plugin |
+| Hermes | `commitlore hermes install` | same command |
+| Other `AGENTS.md` hosts | yes | a written procedure the host may or may not follow |
+
+The last row is the honest one and the README now says it in those words. A
+host without a plugin gets guidance, not a mechanism.
+
+Codex and Hermes both gained a real installation this release. Hermes needed
+its own: its skills load from a configured directory, and an earlier attempt
+that wrote a bundle into the source checkout was never found by a live session.
+
+### Queries stop blocking on a cold index
+
+A path-scoped query on a repository with no index used to rebuild the whole
+index first — 186 seconds on a 21,446-commit repository, on the path that runs
+before every edit. A caller with a shorter timeout killed it, and the next edit
+started cold again, so the index could stay cold forever.
+
+A consumer query now catches an index up but never rebuilds it, and the
+fallback materialises the corpus once instead of once per path alias.
+
+### Fewer warnings that could not be acted on
+
+`context` warned about an unfetched notes mirror in repositories where no notes
+ref existed anywhere, pointing at a fix that could not change anything, while
+`doctor --fix` called the same checks `ok`. `doctor --fix` now asks each remote
+what it advertises and records the answer; the query reads that. A repository
+that has genuinely never been checked still warns — that case is why the
+warning exists.
+
+### Upgrading
+
+Nothing to migrate. Re-run `commitlore init` in each repository to pick up the
+MCP registration and the `AGENTS.md` section; it is idempotent and leaves an
+existing policy file, `.mcp.json` entry or `AGENTS.md` alone.
+
+If you use Codex or Hermes, run its installer once — `commitlore plugin
+install-codex` or `commitlore hermes install` — and start a new session
+afterwards, since both load their skill at session start.
+
+### Still true, and worth repeating
+
+Capture needs an agent host. An ordinary `git commit` typed by a person
+initiates nothing and by design never will: there is no transcript, and a
+record invented from a diff would be a claim about a decision nobody made.
+`doctor` reports whether this repository has an initiator rather than assuming
+the policy file implies one.
+
+### Also in this release
+
+The agent tooling whose local config shipped in 0.5.0 as `.serena/` is no
+longer used, and the configuration that kept it out of future runs is retired
+with it: the ignore entry, the manifest-test guard, and the task-level comments
+that named it. The bench evidence still names the directory, because that is
+what the recorded runs saw (#514).
 
 ## 0.7.1
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -77,7 +77,7 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
 ```
 
 **Hermes** — CLI をインストールした後、host integration を設定します:
@@ -117,11 +117,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh
-sh install.sh v0.7.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh
+sh install.sh v0.8.0
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v0.7.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.8.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -77,7 +77,7 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록하며, 설정이나 cache
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
 ```
 
 **Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
@@ -117,11 +117,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh
-sh install.sh v0.7.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh
+sh install.sh v0.8.0
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v0.7.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.8.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Prerequisites for either path: Node.js 22+ and Git. The script checks both befor
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
 ```
 
 **Hermes** — after installing the CLI, configure its host integration:
@@ -123,11 +123,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh
-sh install.sh v0.7.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh
+sh install.sh v0.8.0
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v0.7.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.8.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,7 +75,7 @@ commitlore plugin install-codex
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
 ```
 
 **Hermes** — 安装 CLI 后，配置它的 host integration：
@@ -115,11 +115,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.7.1/install.sh
-sh install.sh v0.7.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh
+sh install.sh v0.8.0
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v0.7.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v0.8.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump and changelog for 0.8.0. Merges into `dev`; the `dev` → `main` promotion is a separate pull request, and the tag comes after that.

## Why this release matters more than a version number

**Everything 0.7.1 was credited with is in a release for the first time.** 0.7.1 was published 2026-08-09; the work merged 2026-08-11. No published artifact has ever carried `commitlore auto` or `capture --unattended` (#525, #511).

Closing an issue against a tag that does not contain the fix is worse than leaving it open — an open issue is a known gap, a wrong release note is one nobody is looking for.

## What is in it

- `commitlore init` registers the repository's MCP server, so the tools that **start** a capture reach a host. Without it the install was half a product and did not say so.
- Captured records get a minted `Record-Id` — supersession can name what it retires, and an agent can cite the constraint it is following.
- Codex and Hermes each gained a real single-command installation. The `AGENTS.md` capture procedure reaches the hosts that have no plugin.
- Cold-index queries no longer rebuild before answering (186s on a 21,446-commit repository, on the path that runs before every edit).
- The notes warning fires only where there might be something to fetch.
- The README says, per host, what is automatic and what is a procedure a host may or may not follow.

## Version surface

**Three** manifests now — the Codex plugin added a third this cycle — plus 16 install pins across four READMEs. `test/manifest.test.ts` asserts the manifests against `package.json`; `test/readme.test.ts` asserts the pins. All 19 move in this one commit, because a README pointing at a tag that does not exist is a failure this repository has already had.

## Gate status

| | |
|---|---|
| clean clone of the candidate, `npm ci`, committed `dist` == fresh build | pass |
| `dist` byte-identical across two builds | pass |
| package and bench typechecks | pass |
| **full suite, all changes together** | **2,681 passed, 2 skipped, 131 files** |
| one-command `init` → capture → commit → minted id → delivery | pass |
| a trailer the transcript does not support is still refused | pass |
| installed tree carries its runtime data (`spec/`) | pass |

The full-suite run is the first to see this entire batch at once; every pull request in it was green alone.

**Not yet verified, and it cannot be until the tag exists:** `install.sh` clones a pinned tag, so a clean-prefix install currently produces 0.7.1. That check re-runs after tagging, before anyone is told to install.
