### PR TITLE
Stop telling Windows readers that host wiring is install.sh's business

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -92,6 +92,8 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/inst
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 ```
 
+Windows での host 配線には **v1.1.1 以降**が必要です。それ以前は検出が `.cmd` shim を見つけられず、インストーラーもそれを実行できなかったため、Windows へのインストールは CLI を置くだけで何も配線しませんでした — 成功としてではなく `ok: false` として報告されます。1.1.1 で Codex、Gemini CLI、Hermes について実機で確認しました。
+
 **Hermes** — CLI をインストールした後、host integration を設定します:
 
 ```bash
@@ -176,7 +178,7 @@ delivery はコンテキストを渡すものであり、編集を止めるも�
 | Claude Code | **はい — plugin により自動です。** | **はい — plugin により可能です。** |
 | Codex | **はい — plugin により自動です。** | **はい — plugin により可能です。** |
 | Hermes | **はい — `commitlore hermes install`.** | **はい — `commitlore hermes install`.** |
-| Gemini CLI, Cursor, Windsurf, opencode | **はい — `install.sh` が MCP server を配線します。** | **procedure であり自動ではありません。** server が接続ごとに prepare → verify → stage の手順を伝えます。host が従う場合も従わない場合もあります。 |
+| Gemini CLI, Cursor, Windsurf, opencode | **はい — 両方のインストーラーが MCP server を配線します。** それぞれ独自にではなく、共有された一つの手順を通ります。 | **procedure であり自動ではありません。** server が接続ごとに prepare → verify → stage の手順を伝えます。host が従う場合も従わない場合もあります。 |
 | その他の `AGENTS.md` convention host | **procedure であり自動ではありません。** `commitlore init --agents-md` が repository に書きます。 | **procedure であり自動ではありません。** 同じファイル、同じ但し書きです。 |
 
 「はい」は layer がインストールされるという意味であり、すべての commit に record が

--- a/README.ko.md
+++ b/README.ko.md
@@ -92,6 +92,8 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/inst
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 ```
 
+Windows에서 host 배선은 **v1.1.1 이상**이 필요하다. 그 전에는 탐지가 `.cmd` shim을 보지 못하고 설치기가 그것을 실행하지도 못해서, Windows 설치는 CLI만 놓고 아무것도 배선하지 않았다 — 성공이 아니라 `ok: false`로 보고됐다. 1.1.1에서 Codex, Gemini CLI, Hermes에 대해 실기로 확인했다.
+
 **Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
 
 ```bash
@@ -174,7 +176,7 @@ delivery는 맥락을 주며, 편집을 막지 않는다.
 | Claude Code | **예 — plugin을 통해 자동으로 된다.** | **예 — plugin을 통해 된다.** |
 | Codex | **예 — plugin을 통해 자동으로 된다.** | **예 — plugin을 통해 된다.** |
 | Hermes | **예 — `commitlore hermes install`.** | **예 — `commitlore hermes install`.** |
-| Gemini CLI, Cursor, Windsurf, opencode | **된다 — `install.sh`가 MCP server를 배선한다.** | **procedure이며 자동이 아니다.** server가 연결마다 prepare → verify → stage 절차를 알린다. host가 따를 수도, 따르지 않을 수도 있다. |
+| Gemini CLI, Cursor, Windsurf, opencode | **된다 — 두 설치기 모두 MCP server를 배선한다.** 각자가 아니라 공유된 한 단계를 거친다. | **procedure이며 자동이 아니다.** server가 연결마다 prepare → verify → stage 절차를 알린다. host가 따를 수도, 따르지 않을 수도 있다. |
 | 그 밖의 `AGENTS.md` convention host | **procedure이며 자동이 아니다.** `commitlore init --agents-md`가 저장소에 적는다. | **procedure이며 자동이 아니다.** 같은 파일, 같은 단서. |
 
 “예”는 layer가 설치되었다는 뜻이지 모든 commit에 record가 생긴다는 뜻이 아니다.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/inst
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 ```
 
+Host wiring on Windows requires **v1.1.1 or later**. Before it, detection could not see a `.cmd` shim and the installer could not run one, so a Windows install placed the CLI and wired nothing — reported as `ok: false`, never as success. Verified on a real machine at 1.1.1 for Codex, Gemini CLI and Hermes.
+
 **Hermes** — after installing the CLI, configure its host integration:
 
 ```bash
