### PR TITLE
Bind the version a caller asked for to the runtime that answers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,10 +373,14 @@ jobs:
           printf 'COMMITLORE_CI_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
           printf 'COMMITLORE_CI_WRONG_VERSION=%s\n' "$wrong_version" >> "$GITHUB_ENV"
           git tag -f "$version"
-          # This clean checkout is deliberately put at the requested tag's path
-          # below. It is a different tag even though this local CI source can
-          # share bytes; tag binding must still reject the mislabelled path.
-          git tag -f "$wrong_version"
+          # The wrong tag must name a different *commit*, not just a different
+          # name for this one. Tagging both at HEAD made the mislabelled clone
+          # contain the requested tag at its own HEAD, so binding passed and the
+          # step proved nothing. Reusing HEAD's tree keeps the checkout
+          # internally valid -- the manifest and smoke test still pass -- so the
+          # only thing left to reject it is the version binding under test.
+          wrong_commit="$(git commit-tree 'HEAD^{tree}' -p HEAD -m 'ci: a clean tree that is not the requested release')"
+          git tag -f "$wrong_version" "$wrong_commit"
 
       # -File, under 5.1, with the version as a positional argument: the same
       # entry point a user gets from `& ([scriptblock]::Create((irm ...))) <tag>`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,8 +254,10 @@ jobs:
       - name: Tag the checkout so install.sh has a pinned version to clone
         run: |
           set -euo pipefail
-          git -c user.name=ci -c user.email=ci@example.invalid tag -f v9.9.9
-          git tag --list v9.9.9
+          version="v$(node -p 'require("./package.json").version')"
+          printf 'COMMITLORE_CI_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+          git -c user.name=ci -c user.email=ci@example.invalid tag -f "$version"
+          git tag --list "$version"
 
       - name: Fresh install, then upgrade over it
         run: |
@@ -264,18 +266,19 @@ jobs:
           mkdir -p "$HOME"
           export COMMITLORE_INSTALL_SOURCE="$GITHUB_WORKSPACE"
 
-          sh install.sh v9.9.9
+          sh install.sh "$COMMITLORE_CI_VERSION"
           wrapper="$HOME/.local/bin/commitlore"
           test -x "$wrapper"
           grep -qF '# commitlore:wrapper:v1' "$wrapper"
-          test -f "$HOME/.local/share/commitlore/v9.9.9/dist/commitlore.mjs"
-          "$wrapper" --version
+          test -f "$HOME/.local/share/commitlore/$COMMITLORE_CI_VERSION/dist/commitlore.mjs"
+          installed_version="$("$wrapper" --version)"
+          test "$installed_version" = "${COMMITLORE_CI_VERSION#v}"
 
           # The wrapper is replaced by rename, and a second run is an upgrade
           # rather than a refusal. An in-place overwrite of a file that may be
           # executing is the defect that forced a same-day patch release.
-          sh install.sh v9.9.9
-          "$wrapper" --version
+          sh install.sh "$COMMITLORE_CI_VERSION"
+          test "$("$wrapper" --version)" = "${COMMITLORE_CI_VERSION#v}"
 
           # No shell profile is written. Printing the PATH line is the whole of
           # what this script does about PATH.
@@ -301,9 +304,9 @@ jobs:
       - name: Bare debian names the missing prerequisite and installs nothing
         run: |
           set -euo pipefail
-          docker run --rm -v "$PWD:/w" -w /w debian:stable-slim sh -c '
+          docker run --rm -e COMMITLORE_CI_VERSION="$COMMITLORE_CI_VERSION" -v "$PWD:/w" -w /w debian:stable-slim sh -c '
             set -eu
-            out=$(COMMITLORE_INSTALL_SOURCE=/w sh install.sh v9.9.9 2>&1 || true)
+            out=$(COMMITLORE_INSTALL_SOURCE=/w sh install.sh "$COMMITLORE_CI_VERSION" 2>&1 || true)
             printf "%s\n" "$out"
             printf "%s" "$out" | grep -qi "node" || { echo "expected the message to name Node"; exit 1; }
             test ! -e "$HOME/.local/bin/commitlore" || { echo "something was installed"; exit 1; }
@@ -312,7 +315,7 @@ jobs:
       - name: The same image succeeds once Node and Git are present
         run: |
           set -euo pipefail
-          docker run --rm -v "$PWD:/w" -w /w node:22-bookworm-slim sh -c '
+          docker run --rm -e COMMITLORE_CI_VERSION="$COMMITLORE_CI_VERSION" -v "$PWD:/w" -w /w node:22-bookworm-slim sh -c '
             set -eu
             apt-get update -qq && apt-get install -y -qq git >/dev/null
             # The checkout is owned by the runner uid, not this container user.
@@ -321,10 +324,10 @@ jobs:
             # Raw clone first, unfiltered: if the installer cannot fetch, this
             # shows git saying why instead of leaving it to be inferred.
             echo "--- raw clone probe ---"
-            git clone --depth 1 --branch v9.9.9 /w /tmp/probe || echo "(probe failed, see above)"
+            git clone --depth 1 --branch "$COMMITLORE_CI_VERSION" /w /tmp/probe || echo "(probe failed, see above)"
             echo "--- installer ---"
-            COMMITLORE_INSTALL_SOURCE=/w sh install.sh v9.9.9
-            "$HOME/.local/bin/commitlore" --version
+            COMMITLORE_INSTALL_SOURCE=/w sh install.sh "$COMMITLORE_CI_VERSION"
+            test "$("$HOME/.local/bin/commitlore" --version)" = "${COMMITLORE_CI_VERSION#v}"
           '
 
   # T-1121 (#282): install.ps1 is install.sh's twin, and a shape test cannot show
@@ -364,17 +367,26 @@ jobs:
           set -euo pipefail
           git config user.email t@example.com
           git config user.name "CommitLore CI"
