### PR TITLE
Make a successful install mean the CLI starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,56 @@ jobs:
           if ($out -notmatch 'reusing the existing checkout') { throw 'the checkout was not reused' }
           if ($out -notmatch 'upgrading the existing commitlore shim') { throw 'the shim was not recognized as its own' }
 
+      # This has to run on Windows rather than be inferred from the shape test:
+      # cmd.exe is the active wrapper, and the transaction is only established
+      # when its unchanged bytes survive both damaged-checkout attempts.
+      - name: Damaged installed bundles are refused without replacing the Windows shim
+        shell: cmd
+        env:
+          COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
+        run: |
+          set "root=%TEMP%\commitlore-installer-transaction"
+          rmdir /s /q "%root%" 2>nul
+          set "LOCALAPPDATA=%root%"
+          set "COMMITLORE_INSTALL_DIR=%root%\bin"
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 > "%root%-initial.log" 2>&1
+          if errorlevel 1 exit /b 1
+          set "shim=%root%\bin\commitlore.cmd"
+          set "bundle=%root%\commitlore\v9.9.9\dist\commitlore.mjs"
+          copy /y "%shim%" "%root%-shim-before.cmd" >nul
+          del "%bundle%"
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 > "%root%-deleted.log" 2>&1
+          set "code=%ERRORLEVEL%"
+          type "%root%-deleted.log"
+          if not "%code%"=="3" (
+            echo ::error::expected exit 3 for a deleted bundle, got %code%
+            exit /b 1
+          )
+          findstr /C:"%bundle%" "%root%-deleted.log" >nul || (
+            echo ::error::the deleted bundle path was not named
+            exit /b 1
+          )
+          fc /b "%root%-shim-before.cmd" "%shim%" >nul || (
+            echo ::error::the shim changed after a deleted bundle was refused
+            exit /b 1
+          )
+          mkdir "%bundle%"
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 > "%root%-directory.log" 2>&1
+          set "code=%ERRORLEVEL%"
+          type "%root%-directory.log"
+          if not "%code%"=="3" (
+            echo ::error::expected exit 3 for a bundle replaced by a directory, got %code%
+            exit /b 1
+          )
+          findstr /C:"%bundle%" "%root%-directory.log" >nul || (
+            echo ::error::the directory bundle path was not named
+            exit /b 1
+          )
+          fc /b "%root%-shim-before.cmd" "%shim%" >nul || (
+            echo ::error::the shim changed after a directory bundle was refused
+            exit /b 1
+          )
+
       # These two run under cmd, deliberately. A pwsh step on GitHub runs with
       # $ErrorActionPreference = 'Stop', which promotes a native command's stderr
       # to a terminating error -- so a step that captures the installer's own

--- a/install.ps1
+++ b/install.ps1
@@ -24,11 +24,14 @@
         script does about it. Two active records on install.sh reject an
         installer that edits the user's environment behind their back, and a
         user-scope PATH write is the same act in Windows spelling.
-      - Post-install verification reports; it never decides the exit code.
+      - Runtime verification completes before the shim is activated. An incoming
+        checkout that cannot start is never reported as installed.
 
     Exit codes, identical to install.sh: 1 = missing or too-old prerequisite, or
-    bad usage (nothing was written), 2 = the source could not be fetched, 4 = the
-    install target is occupied by something this script did not put there.
+    bad usage (nothing was written), 2 = the source could not be fetched, 3 =
+    runtime verification ran and found an unusable checkout, 4 = the install
+    target is occupied by something this script did not put there, 5 = runtime
+    verification could not run on this machine.
 
     Windows support is not claimed by this file. It installs, and what it
     installs runs; whether the containment property #71 establishes holds on
@@ -74,6 +77,272 @@ function Stop-Install {
     exit $Code
 }
 
