### PR TITLE
Release 1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
+[GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
+were not written here.
+
+## 1.1.0
+
+A machine can now differ from the committed capture policy without modifying
+it. `.commitlore-policy.local.json` sits beside `.commitlore-policy.json` and
+wins **per key**: an overlay setting only `unattended` leaves `mode` and
+`max_records_per_commit` as the repository set them. `commitlore auto on
+--local` and `auto off --local` write it, and once it exists it is the file
+`commitlore auto` writes — so opting in or out never touches the tracked file
+again. Previously the only route was to edit the committed file, which left the
+worktree permanently modified and stopped any release script that refuses a
+dirty tree (#709, ADR-0035).
+
+The policy identity hash is computed over the *effective* policy whenever an
+overlay is present, so a record prepared under one is stamped with the policy
+that produced it. A repository with no overlay keeps exactly the digest it had:
+no capture in flight is refused by this upgrade.
+
+A new `policy-overlay` doctor check names both files, the value beneath, the
+value in the overlay and the one in force. It reports `ok` when they disagree —
+that is the feature working — and warns only when a file cannot be used, since
+then neither file's values are in force and capture runs on the built-in
+defaults.
+
+`doctor` no longer tells a repository whose captures never reached staging that
+a record was "never written to the history". Nothing was dropped there: the
+commit each draft was prepared for either never happened or happened without it
+(#710).
+
+On Windows the installer built every config's temporary file name out of the
+whole target path — `path.split('/').pop()` returns its argument unchanged when
+there is no `/` in it — so the write was `ENOENT` before it began and no host
+was wired. **This does not mean host wiring works on Windows now.** A real
+Windows run of 1.0.2 found a second cause that this release does not fix:
+`hasCommand` never consults `PATHEXT`, so it cannot see `cursor.cmd` or
+`claude.cmd`, and `spawnSync` with `shell: false` cannot execute a `.cmd` shim.
+The installer reports these honestly — `ok:false`, per-host `outcome:"failed"`,
+no config silently changed — but it cannot yet complete the work on that
+platform (#716; the observation is #714).
+
+The installer's host wiring was cut to the code that runs. `install.sh` and
+`install.ps1` have delegated every detection, config write and MCP probe to one
+shared TypeScript command since 0.9.0, and both files still carried the
+superseded shell and PowerShell implementations below an unconditional exit —
+845 lines that no install has executed, and that three readers in three days
+took for live code (#691).
+
 ## 0.8.2
 
 SHA-256 repositories now distinguish a full object id from a revision a user

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,13 +83,13 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
 ```
 
 **Windows** — PowerShell で同じインストールを行います:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
 ```
 
 **Hermes** — CLI をインストールした後、host integration を設定します:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh
-sh install.sh v1.0.2
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh
+sh install.sh v1.1.0
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.0.2 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,13 +83,13 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록하며, 설정이나 cache
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
 ```
 
 **Windows** — PowerShell에서 같은 설치를 한다:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
 ```
 
 **Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh
-sh install.sh v1.0.2
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh
+sh install.sh v1.1.0
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v1.0.2 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Prerequisites for either path: Node.js 22.23.2+ and Git. The script checks both 
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
 ```
 
 **Windows** — the same install, in PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
 ```
 
 **Hermes** — after installing the CLI, configure its host integration:
@@ -157,11 +157,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh
-sh install.sh v1.0.2
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh
+sh install.sh v1.1.0
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.0.2 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,13 +80,13 @@ commitlore plugin install-codex
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
 ```
 
 **Windows** — 在 PowerShell 中执行同样的安装：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
 ```
 
 **Hermes** — 安装 CLI 后，配置它的 host integration：
@@ -126,11 +126,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh
-sh install.sh v1.0.2
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh
+sh install.sh v1.1.0
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.0.2 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.ps1))) v1.0.2
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.0.2/install.sh | sh -s v1.0.2
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "d2e165b967f9e730b41147ad3e5c3d73ffd88dfb3384b3f46d78882c963f4180"
+    "sha256": "73abfbac1f65e3aafcca4efc089a8b2485dbc736572975a7dfba5132d3cdfdee"
   },
   "artifact": {
     "sha256": "2dcf0c4aeca193839f284c1b4fa5da57db8e29764ee02a36dad40d6768910101",

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "73abfbac1f65e3aafcca4efc089a8b2485dbc736572975a7dfba5132d3cdfdee"
+    "sha256": "0f24bab630842287afd8990604c38b41d7315c83e9343c726d19b99a3033db10"
   },
   "artifact": {
     "sha256": "2dcf0c4aeca193839f284c1b4fa5da57db8e29764ee02a36dad40d6768910101",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -45,6 +45,19 @@ export const EXPECTED_CI_WORKFLOW_SHA256 = '87f33a8cea5b04369e118f68d64798f46dcf
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore
 // deliberately not a member of the push-event release contract.
+//
+// That exclusion is about which contexts exist on a main commit, not about
+// whether `lint` ran. It is one of the eleven required status checks on the
+// `main` branch protection, so it is evaluated on the pull request's head and
+// has to pass before anything reaches main; the squash then produces a new
+// commit that carries no `lint` context for this gate to find. Ten here plus
+// `lint` is the eleven that protection requires.
+//
+// Written down because the shorter version reads as a hole: a reader took it
+// that way on 2026-08-17 and asked whether main could be pushed unlinted. The
+// release gate not requiring `lint` is not the same as main never being
+// linted, and saying only the first invites someone to add `lint` to this
+// list, which would block every release.
 export const REQUIRED_CHECKS = Object.freeze([
   'check (22.23.2)',
   'check (24)',


### PR DESCRIPTION
Cuts 1.1.0.

## What ships

**A local policy overlay (#709, ADR-0035).** `.commitlore-policy.local.json` wins per key over the committed `.commitlore-policy.json`; `commitlore auto on|off --local` writes it. A contributor who needs a different answer than the repository committed no longer has to leave a tracked file permanently modified — the reported failure was a release script refusing to tag a worktree dirtied exactly that way. The policy identity hash is taken over the *effective* policy when an overlay is present, and a repository without one keeps exactly the digest it had, so no capture in flight is refused by the upgrade. A new `policy-overlay` doctor check names both files, both values and the one in force.

**doctor stops claiming a record was lost when none was staged (#710).**

**Both installers carry only the code that runs (#691)** — 845 lines of unreachable shell and PowerShell removed.

**One of two Windows host-wiring defects fixed (#716)**, and every host failure now names the file it read.

## What this release does not do

It does not make host wiring work on Windows. Detection still cannot see a `.cmd` and spawn still cannot run one. The release notes say that before they say anything else about Windows — #720 is the fix for the remaining cause and is not in this release, so a note claiming otherwise would be false in both directions.

## Version surfaces

Nineteen move together: three manifests, five install pins in each of four READMEs, three header examples in each of `install.sh` and `install.ps1`.

Two lines in `README.md` deliberately do **not** move:

```
129: One installed before v1.0.2
142: Hooks installed from v1.0.2 onward follow upgrades on their own.
```

Those are statements about a release boundary — bumping them makes the README say something false, and `test/readme.test.ts` reads only the install shapes, so nothing would have caught it. The bump was dry-run on a scratch copy first for that reason.

`install.sh` and `install.ps1` documenting themselves at 1.0.2 was **not** caught by the dry run — the scratch copy did not include them. `test/readme.test.ts` caught it here. Worth knowing for the next release: the surface is nineteen, not sixteen.

`dist/` is unchanged and needs no rebuild; the CLI reads its version at runtime.

## The REQUIRED_CHECKS comment

Included here rather than separately because it documents the gate this commit is about to be judged by. It said why `lint` is excluded from the tag gate and stopped, which reads as a hole — a reader asked today whether main could be pushed unlinted. It cannot: `lint` is one of the eleven required status checks on main's branch protection, evaluated on the pull request head. Ten here plus `lint` is that eleven. The exclusion is about which contexts survive a squash onto main, not about whether the job ran.

## Verification

95 cases pass across `manifest`, `readme` and `release-publish-prerequisites`. The `readme` suite is what caught the installer self-documentation.
