### PR TITLE
Release 1.0.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,13 +83,13 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
 ```
 
 **Windows** — PowerShell で同じインストールを行います:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
 ```
 
 **Hermes** — CLI をインストールした後、host integration を設定します:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh
-sh install.sh v1.0.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh
+sh install.sh v1.0.2
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.0.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.2 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,13 +83,13 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록하며, 설정이나 cache
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
 ```
 
 **Windows** — PowerShell에서 같은 설치를 한다:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
 ```
 
 **Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh
-sh install.sh v1.0.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh
+sh install.sh v1.0.2
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v1.0.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.2 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ commitlore init
 commitlore context .
 ```
 
+### Upgrading
+
+Re-run the install command. It updates the CLI and the agent registrations, and
+it cannot reach two things:
+
+- **Hooks already installed in a repository.** One installed before v1.0.2
+  records the release it came from, so it keeps validating commits with that
+  build. The installer has no way to know which repositories have hooks.
+- **Sessions already running.** A host loads its runtime once and keeps it.
+
+So after upgrading:
+
+```bash
+commitlore doctor          # names any hook still pinned, and any stale session
+commitlore hooks install   # in each repository doctor names
+```
+
+Neither is a defect in the release; both are state a release cannot reach.
+Hooks installed from v1.0.2 onward follow upgrades on their own.
+
 After that:
 
 - Commit normally. Most commits carry no record.

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Prerequisites for either path: Node.js 22.23.2+ and Git. The script checks both 
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
 ```
 
 **Windows** — the same install, in PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
 ```
 
 **Hermes** — after installing the CLI, configure its host integration:
@@ -137,11 +137,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh
-sh install.sh v1.0.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh
+sh install.sh v1.0.2
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.0.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.2 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,13 +80,13 @@ commitlore plugin install-codex
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
 ```
 
 **Windows** — 在 PowerShell 中执行同样的安装：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
 ```
 
 **Hermes** — 安装 CLI 后，配置它的 host integration：
@@ -126,11 +126,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh
-sh install.sh v1.0.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh
+sh install.sh v1.0.2
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.0.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.0.2 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.ps1))) v1.0.1
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.1/install.sh | sh -s v1.0.1
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP
@@ -834,7 +834,7 @@ wire_claude_code() {
   # (#660). Returning here meant a release reached the CLI wrapper and never
   # the plugin cache: `claude plugin list` says commitlore is installed, and
   # the copy it names stays at whatever version installed it. Four generations
-  # accumulated that way, and v1.0.1 joined them without displacing one.
+  # accumulated that way, and v1.0.2 joined them without displacing one.
   #
   # `marketplace update` is the step that was missing. Adding a marketplace
   # that is already present is a no-op, so the old path could never see a new

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "b4cd86d75920080ae4da5473e547f3140a63fa8478d7ba4615ab4b7d649b4805"
+    "sha256": "2795934b30245d604a1ad06050b1ae7a4dd3ca9031b86406aa9cac117cd2f9de"
   },
   "artifact": {
     "sha256": "ca6089272805d75898b626d228090a10b6174b1bf9a525cf3e5aea467730d4c1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Five fixes have been on `main` since v1.0.1 and none has reached anyone.

```
#696  the hook pinned the release it was installed from
#698  install.sh never installed the Codex plugin; install.ps1 did
#700  a failed Codex integration reported healthy and exited 0
#702  documents claiming more than the product does
#704  the PowerShell 5.1 floor documented but not enforced
```

Four are at the installer and hook boundary, and that boundary has exactly one
delivery mechanism. Measured at v1.0.1: re-installing with `main`'s `install.sh`
changed nothing, because the code being installed is the *released* binary.

**#700 is the one a user meets first.** Registering Codex is two steps, and the
installer called the host healthy when the second failed — it said *plugin step
failed* in its detail and exited 0, because `ok` is computed from the field
rather than the sentence. That defect was introduced in #698 while fixing #697,
and found by the closeout review.

## The bump

Thirty-eight pins across nine files. `dist` unchanged, canonical digest
identical — `ca608927`. The version is read from `package.json` at runtime rather
than compiled in; rebuilt through the canonical builder and verified rather than
assumed, as with the two releases before it.

The installers and READMEs carry the tag in URLs that resolve only once the tag
exists, so this is one commit and the tag goes on it.

## After publishing

`docs/RELEASE-GATE.md` §6b and §6c apply: read the check runs at the commit the
merge creates, and install **over** v1.0.1 rather than fresh. The specific
readbacks this release needs:

```
commitlore --version                 → 1.0.2
commitlore hooks install             → repoints commitlore.bin at <data-root>/current
commitlore doctor                    → hook/CLI identity agrees
codex plugin present on macOS/Linux  → the #698 fix, absent before
```

Baseline measured before the release, for comparison: CLI `1.0.1`, hook pinned
at `…/v1.0.1/dist/commitlore.mjs`, `doctor` 12 ok / 6 warnings / 0 failed.

## Not in this release

#691 — `install.ps1` wires hosts directly as well as delegating. Removing the
duplicates needs a Windows machine with agents installed; CI cannot substitute,
because its runners have none and every host reports `notDetected` there.