### PR TITLE
docs: correct four factual defects in the README, and fix the hero SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,18 @@ separate layers:
 | Gemini CLI, Cursor, Windsurf, opencode | **Yes — the MCP server is wired by `install.sh`.** | **Procedure, not automatic.** The server states the prepare → verify → stage procedure in its `instructions` on every connection. The host may or may not act on it. |
 | Any other `AGENTS.md`-convention host | **Procedure, not automatic.** `commitlore init --agents-md` writes it into the repository. | **Procedure, not automatic.** Same file, same caveat. |
 
-“Yes” means the layer is installed, not that every commit gains a record.
-Most commits should carry none. The first three rows install a skill that
-drives capture; the fourth receives the same procedure over MCP, which is what
-a host that loads no skills has to work from — verified with the plugin
-disabled, and it captured. Whether a given host surfaces those instructions to
-its model is the host's choice, and nothing here detects it. A host still has to start capture, and the candidate must pass
+“Yes” in the Capture column means the workflow is installed and available — the
+prepare → verify → stage path exists for that host. It does not mean every
+eligible commit reaches a terminal assessment on its own. **That stronger
+property, deterministic autocapture, is not certified on any host yet**, so
+treat capture as available rather than guaranteed. Most commits should carry no
+record in any case.
+
+The first three rows install a skill that drives capture; the fourth receives
+the same procedure over MCP, which is what a host that loads no skills has to
+work from — verified with the plugin disabled, and it captured. Whether a given
+host surfaces those instructions to its model is the host's choice, and nothing
+here detects it. A host still has to start capture, and the candidate must pass
 verification before the commit hook attaches it. The commit-msg hook validates
 a record when present; it never invents one.
 
@@ -270,12 +276,12 @@ rather than in a review comment after.
 
 **Whether it acts on that is now measured.** Across 1,160 registered runs, an
 agent handed the repository's active records re-proposed a ruled-out approach in
-**2.8%** of them (16/580). Without them: **18.8%** (109/579).
+**2.7%** of them (16/585). Without them: **18.8%** (110/584).
 
 | arm | re-proposed a ruled-out approach |
 |---|---:|
-| the agent alone | **18.8%** (109/579) |
-| **with CommitLore** | **2.8%** (16/580) |
+| the agent alone | **18.8%** (110/584) |
+| **with CommitLore** | **2.7%** (16/585) |
 
 **The threshold was registered before the run**, and the preregistration
 predicted a *smaller* effect than it got — that prediction, with its stated
@@ -513,7 +519,7 @@ CommitLore-Version: 2.0.0
 | `Follows:` / `Supersedes:` | Decision-chain and lifecycle links |
 | `Expires:` | Date or condition that ends a limit |
 | `Evidence:` | Path, anchor, or URL supporting a claim |
-| `Provenance:` | `authored` \| `inherited <sha>` \| `reconstructed` |
+| `Provenance:` | `authored` \| `drafted` \| `inherited <sha>` \| `reconstructed` \| `unknown` |
 | `CommitLore-Version:` / `X-*:` | Protocol identity and extensions |
 
 Read a path's history with `commitlore context <path>`. Smaller examples, and how to read records with plain Git instead, are in [docs/protocol.md](docs/protocol.md); the normative definitions are in [SPEC §3](spec/SPEC.md).
@@ -521,7 +527,7 @@ Read a path's history with `commitlore context <path>`. Smaller examples, and ho
 ## What the repository proves
 
 - Decision history survives rebase, remote transfer, and path renames in the tested Git workflows. Squash-merge discards the trailer block, as any ordinary trailer would be: `commitlore squash-preserve` or its GitHub Action carries the records across, and the tested workflows cover that route.
