### PR TITLE
MEASUREMENT ONLY — do not merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,6 +538,67 @@ jobs:
   # The hosts are named literally. `shell:` accepts no expression -- a
   # `${{ matrix.shell }}` there makes the workflow unloadable, which is how this
   # job was first written and how it first failed (actions/runner#444).
+  # install.ps1's unit coverage reads the file as text, so a change that leaves
+  # every asserted string in place while inverting behaviour goes unnoticed:
+  # measured at 0 of 5 such mutations caught, against 4 of 4 for install.sh,
+  # whose tests run the script and read what it produced (#691).
+  #
+  # The reason given for that asymmetry was that a Linux runner cannot execute
+  # PowerShell. It can — this workflow already uses `shell: pwsh` in four
+  # places. Nobody had run install.ps1 under it outside Windows.
+  #
+  # What this job can and cannot see is worth stating: the script's Windows
+  # environment variables are injected, so its path logic runs, but the .cmd
+  # shim it writes is only meaningful to cmd.exe. Whether that shim *executes*
+  # stays a windows-latest question, and install-ps1 below remains the job that
+  # answers it. This one answers the cheaper half, on every push.
+  install-ps1-behaviour:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Run install.ps1 under PowerShell Core with a synthetic Windows home
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $home_ = Join-Path ([System.IO.Path]::GetTempPath()) "cl-home-$(Get-Random)"
+          $local = Join-Path $home_ 'AppData/Local'
+          New-Item -ItemType Directory -Force -Path $local | Out-Null
+          $env:USERPROFILE = $home_
+          $env:LOCALAPPDATA = $local
+
+          # A failure here is the point: the assertions below say which part.
+          & ./install.ps1 2>&1 | Tee-Object -Variable output | Out-Host
+          $code = $LASTEXITCODE
+          "$output" | Set-Content -LiteralPath "$home_/output.txt"
+          "exit=$code" | Out-Host
+          "$code" | Set-Content -LiteralPath "$home_/exit.txt"
+          "$home_" | Set-Content -LiteralPath "$env:GITHUB_ENV" -Append -Value "CL_HOME=$home_"
+
+      - name: It reports what it did, rather than exiting quietly
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $out = Get-Content -Raw -LiteralPath "$env:CL_HOME/output.txt"
+          # Catches `exit 1` -> `exit 0` and a neutralised $LASTEXITCODE check:
+          # both make the script claim success while having done nothing.
+          if ($out -notmatch 'commitlore-install:') { throw 'the installer produced no diagnostics at all' }
+          if ($out -match 'installed to' -and $out -notmatch 'commitlore') {
+            throw 'it claimed an install without naming what it installed'
+          }
+
+      - name: A directory it creates is a directory
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $local = Join-Path $env:CL_HOME 'AppData/Local'
+          # Catches New-Item -ItemType Directory -> File: the path exists either
+          # way, and only the type separates them.
+          foreach ($p in (Get-ChildItem -Path $local -Recurse -ErrorAction SilentlyContinue)) {
+            if ($p.Name -eq 'commitlore' -and -not $p.PSIsContainer) {
+              throw "commitlore data root was created as a file, not a directory: $($p.FullName)"
+            }
+          }
+
   install-ps1:
     runs-on: windows-latest
     # A hook that hangs rather than refusing is one of the outcomes this job now

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,6 +574,36 @@ jobs:
           "$code" | Set-Content -LiteralPath "$home_/exit.txt"
           "$home_" | Set-Content -LiteralPath "$env:GITHUB_ENV" -Append -Value "CL_HOME=$home_"
 
+      - name: MEASUREMENT ONLY — how many behaviour mutations does this job catch
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $muts = @(
+            @{ n='exit 1 -> exit 0';        f={ (Get-Content install.ps1 -Raw) -replace 'exit 1','exit 0' } },
+            @{ n='LASTEXITCODE -> $true';   f={ (Get-Content install.ps1 -Raw) -replace '\$LASTEXITCODE -eq 0','$true' } },
+            @{ n='Test-Path typo x3';       f={ $t=(Get-Content install.ps1 -Raw); ([regex]'Test-Path').Replace($t,'Test-PathX',3) } },
+            @{ n='ExecutionPolicy widened'; f={ (Get-Content install.ps1 -Raw) -replace 'Bypass','Unrestricted' } },
+            @{ n='Directory -> File';       f={ (Get-Content install.ps1 -Raw) -replace "-ItemType Directory -Force","-ItemType File -Force" } }
+          )
+          $orig = Get-Content install.ps1 -Raw
+          $caught = 0
+          foreach ($m in $muts) {
+            Set-Content -LiteralPath install.ps1 -Value (& $m.f) -NoNewline
+            $h = Join-Path ([System.IO.Path]::GetTempPath()) "m-$(Get-Random)"
+            $l = Join-Path $h 'AppData/Local'
+            New-Item -ItemType Directory -Force -Path $l | Out-Null
+            $env:USERPROFILE = $h; $env:LOCALAPPDATA = $l
+            $out = (& ./install.ps1 2>&1 | Out-String)
+            $bad = $false
+            if ($out -notmatch 'commitlore-install:') { $bad = $true }
+            foreach ($p in (Get-ChildItem -Path $l -Recurse -ErrorAction SilentlyContinue)) {
+              if ($p.Name -eq 'commitlore' -and -not $p.PSIsContainer) { $bad = $true }
+            }
+            if ($bad) { $caught++; "CAUGHT  $($m.n)" | Out-Host } else { "MISSED  $($m.n)" | Out-Host }
+            Set-Content -LiteralPath install.ps1 -Value $orig -NoNewline
+          }
+          "=== RESULT $caught / $($muts.Count)" | Out-Host
+
       - name: It reports what it did, rather than exiting quietly
         shell: pwsh
         run: |

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,7 +40,7 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = '87f33a8cea5b04369e118f68d64798f46dcf7dd7d549af374c5ee29b89c9352e';
+export const EXPECTED_CI_WORKFLOW_SHA256 = '93c0db75e0f4218b3a44e83521fd5c9d26e5b1194cc5e3566f5f8c619160bb12';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore
@@ -53,6 +53,7 @@ export const REQUIRED_CHECKS = Object.freeze([
   'git-matrix (macos-latest)',
   'install-script',
   'install-ps1',
+  'install-ps1-behaviour',
   'install-macos',
   'install-alpine (linux/amd64)',
   'install-alpine (linux/arm64)',


### PR DESCRIPTION
Temporary. Runs the five behaviour mutations against the new install-ps1-behaviour job in one CI run, to replace the unmeasured 'Catches X' claims in #706 with N/5. Closed as soon as the number is read.