### PR TITLE
Stop the history from gaining another session identifier

### DIFF
--- a/test/dogfood.test.ts
+++ b/test/dogfood.test.ts
@@ -165,6 +165,44 @@ describe('dogfooding: this repository obeys its own protocol', () => {
     expect(missing, `\n${missing.join('\n')}\n`).toEqual([]);
   });
 
+  /**
+   * #652: this repository publishes its history, so an agent session identifier
+   * in a commit message is published too. Two are already there —
+   * `fc1009b` and `97c6b45`, both merged before anything checked — and `main`
+   * forbids force pushes, so they are permanent. Rewriting public history does
+   * not un-publish anything; it only breaks every clone that has it.
+   *
+   * So the baseline is those two, by sha, and the check is that the list does
+   * not grow. A baseline that named the trailer *key* would have been defeated
+   * on its first attempt: `Claude-Session:` was refused by SPEC section 3 and
+   * came back as `X-Claude-Session:`, which the extension slot accepts. The
+   * protocol is right to accept it — `X-<Name>` is an organization's own space
+   * — which is why this is a repository policy and not a schema rule.
+   *
+   * Matching is on the value's shape rather than the key's name, so the next
+   * tool's identifier is caught without anyone maintaining a list of vendors.
+   */
+  it('no new commit publishes an agent session identifier', () => {
+    // Permanent, and not being rewritten. Recorded by sha so a later commit
+    // reusing the same shape is not silently forgiven along with them.
+    const PUBLISHED = new Set([
+      'fc1009bdc7406cbd25766af6a276b5ffc92e0369',
+      '97c6b455705605980b89b66cd4626c1dc4a20da6',
+      '8a49ddc9f76b4fc65c03fc874a8478ce3ca2f860',
+    ]);
+    const SESSION_VALUE = /(?:\bclaude\.ai\/code\/session[_/]|\bsession[_-][0-9a-z]{16,})/i;
+
+    const offenders = history
+      .filter((entry) => !PUBLISHED.has(entry.sha))
+      .filter((entry) => entry.trailers.some((t) => SESSION_VALUE.test(t.value)))
+      .map((entry) => `${entry.sha.slice(0, 7)} ${entry.subject}`);
+
+    expect(
+      offenders,
+      `\n${offenders.join('\n')}\n\nremove the session identifier from the message; this repository is public\n`,
+    ).toEqual([]);
+  });
+
   it('Record-Ids are unique across the history', () => {
     const collisions = findIdCollisions(
       withRecords.map((entry) => ({ ...entry, source: 'commit' as const })),


### PR DESCRIPTION
Closes #652.

This repository is public, so an agent session identifier in a commit message is
published. Three are already there:

```
fc1009b  docs: correct four factual defects in the README, and fix the hero SVG (#643)
97c6b45  spec: 서명 모드에 signer allowlist 요구를 정본에 반영 (#645)
8a49ddc  COMMITLORE_BIN carried none of the checks its sibling config key already had
```

`main` forbids force pushes and they are permanent. Rewriting public history
does not un-publish anything — it breaks every clone that has it, immediately
before a release. So the baseline names those three by sha and the check is that
the list does not grow.

**I reported two.** The third appeared the moment the check ran over the whole
history instead of the last four hundred commits — the difference between a scan
whose bounds I chose and one the product runs every time. That is the argument
for the check in one line.

## Why the value's shape and not the key's name

`Claude-Session:` was refused by SPEC §3 and came back as `X-Claude-Session:`,
which the extension slot accepts. A key list would have been defeated on its
first attempt, by the person who wrote it.

The protocol is right to accept `X-<Name>` — it is an organization's own space,
preserved verbatim by design. Teaching the schema about particular vendors would
be worse than the problem. This is a property of *this repository* (it publishes
its history), so it belongs in this repository's dogfooding.

## Baseline by sha, not by pattern

Forgiving the shape would forgive the next one too. Naming the three commits
forgives exactly them; a new commit carrying the same trailer fails.

Verified by removing one sha from the baseline — that commit is then reported.

Test-only; no code, no artifact change.