### PR TITLE
Give Windows an install command instead of twenty-three mentions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -80,6 +80,12 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
 ```
 
+**Windows** — PowerShell で同じインストールを行います:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.ps1))) v0.8.0
+```
+
 **Hermes** — CLI をインストールした後、host integration を設定します:
 
 ```bash

--- a/README.ko.md
+++ b/README.ko.md
@@ -80,6 +80,12 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록하며, 설정이나 cache
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
 ```
 
+**Windows** — PowerShell에서 같은 설치를 한다:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.ps1))) v0.8.0
+```
+
 **Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Prerequisites for either path: Node.js 22+ and Git. The script checks both befor
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
 ```
 
+**Windows** — the same install, in PowerShell:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.ps1))) v0.8.0
+```
+
 **Hermes** — after installing the CLI, configure its host integration:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,6 +78,12 @@ commitlore plugin install-codex
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
 ```
 
+**Windows** — 在 PowerShell 中执行同样的安装：
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.ps1))) v0.8.0
+```
+
 **Hermes** — 安装 CLI 后，配置它的 host integration：
 
 ```bash

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.ps1))) v0.4.1
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.ps1))) v0.8.0
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the
@@ -493,7 +493,7 @@ if (-not [string]::IsNullOrEmpty($Version)) {
     } elseif ($Version -match '^[0-9]') {
         $Version = "v$Version"
     } else {
-        Stop-Install """$Version"" is not a version tag. Pass a tag such as v0.4.1, or pass nothing to install the newest one." 1
+        Stop-Install """$Version"" is not a version tag. Pass a tag such as v1.2.3, or pass nothing to install the newest one." 1
     }
 } else {
     # Only vMAJOR.MINOR.PATCH is considered. A pre-release tag would otherwise
@@ -513,7 +513,7 @@ if (-not [string]::IsNullOrEmpty($Version)) {
         }
     }
     if ($tags.Count -eq 0) {
-        Stop-Install "no version tag could be resolved from $SourceUrl. Pass one explicitly, for example: & ([scriptblock]::Create((irm <url>/install.ps1))) v0.4.1" 2
+        Stop-Install "no version tag could be resolved from $SourceUrl. Pass one explicitly, for example: & ([scriptblock]::Create((irm <url>/install.ps1))) v1.2.3" 2
     }
     $Version = ($tags | Sort-Object -Property { [version]($_.TrimStart('v')) } | Select-Object -Last 1)
 }

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.4.1/install.sh | sh -s v0.4.1
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.sh | sh -s v0.8.0
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP
@@ -376,7 +376,7 @@ if [ -n "$version" ]; then
   case "$version" in
     v[0-9]*) ;;
     [0-9]*) version="v$version" ;;
-    *) die "\"$version\" is not a version tag. Pass a tag such as v0.4.1, or pass nothing to install the newest one." 1 ;;
+    *) die "\"$version\" is not a version tag. Pass a tag such as v1.2.3, or pass nothing to install the newest one." 1 ;;
   esac
 else
   # Newest release tag, compared numerically without `sort -V`. That flag is a
@@ -395,7 +395,7 @@ else
     | sort \
     | tail -n 1 \
     | awk '{ print $4 }' || true)"
-  [ -n "$version" ] || die "no version tag could be resolved from $SOURCE_URL. Pass one explicitly, for example: sh install.sh v0.4.1" 2
+  [ -n "$version" ] || die "no version tag could be resolved from $SOURCE_URL. Pass one explicitly, for example: sh install.sh v1.2.3" 2
 fi
 
 log "installing $version"

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -154,3 +154,54 @@ describe('T-1021 mutation oracles', () => {
     expect(mutated).toMatch(/57\.5%/);
   });
 });
+
+/**
+ * Windows was documented as supported and never documented as installable.
+ * `install.ps1` was named twenty-three times across the READMEs and docs, and
+ * not once shown as a command anyone could run — a reader on Windows had to
+ * reconstruct the URL from the shell one-liner. The platform has a required CI
+ * job proving the installer works; the evidence outran the instructions.
+ *
+ * The installers' own header examples had gone stale in the other direction:
+ * they carried copy-pasteable URLs pinned to v0.4.1, four releases behind, so
+ * following the file's own documentation installed an old release. Nothing
+ * checked them, because the pin test only ever read the READMEs.
+ */
+describe('every supported install path is documented and pinned to this release', () => {
+  const INSTALLERS = ['install.sh', 'install.ps1'] as const;
+
+  for (const file of README_FILES) {
+    it(`${file} gives Windows a command, not just a mention`, () => {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      const oneLiner = content
+        .split('\n')
+        .find((line) => line.includes('install.ps1') && line.includes('irm'));
+
+      expect(oneLiner, 'no runnable PowerShell install line').toBeDefined();
+      expect(oneLiner).not.toContain('/dev/');
+      expect(oneLiner).toContain(`/v${PACKAGE_VERSION}/`);
+    });
+  }
+
+  for (const file of INSTALLERS) {
+    it(`${file} documents itself at this release, not an older one`, () => {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      const urls = content.match(/raw\.githubusercontent\.com\/[^\s"']*/g) ?? [];
+
+      expect(urls.length, 'the header lost its example URLs').toBeGreaterThan(0);
+      for (const url of urls) {
+        expect(url, `${url} is not pinned to this release`).toContain(`/v${PACKAGE_VERSION}/`);
+      }
+    });
+
+    it(`${file} illustrates a tag with a placeholder that cannot go stale`, () => {
+      // "Pass a tag such as v0.4.1" reads as advice to install v0.4.1, and it
+      // silently rots every release. A number that was never a release cannot.
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      const examples = content.match(/such as (v\d+\.\d+\.\d+)/g) ?? [];
+
+      expect(examples.length, 'the illustrative tag example is gone').toBeGreaterThan(0);
+      for (const example of examples) expect(example).toContain('v1.2.3');
+    });
+  }
+});


### PR DESCRIPTION
Two documentation defects found while pre-checking the release. Both are about install paths, and neither was covered by the pin test.

## Windows was supported everywhere except where someone could act on it

`install.ps1` is named **23 times** across the READMEs and docs — prerequisites it checks, what it writes, how to undo it — and never once shown as a runnable command. A reader on Windows had to reconstruct the URL from the shell one-liner.

The platform has a required CI job proving that installer works. The evidence outran the instructions.

All four READMEs now carry it beside the shell one-liner:

```powershell
& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.0/install.ps1))) v0.8.0
```

## The installers' own headers pointed four releases back

Both opened with copy-pasteable URLs pinned to `v0.4.1`, so following a file's own documentation installed an old release. Nothing caught it — the pin test only ever read the READMEs.

| where | was | now |
|---|---|---|
| `install.sh` / `install.ps1` header URLs | `v0.4.1` | `v0.8.0`, and the test reads them |
| `"Pass a tag such as …"` | `v0.4.1` | `v1.2.3` — never a release, so it cannot rot or be followed by mistake |

## Enforcement

The gap was that `test/readme.test.ts` only checked `install.sh` lines in the READMEs. It now also checks that each README gives Windows a pinned command, and that every `raw.githubusercontent.com` URL inside both installers names the current version.

87 cases pass across install-script, install-ps1 and readme. Restoring either defect fails the new cases.