-          git tag v9.9.9
+          version="v$(node -p 'require("./package.json").version')"
+          wrong_version='v0.0.1'
+          if [ "$wrong_version" = "$version" ]; then wrong_version='v0.0.2'; fi
+          printf 'COMMITLORE_CI_VERSION=%s\n' "$version" >> "$GITHUB_ENV"
+          printf 'COMMITLORE_CI_WRONG_VERSION=%s\n' "$wrong_version" >> "$GITHUB_ENV"
+          git tag -f "$version"
+          # This clean checkout is deliberately put at the requested tag's path
+          # below. It is a different tag even though this local CI source can
+          # share bytes; tag binding must still reject the mislabelled path.
+          git tag -f "$wrong_version"
 
       # -File, under 5.1, with the version as a positional argument: the same
-      # entry point a user gets from `& ([scriptblock]::Create((irm ...))) v9.9.9`,
+      # entry point a user gets from `& ([scriptblock]::Create((irm ...))) <tag>`,
       # and the one that proves param() binds.
       - name: Install under Windows PowerShell 5.1
         shell: cmd
         env:
           COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
         run: |
-          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 %COMMITLORE_CI_VERSION%
           if errorlevel 1 exit /b 1
 
       - name: The 5.1 host reports its own version, for the record
@@ -405,13 +417,45 @@ jobs:
         shell: pwsh
         env:
           COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
-          COMMITLORE_VERSION: v9.9.9
         run: |
           $ErrorActionPreference = 'Stop'
+          $env:COMMITLORE_VERSION = $env:COMMITLORE_CI_VERSION
           $out = (Get-Content -LiteralPath .\install.ps1 -Raw | Invoke-Expression 2>&1 | Out-String)
           Write-Host $out
           if ($out -notmatch 'reusing the existing checkout') { throw 'the checkout was not reused' }
           if ($out -notmatch 'upgrading the existing commitlore shim') { throw 'the shim was not recognized as its own' }
+
+      # A clean checkout can be internally valid and still be the wrong release.
+      # This is Windows evidence for the same version-binding condition the shell
+      # installer exercises locally: a directory named for the requested tag does
+      # not authorize activation until its own tag agrees.
+      - name: A clean wrong tag at the requested checkout path is refused
+        shell: cmd
+        env:
+          COMMITLORE_INSTALL_SOURCE: ${{ github.workspace }}
+        run: |
+          set "root=%TEMP%\commitlore-version-binding"
+          rmdir /s /q "%root%" 2>nul
+          mkdir "%root%\commitlore"
+          set "LOCALAPPDATA=%root%"
+          set "COMMITLORE_INSTALL_DIR=%root%\bin"
+          git clone --quiet --depth 1 --branch %COMMITLORE_CI_WRONG_VERSION% "%GITHUB_WORKSPACE%" "%root%\commitlore\%COMMITLORE_CI_VERSION%" > "%root%-clone.log" 2>&1
+          if errorlevel 1 exit /b 1
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 %COMMITLORE_CI_VERSION% > "%root%-wrong-tag.log" 2>&1
+          set "code=%ERRORLEVEL%"
+          type "%root%-wrong-tag.log"
+          if not "%code%"=="3" (
+            echo ::error::expected exit 3 for a clean wrong-tag checkout, got %code%
+            exit /b 1
+          )
+          findstr /C:"requested tag %COMMITLORE_CI_VERSION%" "%root%-wrong-tag.log" >nul || (
+            echo ::error::the requested-tag mismatch was not named
+            exit /b 1
+          )
+          if exist "%root%\bin\commitlore.cmd" (
+            echo ::error::a shim was activated for the wrong tag
+            exit /b 1
+          )
 
       # This has to run on Windows rather than be inferred from the shape test:
       # cmd.exe is the active wrapper, and the transaction is only established
@@ -425,13 +469,13 @@ jobs:
           rmdir /s /q "%root%" 2>nul
           set "LOCALAPPDATA=%root%"
           set "COMMITLORE_INSTALL_DIR=%root%\bin"
-          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 > "%root%-initial.log" 2>&1
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 %COMMITLORE_CI_VERSION% > "%root%-initial.log" 2>&1
           if errorlevel 1 exit /b 1
           set "shim=%root%\bin\commitlore.cmd"
-          set "bundle=%root%\commitlore\v9.9.9\dist\commitlore.mjs"
+          set "bundle=%root%\commitlore\%COMMITLORE_CI_VERSION%\dist\commitlore.mjs"
           copy /y "%shim%" "%root%-shim-before.cmd" >nul
           del "%bundle%"
-          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 > "%root%-deleted.log" 2>&1
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 %COMMITLORE_CI_VERSION% > "%root%-deleted.log" 2>&1
           set "code=%ERRORLEVEL%"
           type "%root%-deleted.log"
           if not "%code%"=="3" (
@@ -446,8 +490,18 @@ jobs:
             echo ::error::the shim changed after a deleted bundle was refused
             exit /b 1
           )
+          findstr /C:"Remove-Item -LiteralPath" "%root%-deleted.log" >nul || (
+            echo ::error::the damaged-checkout repair command was not named
+            exit /b 1
+          )
+          powershell.exe -NoProfile -Command "$repair = (Get-Content -LiteralPath '%root%-deleted.log' | Where-Object { $_.TrimStart().StartsWith('Remove-Item -LiteralPath ') } | Select-Object -First 1).Trim(); if ([string]::IsNullOrEmpty($repair)) { throw 'repair command missing' }; Write-Host $repair; Invoke-Expression $repair"
+          if errorlevel 1 exit /b 1
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 %COMMITLORE_CI_VERSION% > "%root%-repaired.log" 2>&1
+          if errorlevel 1 exit /b 1
+          "%shim%" --version > "%root%-repaired-version.log" 2>&1
+          if errorlevel 1 exit /b 1
           mkdir "%bundle%"
-          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 v9.9.9 > "%root%-directory.log" 2>&1
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File install.ps1 %COMMITLORE_CI_VERSION% > "%root%-directory.log" 2>&1
           set "code=%ERRORLEVEL%"
           type "%root%-directory.log"
           if not "%code%"=="3" (

--- a/install.ps1
+++ b/install.ps1
@@ -213,6 +213,86 @@ function New-VerificationResult {
     }
 }
 
