### PR TITLE
Freeze the protocol at 2.0 Stable, and say what Stable costs us

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -10,6 +10,38 @@ There is no compiled artifact anywhere in the product ([ADR-0026](adr/ADR-0026-n
 and neither install script contains a platform, architecture or libc check —
 there is no platform-specific artifact to choose between.
 
+## The protocol contract (2.0 Stable)
+
+`spec/SPEC.md` is Stable as of v1.0.0. What that promises, and what it does not:
+
+**Will not change incompatibly within 2.x**
+
+- The trailer grammar (SPEC §2) and where git decides a trailer block begins and
+  ends. CommitLore does not overrule git on that boundary and will not start.
+- The meaning of every key in SPEC §3, and `Record-Id`'s format.
+- The `X-<Name>` extension slot. An organization's own keys are preserved
+  verbatim, and no future version will start interpreting them.
+- The three trust grades and what each asserts. Their *strength* depends on the
+  configured mode — see `SECURITY.md` — but the words do not change meaning.
+- A record written today validates under any 2.x reader.
+
+**May change**
+
+- New optional keys in §3. A reader that does not know a key ignores it, which
+  is what makes this compatible.
+- Diagnostics, exit-code detail, and output formatting outside the JSON
+  contract. The JSON answer's shape is pinned by tests; prose is not.
+- The index schema. It is a derived cache (ADR-0003) and rebuilds; a reader that
+  meets an index it does not understand rebuilds rather than guessing.
+
+**How anything is retired**
+
+Nothing in §3 is removed in 2.x. If a key must go, it is deprecated in a minor
+release — still accepted, still validating, documented as deprecated with what
+replaces it — and removed no earlier than 3.0. A record already committed is
+history and remains readable regardless: the repository is the record, and a
+reader that cannot read old commits has broken the product's one promise.
+
 ## Install paths
 
 | Path | Command | Who it is for |

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,6 +1,10 @@
 # CommitLore Protocol Specification
 
-**Version 2.0** · Status: Draft · Canonical source for all implementations
+**Version 2.0** · Status: **Stable** · Canonical source for all implementations
+
+Stable means the vocabulary and grammar below do not change incompatibly within
+2.x. See `docs/COMPATIBILITY.md` for what may still change and how anything is
+retired.
 
 This document defines the CommitLore protocol: how decision context is inscribed into git commits as trailers, what each field means, and which route consumes it. An implementation that passes `spec/fixtures/` and `spec/contract-cases/` is a conforming CommitLore implementation, regardless of language.
 


### PR DESCRIPTION
Gate 2 contract freeze.

`spec/SPEC.md` has said **Version 2.0 · Status: Draft** while four language
READMEs, an MCP server and a published benchmark were built on it. Draft was
true when the vocabulary was still moving. It has not been true for some time,
and shipping v1.0.0 on a draft protocol would be the same overclaim in reverse.

Stable is only meaningful with a retirement rule, so both land together.

## Will not change incompatibly within 2.x

- The trailer grammar (§2), and where git decides a block begins and ends.
  CommitLore does not overrule git on that boundary and will not start.
- The meaning of every key in §3, and `Record-Id`'s format.
- The `X-<Name>` extension slot — an organization's keys are preserved verbatim
  and no future version starts interpreting them.
- What the three trust grades assert.
- A record written today validates under any 2.x reader.

## May change

New optional keys in §3 (an unknown key is ignored, which is what makes it
compatible), diagnostics and prose outside the JSON contract, and the index
schema — a derived cache (ADR-0003) that rebuilds rather than guessing.

## How anything is retired

Nothing in §3 is removed in 2.x. A key that must go is deprecated in a minor —
still accepted, still validating, documented with its replacement — and removed
no earlier than 3.0.

A record already committed stays readable regardless. The repository *is* the
record, and a reader that cannot read old commits has broken the one promise
this product makes.

## One thing Stable does not promise

The grades' *strength* depends on the configured trust mode, and #677 makes
`SECURITY.md` say so. Stable pins what the words mean, not how strong the weaker
mode is. Those are different guarantees and conflating them is what #677 fixes.

Documentation only; no code, no artifact change.