### PR TITLE
Release 1.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,13 +83,13 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
 ```
 
 **Windows** — PowerShell で同じインストールを行います:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
 ```
 
 **Hermes** — CLI をインストールした後、host integration を設定します:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh
-sh install.sh v1.0.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh
+sh install.sh v1.0.1
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.0.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,13 +83,13 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록하며, 설정이나 cache
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
 ```
 
 **Windows** — PowerShell에서 같은 설치를 한다:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
 ```
 
 **Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh
-sh install.sh v1.0.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh
+sh install.sh v1.0.1
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v1.0.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Prerequisites for either path: Node.js 22.23.2+ and Git. The script checks both 
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
 ```
 
 **Windows** — the same install, in PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
 ```
 
 **Hermes** — after installing the CLI, configure its host integration:
@@ -137,11 +137,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh
-sh install.sh v1.0.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh
+sh install.sh v1.0.1
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.0.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,13 +80,13 @@ commitlore plugin install-codex
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
 ```
 
 **Windows** — 在 PowerShell 中执行同样的安装：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
 ```
 
 **Hermes** — 安装 CLI 后，配置它的 host integration：
@@ -126,11 +126,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh
-sh install.sh v1.0.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh
+sh install.sh v1.0.1
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.0.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.ps1))) v1.0.0
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.0/install.sh | sh -s v1.0.0
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP
@@ -806,7 +806,7 @@ wire_claude_code() {
   # (#660). Returning here meant a release reached the CLI wrapper and never
   # the plugin cache: `claude plugin list` says commitlore is installed, and
   # the copy it names stays at whatever version installed it. Four generations
-  # accumulated that way, and v1.0.0 joined them without displacing one.
+  # accumulated that way, and v1.0.1 joined them without displacing one.
   #
   # `marketplace update` is the step that was missing. Adding a marketplace
   # that is already present is a no-op, so the old path could never see a new

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "fcfc5f3245f6ab6f9f52b02a9009fe487e6c2ce8edf10e0cc7d59ae7ce7caa1d"
+    "sha256": "064b3810c7c371bfa1cc838fbc3c2e8db8c856f22c0d07e8b2a4e61d3a660c11"
   },
   "artifact": {
     "sha256": "c312755d70a4d15b2743f95b9999694ef0fbc433f9ee645acc903c5275ef5a5d",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Five fixes have been on `main` since v1.0.0 and none has reached anyone.

```
#683  the release workflow failing on a release that already exists
#684  hermes install refusing the config it wrote
#687  the skills root taken from the running bundle instead of --data-root
#688  an installed plugin treated as a reason to stop rather than upgrade
#690  claude-code wired by nothing, in neither hosts nor notDetected
```

All five are defects at the install and distribution boundary, and that boundary
has exactly one delivery mechanism.

## Measured, not assumed

Re-installing with `main`'s `install.sh` still left the plugin cache at `0.8.0`
and `claude-code` out of both lists. The enumeration #690 fixed is compiled into
the binary being installed, and that binary is v1.0.0. Same for #684 and #687:
verified working from `main`'s dist, still refused by the installed wrapper.

## The bump

Thirty-eight pins across nine files. `dist` is unchanged and the canonical
digest is identical — `c312755d`. The version is read from `package.json` at
runtime rather than compiled in, so a bump moves no bytes; rebuilt through the
canonical builder and verified rather than assumed, as with v1.0.0.

The installers and READMEs carry the tag in URLs that resolve only once the tag
exists, so this is one commit and the tag goes on it.

## First release under §6c

`docs/RELEASE-GATE.md` §6c asks for an **upgrade over the previous version**
rather than a fresh install, and a fresh host process that actually lists the
tools. The five fixes above are why that section exists — every one of them was
invisible to a suite that starts from nothing.

After publishing, the measurements that close #660:

```
install → does claude-code appear in hosts
        → does the plugin cache move to 1.0.1
        → does doctor's unusable count fall
        → does hermes report healthy
```

Each is a control for something measured today at v1.0.0.

## Not in this release

#691 — `install.sh` carries seven `has_`/`wire_` host pairs nothing calls, ~140
lines. A deletion that size does not belong immediately before a release.