+# A directory named after a release is not itself evidence that it contains
+# that release. An interrupted or hand-copied upgrade can leave a clean older
+# checkout at the newer path, so bind HEAD to the requested tag before reuse or
+# activation.
+function Test-RequestedTag {
+    param(
+        [string] $Root,
+        [string] $Tag
+    )
+    $tagRef = "refs/tags/$Tag"
+
+    try {
+        $previousTagPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        & git -C $Root show-ref --verify --quiet $tagRef > $null 2>$null
+        $tagCode = $LASTEXITCODE
+        $ErrorActionPreference = $previousTagPreference
+    } catch {
+        $ErrorActionPreference = $previousTagPreference
+        return (New-VerificationResult 'unavailable' $Root "Git could not read requested tag $Tag ($($_.Exception.Message))")
+    }
+    if ($tagCode -eq 1) {
+        return (New-VerificationResult 'failed' $Root "the checkout does not contain requested tag $Tag")
+    }
+    if ($tagCode -ne 0) {
+        return (New-VerificationResult 'unavailable' $Root "Git could not read requested tag $Tag (exit $tagCode)")
+    }
+
+    try {
+        $previousTagPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $requestedHead = ((& git -C $Root rev-parse --verify "$tagRef^{commit}" 2>$null | Out-String).Trim())
+        $requestedCode = $LASTEXITCODE
+        $ErrorActionPreference = $previousTagPreference
+    } catch {
+        $ErrorActionPreference = $previousTagPreference
+        return (New-VerificationResult 'unavailable' $Root "Git could not resolve requested tag $Tag ($($_.Exception.Message))")
+    }
+    if ($requestedCode -ne 0) {
+        return (New-VerificationResult 'unavailable' $Root "Git could not resolve requested tag $Tag to a commit (exit $requestedCode)")
+    }
+
+    try {
+        $previousTagPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $checkoutHead = ((& git -C $Root rev-parse --verify HEAD 2>$null | Out-String).Trim())
+        $headCode = $LASTEXITCODE
+        $ErrorActionPreference = $previousTagPreference
+    } catch {
+        $ErrorActionPreference = $previousTagPreference
+        return (New-VerificationResult 'unavailable' $Root "Git could not resolve checkout HEAD ($($_.Exception.Message))")
+    }
+    if ($headCode -ne 0) {
+        return (New-VerificationResult 'unavailable' $Root "Git could not resolve checkout HEAD (exit $headCode)")
+    }
+    if ($checkoutHead -cne $requestedHead) {
+        return (New-VerificationResult 'failed' $Root "checkout HEAD $checkoutHead does not match requested tag $Tag ($requestedHead)")
+    }
+    return (New-VerificationResult 'passed' $Root '')
+}
+
+# The installer may have arrived through Invoke-Expression, so it cannot safely
+# reconstruct the command that invoked it. It can name the one deliberate repair
+# that returns this transaction to a state a rerun can install into. The quoted
+# command is valid in both Windows PowerShell 5.1 and PowerShell 7+.
+function Stop-UnusableCheckout {
+    param(
+        [object] $Result,
+        [string] $Checkout,
+        [string] $Destination
+    )
+    [Console]::Error.WriteLine(('commitlore-install: error: runtime verification ran and found an unusable path: "{0}" ({1}). The existing shim at {2} was left unchanged.' -f $Result.Path, $Result.Detail, $Destination))
+    if (Test-Path -LiteralPath $Checkout) {
+        $quotedCheckout = $Checkout.Replace("'", "''")
+        [Console]::Error.WriteLine('commitlore-install: error: To repair this checkout deliberately, remove only it, then rerun the same install command:')
+        [Console]::Error.WriteLine("  Remove-Item -LiteralPath '$quotedCheckout' -Recurse -Force")
+    }
+    exit 3
+}
+
 # Smoke-test the checkout directly, while it is still only an incoming tree.
 # doctor --json can legitimately exit 1 for a repository that needs setup; its
 # JSON report proves the command ran. Exit 2 is the documented could-not-run