+# The full runtime inventory is data in the checkout it describes. A tag can
+# add an asset and its manifest together, so an installer fetched from a newer
+# ref never judges that tag against a list it could not contain.
+$RuntimeManifestPath = 'installer/runtime-manifest.txt'
+$RuntimeManifestFormat = 'commitlore-runtime-manifest-v1'
+
+# Check one asset against both the working tree and the pinned tree. The
+# manifest itself goes through this check before its contents are read, so
+# emptying or truncating it locally cannot reduce what the installer verifies.
+function Test-TrackedRuntimeFile {
+    param(
+        [string] $Root,
+        [string] $RelativePath,
+        [string] $Label
+    )
+    $path = Join-Path $Root ($RelativePath.Replace('/', '\'))
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return (New-VerificationResult 'failed' $path "the $Label requires a regular file there")
+    }
+    try {
+        $treeEntry = ((& git -C $Root ls-tree --name-only HEAD -- $RelativePath 2>$null | Out-String).Trim())
+        $gitCode = $LASTEXITCODE
+    } catch {
+        return (New-VerificationResult 'unavailable' $path "Git could not read the pinned checkout tree: $($_.Exception.Message)")
+    }
+    if ($gitCode -ne 0) {
+        return (New-VerificationResult 'unavailable' $path "Git could not read the pinned checkout tree (exit $gitCode)")
+    }
+    if ($treeEntry -cne $RelativePath) {
+        return (New-VerificationResult 'failed' $path "the pinned checkout does not record this $Label entry")
+    }
+    try {
+        $previousGitPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        & git -C $Root diff --quiet HEAD -- $RelativePath > $null 2>$null
+        $gitCode = $LASTEXITCODE
+        $ErrorActionPreference = $previousGitPreference
+    } catch {
+        return (New-VerificationResult 'unavailable' $path "Git could not compare the pinned checkout ${Label}: $($_.Exception.Message)")
+    }
+    if ($gitCode -eq 0) {
+        return (New-VerificationResult 'passed' $path '')
+    }
+    if ($gitCode -eq 1) {
+        return (New-VerificationResult 'failed' $path "the $Label entry differs from the pinned checkout")
+    }
+    return (New-VerificationResult 'unavailable' $path "Git could not compare the pinned checkout $Label (exit $gitCode)")
+}
+
+# Releases before installer/runtime-manifest.txt cannot provide a full runtime
+# inventory. They are still checked for the bundle the installer can name on
+# its own, then receive the cross-version --version smoke test.
+function Test-LegacyRuntime {
+    param([string] $Root)
+    $legacy = Test-TrackedRuntimeFile $Root 'dist/commitlore.mjs' 'legacy runtime check'
+    if ($legacy.State -ne 'passed') { return $legacy }
+    return (New-VerificationResult 'passed' $Root '' '' 'legacy')
+}
+
+function Test-RuntimeManifest {
+    param([string] $Root)
+    $manifestPath = Join-Path $Root ($RuntimeManifestPath.Replace('/', '\'))
+
+    # `ls-tree` distinguishes an old tag (no path in the pinned tree) from a
+    # damaged checkout (the pinned tree has it but the file is missing locally).
+    try {
+        $manifestTreeEntry = ((& git -C $Root ls-tree --name-only HEAD -- $RuntimeManifestPath 2>$null | Out-String).Trim())
+        $gitCode = $LASTEXITCODE
+    } catch {
+        return (New-VerificationResult 'unavailable' $manifestPath "Git could not read the pinned checkout tree: $($_.Exception.Message)")
+    }
+    if ($gitCode -ne 0) {
+        return (New-VerificationResult 'unavailable' $manifestPath "Git could not read the pinned checkout tree (exit $gitCode)")
+    }
+    if ([string]::IsNullOrEmpty($manifestTreeEntry)) {
+        return (Test-LegacyRuntime $Root)
+    }
+    if ($manifestTreeEntry -cne $RuntimeManifestPath) {
+        return (New-VerificationResult 'failed' $manifestPath 'the pinned checkout records an unexpected runtime manifest path')
+    }
+
+    $manifest = Test-TrackedRuntimeFile $Root $RuntimeManifestPath 'runtime manifest'
+    if ($manifest.State -ne 'passed') { return $manifest }
+    try {
+        $manifestLines = @(Get-Content -LiteralPath $manifestPath -ErrorAction Stop)
+    } catch {
+        return (New-VerificationResult 'unavailable' $manifestPath "the runtime manifest could not be read: $($_.Exception.Message)")
+    }
+    if ($manifestLines.Count -eq 0) {
+        return (New-VerificationResult 'failed' $manifestPath 'the runtime manifest is empty')
+    }
+    if ($manifestLines[0] -cne $RuntimeManifestFormat) {
+        return (New-VerificationResult 'failed' $manifestPath "the runtime manifest format is not $RuntimeManifestFormat")
+    }
+    if ($manifestLines.Count -eq 1) {
+        return (New-VerificationResult 'failed' $manifestPath 'the runtime manifest must name at least one runtime asset')
+    }
+
+    $seen = @{}
+    for ($index = 1; $index -lt $manifestLines.Count; $index++) {
+        $relativePath = $manifestLines[$index]
+        if ([string]::IsNullOrEmpty($relativePath)) {
+            return (New-VerificationResult 'failed' $manifestPath 'the runtime manifest contains an empty asset entry')
+        }
+        # Each entry is a canonical repository-relative file path. In particular,
+        # no manifest may escape its checkout or use a second spelling of an asset.
+        if ($relativePath -notmatch '^[A-Za-z0-9._-][A-Za-z0-9._/-]*$' -or $relativePath -match '(^/|/$|//|(^|/)\.\.?(/|$))') {
+            return (New-VerificationResult 'failed' $manifestPath "the runtime manifest contains a non-canonical asset path: $relativePath")
+        }
+        if ($seen.ContainsKey($relativePath)) {
+            return (New-VerificationResult 'failed' $manifestPath "the runtime manifest repeats an asset path: $relativePath")
+        }
+        $seen[$relativePath] = $true
+        $asset = Test-TrackedRuntimeFile $Root $relativePath 'runtime manifest'
+        if ($asset.State -ne 'passed') { return $asset }
+    }
+    return (New-VerificationResult 'passed' $Root '' '' 'manifest')
+}
+
+function New-VerificationResult {
+    param(
+        [string] $State,
+        [string] $Path,
+        [string] $Detail,
+        [string] $Version = '',
+        [string] $Mode = ''
+    )
+    return [pscustomobject]@{
+        State = $State
+        Path = $Path
+        Detail = $Detail
+        Version = $Version
+        Mode = $Mode
+    }
+}
+
+# Smoke-test the checkout directly, while it is still only an incoming tree.
+# doctor --json can legitimately exit 1 for a repository that needs setup; its
+# JSON report proves the command ran. Exit 2 is the documented could-not-run
+# result and is distinguished from a runtime failure below.
+function Invoke-IncomingSmoke {
+    param(
+        [string] $Root,
+        [string] $NodePath
+    )
+
+    $entry = Join-Path $Root 'dist\commitlore.mjs'
+    $smokeDir = Join-Path ([System.IO.Path]::GetTempPath()) ("commitlore-smoke-{0}" -f $PID)
+    try {
+        New-Item -ItemType Directory -Force -Path $smokeDir | Out-Null
+    } catch {
+        return (New-VerificationResult 'unavailable' $entry "could not create smoke-test directory: $($_.Exception.Message)")
+    }
+
+    try {
+        try {
+            $previousSmokePreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            $version = ((& $NodePath $entry --version 2>$null | Out-String).Trim())
+            $versionCode = $LASTEXITCODE
+            $ErrorActionPreference = $previousSmokePreference
+        } catch {
+            return (New-VerificationResult 'unavailable' $entry "--version could not start: $($_.Exception.Message)")
+        }
+        if ($versionCode -ne 0) {
+            return (New-VerificationResult 'failed' $entry "--version ran and exited $versionCode")
+        }
+        if ([string]::IsNullOrEmpty($version)) {
+            return (New-VerificationResult 'failed' $entry '--version exited 0 without reporting a version')
+        }
+
+        $validMessage = Join-Path $smokeDir 'valid-message'
+        $invalidMessage = Join-Path $smokeDir 'invalid-message'
+        [System.IO.File]::WriteAllText($validMessage, "installer smoke test`n`nBlast: local`n", (New-Object System.Text.UTF8Encoding($false)))
+        [System.IO.File]::WriteAllText($invalidMessage, "installer smoke test`n`nBlast: invalid`n", (New-Object System.Text.UTF8Encoding($false)))
+
+        try {
+            $previousSmokePreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            & $NodePath $entry validate --message-file $validMessage > $null 2>$null
+            $validCode = $LASTEXITCODE
+            $ErrorActionPreference = $previousSmokePreference
+        } catch {
+            return (New-VerificationResult 'unavailable' $entry "validate could not start: $($_.Exception.Message)")
+        }
+        if ($validCode -ne 0) {
+            return (New-VerificationResult 'failed' $entry "validate of a valid record ran and exited $validCode")
+        }
+
+        try {
+            $previousSmokePreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            & $NodePath $entry validate --message-file $invalidMessage > $null 2>$null
+            $invalidCode = $LASTEXITCODE
+            $ErrorActionPreference = $previousSmokePreference
+        } catch {
+            return (New-VerificationResult 'unavailable' $entry "validate could not start: $($_.Exception.Message)")
+        }
+        if ($invalidCode -ne 1) {
+            return (New-VerificationResult 'failed' $entry "validate of an invalid record exited $invalidCode, want 1")
+        }
+
+        $doctorOutput = ''
+        $doctorLocationPushed = $false
+        try {
+            Push-Location -LiteralPath $Root
+            $doctorLocationPushed = $true
+            $previousSmokePreference = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            $doctorOutput = (& $NodePath $entry doctor --json 2>$null | Out-String)
+            $doctorCode = $LASTEXITCODE
+            $ErrorActionPreference = $previousSmokePreference
+        } catch {
+            return (New-VerificationResult 'unavailable' $entry "doctor --json could not start: $($_.Exception.Message)")
+        } finally {
+            if ($doctorLocationPushed) { Pop-Location }
+        }
+        if ($doctorCode -ne 0 -and $doctorCode -ne 1) {
+            if ($doctorCode -eq 2 -or $doctorCode -eq 126 -or $doctorCode -eq 127) {
+                return (New-VerificationResult 'unavailable' $entry "doctor --json could not run (exit $doctorCode)")
+            }
+            return (New-VerificationResult 'failed' $entry "doctor --json ran and exited $doctorCode")
+        }
+        if ($doctorOutput -notmatch '"schema"\s*:\s*"commitlore_doctor\.v2"') {
+            return (New-VerificationResult 'failed' $entry 'doctor --json did not emit a CommitLore doctor report')
+        }
+
+        return (New-VerificationResult 'passed' $entry '' $version)
+    } finally {
+        if (Test-Path -LiteralPath $smokeDir) {
+            Remove-Item -LiteralPath $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# A pre-manifest release also predates the current smoke-test contract. It may
+# not emit today's doctor schema (or expose every later command), so only prove
+# that the bundle the installer can name starts and reports its version. Tagged
+# releases that carry the manifest always take Invoke-IncomingSmoke above.
+function Invoke-LegacySmoke {
+    param(
+        [string] $Root,
+        [string] $NodePath
+    )
+    $entry = Join-Path $Root 'dist\commitlore.mjs'
+    try {
+        $previousSmokePreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $version = ((& $NodePath $entry --version 2>$null | Out-String).Trim())
+        $versionCode = $LASTEXITCODE
+        $ErrorActionPreference = $previousSmokePreference
+    } catch {
+        return (New-VerificationResult 'unavailable' $entry "--version could not start: $($_.Exception.Message)")
+    }
+    if ($versionCode -ne 0) {
+        if ($versionCode -eq 126 -or $versionCode -eq 127) {
+            return (New-VerificationResult 'unavailable' $entry "--version could not start (exit $versionCode)")
+        }
+        return (New-VerificationResult 'failed' $entry "--version ran and exited $versionCode")
+    }
+    if ([string]::IsNullOrEmpty($version)) {
+        return (New-VerificationResult 'failed' $entry '--version exited 0 without reporting a version')
+    }
+    return (New-VerificationResult 'passed' $entry '' $version)
+}
+
 # --- 1. prerequisites, before anything is written ---------------------------
 #
 # Both are hard requirements rather than conveniences: the shim runs the bundle
@@ -111,8 +380,11 @@ if ($nodeMajor -lt $NodeMajorMin) {
 # here as a missing one, and this is the check that catches both.
 $gitRan = $false
 try {
-    & git --version > $null 2>&1
+    $previousGitPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    & git --version > $null 2>$null
     $gitRan = ($LASTEXITCODE -eq 0)
+    $ErrorActionPreference = $previousGitPreference
 } catch {
     $gitRan = $false
 }
@@ -160,18 +432,75 @@ if (-not [string]::IsNullOrEmpty($Version)) {
 
 Write-Log "installing $Version"
 
-# --- 3. fetch the pinned checkout ------------------------------------------
+# --- 3. check the activation target before materializing anything -----------
 #
-# Into the user's local application data, keyed by tag, so an upgrade adds a
-# checkout beside the old one instead of mutating it. Cloned to a temporary name
-# and renamed, so a failed clone never leaves a half-checkout that looks
-# installed.
+# A foreign shim is rejected before a checkout is fetched. This preserves both
+# the foreign file and any prior working installation if the transaction cannot
+# reach its activation point.
 
 $dataRoot = Join-Path $env:LOCALAPPDATA 'commitlore'
-$checkout = Join-Path $dataRoot $Version
+$destDir = $env:COMMITLORE_INSTALL_DIR
+if ([string]::IsNullOrEmpty($destDir)) {
+    $destDir = Join-Path $dataRoot 'bin'
+}
+$dest = Join-Path $destDir 'commitlore.cmd'
 
-if (Test-Path -LiteralPath (Join-Path $checkout 'dist')) {
-    Write-Log "reusing the existing checkout at $checkout"
+# Refuse to clobber a file this script did not put there. A previous shim
+# carries the marker; a previous install prints a bare semver. Anything else is
+# somebody else's file and is left exactly where it is.
+if (Test-Path -LiteralPath $dest) {
+    $existing = ''
+    try {
+        $existing = (Get-Content -LiteralPath $dest -Raw -ErrorAction SilentlyContinue)
+    } catch {
+        $existing = ''
+    }
+    if ($null -eq $existing) { $existing = '' }
+    if ($existing.Contains($WrapperMarker)) {
+        Write-Log "upgrading the existing commitlore shim at $dest"
+    } else {
+        $existingVersion = ''
+        try {
+            $existingVersion = (& $dest --version 2>$null | Select-Object -First 1)
+        } catch {
+            $existingVersion = ''
+        }
+        if ($null -eq $existingVersion) { $existingVersion = '' }
+        $existingVersion = $existingVersion.Trim()
+        if ($existingVersion -match '^[0-9]+\.[0-9]+\.[0-9]+') {
+            Write-Log "replacing a previous commitlore install at $dest ($existingVersion -> $Version)"
+        } else {
+            Stop-Install "$dest already exists and is not a commitlore shim (got: ""$existingVersion"") -- refusing to overwrite it. Remove it first, or set COMMITLORE_INSTALL_DIR to install elsewhere." 4
+        }
+    }
+}
+
+# --- 4. materialize and verify the pinned checkout -------------------------
+#
+# Into the user's local application data, keyed by tag, so an upgrade adds a
+# checkout beside the old one instead of mutating it. A source checkout is
+# always cloned into an incoming directory, then fully checked before it
+# receives its stable name or the shim can point at it.
+
+$checkout = Join-Path $dataRoot $Version
+$checkoutTmp = ''
+$candidate = ''
+$manifest = $null
+
+if (Test-Path -LiteralPath $checkout) {
+    if (-not (Test-Path -LiteralPath $checkout -PathType Container)) {
+        $manifest = New-VerificationResult 'failed' $checkout 'the existing checkout path is not a directory'
+    } else {
+        $manifest = Test-RuntimeManifest $checkout
+    }
+    if ($manifest.State -eq 'passed') {
+        $candidate = $checkout
+        if ($manifest.Mode -eq 'legacy') {
+            Write-Log "reusing the existing checkout at $checkout (legacy runtime check and --version smoke test; this release predates $RuntimeManifestPath)"
+        } else {
+            Write-Log "reusing the existing checkout at $checkout (runtime manifest verified)"
+        }
+    }
 } else {
     New-Item -ItemType Directory -Force -Path $dataRoot | Out-Null
     $checkoutTmp = Join-Path $dataRoot (".{0}.incoming.{1}" -f $Version, $PID)
@@ -216,18 +545,57 @@ if (Test-Path -LiteralPath (Join-Path $checkout 'dist')) {
         if ([string]::IsNullOrEmpty($reason)) { $reason = 'nothing' }
         Stop-Install "could not fetch $Version from $SourceUrl. git said: $reason. Nothing was installed." 2
     }
-    if (-not (Test-Path -LiteralPath (Join-Path $checkoutTmp 'dist\commitlore.mjs'))) {
-        Remove-Item -LiteralPath $checkoutTmp -Recurse -Force -ErrorAction SilentlyContinue
-        Stop-Install "$Version does not carry dist/commitlore.mjs, so there is nothing to run. Nothing was installed." 2
+    $manifest = Test-RuntimeManifest $checkoutTmp
+    if ($manifest.State -eq 'passed') {
+        $candidate = $checkoutTmp
+        if ($manifest.Mode -eq 'legacy') {
+            Write-Log "$Version predates $RuntimeManifestPath; using the installer's legacy runtime check and --version smoke test"
+        }
     }
-    if (Test-Path -LiteralPath $checkout) {
-        Remove-Item -LiteralPath $checkout -Recurse -Force
-    }
-    Move-Item -LiteralPath $checkoutTmp -Destination $checkout
-    Write-Log "checked out $Version into $checkout"
 }
 
-# --- 4. install the shim ---------------------------------------------------
+if ([string]::IsNullOrEmpty($candidate)) {
+    if (-not [string]::IsNullOrEmpty($checkoutTmp) -and (Test-Path -LiteralPath $checkoutTmp)) {
+        Remove-Item -LiteralPath $checkoutTmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if ($manifest.State -eq 'unavailable') {
+        Stop-Install "runtime verification could not run for ""$($manifest.Path)"": $($manifest.Detail). The existing shim at $dest was left unchanged." 5
+    }
+    Stop-Install "runtime verification ran and found an unusable path: ""$($manifest.Path)"" ($($manifest.Detail)). The existing shim at $dest was left unchanged." 3
+}
+
+if ($manifest.Mode -eq 'legacy') {
+    $smoke = Invoke-LegacySmoke $candidate $nodeBin
+} else {
+    $smoke = Invoke-IncomingSmoke $candidate $nodeBin
+}
+if ($smoke.State -ne 'passed') {
+    if (-not [string]::IsNullOrEmpty($checkoutTmp) -and (Test-Path -LiteralPath $checkoutTmp)) {
+        Remove-Item -LiteralPath $checkoutTmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if ($smoke.State -eq 'unavailable') {
+        Stop-Install "runtime verification could not run for ""$($smoke.Path)"": $($smoke.Detail). The existing shim at $dest was left unchanged." 5
+    }
+    Stop-Install "runtime verification ran and found an unusable path: ""$($smoke.Path)"" ($($smoke.Detail)). The existing shim at $dest was left unchanged." 3
+}
+
+if ($candidate -eq $checkoutTmp) {
+    if (Test-Path -LiteralPath $checkout) {
+        Remove-Item -LiteralPath $checkoutTmp -Recurse -Force -ErrorAction SilentlyContinue
+        Stop-Install "could not materialize verified incoming checkout at $checkout because that path became occupied. The existing shim at $dest was left unchanged." 4
+    }
+    try {
+        Move-Item -LiteralPath $checkoutTmp -Destination $checkout
+    } catch {
+        Remove-Item -LiteralPath $checkoutTmp -Recurse -Force -ErrorAction SilentlyContinue
+        Stop-Install "could not materialize verified incoming checkout at $checkout. The existing shim at $dest was left unchanged." 3
+    }
+    $checkoutTmp = ''
+    $candidate = $checkout
+    Write-Log "checked out and verified $Version into $checkout"
+}
+
+# --- 5. activate the verified shim -----------------------------------------
 #
 # A .cmd shim rather than an extensionless file: cmd.exe and PowerShell both
 # find and run a .cmd from PATH, and an extensionless script is not executable
@@ -235,45 +603,9 @@ if (Test-Path -LiteralPath (Join-Path $checkout 'dist')) {
 # records the bundle and the interpreter in the repository's git config -- so the
 # shim is for the terminal, which is where a user types the name.
 
-$destDir = $env:COMMITLORE_INSTALL_DIR
-if ([string]::IsNullOrEmpty($destDir)) {
-    $destDir = Join-Path $dataRoot 'bin'
-}
-$dest = Join-Path $destDir 'commitlore.cmd'
-
-# Refuse to clobber a file this script did not put there. A previous shim
-# carries the marker; a previous install prints a bare semver. Anything else is
-# somebody else's file and is left exactly where it is.
-if (Test-Path -LiteralPath $dest) {
-    $existing = ''
-    try {
-        $existing = (Get-Content -LiteralPath $dest -Raw -ErrorAction SilentlyContinue)
-    } catch {
-        $existing = ''
-    }
-    if ($null -eq $existing) { $existing = '' }
-    if ($existing.Contains($WrapperMarker)) {
-        Write-Log "upgrading the existing commitlore shim at $dest"
-    } else {
-        $existingVersion = ''
-        try {
-            $existingVersion = (& $dest --version 2>$null | Select-Object -First 1)
-        } catch {
-            $existingVersion = ''
-        }
-        if ($null -eq $existingVersion) { $existingVersion = '' }
-        $existingVersion = $existingVersion.Trim()
-        if ($existingVersion -match '^[0-9]+\.[0-9]+\.[0-9]+') {
-            Write-Log "replacing a previous commitlore install at $dest ($existingVersion -> $Version)"
-        } else {
-            Stop-Install "$dest already exists and is not a commitlore shim (got: ""$existingVersion"") -- refusing to overwrite it. Remove it first, or set COMMITLORE_INSTALL_DIR to install elsewhere." 4
-        }
-    }
-}
-
 New-Item -ItemType Directory -Force -Path $destDir | Out-Null
 
-$bundle = Join-Path $checkout 'dist\commitlore.mjs'
+$bundle = Join-Path $candidate 'dist\commitlore.mjs'
 # CRLF, written explicitly. cmd.exe mis-parses a batch file with LF endings in
 # ways that depend on the line -- a `set` can swallow the next line -- so the
 # endings are part of the file format here rather than a preference.
@@ -294,33 +626,18 @@ $shimText = ($shimLines -join "`r`n") + "`r`n"
 # shell installer's history; a move is the closest thing Windows offers to the
 # atomic rename that fixed it.
 $destTmp = "$dest.commitlore-install.$PID"
-[System.IO.File]::WriteAllText($destTmp, $shimText, (New-Object System.Text.UTF8Encoding($false)))
-Move-Item -LiteralPath $destTmp -Destination $dest -Force
+try {
+    [System.IO.File]::WriteAllText($destTmp, $shimText, (New-Object System.Text.UTF8Encoding($false)))
+    Move-Item -LiteralPath $destTmp -Destination $dest -Force
+} catch {
+    if (Test-Path -LiteralPath $destTmp) {
+        Remove-Item -LiteralPath $destTmp -Force -ErrorAction SilentlyContinue
+    }
+    Stop-Install "could not activate verified checkout $candidate at $dest. The existing shim was left unchanged." 3
+}
 
 Write-Log "installed to $dest"
-
-# The install is complete by this point. Verification reports; it does not
-# decide. A single failure is retried once before it is reported, and a reported
-# failure still exits 0 -- an install that succeeded must not be failed by a
-# check that could not run.
-$installedVersion = ''
-foreach ($attempt in 1, 2) {
-    try {
-        $installedVersion = (& $dest --version 2>$null | Select-Object -First 1)
-    } catch {
-        $installedVersion = ''
-    }
-    if ($null -eq $installedVersion) { $installedVersion = '' }
-    $installedVersion = $installedVersion.Trim()
-    if (-not [string]::IsNullOrEmpty($installedVersion)) { break }
-    if ($attempt -eq 1) { Start-Sleep -Seconds 1 }
-}
-if (-not [string]::IsNullOrEmpty($installedVersion)) {
-    Write-Host $installedVersion
-} else {
-    Write-Log "installed, but unverified: ""$dest --version"" did not run in this shell."
-    Write-Log "the shim is in place; verify it yourself with: $dest --version"
-}
+Write-Host $smoke.Version
 
 # Printed, never written. Rewriting a user's environment from a piped installer
 # is ruled out on install.sh, and this is the same act in Windows spelling.
@@ -334,10 +651,10 @@ if (-not $onPath) {
     Write-Log "  [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';$destDir', 'User')"
 }
 
-# --- 5. detect and wire coding agents --------------------------------------
+# --- 6. detect and wire coding agents --------------------------------------
 #
 # Everything below is additive and best-effort: it never touches the exit codes
-# above (1-4 stay reserved for phase 1 -- the tool is already installed and
+# above (1-5 stay reserved for the transactional install -- the tool is already installed and
 # working by the time this runs), and every agent it wires is detect-then-act, in
 # the same order as install.sh:
 #

--- a/install.sh
+++ b/install.sh
@@ -21,13 +21,10 @@
 # before anything is written rather than assumed.
 #
 # Exit codes: 1 = missing or too-old prerequisite, or bad usage (nothing was
-# written), 2 = the source could not be fetched, 4 = the install target is
-# occupied by something this script did not put there.
-#
-# Post-install verification never decides the exit code. An install that
-# succeeded is not retroactively failed by a check that could not run: that
-# was a real defect once, where the installer's own `--version` was killed by
-# a signal and its exit code became the script's.
+# written), 2 = the source could not be fetched, 3 = runtime verification ran
+# and found an unusable checkout, 4 = the install target is occupied by
+# something this script did not put there, 5 = runtime verification could not
+# run on this machine. Verification never activates an unchecked checkout.
 #
 # This script never edits a shell profile. If the wrapper's directory is not
 # on PATH it prints the line to add, which is the whole of what it does about
@@ -48,6 +45,250 @@ log() { printf 'commitlore-install: %s\n' "$1"; }
 die() {
   printf 'commitlore-install: error: %s\n' "$1" >&2
   exit "${2:-1}"
+}
+
+# The full runtime inventory lives in the checkout it describes. A tag can add
+# an asset and its manifest together; an installer fetched from a newer ref
+# therefore never judges that tag against a list it could not contain.
+RUNTIME_MANIFEST="installer/runtime-manifest.txt"
+RUNTIME_MANIFEST_FORMAT="commitlore-runtime-manifest-v1"
+
+# Check one asset against both the working tree and the pinned tree. The
+# manifest itself goes through this check before its contents are read, so
+# emptying or truncating it locally cannot reduce what the installer verifies.
+verify_tracked_runtime_file() {
+  runtime_root="$1"
+  runtime_path="$2"
+  runtime_label="$3"
+  runtime_file="$runtime_root/$runtime_path"
+
+  if [ ! -f "$runtime_file" ]; then
+    verification_failed "$runtime_file" "the $runtime_label requires a regular file there"
+    return 1
+  fi
+  if runtime_tree_path="$(git -C "$runtime_root" ls-tree --name-only HEAD -- "$runtime_path" 2>/dev/null)"; then
+    :
+  else
+    runtime_status=$?
+    verification_unavailable "$runtime_file" "Git could not read the pinned checkout tree (exit $runtime_status)"
+    return 1
+  fi
+  if [ "$runtime_tree_path" != "$runtime_path" ]; then
+    verification_failed "$runtime_file" "the pinned checkout does not record this $runtime_label entry"
+    return 1
+  fi
+  if git -C "$runtime_root" diff --quiet HEAD -- "$runtime_path"; then
+    return 0
+  else
+    runtime_status=$?
+  fi
+  if [ "$runtime_status" -eq 1 ]; then
+    verification_failed "$runtime_file" "the $runtime_label entry differs from the pinned checkout"
+  else
+    verification_unavailable "$runtime_file" "Git could not compare the pinned checkout $runtime_label (exit $runtime_status)"
+  fi
+  return 1
+}
+
+# Releases before installer/runtime-manifest.txt cannot provide a full runtime
+# inventory. They are still checked for the bundle the installer can name on
+# its own, then receive the cross-version --version smoke test.
+verify_legacy_runtime() {
+  runtime_root="$1"
+  runtime_manifest_mode="legacy"
+  verify_tracked_runtime_file "$runtime_root" "dist/commitlore.mjs" "legacy runtime check"
+}
+
+verify_runtime_manifest() {
+  runtime_root="$1"
+  runtime_manifest_file="$runtime_root/$RUNTIME_MANIFEST"
+  verification_state="failed"
+  verification_path=""
+  verification_detail=""
+  runtime_manifest_mode=""
+
+  # `ls-tree` distinguishes an old tag (no path in the pinned tree) from a
+  # damaged checkout (the pinned tree has it but the file is missing locally).
+  if runtime_manifest_tree_path="$(git -C "$runtime_root" ls-tree --name-only HEAD -- "$RUNTIME_MANIFEST" 2>/dev/null)"; then
+    :
+  else
+    runtime_status=$?
+    verification_unavailable "$runtime_manifest_file" "Git could not read the pinned checkout tree (exit $runtime_status)"
+    return 1
+  fi
+  if [ -z "$runtime_manifest_tree_path" ]; then
+    verify_legacy_runtime "$runtime_root"
+    return $?
+  fi
+  if [ "$runtime_manifest_tree_path" != "$RUNTIME_MANIFEST" ]; then
+    verification_failed "$runtime_manifest_file" "the pinned checkout records an unexpected runtime manifest path"
+    return 1
+  fi
+  if ! verify_tracked_runtime_file "$runtime_root" "$RUNTIME_MANIFEST" "runtime manifest"; then
+    return 1
+  fi
+
+  runtime_manifest_line=0
+  runtime_manifest_assets=0
+  while IFS= read -r runtime_path || [ -n "$runtime_path" ]; do
+    runtime_manifest_line=$((runtime_manifest_line + 1))
+    if [ "$runtime_manifest_line" -eq 1 ]; then
+      if [ "$runtime_path" != "$RUNTIME_MANIFEST_FORMAT" ]; then
+        verification_failed "$runtime_manifest_file" "the runtime manifest format is not $RUNTIME_MANIFEST_FORMAT"
+        return 1
+      fi
+      continue
+    fi
+    if [ -z "$runtime_path" ]; then
+      verification_failed "$runtime_manifest_file" "the runtime manifest contains an empty asset entry"
+      return 1
+    fi
+    # Each entry is a canonical repository-relative file path. In particular,
+    # no manifest may escape its checkout or use a second spelling of an asset.
+    case "$runtime_path" in
+      /*|*/|.|..|./*|../*|*/./*|*/../*|*//*)
+        verification_failed "$runtime_manifest_file" "the runtime manifest contains a non-canonical asset path: $runtime_path"
+        return 1
+        ;;
+      *[!A-Za-z0-9._/-]*)
+        verification_failed "$runtime_manifest_file" "the runtime manifest contains an invalid asset path: $runtime_path"
+        return 1
+        ;;
+    esac
+    runtime_manifest_assets=$((runtime_manifest_assets + 1))
+    if ! verify_tracked_runtime_file "$runtime_root" "$runtime_path" "runtime manifest"; then
+      return 1
+    fi
+  done <"$runtime_manifest_file"
+
+  if [ "$runtime_manifest_line" -eq 0 ]; then
+    verification_failed "$runtime_manifest_file" "the runtime manifest is empty"
+    return 1
+  fi
+  if [ "$runtime_manifest_assets" -eq 0 ]; then
+    verification_failed "$runtime_manifest_file" "the runtime manifest must name at least one runtime asset"
+    return 1
+  fi
+  runtime_manifest_mode="manifest"
+  return 0
+}
+
+verification_failed() {
+  verification_state="failed"
+  verification_path="$1"
+  verification_detail="$2"
+  return 1
+}
+
+verification_unavailable() {
+  verification_state="unavailable"
+  verification_path="$1"
+  verification_detail="$2"
+  return 1
+}
+
+# Smoke-test the checkout directly, while it is still only an incoming tree.
+# `doctor --json` can legitimately exit 1 for a repository that needs setup;
+# its JSON report proves the command ran. Exit 2 is the documented "could not
+# run" result and is distinguished from a runtime failure below.
+verify_incoming_smoke() {
+  runtime_root="$1"
+  runtime_entry="$runtime_root/dist/commitlore.mjs"
+  smoke_dir="$work/smoke"
+  rm -rf "$smoke_dir"
+  mkdir -p "$smoke_dir"
+
+  if "$node_bin" "$runtime_entry" --version >"$smoke_dir/version.out" 2>"$smoke_dir/version.err"; then
+    verified_version="$(cat "$smoke_dir/version.out")"
+    if [ -z "$verified_version" ]; then
+      verification_failed "$runtime_entry" "--version exited 0 without reporting a version"
+      return 1
+    fi
+  else
+    smoke_status=$?
+    case "$smoke_status" in
+      126|127) verification_unavailable "$runtime_entry" "--version could not start (exit $smoke_status)" ;;
+      *) verification_failed "$runtime_entry" "--version ran and exited $smoke_status" ;;
+    esac
+    return 1
+  fi
+
+  printf 'installer smoke test\n\nBlast: local\n' >"$smoke_dir/valid-message"
+  if "$node_bin" "$runtime_entry" validate --message-file "$smoke_dir/valid-message" >"$smoke_dir/valid.out" 2>"$smoke_dir/valid.err"; then
+    :
+  else
+    smoke_status=$?
+    case "$smoke_status" in
+      126|127) verification_unavailable "$runtime_entry" "validate could not start (exit $smoke_status)" ;;
+      *) verification_failed "$runtime_entry" "validate of a valid record ran and exited $smoke_status" ;;
+    esac
+    return 1
+  fi
+
+  printf 'installer smoke test\n\nBlast: invalid\n' >"$smoke_dir/invalid-message"
+  if "$node_bin" "$runtime_entry" validate --message-file "$smoke_dir/invalid-message" >"$smoke_dir/invalid.out" 2>"$smoke_dir/invalid.err"; then
+    verification_failed "$runtime_entry" "validate accepted an invalid record"
+    return 1
+  else
+    smoke_status=$?
+  fi
+  if [ "$smoke_status" -ne 1 ]; then
+    case "$smoke_status" in
+      126|127) verification_unavailable "$runtime_entry" "validate could not start (exit $smoke_status)" ;;
+      *) verification_failed "$runtime_entry" "validate of an invalid record exited $smoke_status, want 1" ;;
+    esac
+    return 1
+  fi
+
+  if (cd "$runtime_root" && "$node_bin" ./dist/commitlore.mjs doctor --json >"$smoke_dir/doctor.json" 2>"$smoke_dir/doctor.err"); then
+    smoke_status=0
+  else
+    smoke_status=$?
+  fi
+  case "$smoke_status" in
+    0|1) ;;
+    2|126|127)
+      verification_unavailable "$runtime_entry" "doctor --json could not run (exit $smoke_status)"
+      return 1
+      ;;
+    *)
+      verification_failed "$runtime_entry" "doctor --json ran and exited $smoke_status"
+      return 1
+      ;;
+  esac
+  if ! grep -q '"schema": "commitlore_doctor.v2"' "$smoke_dir/doctor.json"; then
+    verification_failed "$runtime_entry" "doctor --json did not emit a CommitLore doctor report"
+    return 1
+  fi
+
+  return 0
+}
+
+# A pre-manifest release also predates the current smoke-test contract. It may
+# not emit today's doctor schema (or expose every later command), so only prove
+# that the bundle the installer can name starts and reports its version. Tagged
+# releases that carry the manifest always take verify_incoming_smoke above.
+verify_legacy_smoke() {
+  runtime_root="$1"
+  runtime_entry="$runtime_root/dist/commitlore.mjs"
+  smoke_dir="$work/legacy-smoke"
+  rm -rf "$smoke_dir"
+  mkdir -p "$smoke_dir"
+
+  if "$node_bin" "$runtime_entry" --version >"$smoke_dir/version.out" 2>"$smoke_dir/version.err"; then
+    verified_version="$(cat "$smoke_dir/version.out")"
+    if [ -z "$verified_version" ]; then
+      verification_failed "$runtime_entry" "--version exited 0 without reporting a version"
+      return 1
+    fi
+    return 0
+  fi
+  smoke_status=$?
+  case "$smoke_status" in
+    126|127) verification_unavailable "$runtime_entry" "--version could not start (exit $smoke_status)" ;;
+    *) verification_failed "$runtime_entry" "--version ran and exited $smoke_status" ;;
+  esac
+  return 1
 }
 
 # --- 1. prerequisites, before anything is written ---------------------------
@@ -109,55 +350,23 @@ fi
 
 log "installing $version"
 
-# Scratch space for the wiring phase's write-temp-then-rename config merges.
-# Created here, removed on exit, exactly as the previous script did.
+# Scratch space for verification and the wiring phase's write-temp-then-rename
+# config merges. Incoming and wrapper temporaries share its exit cleanup.
 work="$(mktemp -d)"
-trap 'rm -rf "$work"' EXIT
+checkout_tmp=""
+dest_tmp=""
+cleanup_install() {
+  [ -z "$dest_tmp" ] || rm -f "$dest_tmp"
+  [ -z "$checkout_tmp" ] || rm -rf "$checkout_tmp"
+  rm -rf "$work"
+}
+trap cleanup_install EXIT
 
-# --- 3. fetch the pinned checkout ------------------------------------------
+# --- 3. check the activation target before materializing anything -----------
 #
-# Into the user's data directory, keyed by tag, so an upgrade adds a checkout
-# beside the old one instead of mutating it. Cloned to a temporary name and
-# renamed, so a failed clone never leaves a half-checkout that looks installed.
-
-data_root="${XDG_DATA_HOME:-$HOME/.local/share}/commitlore"
-checkout="$data_root/$version"
-
-if [ -d "$checkout/dist" ]; then
-  log "reusing the existing checkout at $checkout"
-else
-  mkdir -p "$data_root"
-  checkout_tmp="$data_root/.$version.incoming.$$"
-  rm -rf "$checkout_tmp"
-  cleanup_checkout_tmp() { rm -rf "$checkout_tmp"; }
-  trap cleanup_checkout_tmp EXIT
-  # Keep git's own reason. Swallowing it and printing a guess ("check the tag
-  # name and your network") sends a user looking in the wrong place whenever the
-  # cause is something else, which is most of the time.
-  clone_log="$(mktemp)"
-  if ! git clone --quiet --depth 1 --branch "$version" "$SOURCE_URL" "$checkout_tmp" 2>"$clone_log"; then
-    # git puts the useful line first ("does not appear to be a git repository",
-    # "could not read Username", "dubious ownership") and the generic advice
-    # last, so the first fatal: line is what a reader needs. Falling back to the
-    # whole log keeps the case where there is no fatal: at all.
-    # `sed -n '/re/{p;q;}'` rather than `grep -m1`: -m is a GNU/BSD extension and
-    # this script is POSIX sh. Same reason sort -V was removed from the version
-    # resolution above.
-    clone_reason="$(sed -n '/^fatal:/{p;q;}' "$clone_log" 2>/dev/null || true)"
-    [ -n "$clone_reason" ] || clone_reason="$(tr '\n' ' ' <"$clone_log" | sed 's/  */ /g')"
-    rm -f "$clone_log"
-    die "could not fetch $version from $SOURCE_URL. git said: ${clone_reason:-nothing}. Nothing was installed." 2
-  fi
-  rm -f "$clone_log"
-  [ -f "$checkout_tmp/dist/commitlore.mjs" ] \
-    || die "$version does not carry dist/commitlore.mjs, so there is nothing to run. Nothing was installed." 2
-  rm -rf "$checkout"
-  mv "$checkout_tmp" "$checkout"
-  trap - EXIT
-  log "checked out $version into $checkout"
-fi
-
-# --- 4. install the wrapper ------------------------------------------------
+# A foreign wrapper is rejected before a checkout is fetched. This preserves
+# both the foreign file and any prior working installation if the transaction
+# cannot reach its activation point.
 
 if [ -n "${COMMITLORE_INSTALL_DIR:-}" ]; then
   dest_dir="$COMMITLORE_INSTALL_DIR"
@@ -189,41 +398,123 @@ if [ -e "$dest" ]; then
   fi
 fi
 
+# --- 4. materialize and verify the pinned checkout -------------------------
+#
+# Into the user's data directory, keyed by tag, so an upgrade adds a checkout
+# beside the old one instead of mutating it. A source checkout is always cloned
+# into an incoming directory, then fully checked before it receives its stable
+# name or the wrapper can point at it.
+
+data_root="${XDG_DATA_HOME:-$HOME/.local/share}/commitlore"
+checkout="$data_root/$version"
+candidate=""
+
+if [ -e "$checkout" ]; then
+  if [ ! -d "$checkout" ]; then
+    verification_state="failed"
+    verification_path="$checkout"
+    verification_detail="the existing checkout path is not a directory"
+  elif ! verify_runtime_manifest "$checkout"; then
+    :
+  else
+    candidate="$checkout"
+    if [ "$runtime_manifest_mode" = "legacy" ]; then
+      log "reusing the existing checkout at $checkout (legacy runtime check and --version smoke test; this release predates $RUNTIME_MANIFEST)"
+    else
+      log "reusing the existing checkout at $checkout (runtime manifest verified)"
+    fi
+  fi
+else
+  mkdir -p "$data_root"
+  checkout_tmp="$data_root/.$version.incoming.$$"
+  rm -rf "$checkout_tmp"
+  # Keep git's own reason. Swallowing it and printing a guess ("check the tag
+  # name and your network") sends a user looking in the wrong place whenever the
+  # cause is something else, which is most of the time.
+  clone_log="$(mktemp)"
+  if ! git clone --quiet --depth 1 --branch "$version" "$SOURCE_URL" "$checkout_tmp" 2>"$clone_log"; then
+    # git puts the useful line first ("does not appear to be a git repository",
+    # "could not read Username", "dubious ownership") and the generic advice
+    # last, so the first fatal: line is what a reader needs. Falling back to the
+    # whole log keeps the case where there is no fatal: at all.
+    # `sed -n '/re/{p;q;}'` rather than `grep -m1`: -m is a GNU/BSD extension and
+    # this script is POSIX sh. Same reason sort -V was removed from the version
+    # resolution above.
+    clone_reason="$(sed -n '/^fatal:/{p;q;}' "$clone_log" 2>/dev/null || true)"
+    [ -n "$clone_reason" ] || clone_reason="$(tr '\n' ' ' <"$clone_log" | sed 's/  */ /g')"
+    rm -f "$clone_log"
+    die "could not fetch $version from $SOURCE_URL. git said: ${clone_reason:-nothing}. Nothing was installed." 2
+  fi
+  rm -f "$clone_log"
+  if verify_runtime_manifest "$checkout_tmp"; then
+    candidate="$checkout_tmp"
+    if [ "$runtime_manifest_mode" = "legacy" ]; then
+      log "$version predates $RUNTIME_MANIFEST; using the installer's legacy runtime check and --version smoke test"
+    fi
+  fi
+fi
+
+if [ -z "$candidate" ]; then
+  if [ "$verification_state" = "unavailable" ]; then
+    die "runtime verification could not run for \"$verification_path\": $verification_detail. The existing wrapper at $dest was left unchanged." 5
+  fi
+  die "runtime verification ran and found an unusable path: \"$verification_path\" ($verification_detail). The existing wrapper at $dest was left unchanged." 3
+fi
+
+verification_smoke_ok="true"
+if [ "$runtime_manifest_mode" = "legacy" ]; then
+  verify_legacy_smoke "$candidate" || verification_smoke_ok="false"
+else
+  verify_incoming_smoke "$candidate" || verification_smoke_ok="false"
+fi
+if [ "$verification_smoke_ok" != "true" ]; then
+  if [ "$verification_state" = "unavailable" ]; then
+    die "runtime verification could not run for \"$verification_path\": $verification_detail. The existing wrapper at $dest was left unchanged." 5
+  else
+    die "runtime verification ran and found an unusable path: \"$verification_path\" ($verification_detail). The existing wrapper at $dest was left unchanged." 3
+  fi
+fi
+
+if [ "$candidate" = "$checkout_tmp" ]; then
+  if [ -e "$checkout" ]; then
+    die "could not materialize verified incoming checkout at $checkout because that path became occupied. The existing wrapper at $dest was left unchanged." 4
+  fi
+  if ! mv "$checkout_tmp" "$checkout"; then
+    die "could not materialize verified incoming checkout at $checkout. The existing wrapper at $dest was left unchanged." 3
+  fi
+  checkout_tmp=""
+  candidate="$checkout"
+  log "checked out and verified $version into $checkout"
+fi
+
+# --- 5. activate the verified wrapper --------------------------------------
+
 mkdir -p "$dest_dir"
 # Write beside the destination and rename. An in-place overwrite of a file that
 # may be executing is the defect that forced a same-day patch release; rename is
 # atomic, so a reader sees either the old wrapper or the new one.
 dest_tmp="$dest.commitlore-install.$$"
-cleanup_dest_tmp() { rm -f "$dest_tmp"; }
-trap cleanup_dest_tmp EXIT
-cat >"$dest_tmp" <<WRAPPER
+if ! cat >"$dest_tmp" <<WRAPPER
 #!/bin/sh
 $WRAPPER_MARKER
 # Installed by install.sh. Edits are lost on reinstall.
 NODE="$node_bin"
 [ -x "\$NODE" ] || NODE=node
-exec "\$NODE" "$checkout/dist/commitlore.mjs" "\$@"
+exec "\$NODE" "$candidate/dist/commitlore.mjs" "\$@"
 WRAPPER
-chmod +x "$dest_tmp"
-mv "$dest_tmp" "$dest"
-trap - EXIT
+then
+  die "could not prepare activation at $dest. Verified checkout $candidate was not activated." 3
+fi
+if ! chmod +x "$dest_tmp"; then
+  die "could not prepare activation at $dest. Verified checkout $candidate was not activated." 3
+fi
+if ! mv "$dest_tmp" "$dest"; then
+  die "could not activate verified checkout $candidate at $dest. The existing wrapper was left unchanged." 3
+fi
+dest_tmp=""
 
 log "installed to $dest"
-
-# The install is complete by this point. Verification reports; it does not
-# decide. A single failure is retried once before it is reported, and a
-# reported failure still exits 0 -- an install that succeeded must not be
-# failed by a check that could not run.
-if ! installed_version=$("$dest" --version 2>/dev/null); then
-  sleep 1
-  installed_version=$("$dest" --version 2>/dev/null) || installed_version=""
-fi
-if [ -n "$installed_version" ]; then
-  printf '%s\n' "$installed_version"
-else
-  log "installed, but unverified: \"$dest --version\" did not run in this shell."
-  log "the wrapper is in place; verify it yourself with: $dest --version"
-fi
+printf '%s\n' "$verified_version"
 
 path_file="$HOME/.profile"
 case "${SHELL:-}" in
@@ -243,10 +534,10 @@ case ":$PATH:" in
     ;;
 esac
 
-# --- 5. detect and wire coding agents --------------------------------------
+# --- 6. detect and wire coding agents --------------------------------------
 #
 # Everything below is additive and best-effort: it never touches the exit
-# codes above (1-4 stay reserved for phase 1 -- the binary is already
+# codes above (1-5 stay reserved for the transactional install -- the binary is already
 # installed and working by the time this runs), and every agent it wires is
 # detect-then-act, in the same order every time:
 #

--- a/installer/runtime-manifest.txt
+++ b/installer/runtime-manifest.txt
@@ -1,0 +1,10 @@
+commitlore-runtime-manifest-v1
+AGENTS.md
+dist/commitlore.mjs
+package.json
+spec/SPEC.md
+spec/schema/record.schema.json
+hermes/skills/commitlore/DESCRIPTION.md
+hermes/skills/commitlore/commits/SKILL.md
+hermes/skills/commitlore/query/SKILL.md
+hermes/skills/commitlore/setup/SKILL.md

--- a/test/install-ps1.test.ts
+++ b/test/install-ps1.test.ts
@@ -3,12 +3,13 @@
  *
  * PRD-F14 requirements 16-19.
  *
- * These are shape assertions, and shape is not the evidence. The evidence is the
- * `windows-latest` CI job that runs the script on a real runner: prerequisites,
- * checkout, shim, re-run, and a repository that ends up with a working hook.
- * What this file is for is the part a Windows runner cannot show cheaply --
- * that the two installers agree, clause by clause, on the decisions that were
- * already argued out for the shell one.
+ * These are shape assertions, and shape is not the evidence. This test runs on
+ * a non-Windows host, so it cannot establish PowerShell behavior. The evidence
+ * is the `windows-latest` CI job that runs the script on a real runner:
+ * prerequisites, checkout, shim, re-run, and a repository that ends up with a
+ * working hook. What this file is for is the part a Windows runner cannot show
+ * cheaply -- that the two installers agree, clause by clause, on the decisions
+ * that were already argued out for the shell one.
  *
  * Two of those decisions exist because this project shipped the defect they
  * forbid, and both are recorded on `install.sh`:
@@ -16,8 +17,8 @@
  *   - the installer never edits the user's environment. Printing the line is
  *     honest; writing it silently is what makes people distrust a piped
  *     installer. A user-scope `PATH` write is that same act in Windows spelling.
- *   - post-install verification never decides the exit code. An install that
- *     succeeded must not be failed by a check that could not run.
+ *   - runtime verification decides activation. A checkout that proves unusable
+ *     cannot be reported as a successful install.
  */
 import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -28,8 +29,67 @@ import { describe, expect, it } from 'vitest';
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const PS1 = join(REPO_ROOT, 'install.ps1');
 const SH = join(REPO_ROOT, 'install.sh');
+const RUNTIME_MANIFEST = join(REPO_ROOT, 'installer', 'runtime-manifest.txt');
 
 const body = (): string => readFileSync(PS1, 'utf8');
+
+/**
+ * A parse error reached CI because nothing here parses the file. PowerShell is
+ * not installed on most contributors' machines, so the suite checks shape and
+ * the `windows-latest` job is the only thing that ever executes the script —
+ * which is correct as a gate and slow as feedback.
+ *
+ * This catches one mechanically detectable class rather than pretending to be a
+ * parser. `"$Label: ..."` reads as a drive-qualified variable and fails to
+ * parse; `${Label}:` is the form that works. `$env:NAME` is the legitimate use
+ * of that syntax and is excluded.
+ */
+/**
+ * PowerShell promotes a native command's stderr to a terminating error under
+ * `$ErrorActionPreference = 'Stop'`, so a harmless warning aborts a run that
+ * succeeded. This repository has hit it twice: once when git's "--depth is
+ * ignored in local clones" killed a good clone, and again when Node's
+ * "ExperimentalWarning: SQLite is an experimental feature" — printed on every
+ * single invocation — made the installer's smoke test report that `validate`
+ * could not start, and refuse a working installation.
+ *
+ * The call site that learned it first left a comment explaining the trap. The
+ * next author did not read that comment, which is what comments cost. Only the
+ * exit code says whether a native command worked, so every invocation runs with
+ * the preference relaxed and is judged on its status.
+ */
+describe('install.ps1 does not let a native command\'s stderr abort a good run', () => {
+  it('every native invocation relaxes ErrorActionPreference first', () => {
+    const source = readFileSync(PS1, 'utf8');
+    const lines = source.split('\n');
+    const unguarded: string[] = [];
+
+    for (const [index, line] of lines.entries()) {
+      if (!/(?:^|[^`])&\s+\$(?:NodePath|git\b)/.test(line) && !/^\s*&\s+git\s/.test(line)) continue;
+      const window = lines.slice(Math.max(0, index - 6), index).join('\n');
+      if (!window.includes("$ErrorActionPreference = 'Continue'")) {
+        unguarded.push(`${String(index + 1)}: ${line.trim()}`);
+      }
+    }
+
+    expect(
+      unguarded,
+      "wrap native calls in $ErrorActionPreference = 'Continue' and judge them by $LASTEXITCODE",
+    ).toEqual([]);
+  });
+});
+
+describe('install.ps1 avoids drive-qualified variable references in strings', () => {
+  it('every interpolated variable followed by a colon is brace-delimited', () => {
+    const source = readFileSync(PS1, 'utf8');
+    const hazards = [...source.matchAll(/\$(?!env:)([A-Za-z_][A-Za-z0-9_]*):/g)].map((match) => {
+      const line = source.slice(0, match.index).split('\n').length;
+      return `${String(line)}: $${match[1] ?? ''}:`;
+    });
+
+    expect(hazards, 'use ${Name}: so PowerShell does not read Name as a drive').toEqual([]);
+  });
+});
 
 describe('T-1121 install.ps1 exists and matches install.sh clause for clause', () => {
   it('is ASCII only, like its shell twin', () => {
@@ -45,7 +105,9 @@ describe('T-1121 install.ps1 exists and matches install.sh clause for clause', (
     const text = body();
     const nodeCheck = text.indexOf('NodeMajorMin = 22');
     const gitCheck = text.indexOf('git --version');
-    const firstWrite = text.indexOf('New-Item -ItemType Directory');
+    // Helper definitions appear first, but their writes run only after the
+    // prerequisites. This is the first write in the installation transaction.
+    const firstWrite = text.indexOf('New-Item -ItemType Directory -Force -Path $dataRoot');
     expect(nodeCheck).toBeGreaterThan(-1);
     expect(gitCheck).toBeGreaterThan(-1);
     expect(nodeCheck).toBeLessThan(firstWrite);
@@ -69,10 +131,13 @@ describe('T-1121 install.ps1 exists and matches install.sh clause for clause', (
 
   it('uses the same exit codes for the same conditions', () => {
     const text = body();
-    // 1 prerequisite or usage, 2 fetch, 4 occupied destination.
+    // 1 prerequisite or usage, 2 fetch, 3 verified-unusable, 4 occupied
+    // destination, 5 verification could not run.
     expect(text).toMatch(/Stop-Install "Node\.js \$NodeMajorMin or newer is required[\s\S]*?" 1/);
     expect(text).toMatch(/could not fetch \$Version[\s\S]*?" 2/);
+    expect(text).toMatch(/runtime verification ran and found an unusable path[\s\S]*?" 3/);
     expect(text).toMatch(/refusing to overwrite it[\s\S]*?" 4/);
+    expect(text).toMatch(/runtime verification could not run[\s\S]*?" 5/);
   });
 
   it('installs a pinned tag and never resolves a branch', () => {
@@ -123,18 +188,40 @@ describe('T-1121 install.ps1 exists and matches install.sh clause for clause', (
     expect(writes).toEqual([]);
   });
 
-  it('lets verification report without deciding the exit code', () => {
+  it('reads the checkout-owned runtime manifest and smoke-tests before activation', () => {
     const text = body();
-    expect(text).toContain('installed, but unverified');
-    // The retry, then exit 0 regardless.
-    expect(text).toContain('Start-Sleep -Seconds 1');
-    const lastExit = text.lastIndexOf('exit 0');
-    expect(lastExit).toBeGreaterThan(text.indexOf('installed, but unverified'));
+    expect(text).toContain("$RuntimeManifestPath = 'installer/runtime-manifest.txt'");
+    expect(text).toContain("$RuntimeManifestFormat = 'commitlore-runtime-manifest-v1'");
+    expect(text).toContain('Test-TrackedRuntimeFile $Root $RuntimeManifestPath');
+    expect(text).toContain('Get-Content -LiteralPath $manifestPath');
+    expect(text).toContain('Test-LegacyRuntime $Root');
+    expect(text).toContain('Invoke-LegacySmoke $candidate $nodeBin');
+    expect(readFileSync(SH, 'utf8')).toContain('RUNTIME_MANIFEST="installer/runtime-manifest.txt"');
+    for (const asset of [
+      'AGENTS.md',
+      'dist/commitlore.mjs',
+      'package.json',
+      'spec/SPEC.md',
+      'spec/schema/record.schema.json',
+      'hermes/skills/commitlore/DESCRIPTION.md',
+      'hermes/skills/commitlore/commits/SKILL.md',
+      'hermes/skills/commitlore/query/SKILL.md',
+      'hermes/skills/commitlore/setup/SKILL.md',
+    ]) {
+      expect(readFileSync(RUNTIME_MANIFEST, 'utf8')).toContain(asset);
+    }
+    expect(text).toContain('Invoke-IncomingSmoke $candidate $nodeBin');
+    expect(text).toContain('validate --message-file $validMessage');
+    expect(text).toContain('validate --message-file $invalidMessage');
+    expect(text).toContain('doctor --json');
+    expect(text.indexOf('Invoke-IncomingSmoke $candidate $nodeBin')).toBeLessThan(text.indexOf('$destTmp ='));
+    expect(text).not.toContain('installed, but unverified');
+    expect(text).not.toContain('Start-Sleep -Seconds 1');
   });
 
-  it('is re-runnable: an existing checkout and an existing shim are both upgrades', () => {
+  it('is re-runnable only after an existing checkout passes the runtime manifest', () => {
     const text = body();
-    expect(text).toContain('reusing the existing checkout at');
+    expect(text).toContain('reusing the existing checkout at $checkout (runtime manifest verified)');
     expect(text).toContain('upgrading the existing commitlore shim at');
     expect(text).toContain('already mentions commitlore -- left unchanged');
   });

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -11,14 +11,13 @@
  *
  *   - req 9: the wrapper is installed by atomic rename. An in-place overwrite of
  *     a file that may be executing forced a same-day patch release.
- *   - req 10: post-install verification never decides the exit code. That was
- *     the other half of the same defect: the install had succeeded and the
- *     script reported failure with exit 137.
+ *   - req 10: runtime verification decides whether activation may happen. The
+ *     old installer reported success after a bundle had already proved unusable.
  *   - req 11: the installer never edits a shell profile. An active ruled-out
  *     record on this file rejects it.
  */
 import { execFileSync, spawnSync } from 'node:child_process';
-import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -28,6 +27,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const INSTALLER = join(REPO_ROOT, 'install.sh');
 const READMES = ['README.md', 'README.ko.md', 'README.ja.md', 'README.zh-CN.md'];
+const RUNTIME_MANIFEST = join('installer', 'runtime-manifest.txt');
+const RUNTIME_MANIFEST_FORMAT = 'commitlore-runtime-manifest-v1';
 
 const scratch: string[] = [];
 const tempDir = (label: string): string => {
@@ -53,6 +54,33 @@ const git = (cwd: string, args: string[]): void => {
   });
 };
 
+const writeRuntimeManifest = (target: string, assets: string[]): void => {
+  const path = join(target, RUNTIME_MANIFEST);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${[RUNTIME_MANIFEST_FORMAT, ...assets].join('\n')}\n`);
+};
+
+/** The non-bundle files the installed CLI reads at runtime. */
+const copyRuntimeAssets = (
+  target: string,
+  options: { manifest?: string[] | false; includeHermes?: boolean } = {},
+): void => {
+  cpSync(join(REPO_ROOT, 'AGENTS.md'), join(target, 'AGENTS.md'));
+  cpSync(join(REPO_ROOT, 'spec'), join(target, 'spec'), { recursive: true });
+  if (options.includeHermes !== false) {
+    cpSync(join(REPO_ROOT, 'hermes'), join(target, 'hermes'), { recursive: true });
+  }
+  writeFileSync(join(target, 'package.json'), JSON.stringify({ name: 'commitlore', version: '9.9.9' }));
+  if (options.manifest === false) return;
+  if (options.manifest !== undefined) {
+    writeRuntimeManifest(target, options.manifest);
+  } else {
+    const destination = join(target, RUNTIME_MANIFEST);
+    mkdirSync(dirname(destination), { recursive: true });
+    cpSync(join(REPO_ROOT, RUNTIME_MANIFEST), destination);
+  }
+};
+
 beforeAll(() => {
   sourceRepo = join(tempDir('source'), 'commitlore');
   mkdirSync(join(sourceRepo, 'dist'), { recursive: true });
@@ -60,8 +88,7 @@ beforeAll(() => {
   // read from this fixture package.json, so the installer's ordinary wrapper
   // verification remains deterministic without a network or another worktree.
   cpSync(join(REPO_ROOT, 'dist', 'commitlore.mjs'), join(sourceRepo, 'dist', 'commitlore.mjs'));
-  cpSync(join(REPO_ROOT, 'hermes'), join(sourceRepo, 'hermes'), { recursive: true });
-  writeFileSync(join(sourceRepo, 'package.json'), JSON.stringify({ name: 'commitlore', version: '9.9.9' }));
+  copyRuntimeAssets(sourceRepo);
   execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: sourceRepo });
   git(sourceRepo, ['add', '-A']);
   git(sourceRepo, ['commit', '--quiet', '-m', 'source']);
@@ -70,6 +97,7 @@ beforeAll(() => {
   brokenRepo = join(tempDir('broken'), 'commitlore');
   mkdirSync(join(brokenRepo, 'dist'), { recursive: true });
   writeFileSync(join(brokenRepo, 'dist', 'commitlore.mjs'), "process.exit(3);\n");
+  copyRuntimeAssets(brokenRepo);
   execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: brokenRepo });
   git(brokenRepo, ['add', '-A']);
   git(brokenRepo, ['commit', '--quiet', '-m', 'broken bundle']);
@@ -394,14 +422,139 @@ describe('T-1120 upgrade and verification', () => {
     expect(`${r.stdout}${r.stderr}`).toMatch(/refus|already exists|not .*commitlore/i);
   });
 
-  it('still exits 0 when post-install verification cannot complete', () => {
-    // req 10: verification may report, never decide. Forced by making the
-    // bundle unusable at the moment the installer checks it.
+  it('fails before activation when runtime verification runs and fails', () => {
+    // #541 flips the old expectation: a bundle that runs and exits 3 has
+    // conclusively failed verification, so reporting a successful install would
+    // promise a CLI that cannot start.
     const r = runInstaller({ extraEnv: { COMMITLORE_INSTALL_SOURCE: brokenRepo } });
+    expect(r.status).toBe(3);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/verification ran.*unusable/i);
+    expect(existsSync(r.wrapper)).toBe(false);
+  });
+
+  it('accepts an older tag whose own manifest names fewer runtime assets', () => {
+    // This source predates the Hermes bundle. Its manifest deliberately lists
+    // only the files that tag reads, and the checkout itself carries that
+    // smaller list. A newer installer must not demand newer Hermes files.
+    const olderRepo = join(tempDir('older-manifest'), 'commitlore');
+    const olderTag = 'v9.8.0';
+    mkdirSync(join(olderRepo, 'dist'), { recursive: true });
+    cpSync(join(REPO_ROOT, 'dist', 'commitlore.mjs'), join(olderRepo, 'dist', 'commitlore.mjs'));
+    copyRuntimeAssets(olderRepo, {
+      includeHermes: false,
+      manifest: ['AGENTS.md', 'dist/commitlore.mjs', 'package.json', 'spec/SPEC.md', 'spec/schema/record.schema.json'],
+    });
+    execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: olderRepo });
+    git(olderRepo, ['add', '-A']);
+    git(olderRepo, ['commit', '--quiet', '-m', 'older runtime manifest']);
+    git(olderRepo, ['tag', olderTag]);
+
+    const r = runInstaller({ args: [olderTag], extraEnv: { COMMITLORE_INSTALL_SOURCE: olderRepo } });
     expect(r.status).toBe(0);
-    expect(`${r.stdout}${r.stderr}`).toMatch(/unverified/i);
+    expect(existsSync(join(r.dataDir, olderTag, 'hermes'))).toBe(false);
     expect(existsSync(r.wrapper)).toBe(true);
   });
+
+  it('uses legacy bootstrap checks when the pinned tree predates the manifest', () => {
+    // No manifest in the pinned Git tree means an older release, not a reason
+    // to trust it silently. The installer checks the bundle it can name itself
+    // and runs its only cross-version smoke check: --version. This fixture has
+    // no current doctor/validate interface, as a genuinely old CLI may not.
+    const legacyRepo = join(tempDir('legacy-manifest'), 'commitlore');
+    const legacyTag = 'v9.7.0';
+    mkdirSync(join(legacyRepo, 'dist'), { recursive: true });
+    writeFileSync(
+      join(legacyRepo, 'dist', 'commitlore.mjs'),
+      "if (process.argv[2] === '--version') process.stdout.write('9.7.0\\n'); else process.exit(1);\n",
+    );
+    copyRuntimeAssets(legacyRepo, { manifest: false });
+    execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: legacyRepo });
+    git(legacyRepo, ['add', '-A']);
+    git(legacyRepo, ['commit', '--quiet', '-m', 'release before runtime manifest']);
+    git(legacyRepo, ['tag', legacyTag]);
+
+    const r = runInstaller({ args: [legacyTag], extraEnv: { COMMITLORE_INSTALL_SOURCE: legacyRepo } });
+    expect(r.status).toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toContain('predates installer/runtime-manifest.txt');
+    expect(existsSync(r.wrapper)).toBe(true);
+  });
+
+  it('refuses a manifest missing from a checkout whose pinned tree records it', () => {
+    // This is the damaged-checkout side of the missing-manifest rule. Unlike a
+    // legacy tag, HEAD names the manifest, so its disappearance is corruption.
+    const home = tempDir('missing-manifest');
+    const first = runInstaller({ home });
+    expect(first.status).toBe(0);
+    const wrapperBefore = readFileSync(first.wrapper, 'utf8');
+    const manifest = join(first.dataDir, TAG, RUNTIME_MANIFEST);
+    rmSync(manifest);
+
+    const rerun = runInstaller({ home });
+    expect(rerun.status).toBe(3);
+    expect(`${rerun.stdout}${rerun.stderr}`).toContain(manifest);
+    expect(readFileSync(first.wrapper, 'utf8')).toBe(wrapperBefore);
+  });
+
+  it('refuses a checkout that ships an empty manifest instead of trusting less', () => {
+    // The manifest is checkout-owned, but it cannot opt out of verification by
+    // committing only its format header. This exercises the parser after the
+    // manifest has already matched the pinned tree, not merely Git's dirty-tree
+    // detection for a locally edited file.
+    const emptyManifestRepo = join(tempDir('empty-manifest-source'), 'commitlore');
+    mkdirSync(join(emptyManifestRepo, 'dist'), { recursive: true });
+    cpSync(join(REPO_ROOT, 'dist', 'commitlore.mjs'), join(emptyManifestRepo, 'dist', 'commitlore.mjs'));
+    copyRuntimeAssets(emptyManifestRepo, { manifest: [] });
+    execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: emptyManifestRepo });
+    git(emptyManifestRepo, ['add', '-A']);
+    git(emptyManifestRepo, ['commit', '--quiet', '-m', 'empty runtime manifest']);
+    git(emptyManifestRepo, ['tag', TAG]);
+
+    const r = runInstaller({ extraEnv: { COMMITLORE_INSTALL_SOURCE: emptyManifestRepo } });
+    expect(r.status).toBe(3);
+    expect(`${r.stdout}${r.stderr}`).toContain('the runtime manifest must name at least one runtime asset');
+    expect(existsSync(r.wrapper)).toBe(false);
+  });
+
+  it('refuses a locally emptied manifest instead of letting it weaken verification', () => {
+    const home = tempDir('empty-manifest');
+    const first = runInstaller({ home });
+    expect(first.status).toBe(0);
+    const wrapperBefore = readFileSync(first.wrapper, 'utf8');
+    const manifest = join(first.dataDir, TAG, RUNTIME_MANIFEST);
+    writeFileSync(manifest, '');
+
+    const rerun = runInstaller({ home });
+    expect(rerun.status).toBe(3);
+    expect(`${rerun.stdout}${rerun.stderr}`).toContain(manifest);
+    expect(readFileSync(first.wrapper, 'utf8')).toBe(wrapperBefore);
+  });
+
+  for (const damage of ['deleted', 'replaced with a directory'] as const) {
+    it(`refuses a ${damage} installed bundle without changing the previous wrapper`, () => {
+      const home = tempDir(`damaged-${damage.replace(/\W+/g, '-')}`);
+      const first = runInstaller({ home });
+      expect(first.status).toBe(0);
+      const wrapperBefore = readFileSync(first.wrapper, 'utf8');
+      const bundle = join(first.dataDir, TAG, 'dist', 'commitlore.mjs');
+
+      if (damage === 'deleted') {
+        rmSync(bundle);
+      } else {
+        rmSync(bundle);
+        mkdirSync(bundle);
+      }
+
+      const rerun = runInstaller({ home });
+      expect(rerun.status).toBe(3);
+      expect(`${rerun.stdout}${rerun.stderr}`).toContain(bundle);
+      expect(readFileSync(first.wrapper, 'utf8')).toBe(wrapperBefore);
+      if (damage === 'deleted') {
+        expect(existsSync(bundle)).toBe(false);
+      } else {
+        expect(statSync(bundle).isDirectory()).toBe(true);
+      }
+    });
+  }
 });
 
 describe('#298 tag auto-resolution needs no sort extension', () => {
@@ -449,7 +602,12 @@ describe('#298 tag auto-resolution needs no sort extension', () => {
   it('resolves the newest tag when a double-digit major exists', () => {
     const repo = join(tempDir('majors'), 'commitlore');
     mkdirSync(join(repo, 'dist'), { recursive: true });
-    writeFileSync(join(repo, 'dist', 'commitlore.mjs'), "console.log('10.0.0');\n");
+    // Version resolution needs a real release-shaped checkout: the transaction
+    // now validates every runtime asset and runs its smoke commands before it
+    // activates the wrapper, so a one-line version stub is not an installable
+    // source repository.
+    cpSync(join(REPO_ROOT, 'dist', 'commitlore.mjs'), join(repo, 'dist', 'commitlore.mjs'));
+    copyRuntimeAssets(repo);
     execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: repo });
     git(repo, ['add', '-A']);
     git(repo, ['commit', '--quiet', '-m', 'src']);


### PR DESCRIPTION
Blocking finding 1 from the independent review — the one they called the single most important change.

## What they did

Installed the product, deleted the installed bundle, replaced it with a directory, and re-ran the installer.

**Both damaged reinstalls exited 0**, printed `reusing existing checkout` and `installed, but unverified`, and finished with a success summary. The command the user was left holding died with `MODULE_NOT_FOUND`.

Three things made that possible:

- a checkout was reused after confirming only that `dist/` was a directory
- failed verification was explicitly non-fatal
- **the shell test asserted it as intended** — a bundle exiting 3 still had to produce installer status 0, which is the defect written down as a requirement

## The invariant

**If the installer exits successfully, the installed CLI starts successfully.**

Installation is now a transaction whose commit point is activation: materialize elsewhere → verify the runtime assets → smoke test by running the commands a user runs → only then move the wrapper. Any failure leaves the previous working installation exactly as it was and exits non-zero naming the unusable path.

The distinction the old behaviour collapsed is kept. Verification that **could not run** is not verification that **ran and failed**, and only the second is fatal — the original reasoning (do not fail a good install over a transient signal) was right, and the remedy was too broad.

## A correction inside this change

The first version carried the manifest **in the script**. The script installs whatever the newest remote tag is, so a script newer than that tag demanded files the tree could not contain and refused every version — I hit this on a clean install before it ever reached a user.

Replacing "installs something unusable and says it worked" with "refuses to install something that works" is not a fix.

The manifest now travels with the tree it describes, so a version is judged by its own list. A checkout from before the mechanism installs under the checks the script can still make alone; a checkout whose manifest is missing or emptied does not thereby install unverified.

## Verified by running it

```
clean install into an isolated home     exit 0
delete the bundle, re-run               exit 3, wrapper byte-identical
a tag predating the manifest            installs cleanly
```

117 cases pass across the install-script, install-ps1, agent-configs, uninstall and manifest suites; typecheck clean; two builds produce a byte-identical `dist`.

`Limit:` this establishes that the installed tree is complete and its commands run on this machine at this moment — not that the machine will still have a working node tomorrow, and not that any agent host will load what was installed.

`Unverified:` PowerShell could not be executed here. `install.ps1` carries the same structure by inspection, and only the `windows-latest` job's output should be read as evidence.
