### PR TITLE
Stop naming a second runtime as the condition for a grade to diverge

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Read a path's history with `commitlore context <path>`. Smaller examples, and ho
 ## What the repository proves
 
 - Decision history survives rebase, remote transfer, and path renames in the tested Git workflows. Squash-merge discards the trailer block, as any ordinary trailer would be: `commitlore squash-preserve` or its GitHub Action carries the records across, and the tested workflows cover that route.
-- Routes share one grading core, so untrusted text is information rather than an instruction — but a record has been observed grading differently through the CLI and through MCP when more than one CommitLore runtime was installed ([#631](https://github.com/MongLong0214/commitlore/issues/631), [#635](https://github.com/MongLong0214/commitlore/issues/635)).
+- Routes share one grading core, so untrusted text is information rather than an instruction — but the index caches a signature status, and a signature status is not a property of the repository. The same record can therefore grade `directive` on one route and `claim` on another from a single installation, if the index was built where the signing keys were not reachable. Comparing a route against `--no-index` tells you whether you are reading a stale verdict ([#653](https://github.com/MongLong0214/commitlore/issues/653), [#631](https://github.com/MongLong0214/commitlore/issues/631), [#635](https://github.com/MongLong0214/commitlore/issues/635)).
 - Injection-like text in free-form trailers is withheld from model-readable routes.
 - A readable repository with no records is distinct from incomplete history or an unfetched notes mirror.
 


### PR DESCRIPTION
main states something false about when a record's grade can be trusted. Correcting it ahead of the F-001 follow-ups, because waiting means holding the false statement for that long.

## The sentence, on main today

> Routes share one grading core, so untrusted text is information rather than an instruction — but a record has been observed grading differently through the CLI and through MCP **when more than one CommitLore runtime was installed** (#631, #635).

That reads as a safety condition. A reader with one runtime installed concludes this cannot happen to them.

## Why it is wrong

#653 reproduces the divergence **from a single build**:

```
1) index built while the keyring was unreachable   => claim
2) keyring restored, same index                    => claim
3) same moment, --no-index                         => directive
```

Steps 2 and 3 are the same repository, the same record, the same moment and the same binary. The cause is not how many runtimes are installed — it is that the index caches a signature status, and a signature status is not a property of the repository. It is the verdict of whichever process ran `git log`, and it depends on the keys that process could reach.

## What the replacement does

It moves the cause from the runtime count to the nature of the cache, and it gives the reader a check they can actually run: comparing a route against `--no-index` tells them whether they are reading a stale verdict. The old wording offered nothing to do, because it named a condition that was not the cause.

## Scope

Only the English README carries this sentence — the three translations do not, so correcting it alone leaves nothing inconsistent, and the four-file section-order contracts are untouched.

`spec/verify.sh` 32 fixtures + README example sync + vocab table, `check-readme-numbers` matches `bench/report.ts`, `readme-order` 18 cases.

## Provenance

The sentence was added earlier today in #643, in the same PR that corrected four other README claims for overstating what is proven. This is the same class of defect in the same place — a statement stronger than the evidence — found by the finding that came after it.