### PR TITLE
Follow a notes-backed record from one clone to another

### DIFF
--- a/test/two-clone-notes.test.ts
+++ b/test/two-clone-notes.test.ts
@@ -1,0 +1,180 @@
+/**
+ * #551: a fresh clone can see the commits but not the notes mirror, so a
+ * notes-only record must be reported as unavailable rather than as empty.
+ */
+
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { formatContext } from '../src/commands/query.js';
+import { execGit } from '../src/core/git.js';
+import { NOTES_REF, NOTES_REFSPEC, writeRecord } from '../src/core/notes.js';
+import { runQuery } from '../src/core/query.js';
+import type { Trailer } from '../src/core/types.js';
+import { createTestRepo } from './git-fixtures.js';
+
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/** `realpathSync` because macOS reports `/var` for a `/private/var` tmpdir. */
+const tempDir = (label: string): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `commitlore-${label}-`));
+  scratch.push(dir);
+  return dir;
+};
+
+const git = (cwd: string, args: string[], stdin?: string): string => {
+  const result = execGit(args, {
+    cwd,
+    ...(stdin === undefined ? {} : { stdin }),
+  });
+  if (result.code !== 0) {
+    throw new Error(`git ${args.join(' ')} failed (exit ${result.code}): ${result.stderr}`);
+  }
+  return result.stdout;
+};
+
+const initBare = (label: string): string => {
+  const dir = tempDir(label);
+  return createTestRepo({ path: dir, bare: true });
+};
+
+const clone = (source: string, label: string): string => {
+  const parent = tempDir(label);
+  return createTestRepo({ path: join(parent, 'clone'), source });
+};
+
+const RECORD_PATH = 'src/queue/worker.ts';
+
+const NOTE_RECORD: Trailer[] = [
+  { key: 'Limit', value: 'the queue worker owns retries' },
+  { key: 'Record-Id', value: 'r-twoclone551' },
+];
+
+const COMMIT_RECORD: Trailer[] = [
+  { key: 'Limit', value: 'the commit carries the queue constraint' },
+  { key: 'Record-Id', value: 'r-twocmt551' },
+];
+
+const writeWorker = (cwd: string): void => {
+  const path = join(cwd, RECORD_PATH);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, 'worker\n');
+};
+
+interface NotesFixture {
+  readonly cloneB: string;
+  readonly record: Trailer[];
+}
+
+const notesFixture = (label: string): NotesFixture => {
+  const origin = initBare(`${label}-origin`);
+  const cloneA = clone(origin, `${label}-a`);
+
+  writeWorker(cloneA);
+  git(cloneA, ['add', '--', RECORD_PATH]);
+  git(cloneA, ['commit', '--quiet', '--message', 'add the queue worker']);
+  const sha = git(cloneA, ['rev-parse', 'HEAD']).trim();
+
+  writeRecord(sha, NOTE_RECORD, { cwd: cloneA });
+  git(cloneA, ['push', '--quiet', 'origin', 'HEAD:refs/heads/main']);
+  git(cloneA, ['push', '--quiet', 'origin', NOTES_REF]);
+
+  return { cloneB: clone(origin, `${label}-b`), record: NOTE_RECORD };
+};
+
+const messageFixture = (label: string): string => {
+  const origin = initBare(`${label}-origin`);
+  const cloneA = clone(origin, `${label}-a`);
+
+  writeWorker(cloneA);
+  git(cloneA, ['add', '--', RECORD_PATH]);
+  git(
+    cloneA,
+    ['commit', '--quiet', '--file', '-'],
+    `add the queue worker\n\nLimit: ${COMMIT_RECORD[0]?.value}\nRecord-Id: ${COMMIT_RECORD[1]?.value}\n`,
+  );
+  git(cloneA, ['push', '--quiet', 'origin', 'HEAD:refs/heads/main']);
+
+  return clone(origin, `${label}-b`);
+};
+
+const queryPath = (cwd: string) =>
+  runQuery({ cwd, path: RECORD_PATH, noIndex: true });
+
+const exactConfigPattern = (value: string): string =>
+  `^${value.replace(/[\\.*+?[\]^$(){}|]/g, '\\$&')}$`;
+
+describe('two-clone notes availability', () => {
+  it('clone B without bootstrap refuses rather than answering empty', () => {
+    const fixture = notesFixture('without-bootstrap');
+    const result = queryPath(fixture.cloneB);
+    const rendered = formatContext(result);
+
+    expect(result.records).toEqual([]);
+    expect(result.notes).toBe('unfetched');
+    expect(rendered).toContain(
+      'the notes mirror has not been fetched here, so this is not the same as "none exist"',
+    );
+  });
+
+  it('clone B after the documented bootstrap receives the record', () => {
+    const fixture = notesFixture('with-bootstrap');
+
+    git(fixture.cloneB, ['config', '--add', 'remote.origin.fetch', NOTES_REFSPEC]);
+    git(fixture.cloneB, ['fetch', '--quiet', 'origin']);
+
+    const result = queryPath(fixture.cloneB);
+    const [record] = result.records;
+
+    expect(result.notes).toBe('present');
+    expect(result.records).toHaveLength(1);
+    expect(record).toMatchObject({
+      source: 'notes',
+      paths: [RECORD_PATH],
+      trailers: fixture.record,
+    });
+  });
+
+  it('removing the refspec returns clone B to refusal', () => {
+    const fixture = notesFixture('remove-bootstrap');
+
+    git(fixture.cloneB, ['config', '--add', 'remote.origin.fetch', NOTES_REFSPEC]);
+    git(fixture.cloneB, ['fetch', '--quiet', 'origin']);
+    git(fixture.cloneB, [
+      'config',
+      '--unset-all',
+      'remote.origin.fetch',
+      exactConfigPattern(NOTES_REFSPEC),
+    ]);
+    git(fixture.cloneB, ['update-ref', '-d', NOTES_REF]);
+
+    const result = queryPath(fixture.cloneB);
+    const rendered = formatContext(result);
+
+    expect(result.records).toEqual([]);
+    expect(result.notes).toBe('unfetched');
+    expect(rendered).toContain(
+      'the notes mirror has not been fetched here, so this is not the same as "none exist"',
+    );
+  });
+
+  it('a record in the commit message alone needs no bootstrap', () => {
+    const cloneB = messageFixture('message-only');
+    const result = queryPath(cloneB);
+    const [record] = result.records;
+
+    expect(result.records).toHaveLength(1);
+    expect(record).toMatchObject({
+      source: 'commit',
+      paths: [RECORD_PATH],
+      trailers: COMMIT_RECORD,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #551.

Nothing followed a notes-backed record from one clone, through a remote, into another. That seam is where the product makes its most consequential distinction: notes are not part of a default clone, so a fresh clone that has not been bootstrapped **cannot see** notes-backed records — and the answer then has to be *unknown*, never a clean empty. A clean empty tells an agent "no constraints recorded" when the truth is "I could not look".

Test-only. `git diff origin/main...HEAD` touches nothing outside `test/`.

## The four cases

| case | pins |
|---|---|
| `clone B without bootstrap refuses rather than answering empty` | `notes === 'unfetched'` and the rendered caveat, not just an empty record list |
| `clone B after the documented bootstrap receives the record` | the record comes back and is injected for the right path |
| `removing the refspec returns clone B to refusal` | case 2 passed because of the bootstrap, not because of something cached |
| `a record in the commit message alone needs no bootstrap` | separates "notes unavailable" from "no records exist", so case 1 cannot pass for the wrong reason |

Real git, a real bare remote on disk, two real clones. No mocking, no sleeps, no retry-until-pass.

## Negative control

Reproduced independently of the change's own report. Forcing the availability computation to answer `absent` in both of its return paths:

```
× clone B without bootstrap refuses rather than answering empty
  → expected 'absent' to be 'unfetched'
```

Restored: 4/4 pass, and `git diff -- src/` is empty.

A first attempt at this control was **invalid** and is worth recording: mutating the first `'unfetched'` occurrence in `query.ts` changed a line of comment prose, the suite stayed green, and that green proved nothing. The control only became meaningful once it targeted the branch that actually computes availability.
