### PR TITLE
Name the diagnosis this product cannot make

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -40,6 +40,31 @@ Reachability is not support. A script that runs on a host says nothing about
 whether the properties the product depends on hold there, and the two are kept
 apart on purpose.
 
+### A diagnosis this product cannot make (#657)
+
+`doctor` probes a registered MCP command by starting it and waiting for the
+protocol. On Windows, a `.cmd` launcher naming an interpreter that is not on disk
+produces no signal at all: `cmd.exe` exits silently, nothing ever speaks, and the
+probe waits out its budget and reports `initialize-timed-out`.
+
+Measured on `windows-latest` with three independent drivers, so this is the
+host's behaviour rather than a defect in the probe.
+
+The consequence is that **two different faults share one report**: a registration
+that is slow, and a registration whose interpreter does not exist. `doctor` says
+*could not verify this time* for both, which is honest about what it observed and
+silent about which of the two it was.
+
+This is accepted rather than fixed. Distinguishing them would mean inspecting the
+launcher's contents and resolving the interpreter it names — reimplementing part
+of the host's own command resolution, in a place where being subtly wrong would
+produce a confident diagnosis that is false. A timeout that names both
+possibilities is the weaker claim and the true one.
+
+What still holds: execution correctness is unaffected. A registration that works
+is verified normally, and one that is genuinely broken is still reported as
+unverified — a user is never told a broken registration is healthy.
+
 ## Prerequisites
 
 Two columns, because **required** and **checked** are not the same claim. Only


### PR DESCRIPTION
Closes #657.

On Windows, a `.cmd` launcher naming an interpreter that is not on disk produces
no signal at all: `cmd.exe` exits silently, nothing ever speaks the protocol, and
the probe waits out its budget. So two different faults arrive as one report —

```
a slow registration            → initialize-timed-out
a missing interpreter          → initialize-timed-out
```

Measured on `windows-latest` with three independent drivers, which is what makes
this the host's behaviour rather than a defect in the probe.

## Accepted, not fixed

Telling the two apart means reading the launcher's contents and resolving the
interpreter it names — reimplementing part of the host's own command resolution,
in a place where being subtly wrong produces a *confident* diagnosis that is
false. A timeout naming both possibilities is the weaker claim and the true one.

That is the same trade #636 made when the probe's budget stopped being a verdict:
`initialize-timed-out` now means *could not verify this time*, not *this
registration is broken*.

## Why this is worth a document rather than nothing

An unstated limit is a defect; a stated one is a boundary. `docs/COMPATIBILITY.md`
already separates **supported**, **unsupported** and **undecided** precisely so
that "nobody measured it" cannot be read as "it works" — this is the same
distinction applied to a diagnosis instead of a host.

What still holds is written down with it: execution correctness is unaffected, a
working registration verifies normally, and a genuinely broken one is still
reported as unverified. A user is never told a broken registration is healthy.

Documentation only; no code, no artifact change. The Windows measurement comes
from the issue's own `windows-latest` runs — none of it is inferred locally.