### PR TITLE
Stop the suite from rebuilding the artifact it is running

### DIFF
--- a/test/action-lint.test.ts
+++ b/test/action-lint.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -28,7 +28,7 @@ import { createTestRepo } from './git-fixtures.js';
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const TSC = fileURLToPath(new URL('../node_modules/typescript/bin/tsc', import.meta.url));
-const CLI = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+let CLI = '';
 const ACTION_DIR = fileURLToPath(new URL('../action/lint/', import.meta.url));
 const LINT = join(ACTION_DIR, 'lint.mjs');
 const ACTION_YML = join(ACTION_DIR, 'action.yml');
@@ -150,7 +150,13 @@ let repo = '';
 let shallow = '';
 
 beforeAll(() => {
-  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json'], {
+  const harness = tempDir('dist');
+  CLI = join(harness, 'dist', 'cli.js');
+  symlinkSync(join(REPO_ROOT, 'node_modules'), join(harness, 'node_modules'), 'dir');
+  symlinkSync(join(REPO_ROOT, 'spec'), join(harness, 'spec'), 'dir');
+  symlinkSync(join(REPO_ROOT, 'package.json'), join(harness, 'package.json'));
+
+  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json', '--outDir', join(harness, 'dist')], {
     shell: false,
     encoding: 'utf8',
     cwd: REPO_ROOT,

--- a/test/action-preserve.test.ts
+++ b/test/action-preserve.test.ts
@@ -23,6 +23,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -36,7 +37,7 @@ import { createTestRepo } from './git-fixtures.js';
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const TSC = fileURLToPath(new URL('../node_modules/typescript/bin/tsc', import.meta.url));
-const CLI = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+let CLI = '';
 const ACTION_DIR = fileURLToPath(new URL('../action/preserve/', import.meta.url));
 const PRESERVE = join(ACTION_DIR, 'preserve.mjs');
 const ACTION_YML = join(ACTION_DIR, 'action.yml');
@@ -246,7 +247,13 @@ const runPreserve = (
 };
 
 beforeAll(() => {
-  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json'], {
+  const harness = tempDir('dist');
+  CLI = join(harness, 'dist', 'cli.js');
+  symlinkSync(join(REPO_ROOT, 'node_modules'), join(harness, 'node_modules'), 'dir');
+  symlinkSync(join(REPO_ROOT, 'spec'), join(harness, 'spec'), 'dir');
+  symlinkSync(join(REPO_ROOT, 'package.json'), join(harness, 'package.json'));
+
+  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json', '--outDir', join(harness, 'dist')], {
     shell: false,
     encoding: 'utf8',
     cwd: REPO_ROOT,

--- a/test/auto.test.ts
+++ b/test/auto.test.ts
@@ -1,7 +1,7 @@
 /** #527 — `auto status` reports whether the policy can begin a capture. */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,7 +14,7 @@ import { createTestRepo } from './git-fixtures.js';
 
 const PACKAGE_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const TSC = fileURLToPath(new URL('../node_modules/typescript/bin/tsc', import.meta.url));
-const CLI = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+let CLI = '';
 const scratch: string[] = [];
 
 afterAll(() => {
@@ -22,7 +22,14 @@ afterAll(() => {
 });
 
 beforeAll(() => {
-  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json'], {
+  const harness = mkdtempSync(join(realpathSync(tmpdir()), 'commitlore-auto-dist-'));
+  scratch.push(harness);
+  CLI = join(harness, 'dist', 'cli.js');
+  symlinkSync(join(PACKAGE_ROOT, 'node_modules'), join(harness, 'node_modules'), 'dir');
+  symlinkSync(join(PACKAGE_ROOT, 'spec'), join(harness, 'spec'), 'dir');
+  symlinkSync(join(PACKAGE_ROOT, 'package.json'), join(harness, 'package.json'));
+
+  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json', '--outDir', join(harness, 'dist')], {
     cwd: PACKAGE_ROOT,
     encoding: 'utf8',
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,17 +5,20 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { loadFixtures } from './fixtures.js';
 
 const PACKAGE_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const TSC = fileURLToPath(new URL('../node_modules/typescript/bin/tsc', import.meta.url));
-const CLI = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
-const SCHEMA_MODULE = fileURLToPath(new URL('../dist/core/schema.js', import.meta.url));
+let CLI = '';
+let SCHEMA_MODULE = '';
+let harness = '';
 
 const runCli = (args: string[], stdin = '') =>
   spawnSync(process.execPath, [CLI, ...args], {
@@ -26,7 +29,14 @@ const runCli = (args: string[], stdin = '') =>
   });
 
 beforeAll(() => {
-  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json'], {
+  harness = mkdtempSync(join(realpathSync(tmpdir()), 'commitlore-cli-dist-'));
+  CLI = join(harness, 'dist', 'cli.js');
+  SCHEMA_MODULE = join(harness, 'dist', 'core', 'schema.js');
+  symlinkSync(join(PACKAGE_ROOT, 'node_modules'), join(harness, 'node_modules'), 'dir');
+  symlinkSync(join(PACKAGE_ROOT, 'spec'), join(harness, 'spec'), 'dir');
+  symlinkSync(join(PACKAGE_ROOT, 'package.json'), join(harness, 'package.json'));
+
+  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json', '--outDir', join(harness, 'dist')], {
     shell: false,
     encoding: 'utf8',
     cwd: PACKAGE_ROOT,
@@ -35,6 +45,10 @@ beforeAll(() => {
     throw new Error(`tsc build failed (exit ${build.status}):\n${build.stdout}${build.stderr}`);
   }
 }, 120_000);
+
+afterAll(() => {
+  if (harness !== '') rmSync(harness, { recursive: true, force: true });
+});
 
 describe('commitlore CLI', () => {
   it('starts with a node shebang', () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -36,7 +36,7 @@ import { createTestRepo } from './git-fixtures.js';
 
 const PACKAGE_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const TSC = fileURLToPath(new URL('../node_modules/typescript/bin/tsc', import.meta.url));
-const CLI_JS = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+let CLI_JS = '';
 
 // `hooks install` (called by the `hooks` step below) records the entry point
 // this process was launched from (`process.argv[1]`) as the hook's target
@@ -44,10 +44,19 @@ const CLI_JS = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
 // built commitlore entry; inside this test process it is vitest's own entry,
 // which would make `doctor`'s hook-runtime probe fail for a reason that has
 // nothing to do with `init`. Every `runInit` call below runs with argv[1]
-// pointed at a real, freshly built `dist/cli.js` instead, matching how
-// `test/cli.test.ts` rebuilds it for the same reason.
+// pointed at a real, freshly built `dist/cli.js` in this suite's private
+// harness instead, matching how `test/cli.test.ts` rebuilds it for the same
+// reason.
 beforeAll(() => {
-  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json'], {
+  // `runInit` remains imported from source, so its hook installer records the
+  // source package root. Keep this unique build below that root: the artifact
+  // is private, while the recorded CLI still has the same installation root
+  // the hook's containment check expects.
+  const harness = mkdtempSync(join(PACKAGE_ROOT, '.commitlore-init-dist-'));
+  scratch.push(harness);
+  CLI_JS = join(harness, 'dist', 'cli.js');
+
+  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json', '--outDir', join(harness, 'dist')], {
     cwd: PACKAGE_ROOT,
     encoding: 'utf8',
   });

--- a/test/mcp-capture.test.ts
+++ b/test/mcp-capture.test.ts
@@ -17,6 +17,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -29,7 +30,7 @@ import { execGitOrThrow } from '../src/core/git.js';
 
 const PACKAGE_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const TSC = fileURLToPath(new URL('../node_modules/typescript/bin/tsc', import.meta.url));
-const SERVER_ENTRY = fileURLToPath(new URL('../dist/mcp/main.js', import.meta.url));
+let SERVER_ENTRY = '';
 
 const PROTOCOL_VERSION = '2025-11-25';
 const RPC_TIMEOUT_MS = 30_000;
@@ -165,7 +166,14 @@ const toolJson = (response: RpcResponse): Record<string, unknown> => {
 // ---------------------------------------------------------------------------
 
 beforeAll(() => {
-  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json'], {
+  const harness = mkdtempSync(join(tmpdir(), 'commitlore-mcp-capture-dist-'));
+  temporaries.push(harness);
+  SERVER_ENTRY = join(harness, 'dist', 'mcp', 'main.js');
+  symlinkSync(join(PACKAGE_ROOT, 'node_modules'), join(harness, 'node_modules'), 'dir');
+  symlinkSync(join(PACKAGE_ROOT, 'spec'), join(harness, 'spec'), 'dir');
+  symlinkSync(join(PACKAGE_ROOT, 'package.json'), join(harness, 'package.json'));
+
+  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json', '--outDir', join(harness, 'dist')], {
     shell: false,
     encoding: 'utf8',
     cwd: PACKAGE_ROOT,

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -27,6 +27,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { availableParallelism, tmpdir } from 'node:os';
@@ -41,9 +42,10 @@ import { createTestRepo } from './git-fixtures.js';
 
 const PACKAGE_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const TSC = fileURLToPath(new URL('../node_modules/typescript/bin/tsc', import.meta.url));
-const SERVER_ENTRY = fileURLToPath(new URL('../dist/mcp/main.js', import.meta.url));
-const SERVER_MODULE = fileURLToPath(new URL('../dist/mcp/server.js', import.meta.url));
-const CLI = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+let SERVER_ENTRY = '';
+let SERVER_MODULE = '';
+let CLI = '';
+let buildHarness = '';
 
 /** The files this ticket owns. The source guards below scan exactly these. */
 const OWNED_SOURCES = ['mcp/server.ts', 'mcp/main.ts', 'mcp/lifecycle.ts', 'commands/mcp.ts'];
@@ -79,10 +81,10 @@ const RPC_TIMEOUT_MS = 30_000;
  * that suite's `execFileSync` calls are fully synchronous, so they cannot be
  * pre-empted by vitest's timeout at all -- their failure was a real
  * consistency check tripping on a shared `dist/` raced by another test
- * file's rebuild, not a slow clock. Nothing here reads or rebuilds `dist/`
- * concurrently with anything else, so that specific race does not apply to
- * this file; this is the ordinary case of a fixed budget sized for solo
- * execution running out under real, unavoidable concurrency.
+ * file's rebuild, not a slow clock. This suite's build and runtime output now
+ * live in a private harness, so that specific race does not apply to this
+ * file; this is the ordinary case of a fixed budget sized for solo execution
+ * running out under real, unavoidable concurrency.
  */
 vi.setConfig({ testTimeout: 5_000 * Math.max(availableParallelism() - 1, 1) });
 
@@ -100,7 +102,15 @@ vi.setConfig({ testTimeout: 5_000 * Math.max(availableParallelism() - 1, 1) });
  * output is filtered rather than ignored.
  */
 beforeAll(() => {
-  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json'], {
+  buildHarness = mkdtempSync(join(tmpdir(), 'commitlore-mcp-dist-'));
+  SERVER_ENTRY = join(buildHarness, 'dist', 'mcp', 'main.js');
+  SERVER_MODULE = join(buildHarness, 'dist', 'mcp', 'server.js');
+  CLI = join(buildHarness, 'dist', 'cli.js');
+  symlinkSync(join(PACKAGE_ROOT, 'node_modules'), join(buildHarness, 'node_modules'), 'dir');
+  symlinkSync(join(PACKAGE_ROOT, 'spec'), join(buildHarness, 'spec'), 'dir');
+  symlinkSync(join(PACKAGE_ROOT, 'package.json'), join(buildHarness, 'package.json'));
+
+  const build = spawnSync(process.execPath, [TSC, '-p', 'tsconfig.json', '--outDir', join(buildHarness, 'dist')], {
     shell: false,
     encoding: 'utf8',
     cwd: PACKAGE_ROOT,
@@ -467,6 +477,7 @@ afterAll(async () => {
   // Await the shutdown before removing anything the server may still write to.
   await stub?.close();
   for (const dir of temporaries) rmSync(dir, { recursive: true, force: true });
+  if (buildHarness !== '') rmSync(buildHarness, { recursive: true, force: true });
 });
 
 describe('handshake and declarations', () => {


### PR DESCRIPTION
The full suite was not reliably green, and the reason was the harness rather than the product. The CDEB smoke suite failed five cases in a parallel run and passed all six alone. The independent review flagged the same thing and said it could not use the suite as release evidence.

## The race

Seven suites ran a full TypeScript build into the repository's shared `dist/` while other suites executed from that same directory. Whether a run was green depended on which finished first.

## The pattern was already here, twice

`test/hooks.test.ts` builds into its own harness and reads from there. `bench/hooks-settings.ts` shows the same idea from the other side — it takes an override so a bench suite can hand it a private snapshot, and its comment says this exists precisely so an unrelated rebuild cannot trip a mid-run consistency check.

This applies it to the seven that had not adopted it. **The builds stay** — these suites deliberately compile rather than trust a stale `dist/`, and that is worth keeping. What changed is where the output lands and which artifact each suite then executes.

`Ruled-out:` serialising the run or pinning a single-threaded pool. It makes the symptom rarer without removing the shared state, and charges minutes on every run forever.

## Evidence

**Two consecutive full-suite runs, both green** — 2,698 passed, 3 skipped — where the previous full run failed five cases. One green run would not have been evidence: a race that is merely less likely is not fixed, and the whole point is that the suite's colour must stop depending on scheduling.

Only test files changed; the committed `dist/` is untouched.

`Limit:` the suites still share one repository checkout, one npm cache and the machine's temporary directory, so a test that writes outside its own fixture can still reach another.
