### PR TITLE
Make the ambiguous-prefix test actually test ambiguity

### DIFF
--- a/test/sha256-repo.test.ts
+++ b/test/sha256-repo.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -130,6 +131,35 @@ const sha1Repo = (label: string): string => {
 const stageChange = (cwd: string, path: string, body: string): void => {
   writeFileSync(join(cwd, path), body);
   git(cwd, ['add', '--', path]);
+};
+
+/**
+ * Two *commits* have to share the short name for an ambiguity test to mean
+ * anything, and both halves of that sentence were learned the hard way.
+ *
+ * Git's minimum abbreviation is four hex, so a three-hex name is refused for
+ * being short whether or not anything collides — an assertion fed by one
+ * proves nothing about ambiguity. And for a `^{commit}` query git
+ * disambiguates by type, so a colliding blob is passed over in silence and the
+ * name still resolves.
+ *
+ * Forging the second commit is certain where committing until two ids happen
+ * to collide is not, and it costs one search in process rather than hundreds
+ * of spawns: only the winning body is ever written.
+ */
+const forgeCommitSharingPrefix = (cwd: string, prefix: string, tree: string): string => {
+  const stamp = 'Forged <forged@test.invalid> 1770000000 +0000';
+  for (let attempt = 0; attempt < 10_000_000; attempt += 1) {
+    const body = `tree ${tree}\nauthor ${stamp}\ncommitter ${stamp}\n\nforged ${attempt}\n`;
+    const digest = createHash('sha1')
+      .update(`commit ${Buffer.byteLength(body)}\0`)
+      .update(body)
+      .digest('hex');
+    if (!digest.startsWith(prefix)) continue;
+    expect(git(cwd, ['hash-object', '-w', '-t', 'commit', '--stdin'], body).trim()).toBe(digest);
+    return digest;
+  }
+  throw new Error(`no commit body shares the prefix ${prefix} within the search bound`);
 };
 
 const TRANSCRIPT = 'The team decided to use SQLite instead of PostgreSQL for local storage.';
@@ -272,21 +302,15 @@ describe('resolveRevision turns user input into one full id, or refuses (R0-03)'
 
   it('refuses an ambiguous prefix rather than picking one', () => {
     const cwd = sha1Repo('resolve');
-    // Commit until two commits share a 3-hex prefix, then ask git with it.
-    // 4096 buckets against ~120 commits makes a collision likely but not
-    // certain, so the search is bounded and the assertion is skipped rather
-    // than faked when this run does not produce one.
-    const seen = new Map<string, string>();
-    let ambiguous: string | null = null;
-    for (let i = 0; i < 120 && ambiguous === null; i += 1) {
-      stageChange(cwd, `c${i}.txt`, `body ${i}\n`);
-      git(cwd, ['commit', '--quiet', '--no-verify', '-m', `c${i}`]);
-      const sha = git(cwd, ['rev-parse', 'HEAD']).trim();
-      const prefix = sha.slice(0, 3);
-      if (seen.has(prefix)) ambiguous = prefix;
-      else seen.set(prefix, sha);
-    }
-    if (ambiguous === null) return;
+    stageChange(cwd, 'first.txt', 'first\n');
+    git(cwd, ['commit', '--quiet', '--no-verify', '-m', 'first']);
+    const head = git(cwd, ['rev-parse', 'HEAD']).trim();
+    // Four hex, not three: git refuses a three-hex name for its length alone.
+    const ambiguous = head.slice(0, 4);
+
+    const collided = forgeCommitSharingPrefix(cwd, ambiguous, git(cwd, ['rev-parse', 'HEAD^{tree}']).trim());
+    expect(collided).not.toBe(head);
+    expect(git(cwd, ['cat-file', '-t', collided]).trim()).toBe('commit');
 
     // Guard the guard: git itself must consider this prefix ambiguous, or the
     // refusal below would prove nothing.


### PR DESCRIPTION
Addresses the test defect described in #649. **Not** a close: the unexplained object-database failure recorded in the same issue is untouched here, and the issue must stay open for it.

## What was wrong

`test/sha256-repo.test.ts` > `refuses an ambiguous prefix rather than picking one` asked git to resolve a **three-hex** name:

```ts
const prefix = sha.slice(0, 3);
const direct = execGit(['rev-parse', '--verify', '--quiet', `${ambiguous}^{commit}`], { cwd });
expect(direct.code).not.toBe(0);
```

Git's minimum abbreviation is four hex, so a three-hex name is refused for its length:

```
$ git rev-parse --verify "${SHA:0:3}^{commit}"
fatal: Needed a single revision

3-hex => refused      4-hex => resolves      5-hex => resolves
```

The assertion was therefore answered before ambiguity was ever consulted. **The 120-commit collision search that fed it changed nothing about the outcome.** The test named for ambiguity has never exercised ambiguity.

That is worse than the silent-pass defect filed in #649, which said the test proved nothing in ~17% of runs. It proved nothing in all of them.

## Two measurements that shaped the fix

Forging a colliding **blob** does not work — git disambiguates by type for a `^{commit}` query:

```
commit 0cb55f99…  forged blob 0cb5ace1…  (share "0cb5")
$ git rev-parse --verify --quiet 0cb5^{commit}
0cb55f9926cbf87fc05c7db6b0062d4d2bf3d15d      <- resolves, collision ignored
```

Forging a **commit** does:

```
$ git rev-parse --verify 0cb5^{commit}
error: short object ID 0cb5 is ambiguous
hint: The candidates are:
hint:   0cb55f9 commit 2026-08-14 - seed
```

## The fix

Four hex, and the second commit is forged by searching the `commit <len>\0…` preimage in process — 39k iterations in the measured case, no spawns, and only the winning body is written. The collision exists by construction, so there is no early return and no path where the test reports green without asserting.

## Negative control

Removing the forged commit fails the test:

```
AssertionError: expected +0 not to be +0
Tests  1 failed | 24 skipped (25)
```

Restored: 189 cases pass across `sha256-repo`, `git` and `query`; `tsc --noEmit` clean.

## What this does not claim

The 120-commit loop was the heaviest thing in the file and it is gone, which removes the growing index that CI was building when a staged object went missing on run 31771047613. **That is a side effect, not a diagnosis.** #649 still holds the unexplained failure, and this PR should not be read as closing it.