@@ -217,7 +219,7 @@ separate layers:
 | Claude Code | **Yes — automatic through the plugin.** | **Yes — through the plugin.** |
 | Codex | **Yes — automatic through the plugin.** | **Yes — through the plugin.** |
 | Hermes | **Yes — `commitlore hermes install`.** | **Yes — `commitlore hermes install`.** |
-| Gemini CLI, Cursor, Windsurf, opencode | **Yes — the MCP server is wired by `install.sh`.** | **Procedure, not automatic.** The server states the prepare → verify → stage procedure in its `instructions` on every connection. The host may or may not act on it. |
+| Gemini CLI, Cursor, Windsurf, opencode | **Yes — both installers wire the MCP server**, through one shared step rather than each on its own. | **Procedure, not automatic.** The server states the prepare → verify → stage procedure in its `instructions` on every connection. The host may or may not act on it. |
 | Any other `AGENTS.md`-convention host | **Procedure, not automatic.** `commitlore init --agents-md` writes it into the repository. | **Procedure, not automatic.** Same file, same caveat. |
 
 “Yes” in the Capture column means the workflow is installed and available — the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,6 +89,8 @@ curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/inst
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
 ```
 
+在 Windows 上配置 host 需要 **v1.1.1 或更高版本**。在此之前，检测看不到 `.cmd` shim，安装器也无法运行它，因此 Windows 安装只放下 CLI 而不配置任何 host —— 报告为 `ok: false`，而不是成功。已在 1.1.1 上于真实机器验证 Codex、Gemini CLI 与 Hermes。
+
 **Hermes** — 安装 CLI 后，配置它的 host integration：
 
 ```bash
@@ -171,7 +173,7 @@ mode 的 `[directive]` 仅表示仓库决定将该字符串视为约束，并不
 | Claude Code | **有——通过 plugin 自动完成。** | **有——通过 plugin 提供。** |
 | Codex | **有——通过 plugin 自动完成。** | **有——通过 plugin 提供。** |
 | Hermes | **有——`commitlore hermes install`。** | **有——`commitlore hermes install`。** |
-| Gemini CLI、Cursor、Windsurf、opencode | **是 —— `install.sh` 会配置 MCP server。** | **是 procedure，不自动。** server 在每次连接时说明 prepare → verify → stage 流程。host 可能遵循，也可能不遵循。 |
+| Gemini CLI、Cursor、Windsurf、opencode | **是 —— 两个安装器都会配置 MCP server。** 它们并非各自实现，而是走同一个共享步骤。 | **是 procedure，不自动。** server 在每次连接时说明 prepare → verify → stage 流程。host 可能遵循，也可能不遵循。 |
 | 其他遵循 `AGENTS.md` convention 的 host | **是 procedure，不自动。** `commitlore init --agents-md` 会写入 repository。 | **是 procedure，不自动。** 同一个文件，同样的前提。 |
 
 “有”只表示该 layer 已安装，不表示每次 commit 都会得到 record。绝大多数 commit


### PR DESCRIPTION
All four READMEs said the MCP server is wired by `install.sh`. A Windows reader takes that row as not applying to them — and since #691 it is inaccurate for everyone: neither installer wires anything itself, both call one shared command. The row now names both installers and the shared step.

Each README also gains the version the wiring works from. Before 1.1.1 a Windows install placed the CLI and wired **nothing** — detection could not see a `.cmd` shim and the installer could not run one. The installer reported that honestly (`ok: false`, per-host `failed`, no config touched), but someone upgrading from 1.0.x cannot know their earlier install left them with zero hosts unless the README says which version changed it.

The claim is scoped to what was observed: Codex, Gemini CLI and Hermes on one real machine at 1.1.1. `claude-code` is still `notDetected` there with its config present, and the READMEs do not promise otherwise.

38 cases in `test/readme.test.ts` pass across all four files. Version pins untouched — those came from the 1.1.1 release commit.