@@ -220,7 +300,8 @@ function New-VerificationResult {
 function Invoke-IncomingSmoke {
     param(
         [string] $Root,
-        [string] $NodePath
+        [string] $NodePath,
+        [string] $ExpectedVersion
     )
 
     $entry = Join-Path $Root 'dist\commitlore.mjs'
@@ -246,6 +327,9 @@ function Invoke-IncomingSmoke {
         }
         if ([string]::IsNullOrEmpty($version)) {
             return (New-VerificationResult 'failed' $entry '--version exited 0 without reporting a version')
+        }
+        if ($version -cne $ExpectedVersion) {
+            return (New-VerificationResult 'failed' $entry "--version reported ""$version"", want requested version ""$ExpectedVersion""")
         }
 
         $validMessage = Join-Path $smokeDir 'valid-message'
@@ -319,7 +403,8 @@ function Invoke-IncomingSmoke {
 function Invoke-LegacySmoke {
     param(
         [string] $Root,
-        [string] $NodePath
+        [string] $NodePath,
+        [string] $ExpectedVersion
     )
     $entry = Join-Path $Root 'dist\commitlore.mjs'
     try {
@@ -339,6 +424,9 @@ function Invoke-LegacySmoke {
     }
     if ([string]::IsNullOrEmpty($version)) {
         return (New-VerificationResult 'failed' $entry '--version exited 0 without reporting a version')
+    }
+    if ($version -cne $ExpectedVersion) {
+        return (New-VerificationResult 'failed' $entry "--version reported ""$version"", want requested version ""$ExpectedVersion""")
     }
     return (New-VerificationResult 'passed' $entry '' $version)
 }
@@ -494,11 +582,16 @@ if (Test-Path -LiteralPath $checkout) {
         $manifest = Test-RuntimeManifest $checkout
     }
     if ($manifest.State -eq 'passed') {
-        $candidate = $checkout
-        if ($manifest.Mode -eq 'legacy') {
-            Write-Log "reusing the existing checkout at $checkout (legacy runtime check and --version smoke test; this release predates $RuntimeManifestPath)"
+        $tagBinding = Test-RequestedTag $checkout $Version
+        if ($tagBinding.State -eq 'passed') {
+            $candidate = $checkout
+            if ($manifest.Mode -eq 'legacy') {
+                Write-Log "reusing the existing checkout at $checkout (legacy runtime check and --version smoke test; this release predates $RuntimeManifestPath)"
+            } else {
+                Write-Log "reusing the existing checkout at $checkout (runtime manifest and requested tag verified)"
+            }
         } else {
-            Write-Log "reusing the existing checkout at $checkout (runtime manifest verified)"
+            $manifest = $tagBinding
         }
     }
 } else {
@@ -547,9 +640,14 @@ if (Test-Path -LiteralPath $checkout) {
     }
     $manifest = Test-RuntimeManifest $checkoutTmp
     if ($manifest.State -eq 'passed') {
-        $candidate = $checkoutTmp
-        if ($manifest.Mode -eq 'legacy') {
-            Write-Log "$Version predates $RuntimeManifestPath; using the installer's legacy runtime check and --version smoke test"
+        $tagBinding = Test-RequestedTag $checkoutTmp $Version
+        if ($tagBinding.State -eq 'passed') {
+            $candidate = $checkoutTmp
+            if ($manifest.Mode -eq 'legacy') {
+                Write-Log "$Version predates $RuntimeManifestPath; using the installer's legacy runtime check and --version smoke test"
+            }
+        } else {
+            $manifest = $tagBinding
         }
     }
 }
@@ -561,13 +659,13 @@ if ([string]::IsNullOrEmpty($candidate)) {
     if ($manifest.State -eq 'unavailable') {
         Stop-Install "runtime verification could not run for ""$($manifest.Path)"": $($manifest.Detail). The existing shim at $dest was left unchanged." 5
     }
-    Stop-Install "runtime verification ran and found an unusable path: ""$($manifest.Path)"" ($($manifest.Detail)). The existing shim at $dest was left unchanged." 3
+    Stop-UnusableCheckout $manifest $checkout $dest
 }
 
 if ($manifest.Mode -eq 'legacy') {
-    $smoke = Invoke-LegacySmoke $candidate $nodeBin
+    $smoke = Invoke-LegacySmoke $candidate $nodeBin ($Version.TrimStart('v'))
 } else {
-    $smoke = Invoke-IncomingSmoke $candidate $nodeBin
+    $smoke = Invoke-IncomingSmoke $candidate $nodeBin ($Version.TrimStart('v'))
 }
 if ($smoke.State -ne 'passed') {
     if (-not [string]::IsNullOrEmpty($checkoutTmp) -and (Test-Path -LiteralPath $checkoutTmp)) {
@@ -576,7 +674,7 @@ if ($smoke.State -ne 'passed') {
     if ($smoke.State -eq 'unavailable') {
         Stop-Install "runtime verification could not run for ""$($smoke.Path)"": $($smoke.Detail). The existing shim at $dest was left unchanged." 5
     }
-    Stop-Install "runtime verification ran and found an unusable path: ""$($smoke.Path)"" ($($smoke.Detail)). The existing shim at $dest was left unchanged." 3
+    Stop-UnusableCheckout $smoke $checkout $dest
 }
 
 if ($candidate -eq $checkoutTmp) {

--- a/install.sh
+++ b/install.sh
@@ -187,6 +187,48 @@ verification_unavailable() {
   return 1
 }
 
+# A directory named after a release is not itself evidence that it contains
+# that release. In particular, an interrupted or hand-copied upgrade can leave
+# a clean checkout of an older tag at the newer tag's path. Bind HEAD to the
+# requested tag before reusing or activating any checkout.
+verify_requested_tag() {
+  runtime_root="$1"
+  requested_tag="$2"
+  requested_ref="refs/tags/$requested_tag"
+
+  if git -C "$runtime_root" show-ref --verify --quiet "$requested_ref"; then
+    :
+  else
+    requested_tag_status=$?
+    if [ "$requested_tag_status" -eq 1 ]; then
+      verification_failed "$runtime_root" "the checkout does not contain requested tag $requested_tag"
+    else
+      verification_unavailable "$runtime_root" "Git could not read requested tag $requested_tag (exit $requested_tag_status)"
+    fi
+    return 1
+  fi
+
+  if requested_head="$(git -C "$runtime_root" rev-parse --verify "$requested_ref^{commit}" 2>/dev/null)"; then
+    :
+  else
+    requested_tag_status=$?
+    verification_unavailable "$runtime_root" "Git could not resolve requested tag $requested_tag to a commit (exit $requested_tag_status)"
+    return 1
+  fi
+  if checkout_head="$(git -C "$runtime_root" rev-parse --verify HEAD 2>/dev/null)"; then
+    :
+  else
+    requested_tag_status=$?
+    verification_unavailable "$runtime_root" "Git could not resolve checkout HEAD (exit $requested_tag_status)"
+    return 1
+  fi
+  if [ "$checkout_head" != "$requested_head" ]; then
+    verification_failed "$runtime_root" "checkout HEAD $checkout_head does not match requested tag $requested_tag ($requested_head)"
+    return 1
+  fi
+  return 0
+}
+
 # Smoke-test the checkout directly, while it is still only an incoming tree.
 # `doctor --json` can legitimately exit 1 for a repository that needs setup;
 # its JSON report proves the command ran. Exit 2 is the documented "could not
@@ -202,6 +244,10 @@ verify_incoming_smoke() {
     verified_version="$(cat "$smoke_dir/version.out")"
     if [ -z "$verified_version" ]; then
       verification_failed "$runtime_entry" "--version exited 0 without reporting a version"
+      return 1
+    fi
+    if [ "$verified_version" != "$requested_version" ]; then
+      verification_failed "$runtime_entry" "--version reported \"$verified_version\", want requested version \"$requested_version\""
       return 1
     fi
   else
@@ -281,6 +327,10 @@ verify_legacy_smoke() {
       verification_failed "$runtime_entry" "--version exited 0 without reporting a version"
       return 1
     fi
+    if [ "$verified_version" != "$requested_version" ]; then
+      verification_failed "$runtime_entry" "--version reported \"$verified_version\", want requested version \"$requested_version\""
+      return 1
+    fi
     return 0
   fi
   smoke_status=$?
@@ -349,6 +399,7 @@ else
 fi
 
 log "installing $version"
+requested_version="${version#v}"
 
 # Scratch space for verification and the wiring phase's write-temp-then-rename
 # config merges. Incoming and wrapper temporaries share its exit cleanup.
@@ -409,6 +460,25 @@ data_root="${XDG_DATA_HOME:-$HOME/.local/share}/commitlore"
 checkout="$data_root/$version"
 candidate=""
 
+# The installer may have arrived through a pipe, so it cannot safely recreate
+# the command that invoked it. It can name the one deliberate filesystem repair
+# that returns this transaction to a state a rerun can install into. Quoting is
+# emitted for a POSIX shell, including a data directory whose path has spaces.
+quote_for_sh() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+die_unusable_checkout() {
+  printf 'commitlore-install: error: runtime verification ran and found an unusable path: "%s" (%s). The existing wrapper at %s was left unchanged.\n' \
+    "$verification_path" "$verification_detail" "$dest" >&2
+  if [ -e "$checkout" ]; then
+    printf 'commitlore-install: error: To repair this checkout deliberately, remove only it, then rerun the same install command:\n' >&2
+    printf '  rm -rf %s\n' "$(quote_for_sh "$checkout")" >&2
+  fi
+  exit 3
+}
+
 if [ -e "$checkout" ]; then
   if [ ! -d "$checkout" ]; then
     verification_state="failed"
@@ -416,12 +486,14 @@ if [ -e "$checkout" ]; then
     verification_detail="the existing checkout path is not a directory"
   elif ! verify_runtime_manifest "$checkout"; then
     :
+  elif ! verify_requested_tag "$checkout" "$version"; then
+    :
   else
     candidate="$checkout"
     if [ "$runtime_manifest_mode" = "legacy" ]; then
       log "reusing the existing checkout at $checkout (legacy runtime check and --version smoke test; this release predates $RUNTIME_MANIFEST)"
     else
-      log "reusing the existing checkout at $checkout (runtime manifest verified)"
+      log "reusing the existing checkout at $checkout (runtime manifest and requested tag verified)"
     fi
   fi
 else
@@ -446,7 +518,7 @@ else
     die "could not fetch $version from $SOURCE_URL. git said: ${clone_reason:-nothing}. Nothing was installed." 2
   fi
   rm -f "$clone_log"
-  if verify_runtime_manifest "$checkout_tmp"; then
+  if verify_runtime_manifest "$checkout_tmp" && verify_requested_tag "$checkout_tmp" "$version"; then
     candidate="$checkout_tmp"
     if [ "$runtime_manifest_mode" = "legacy" ]; then
       log "$version predates $RUNTIME_MANIFEST; using the installer's legacy runtime check and --version smoke test"
@@ -458,7 +530,7 @@ if [ -z "$candidate" ]; then
   if [ "$verification_state" = "unavailable" ]; then
     die "runtime verification could not run for \"$verification_path\": $verification_detail. The existing wrapper at $dest was left unchanged." 5
   fi
-  die "runtime verification ran and found an unusable path: \"$verification_path\" ($verification_detail). The existing wrapper at $dest was left unchanged." 3
+  die_unusable_checkout
 fi
 
 verification_smoke_ok="true"
@@ -471,7 +543,7 @@ if [ "$verification_smoke_ok" != "true" ]; then
   if [ "$verification_state" = "unavailable" ]; then
     die "runtime verification could not run for \"$verification_path\": $verification_detail. The existing wrapper at $dest was left unchanged." 5
   else
-    die "runtime verification ran and found an unusable path: \"$verification_path\" ($verification_detail). The existing wrapper at $dest was left unchanged." 3
+    die_unusable_checkout
   fi
 fi
 

--- a/scripts/commitlore-run.sh
+++ b/scripts/commitlore-run.sh
@@ -16,25 +16,29 @@
 set -u
 
 resolve() {
-  # On PATH by whatever means the user chose. The installer's wrapper lands here:
-  # it is a shell script that execs node, so it runs without this script having to
-  # find node itself, and it is tried before the `command -v node` gate for that
-  # reason. ADR-0026 removed the compiled build that used to be probed first.
+  # A plugin is a versioned release artifact. When this script is executing as
+  # a plugin hook, its root is therefore the runtime authority: accepting a
+  # different `commitlore` from PATH would let a newly installed plugin silently
+  # run an older CLI. If this bundle cannot run, fail open rather than substituting
+  # an unrelated installation and presenting its context as the plugin's.
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    command -v node >/dev/null 2>&1 || return 1   # without it `exec node` exits 127
+
+    # The bundle carries its own dependencies, so it runs from a clone that never
+    # had node_modules. The unbundled build remains a development fallback.
+    if [ -f "$CLAUDE_PLUGIN_ROOT/dist/commitlore.mjs" ]; then
+      echo "node|$CLAUDE_PLUGIN_ROOT/dist/commitlore.mjs"; return 0
+    fi
+    if [ -f "$CLAUDE_PLUGIN_ROOT/dist/cli.js" ]; then
+      echo "node|$CLAUDE_PLUGIN_ROOT/dist/cli.js"; return 0
+    fi
+    return 1
+  fi
+
+  # Outside a plugin invocation there is no plugin-owned bundle to bind, so a
+  # caller may deliberately use the normal CLI install from PATH.
   if command -v commitlore >/dev/null 2>&1; then
     echo "commitlore"; return 0
-  fi
-
-  command -v node >/dev/null 2>&1 || return 1   # without it `exec node` exits 127
-
-  # The bundle carries its own dependencies, so it runs from a clone that never
-  # had node_modules. It is tried first among the node-based options for that
-  # reason alone.
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/dist/commitlore.mjs" ]; then
-    echo "node|$CLAUDE_PLUGIN_ROOT/dist/commitlore.mjs"; return 0
-  fi
-  # Unbundled build, which needs node_modules beside it.
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "$CLAUDE_PLUGIN_ROOT/dist/cli.js" ]; then
-    echo "node|$CLAUDE_PLUGIN_ROOT/dist/cli.js"; return 0
   fi
   return 1
 }

--- a/test/install-ps1.test.ts
+++ b/test/install-ps1.test.ts
@@ -188,13 +188,16 @@ describe('T-1121 install.ps1 exists and matches install.sh clause for clause', (
     expect(writes).toEqual([]);
   });
 
-  it('reads the checkout-owned runtime manifest and smoke-tests before activation', () => {
+  it('binds the requested tag and its reported version before activation', () => {
     const text = body();
     expect(text).toContain("$RuntimeManifestPath = 'installer/runtime-manifest.txt'");
     expect(text).toContain("$RuntimeManifestFormat = 'commitlore-runtime-manifest-v1'");
     expect(text).toContain('Test-TrackedRuntimeFile $Root $RuntimeManifestPath');
     expect(text).toContain('Get-Content -LiteralPath $manifestPath');
     expect(text).toContain('Test-LegacyRuntime $Root');
+    expect(text).toContain('function Test-RequestedTag');
+    expect(text).toContain('Test-RequestedTag $checkout $Version');
+    expect(text).toContain('Test-RequestedTag $checkoutTmp $Version');
     expect(text).toContain('Invoke-LegacySmoke $candidate $nodeBin');
     expect(readFileSync(SH, 'utf8')).toContain('RUNTIME_MANIFEST="installer/runtime-manifest.txt"');
     for (const asset of [
@@ -211,6 +214,8 @@ describe('T-1121 install.ps1 exists and matches install.sh clause for clause', (
       expect(readFileSync(RUNTIME_MANIFEST, 'utf8')).toContain(asset);
     }
     expect(text).toContain('Invoke-IncomingSmoke $candidate $nodeBin');
+    expect(text).toContain('if ($version -cne $ExpectedVersion)');
+    expect(text).toContain('want requested version');
     expect(text).toContain('validate --message-file $validMessage');
     expect(text).toContain('validate --message-file $invalidMessage');
     expect(text).toContain('doctor --json');
@@ -219,11 +224,22 @@ describe('T-1121 install.ps1 exists and matches install.sh clause for clause', (
     expect(text).not.toContain('Start-Sleep -Seconds 1');
   });
 
-  it('is re-runnable only after an existing checkout passes the runtime manifest', () => {
+  it('is re-runnable only after an existing checkout binds to its requested tag', () => {
     const text = body();
-    expect(text).toContain('reusing the existing checkout at $checkout (runtime manifest verified)');
+    expect(text).toContain('reusing the existing checkout at $checkout (runtime manifest and requested tag verified)');
     expect(text).toContain('upgrading the existing commitlore shim at');
     expect(text).toContain('already mentions commitlore -- left unchanged');
+  });
+
+  it('names an explicit manual repair for an unusable existing checkout', () => {
+    // The installer must not delete an unverified path by itself. This command
+    // is intentionally printed for the operator to run, after which the same
+    // installer invocation can materialize a fresh requested checkout.
+    const text = body();
+    expect(text).toContain('function Stop-UnusableCheckout');
+    expect(text).toContain("Remove-Item -LiteralPath '$quotedCheckout' -Recurse -Force");
+    expect(text).toContain('Stop-UnusableCheckout $manifest $checkout $dest');
+    expect(text).toContain('Stop-UnusableCheckout $smoke $checkout $dest');
   });
 
   it('writes the shim beside the target and moves it into place', () => {

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -45,7 +45,10 @@ afterAll(() => {
 let sourceRepo: string;
 /** A source whose bundle exits non-zero — a real broken release, not a test hook. */
 let brokenRepo: string;
+/** A correctly named tag whose bundle reports a different release version. */
+let versionMismatchRepo: string;
 const TAG = 'v9.9.9';
+const OLDER_TAG = 'v9.8.8';
 
 const git = (cwd: string, args: string[]): void => {
   execFileSync('git', ['-c', 'user.name=T', '-c', 'user.email=t@e.invalid', ...args], {
@@ -63,14 +66,14 @@ const writeRuntimeManifest = (target: string, assets: string[]): void => {
 /** The non-bundle files the installed CLI reads at runtime. */
 const copyRuntimeAssets = (
   target: string,
-  options: { manifest?: string[] | false; includeHermes?: boolean } = {},
+  options: { manifest?: string[] | false; includeHermes?: boolean; version?: string } = {},
 ): void => {
   cpSync(join(REPO_ROOT, 'AGENTS.md'), join(target, 'AGENTS.md'));
   cpSync(join(REPO_ROOT, 'spec'), join(target, 'spec'), { recursive: true });
   if (options.includeHermes !== false) {
     cpSync(join(REPO_ROOT, 'hermes'), join(target, 'hermes'), { recursive: true });
   }
-  writeFileSync(join(target, 'package.json'), JSON.stringify({ name: 'commitlore', version: '9.9.9' }));
+  writeFileSync(join(target, 'package.json'), JSON.stringify({ name: 'commitlore', version: options.version ?? '9.9.9' }));
   if (options.manifest === false) return;
   if (options.manifest !== undefined) {
     writeRuntimeManifest(target, options.manifest);
@@ -88,10 +91,14 @@ beforeAll(() => {
   // read from this fixture package.json, so the installer's ordinary wrapper
   // verification remains deterministic without a network or another worktree.
   cpSync(join(REPO_ROOT, 'dist', 'commitlore.mjs'), join(sourceRepo, 'dist', 'commitlore.mjs'));
-  copyRuntimeAssets(sourceRepo);
+  copyRuntimeAssets(sourceRepo, { version: '9.8.8' });
   execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: sourceRepo });
   git(sourceRepo, ['add', '-A']);
-  git(sourceRepo, ['commit', '--quiet', '-m', 'source']);
+  git(sourceRepo, ['commit', '--quiet', '-m', 'older source']);
+  git(sourceRepo, ['tag', OLDER_TAG]);
+  writeFileSync(join(sourceRepo, 'package.json'), JSON.stringify({ name: 'commitlore', version: '9.9.9' }));
+  git(sourceRepo, ['add', 'package.json']);
+  git(sourceRepo, ['commit', '--quiet', '-m', 'requested source']);
   git(sourceRepo, ['tag', TAG]);
 
   brokenRepo = join(tempDir('broken'), 'commitlore');
@@ -102,6 +109,15 @@ beforeAll(() => {
   git(brokenRepo, ['add', '-A']);
   git(brokenRepo, ['commit', '--quiet', '-m', 'broken bundle']);
   git(brokenRepo, ['tag', TAG]);
+
+  versionMismatchRepo = join(tempDir('version-mismatch'), 'commitlore');
+  mkdirSync(join(versionMismatchRepo, 'dist'), { recursive: true });
+  cpSync(join(REPO_ROOT, 'dist', 'commitlore.mjs'), join(versionMismatchRepo, 'dist', 'commitlore.mjs'));
+  copyRuntimeAssets(versionMismatchRepo, { version: '9.8.8' });
+  execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: versionMismatchRepo });
+  git(versionMismatchRepo, ['add', '-A']);
+  git(versionMismatchRepo, ['commit', '--quiet', '-m', 'wrong runtime version']);
+  git(versionMismatchRepo, ['tag', TAG]);
 });
 
 /** A PATH holding a shell and the tools the case wants, and nothing else. */
@@ -432,6 +448,34 @@ describe('T-1120 upgrade and verification', () => {
     expect(existsSync(r.wrapper)).toBe(false);
   });
 
+  it('refuses a requested tag whose binary reports another version before activating a wrapper', () => {
+    // Tag identity alone is insufficient: a tag can point at bytes that still
+    // declare an older release. The exact --version value is what the wrapper
+    // will expose to every later invocation.
+    const r = runInstaller({ extraEnv: { COMMITLORE_INSTALL_SOURCE: versionMismatchRepo } });
+    expect(r.status).toBe(3);
+    expect(`${r.stdout}${r.stderr}`).toContain('--version reported "9.8.8", want requested version "9.9.9"');
+    expect(existsSync(r.wrapper)).toBe(false);
+  });
+
+  it('refuses a clean older checkout placed at the requested release path', () => {
+    // This is the upgrade failure that a directory name cannot prove away: the
+    // checkout is internally clean, but its HEAD is the older tag. It must stay
+    // untouched for the operator to inspect or remove deliberately.
+    const home = tempDir('wrong-clean-checkout');
+    const checkout = join(home, '.local', 'share', 'commitlore', TAG);
+    mkdirSync(dirname(checkout), { recursive: true });
+    execFileSync('git', ['clone', '--quiet', '--depth', '1', '--branch', OLDER_TAG, sourceRepo, checkout]);
+    const before = execFileSync('git', ['-C', checkout, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+
+    const r = runInstaller({ home });
+    expect(r.status).toBe(3);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/requested tag v9\.9\.9/);
+    expect(existsSync(r.wrapper)).toBe(false);
+    expect(execFileSync('git', ['-C', checkout, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim()).toBe(before);
+    expect(execFileSync('node', ['dist/commitlore.mjs', '--version'], { cwd: checkout, encoding: 'utf8' }).trim()).toBe('9.8.8');
+  });
+
   it('accepts an older tag whose own manifest names fewer runtime assets', () => {
     // This source predates the Hermes bundle. Its manifest deliberately lists
     // only the files that tag reads, and the checkout itself carries that
@@ -443,6 +487,7 @@ describe('T-1120 upgrade and verification', () => {
     copyRuntimeAssets(olderRepo, {
       includeHermes: false,
       manifest: ['AGENTS.md', 'dist/commitlore.mjs', 'package.json', 'spec/SPEC.md', 'spec/schema/record.schema.json'],
+      version: '9.8.0',
     });
     execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: olderRepo });
     git(olderRepo, ['add', '-A']);
@@ -467,7 +512,7 @@ describe('T-1120 upgrade and verification', () => {
       join(legacyRepo, 'dist', 'commitlore.mjs'),
       "if (process.argv[2] === '--version') process.stdout.write('9.7.0\\n'); else process.exit(1);\n",
     );
-    copyRuntimeAssets(legacyRepo, { manifest: false });
+    copyRuntimeAssets(legacyRepo, { manifest: false, version: '9.7.0' });
     execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: legacyRepo });
     git(legacyRepo, ['add', '-A']);
     git(legacyRepo, ['commit', '--quiet', '-m', 'release before runtime manifest']);
@@ -555,6 +600,34 @@ describe('T-1120 upgrade and verification', () => {
       }
     });
   }
+
+  it('gives a damaged checkout a repair command that returns it to an installable state', () => {
+    const home = tempDir('damaged-repair');
+    const first = runInstaller({ home });
+    expect(first.status).toBe(0);
+    const bundle = join(first.dataDir, TAG, 'dist', 'commitlore.mjs');
+    rmSync(bundle);
+
+    const refused = runInstaller({ home });
+    expect(refused.status).toBe(3);
+    const repair = `${refused.stdout}${refused.stderr}`.match(/^  (rm -rf .+)$/m)?.[1];
+    expect(repair).toBeDefined();
+
+    // Execute the exact command the refusal printed, then rerun the original
+    // installation. The installer never removes an unverified checkout itself.
+    const repairedPath = spawnSync('/bin/sh', ['-c', repair!], { encoding: 'utf8' });
+    expect(repairedPath.status).toBe(0);
+    expect(existsSync(join(first.dataDir, TAG))).toBe(false);
+
+    const repaired = runInstaller({ home });
+    expect(repaired.status).toBe(0);
+    const version = spawnSync('/bin/sh', [repaired.wrapper, '--version'], {
+      encoding: 'utf8',
+      env: { PATH: stubPath({ node: 'current' }), HOME: home },
+    });
+    expect(version.status).toBe(0);
+    expect(version.stdout.trim()).toBe('9.9.9');
+  });
 });
 
 describe('#298 tag auto-resolution needs no sort extension', () => {
@@ -611,7 +684,11 @@ describe('#298 tag auto-resolution needs no sort extension', () => {
     execFileSync('git', ['init', '--quiet', '-b', 'main'], { cwd: repo });
     git(repo, ['add', '-A']);
     git(repo, ['commit', '--quiet', '-m', 'src']);
-    for (const tag of ['v1.0.0', 'v2.5.0', 'v9.9.9', 'v10.0.0']) git(repo, ['tag', tag]);
+    for (const tag of ['v1.0.0', 'v2.5.0', 'v9.9.9']) git(repo, ['tag', tag]);
+    writeFileSync(join(repo, 'package.json'), JSON.stringify({ name: 'commitlore', version: '10.0.0' }));
+    git(repo, ['add', 'package.json']);
+    git(repo, ['commit', '--quiet', '-m', 'newest source']);
+    git(repo, ['tag', 'v10.0.0']);
 
     const home = tempDir('majors-home');
     const run = spawnSync('/bin/sh', [INSTALLER], {

--- a/test/plugin-entry-point.test.ts
+++ b/test/plugin-entry-point.test.ts
@@ -2,21 +2,16 @@
  * #483: the release gate asked whether the plugin entry point resolved, not
  * whether it resolved to the plugin.
  *
- * `scripts/commitlore-run.sh` tries `commitlore` on `PATH` before
- * `CLAUDE_PLUGIN_ROOT`. That order is deliberate — the installer's wrapper
- * execs node itself, so it works where this script would otherwise have to
- * find node, and on the hook hot path a missing node means no context at all.
+ * The old runner tried `commitlore` on `PATH` before `CLAUDE_PLUGIN_ROOT`.
+ * That made a plugin hook silently run a different installed CLI. Found running
+ * the gate against a fresh v0.7.0 clone on a machine with 0.6.0 installed: the
+ * clone answered 0.7.0 and the entry point answered 0.6.0, and the gate passed
+ * because it only checked the exit code.
  *
- * The consequence is that a machine carrying both a CLI install and the plugin
- * runs whichever the CLI install is, silently. Found running the gate against a
- * fresh v0.7.0 clone on a machine with 0.6.0 installed: the clone answered
- * 0.7.0 and the entry point answered 0.6.0, and the gate passed because it
- * only checked the exit code.
- *
- * These cases pin both halves: the entry point reaches the plugin when nothing
- * shadows it, and PATH wins when something does. The second is not a bug being
- * enshrined — it is the documented order, asserted so that changing it becomes
- * a decision someone makes rather than a side effect.
+ * The expected shadowing behavior deliberately flips here: a plugin is a
+ * versioned release artifact, so its hook must run its own bundle. Failing open
+ * when that bundle cannot run is safer than accepting context from an unrelated
+ * PATH install and presenting it as the plugin's output.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -63,14 +58,15 @@ describe('#483 the plugin entry point', () => {
     expect(run(`/usr/bin:/bin:${nodeDir}`)).toBe(OWN_VERSION);
   });
 
-  it('prefers a commitlore on PATH over the plugin root, as documented', () => {
-    // A machine with both runs the CLI install. Asserted rather than assumed,
-    // so that changing the order is a decision rather than a side effect.
+  it('runs the plugin bundle instead of a shadowing commitlore on PATH', () => {
+    // This expectation intentionally changed: allowing PATH to win meant a
+    // newly installed plugin could silently serve every edit with an older CLI.
+    // The plugin root is the release artifact the host selected, so it wins.
     const shadow = temp('shadow');
     const fake = join(shadow, 'commitlore');
     writeFileSync(fake, '#!/bin/sh\necho 0.0.0-shadow\n');
     chmodSync(fake, 0o755);
 
-    expect(run(`${shadow}:/usr/bin:/bin:${nodeDir}`)).toBe('0.0.0-shadow');
+    expect(run(`${shadow}:/usr/bin:/bin:${nodeDir}`)).toBe(OWN_VERSION);
   });
 });


### PR DESCRIPTION
Blocking finding 1 of the third production-readiness review, plus the recovery gap it sits next to.

## The defect

```
place a clean v0.7.1 checkout at .../commitlore/v0.8.0/
install exit=0
wrapper --version -> 0.7.1
```

The installer checked that a checkout matched its own manifest and that `--version` ran. It never asked whether it was the version requested. A colleague upgrading is told the new release is installed and keeps running the old one.

## Binding, two-sided

| side | question | catches |
|---|---|---|
| checkout HEAD ↔ requested tag | is this directory the release it is named for? | a mislabelled or hand-copied tree, before anything is activated |
| runtime `--version` ↔ requested version | does the thing the wrapper runs agree? | a tree that passes the tag check and still ships something else |

Failing either is a refusal, never a deletion — a directory the installer cannot identify may not be its own.

## The refusal now goes somewhere

It named the unusable path and stopped. It now prints the single deliberate removal that returns the transaction to an installable state, quoted for a shell and scoped to the checkout alone. Verified end to end:

```
refusal exit=3          wrapper exists? no
(follow the printed rm -rf verbatim)
after repair exit=0     commitlore --version -> 0.8.0
```

## The plugin entry point had the same shape

`scripts/commitlore-run.sh` tried `commitlore` on PATH *before* the plugin's own bundle, so a machine with both served every edit from whichever CLI was installed — silently.

```
plugin route (CLAUDE_PLUGIN_ROOT set):   0.8.0     <- its own bundle
non-plugin route:                        0.7.0     <- PATH, still correct there
```

A plugin is a versioned release artifact, so its hook runs its own bundle; outside a plugin invocation PATH is still right, because there is no bundle to bind. `test/plugin-entry-point.test.ts` asserted the old order on purpose, so the expectation is flipped on purpose and its comment says why.

## Why CI changed

The install gate tagged its checkout `v9.9.9` and installed that. Version binding makes that permanently unsatisfiable, so the gate now tags and installs the version in `package.json` and asserts the wrapper reports it. Windows gains the wrong-tag refusal and a repair round trip — a repair path is only evidence if it is executed.

## Verification

- 97 cases pass across install-script, install-ps1, plugin-entry-point, manifest, uninstall
- the reproduction above, run against this branch, in both directions
- typecheck and the separate bench typecheck clean; two builds byte-identical
- PowerShell cannot run here — only the `install-ps1` required job is evidence for Windows
