### PR TITLE
Let installer fixtures express executable modes (#716)

### DIFF
--- a/test/installer-hosts.test.ts
+++ b/test/installer-hosts.test.ts
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { resolveCommand } from '../src/commands/installer-hosts.js';
+
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ENTRY = join(ROOT, 'dist', 'commitlore.mjs');
@@ -26,14 +28,14 @@ interface Run {
   summary: { schema: string; runtimeIdentity: { version: string; entrypoint: string; packageRoot: string; indexSchemaVersion: number }; ok: boolean; hosts: Array<{ host: string; outcome: string; healthy: boolean }> };
 }
 
-const wrapper = (root: string, name = 'commitlore'): string => {
+const wrapper = (root: string, name = 'commitlore', mode = 0o755): string => {
   const isWindows = process.platform === 'win32';
   const path = join(root, 'bin', `${name}${isWindows ? '.cmd' : ''}`);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, isWindows
     ? `@echo off\r\n"${process.execPath}" "${ENTRY}" %*\r\n`
     : `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(ENTRY)} "$@"\n`);
-  if (!isWindows) chmodSync(path, 0o755);
+  if (!isWindows) chmodSync(path, mode);
   return path;
 };
 
@@ -150,6 +152,31 @@ describe('installer-hosts accepts only live CommitLore registrations', () => {
     expect(result.status).toBe(0);
     expect(result.summary.hosts).toContainEqual(expect.objectContaining({ host: 'cursor', outcome: 'custom-preserved', healthy: true }));
     expect(readFileSync(config, 'utf8')).toBe(before);
+  });
+});
+
+describe('#716 executable search fixtures', () => {
+  it.runIf(process.platform !== 'win32')('skips a non-executable command shadow earlier on PATH', () => {
+    // Given
+    const shadowRoot = temporary();
+    const executableRoot = temporary();
+    const shadow = wrapper(shadowRoot, 'claude', 0o644);
+    const executable = wrapper(executableRoot, 'claude', 0o755);
+    const previousPath = process.env['PATH'];
+    process.env['PATH'] = `${dirname(shadow)}${delimiter}${dirname(executable)}`;
+
+    // When
+    const resolved = (() => {
+      try {
+        return resolveCommand('claude');
+      } finally {
+        if (previousPath === undefined) delete process.env['PATH'];
+        else process.env['PATH'] = previousPath;
+      }
+    })();
+
+    // Then
+    expect(resolved).toEqual({ path: executable, usesCommandInterpreter: false });
   });
 });
 

--- a/test/installer-windows-command.test.ts
+++ b/test/installer-windows-command.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, join } from 'node:path';
+import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -56,35 +56,6 @@ describe('#716 Windows command resolution', () => {
 
     // Then
     expect(resolved).toEqual({ path: shim, usesCommandInterpreter: true });
-  });
-
-  it.runIf(process.platform !== 'win32')('skips a non-executable command shadow earlier on PATH', () => {
-    // Given
-    const root = temporary();
-    const shadowBin = join(root, 'shadow');
-    const executableBin = join(root, 'executable');
-    const shadow = join(shadowBin, 'claude');
-    const executable = join(executableBin, 'claude');
-    mkdirSync(shadowBin);
-    mkdirSync(executableBin);
-    writeFileSync(shadow, '#!/bin/sh\nexit 1\n');
-    writeFileSync(executable, '#!/bin/sh\nexit 0\n');
-    chmodSync(shadow, 0o644);
-    chmodSync(executable, 0o755);
-    const previousPath = process.env['PATH'];
-    process.env['PATH'] = `${shadowBin}${delimiter}${executableBin}`;
-
-    // When
-    const resolved = (() => {
-      try {
-        return resolveCommand('claude');
-      } finally {
-        restoreEnvironment('PATH', previousPath);
-      }
-    })();
-
-    // Then
-    expect(resolved).toEqual({ path: executable, usesCommandInterpreter: false });
   });
 
   it('uses the same resolver for a concrete batch wrapper path', () => {


### PR DESCRIPTION
﻿Follow-up to #720 and the owner's final non-blocking review note.

The POSIX X_OK regression was correct, but it constructed its non-executable shadow by hand in `installer-windows-command.test.ts` while the shared `wrapper()` fixture in `installer-hosts.test.ts` still forced every POSIX fixture to mode `0o755`. That meant the main fixture API could not express the state the regression protects.

This PR:

- lets `wrapper(root, name, mode)` accept an explicit mode with the existing `0o755` default;
- moves the mode-0644 shadow / mode-0755 real executable assertion beside that helper;
- removes the hand-built duplicate fixture.

No product source changes. `dist/` and `installer/canonical-artifact.json` are deliberately unchanged because the canonical source inputs are unchanged.

Verified on Windows before rebasing onto the squash merge:

- `tsc --noEmit`: clean
- all six installer suites: 29 passed, 1 skipped (the POSIX-only mode case)
- CommitLore record validation after cherry-pick onto current main: `examined:1`, `violations:[]`, reference check `ok`

The POSIX case still needs the approved fork workflow to execute it on Linux.
