### PR TITLE
Release 1.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.1.1
+
+Host wiring works on Windows. 1.1.0 said plainly that it did not; this is the
+release that gets to say otherwise, and only for what was actually observed.
+
+Two defects stood between a Windows install and a wired host, and 1.1.0 fixed
+one of them. The other was in how a command was found and run:
+
+- `hasCommand` joined each `PATH` entry with the bare command name and stopped
+  there, never consulting `PATHEXT`. Windows installs `cursor.cmd`, `codex.cmd`,
+  `claude.cmd` — there is no extensionless file — so detection was false for
+  every host whose executable is a shim, and `claude-code` reported
+  `notDetected` with its config sitting on disk.
+- `spawnSync` ran with `shell: false`, which cannot execute a `.cmd` shim at
+  all. That produced `codex mcp add failed`.
+
+Resolution now finds one concrete executable through `PATHEXT` and both
+detection and execution use it, so the two can no longer disagree about what
+"present" means — which is what the original defect was. A batch shim is
+invoked through an explicit `cmd.exe` argument vector with `shell: false`
+preserved: the wrapper path and user config paths reach these calls, and a
+shell would make quoting an attack surface.
+
+Observed on Windows 10.0.19045.0 with agents installed: Codex and Gemini CLI
+wire, verify through a live MCP `Initialize`, and appear in their configs on
+disk. **`ok` is still false on that machine and the hosts that failed are still
+reported failed** — Hermes fails for a cause that is not this one and is not
+yet named (#716), and a `.cursor/mcp.json` that is zero bytes on the tester's
+machine is a user file, not a defect here.
+
+Two quieter repairs came out of reviewing that work. A trailing backslash in a
+path — every Windows directory can carry one — was passed into the `cmd.exe`
+argument vector unescaped, where the closing quote consumes it and the next
+argument is absorbed. A `--verify` swallowed that way would have let a step
+report `verified` for a verification that never ran, which is the failure this
+project exists to remove. And executable resolution now checks `X_OK`: without
+it a non-executable file of the same name earlier on `PATH` would be selected
+and spawned, breaking macOS and Linux, where this works today.
+
+A literal `%` in a path — legal on Windows, and present for any user whose name
+contains one — is handled rather than refused, and the reason `%%` escaping is
+not the answer is recorded in the code beside it.
+
 ## 1.1.0
 
 A machine can now differ from the committed capture policy without modifying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ A literal `%` in a path — legal on Windows, and present for any user whose nam
 contains one — is handled rather than refused, and the reason `%%` escaping is
 not the answer is recorded in the code beside it.
 
+A failed host also says why. The Hermes step ran with `stdio: 'ignore'`, so
+whatever it printed about its own failure was thrown away and the report was a
+bare `Hermes setup failed` — which is why that cause is still unnamed after a
+real Windows run. The reason now reaches the summary, so the next run on a
+machine with Hermes installed prints it rather than requiring another round
+trip. That is the whole of what is needed to name it (#716).
+
 ## 1.1.0
 
 A machine can now differ from the committed capture policy without modifying

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,13 +83,13 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
 ```
 
 **Windows** — PowerShell で同じインストールを行います:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 ```
 
 **Hermes** — CLI をインストールした後、host integration を設定します:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh
-sh install.sh v1.1.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh
+sh install.sh v1.1.1
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.1.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,13 +83,13 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록하며, 설정이나 cache
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
 ```
 
 **Windows** — PowerShell에서 같은 설치를 한다:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 ```
 
 **Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
@@ -129,11 +129,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh
-sh install.sh v1.1.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh
+sh install.sh v1.1.1
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v1.1.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Prerequisites for either path: Node.js 22.23.2+ and Git. The script checks both 
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
 ```
 
 **Windows** — the same install, in PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 ```
 
 **Hermes** — after installing the CLI, configure its host integration:
@@ -157,11 +157,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh
-sh install.sh v1.1.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh
+sh install.sh v1.1.1
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.1.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,13 +80,13 @@ commitlore plugin install-codex
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
 ```
 
 **Windows** — 在 PowerShell 中执行同样的安装：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 ```
 
 **Hermes** — 安装 CLI 后，配置它的 host integration：
@@ -126,11 +126,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh
-sh install.sh v1.1.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh
+sh install.sh v1.1.1
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.1.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.ps1))) v1.1.0
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.0/install.sh | sh -s v1.1.0
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "6dd692b57aea20b4035c219d0280007dfcdf89134047353029e43fcfbf73f767"
+    "sha256": "018720cb8bdff4d894fc6e2ebaba71d592e1c2faf247ad3a6f414fa01d62faf4"
   },
   "artifact": {
     "sha256": "14ff61683da747382e03b026db252dd06d4f20820c3ab6f6a75282837458429d",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Cuts 1.1.1.

## What it says about Windows, and what it does not

1.1.0 stated plainly that host wiring did not work on Windows. This is the release that gets to say otherwise — for exactly what was observed on a real machine, and no more:

- **Codex and Gemini CLI** wire, verify through a live MCP `Initialize`, and appear in their configs on disk.
- **`ok` is still false** on that machine, and the hosts that failed are still reported failed.
- **Hermes** fails for a cause that is not this one and is not yet named (#716).
- **`.cursor/mcp.json`** was zero bytes on the tester's machine — a user file. The installer read the file it says it reads and reported the true reason.

The note leads with what is still broken, as 1.1.0's did.

## The fix

`hasCommand` joined each `PATH` entry with the bare command name and never consulted `PATHEXT`, so a `.cmd` shim was invisible; `spawnSync` ran with `shell: false`, which cannot execute one. Resolution now finds a single concrete executable and **both detection and execution use it** — the original defect was those two disagreeing about what "present" means.

Two more came out of the review rather than the machine:

- **A trailing backslash** reached the `cmd.exe` argument vector unescaped, where the closing quote consumes it and the following argument is absorbed. A `--verify` swallowed that way would let a step report `verified` for a verification that never ran — the exact failure this project exists to remove, arriving through its fix.
- **`X_OK`** on resolution. Without it a non-executable file of the same name earlier on `PATH` is selected and spawned, breaking macOS and Linux, where this already works. Guarded by a POSIX-only test that puts a mode-0644 shadow ahead of a mode-0755 CLI — the fixtures were all executable before, so nothing could have failed on it.

## Version surfaces: twenty-one, known in advance

1.1.0 found three of them with CI instead of the checklist. This time all twenty-one were asserted before pushing:

```
4   manifests   package.json, two plugin.json, package-lock.json (two fields)
20  README      5 install pins × 4 READMEs
6   installers  3 header examples × install.sh, install.ps1
```

`package-lock.json` is edited **structurally**, not textually: a `"version": "1.1.0"` replacement also matches dependencies genuinely at that version, and no test in the suite reads them, so that corruption would be silent.

`dist/commitlore.mjs` is unchanged — the bundle comes from `src/`, which this release does not touch. `installer/canonical-artifact.json` does move, because `package.json` is one of its four source inputs.

## Verification

104 cases across `manifest`, `readme`, `check-release-version` and `release-publish-prerequisites`. `build:canonical` then `artifact:verify` → `14ff61683da747382e03b026db252dd06d4f20820c3ab6f6a75282837458429d`.

## Note on the merge that preceded this

#720 was squash-merged from a fork, and its four records were discarded — `preserve` cannot push notes with a fork PR's read-only token, and it is not a required check. Recovered with `commitlore squash-preserve` and republished; the structural gap is #723.
