### PR TITLE
Release 1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,13 +83,13 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh | sh -s v0.8.2
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
 ```
 
 **Windows** — PowerShell で同じインストールを行います:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.ps1))) v0.8.2
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
 ```
 
 **Hermes** — CLI をインストールした後、host integration を設定します:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh
-sh install.sh v0.8.2
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh
+sh install.sh v1.0.0
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v0.8.2 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,13 +83,13 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록하며, 설정이나 cache
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh | sh -s v0.8.2
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
 ```
 
 **Windows** — PowerShell에서 같은 설치를 한다:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.ps1))) v0.8.2
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
 ```
 
 **Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh
-sh install.sh v0.8.2
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh
+sh install.sh v1.0.0
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v0.8.2 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Prerequisites for either path: Node.js 22.23.2+ and Git. The script checks both 
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh | sh -s v0.8.2
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
 ```
 
 **Windows** — the same install, in PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.ps1))) v0.8.2
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
 ```
 
 **Hermes** — after installing the CLI, configure its host integration:
@@ -137,11 +137,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh
-sh install.sh v0.8.2
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh
+sh install.sh v1.0.0
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v0.8.2 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,13 +80,13 @@ commitlore plugin install-codex
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh | sh -s v0.8.2
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
 ```
 
 **Windows** — 在 PowerShell 中执行同样的安装：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.ps1))) v0.8.2
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
 ```
 
 **Hermes** — 安装 CLI 后，配置它的 host integration：
@@ -126,11 +126,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh
-sh install.sh v0.8.2
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh
+sh install.sh v1.0.0
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v0.8.2 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.ps1))) v0.8.2
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v0.8.2/install.sh | sh -s v0.8.2
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "7af93d9b147479055e8cf45321541edd02419f57ba4e8dcb8b11b26c27b80f1f"
+    "sha256": "ccc338814a8d7d1843051df2de75e3115f95a54873c4beb4cfd288aab3894913"
   },
   "artifact": {
     "sha256": "069a28692e5799120f51df98cd1773a63bbb353cce8201a4a0814ccc3665356e",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "0.8.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/test/installer-hosts.test.ts
+++ b/test/installer-hosts.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ENTRY = join(ROOT, 'dist', 'commitlore.mjs');
 const scratch: string[] = [];
@@ -111,7 +112,19 @@ describe('installer-hosts accepts only live CommitLore registrations', () => {
     cursorConfig(home, { command: ours, args: ['mcp'] });
     const result = run(home, ours);
     expect(result.status).toBe(0);
-    expect(result.summary.runtimeIdentity).toMatchObject({ version: '0.8.2', indexSchemaVersion: 4 });
+    // Not a literal — that turns every release into a failing test (#680) — and
+    // not `toBe(declaredVersion())` either, which reads the same file the code
+    // reads and can only agree with itself.
+    //
+    // The failure this must catch is the identity not finding a manifest at all,
+    // which surfaces as the `0.0.0-unknown` fallback rather than as a mismatch.
+    expect(result.summary.runtimeIdentity).toMatchObject({ indexSchemaVersion: 4 });
+    expect((result.summary.runtimeIdentity as { version: string }).version, 'a runtime that found no manifest reports this').not.toBe(
+      '0.0.0-unknown',
+    );
+    expect((result.summary.runtimeIdentity as { version: string }).version, 'and what it did find is a version').toMatch(
+      /^\d+\.\d+\.\d+/,
+    );
     expect(result.summary.hosts).toContainEqual(expect.objectContaining({ host: 'cursor', outcome: 'owned', healthy: true }));
   });
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -40,6 +40,7 @@ import { execGitOrThrow } from '../src/core/git.js';
 import { NOTES_REFSPEC, notesAbsenceEvidenceKey } from '../src/core/notes.js';
 import { createTestRepo } from './git-fixtures.js';
 
+
 const PACKAGE_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const TSC = fileURLToPath(new URL('../node_modules/typescript/bin/tsc', import.meta.url));
 let SERVER_ENTRY = '';
@@ -865,7 +866,19 @@ describe('commitlore_guard', () => {
     });
     const content = response.result?.['content'] as Array<{ text?: unknown }> | undefined;
     const identity = JSON.parse(String(content?.[0]?.text ?? '')) as Record<string, unknown>;
-    expect(identity).toMatchObject({ version: '0.8.2', indexSchemaVersion: 4 });
+    // Not a literal — that turns every release into a failing test (#680) — and
+    // not `toBe(declaredVersion())` either, which reads the same file the code
+    // reads and can only agree with itself.
+    //
+    // The failure this must catch is the identity not finding a manifest at all,
+    // which surfaces as the `0.0.0-unknown` fallback rather than as a mismatch.
+    expect(identity).toMatchObject({ indexSchemaVersion: 4 });
+    expect((identity as { version: string }).version, 'a runtime that found no manifest reports this').not.toBe(
+      '0.0.0-unknown',
+    );
+    expect((identity as { version: string }).version, 'and what it did find is a version').toMatch(
+      /^\d+\.\d+\.\d+/,
+    );
     expect(typeof identity['entrypoint']).toBe('string');
     expect(typeof identity['packageRoot']).toBe('string');
   });


### PR DESCRIPTION
Thirty-seven version pins across nine files: `package.json`, both plugin
manifests, both installers, and the four READMEs.

The installers and the READMEs carry the tag in URLs that only resolve **once
the tag exists**, which is why this is one commit and the tag goes on it rather
than before it. Bumping the READMEs earlier would publish install commands that
404; tagging first would tag a tree that names the previous version.

`dist` is unchanged and the canonical artifact digest is identical to before the
bump — `069a2869`. The version is read from `package.json` at runtime rather
than compiled into the bundle, so a bump moves no bytes. Rebuilt through the
canonical builder and verified rather than assumed.

## What 1.0.0 means, stated rather than implied

- `spec/SPEC.md` is **2.0 Stable**, with a retirement rule: nothing in §3 is
  removed in 2.x, and a record committed today stays readable under any 2.x
  reader.
- `SECURITY.md` separates what `[directive]` promises under the default
  author-string mode from what it promises under signature mode. They are not
  the same claim and are no longer published as one.
- `docs/COMPATIBILITY.md` names the one diagnosis this product cannot make.
- The scope is **verified assisted capture**. Deterministic autocapture is
  excluded, and `commitlore auto status` says so in its first line rather than
  contradicting itself three lines later.

## Not in this PR

The tag and the GitHub release. Those are the owner's to cut, and this PR is
what they would be cut from.

Release notes are drafted on `release-notes-draft` with every figure checked
against its source — `bench/VERDICT-M5.md` for the M5 headline, `README.md` for
the guard figures, `src/core/mcp-probe.ts` for the probe budget.