-- Every route uses the same trust grading, so untrusted text is information rather than an instruction.
+- Routes share one grading core, so untrusted text is information rather than an instruction — but a record has been observed grading differently through the CLI and through MCP when more than one CommitLore runtime was installed ([#631](https://github.com/MongLong0214/commitlore/issues/631), [#635](https://github.com/MongLong0214/commitlore/issues/635)).
 - Injection-like text in free-form trailers is withheld from model-readable routes.
 - A readable repository with no records is distinct from incomplete history or an unfetched notes mirror.
 

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,26 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400" role="img" aria-labelledby="title desc">
-  <title id="title">CommitLore — Your agents inherit the code. Make them inherit the judgment.</title>
-  <desc id="desc">A fresh coding agent receives the active decision for a path, carrying a ruled-out alternative and its reason, while a superseded record is withheld because a later decision reversed it.</desc>
-  <rect width="1200" height="400" rx="24" fill="#f7f5f0"/>
-  <path d="M48 48H1152M48 334H1152" stroke="#d8d3c8"/>
-  <g transform="translate(64 76)">
-    <text fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600" letter-spacing="2">GIT-NATIVE DECISION LAYER</text>
-    <text y="66" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">Your agents</text>
-    <text y="122" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">inherit the code.</text>
-    <text y="178" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">Make them inherit</text>
-    <text y="234" fill="#181714" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="48" font-weight="700" letter-spacing="-2">the judgment.</text>
-    <text y="282" fill="#3e3b35" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="22">Only the decisions still in force reach the next edit.</text>
-  </g>
-  <g transform="translate(712 76)">
-    <rect width="424" height="246" rx="14" fill="#fffdf9" stroke="#bdb6aa"/>
-    <text x="28" y="40" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600">A FRESH AGENT RECEIVES</text>
-    <path d="M28 58H396" stroke="#ded9d0"/>
-    <text x="28" y="96" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700"><tspan fill="#3f6b4f">[active]</tspan><tspan fill="#6d675e" x="150">r-demo02</tspan></text>
-    <text x="28" y="128" fill="#181714" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700">Ruled-out: Redis cluster</text>
-    <text x="28" y="154" fill="#3e3b35" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">| cost disproportionate</text>
-    <path d="M28 180H396" stroke="#ede9e2"/>
-    <text x="28" y="212" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" font-weight="700"><tspan fill="#9a8f80">[superseded]</tspan><tspan fill="#9a8f80" x="212">r-demo01</tspan></text>
-    <text x="28" y="238" fill="#9a8f80" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="19">withheld — reversed later</text>
-  </g>
-  <text x="712" y="356" fill="#6d675e" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18">commit trailer → lifecycle → hook context</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="340" viewBox="0 0 1200 340" role="img" aria-labelledby="title" aria-describedby="desc">
+  <title id="title">CommitLore delivers current decisions for a file to the next agent</title>
+  <desc id="desc">Active Limit and Ruled-out records for src/pricing.ts are delivered to the next agent; an earlier superseded Limit is not delivered as current guidance.</desc>
+  <rect width="1200" height="340" fill="#F4EFE6"/>
+  <rect x="0" y="0" width="6" height="220" fill="#3E6A4C"/>
+  <text x="48" y="40" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="24" fill="#4A453E">src/pricing.ts</text>
+  <rect x="48" y="54" width="142" height="38" fill="#3E6A4C"/>
+  <text x="68" y="80" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="1.6" fill="#F4EFE6">ACTIVE</text>
+  <text x="48" y="124" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="24" fill="#1A1814"><tspan fill="#4A453E">Limit — </tspan><tspan font-weight="600">calculatePrice owns final checkout pricing only</tspan></text>
+  <text x="48" y="160" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="22" fill="#1A1814"><tspan fill="#4A453E">Ruled-out — </tspan><tspan font-weight="600">Reuse checkout pricing for admin quotes — eligibility and rounding differ</tspan></text>
+  <text x="48" y="198" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="22"><tspan fill="#4A453E">delivered to the </tspan><tspan fill="#3E6A4C" font-weight="700">next agent</tspan></text>
+  <line x1="48" y1="220" x2="1152" y2="220" stroke="#D9D3C8" stroke-width="1.5"/>
+  <rect x="0" y="220" width="6" height="120" fill="#D9D3C8"/>
+  <text x="48" y="256" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="600" letter-spacing="1.5" fill="#4A453E">SUPERSEDED</text>
+  <text x="48" y="290" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="22" fill="#4A453E">Earlier Limit — calculatePrice also served admin quotes</text>
+  <text x="48" y="322" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Helvetica, Arial, sans-serif" font-size="24" fill="#4A453E">not delivered as current guidance</text>
 </svg>


### PR DESCRIPTION
## What this PR became, and why it is smaller than it started

It began as the A–Z review's README restructure. **The restructure cannot be done in this PR, and the reason is a contract, not a preference.**

`test/readme-order.test.ts:141,174` binds section order across all four language files:

```js
const FILES = ['README.md', 'README.ko.md', 'README.ja.md', 'README.zh-CN.md']
it('all four files have consistent relative order', ...)
```

`T-1016` requires the same demo asset in all four; `T-1015` requires the exposure table, the delivery/capture naming for every host class, and the clone-carried vs notes-backed distinction in every file. Restructuring English alone failed 18 tests across 5 files. Restructuring all four would take over the translated READMEs, which belong to #590.

So the restructure is inherently a coordinated four-file change and belongs with #590, not ahead of it. **What survives here is every factual correction the review found** — those needed no structural change, and they are the part that was actually wrong.

## The four corrections

**1 — the headline denominators contradicted the generated block.** The prose claimed `16/580` and `109/579`; the checker-owned block in the same file reports `585` and `584` runs per arm, with `110` in the off arm. Two different denominators for one study, in one file.

```
prose (unchecked)      2.8% (16/580)  ·  18.8% (109/579)
generated (checked)    585 and 584 runs per arm; commitlore-off 110
corrected              2.7% (16/585)  ·  18.8% (110/584)
```

The prose drifted because nothing owned it — which is exactly the gap #590 is widening.

**2 — the Capture column's "Yes" read as deterministic autocapture.** What is installed is the prepare → verify → stage path. That every eligible commit reaches a terminal assessment on its own is a stronger property, certified on no host. The caption now separates available from guaranteed.

**3 — the `Provenance:` vocabulary was missing two of its five values.** [SPEC §3](spec/SPEC.md) carries `authored | drafted | inherited | reconstructed | unknown`; the table listed three. `drafted` is what unattended capture writes, so the omitted value was the one a reader is likeliest to meet.

**4 — "Every route uses the same trust grading" stated an intention as an observation.** A record has been observed grading `directive` through the CLI and `claim` through MCP with more than one runtime installed ([#631](https://github.com/MongLong0214/commitlore/issues/631), [#635](https://github.com/MongLong0214/commitlore/issues/635)). Users meet the result, not the design.

## The hero SVG

grok's adversarial review found six defects in a version I had already accepted. Two I had missed: the agent appeared nowhere in the image, so "delivered to the next agent" was asserted rather than shown; and 19px text rendered at 5.9px at mobile width. Now: 22px floor (24px for required elements), `aria-labelledby` + `aria-describedby`, no strikethrough, and the superseded record is a genuinely different record rather than the same one crossed out.

## Verification

```
bash spec/verify.sh                    OK: 32 fixtures + README example sync + vocab table
node scripts/check-readme-numbers.mjs  block matches bench/report.ts
vitest readme + positioning + numbers + order + compatibility + demo   107 passed
```

## Filed separately

- **#645** — SPEC §7 still describes signature mode as `G` status only, while #642 also requires the `%GF` fingerprint in `commitlore.trustedSigner`. Every other surface picked that up; the normative text did not.
- **#632** — `notes mirror (origin) failed: spawnSync git ETIMEDOUT` reproduced on every push here.