### PR TITLE
Let a fork's records survive their own squash (#723)

### DIFF
--- a/.github/workflows/demo-preserve.yml
+++ b/.github/workflows/demo-preserve.yml
@@ -9,8 +9,26 @@ name: Demo — squash inheritance
 # Separate from ci.yml and demo-lint.yml on purpose: this job is the only one
 # in the repository that needs `contents: write`, and neither of those must
 # inherit it.
+#
+# `pull_request_target`, not `pull_request`, and the difference is the whole
+# point: a pull request from a fork gets a read-only token on the
+# `pull_request` event, so this job built the note correctly and then failed to
+# publish it. #720's four records were lost that way and had to be recovered by
+# hand. `contents: write` above cannot grant what the event does not carry.
+#
+# The known danger of `pull_request_target` is that it runs with a writable
+# token against a fork's content. This job does not touch that content as code
+# and never has: the checkout below is the **base** branch, `npm ci` and the
+# build run on the base tree, and the fork's commits arrive only as
+# `refs/commitlore/pr-head`, read for their trailer blocks. Data, not scripts.
+#
+# So the two rules that keep this safe, for whoever edits it next: never check
+# out the pull request's head here, and never execute anything reachable from
+# `refs/commitlore/pr-head` -- no script, no config, no `npm` lifecycle from
+# that tree. Either one turns this into the vulnerability the event is famous
+# for.
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:

--- a/test/action-preserve.test.ts
+++ b/test/action-preserve.test.ts
@@ -654,12 +654,19 @@ describe('action.yml', () => {
   it('is dogfooded by a workflow that parses and does not touch CI', () => {
     const demoText = readFileSync(DEMO_WORKFLOW, 'utf8');
     const demo = load(demoText) as {
-      on: { pull_request: { types: string[] } };
+      on: { pull_request?: { types: string[] }; pull_request_target?: { types: string[] } };
       permissions: Record<string, string>;
       jobs: Record<string, { if?: string; steps: ActionStep[] }>;
     };
 
-    expect(demo.on.pull_request.types).toEqual(['closed']);
+    // The event moved to `pull_request_target` in #723 because the plain event
+    // hands a fork's workflow a read-only token, so the note was built and then
+    // discarded. What this case is about is unchanged either way: the job fires
+    // on the closed event and nothing else. Which key carries that is asserted
+    // in `test/preserve-workflow-safety.test.ts`, along with the two rules that
+    // keep the stronger event safe.
+    const trigger = demo.on.pull_request_target ?? demo.on.pull_request;
+    expect(trigger?.types).toEqual(['closed']);
     expect(demo.permissions).toEqual({ contents: 'write' });
     expect(Object.keys(demo.jobs)).toHaveLength(1);
 

--- a/test/preserve-workflow-safety.test.ts
+++ b/test/preserve-workflow-safety.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #723: the squash-inheritance job runs on `pull_request_target`, and that is
+ * only safe because of what it does not do.
+ *
+ * A fork's pull request gets a read-only token on the `pull_request` event, so
+ * the job built its note correctly and then could not publish it — #720's four
+ * records were discarded that way and were recovered by hand. `contents: write`
+ * cannot grant what the event does not carry, so the event had to change.
+ *
+ * `pull_request_target` is the event with the well-known hole: it runs with a
+ * writable token, and checking out the fork's head under it hands an attacker
+ * that token. This job never does. It checks out the base branch, builds from
+ * the base tree, and fetches the fork's commits only as `refs/commitlore/pr-head`
+ * to read their trailer blocks — data, not scripts.
+ *
+ * That distinction is currently a comment, and a comment is a request. These
+ * assertions are what makes it a constraint: an edit that checks out the head
+ * or runs anything from that ref fails here rather than at the next fork
+ * pull request.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'demo-preserve.yml');
+
+const source = (): string => readFileSync(WORKFLOW, 'utf8');
+
+/** The file with comment lines removed — what the runner actually acts on. */
+const directives = (): string =>
+  source()
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+
+describe('#723 the preserve job can publish from a fork', () => {
+  it('triggers on pull_request_target, which is the event that carries a writable token', () => {
+    // With `pull_request` a fork's records are built and then dropped, which is
+    // the defect: silent to every required check, because this job is not one.
+    expect(directives()).toMatch(/^on:\s*\n\s*pull_request_target:/m);
+    expect(directives(), 'the plain event cannot publish from a fork').not.toMatch(
+      /^\s*pull_request:\s*$/m,
+    );
+  });
+
+  it('still asks for contents: write, which the event now actually grants', () => {
+    expect(directives()).toMatch(/permissions:\s*\n\s*contents:\s*write/);
+  });
+});
+
+describe('#723 and it is safe only because it never runs the fork', () => {
+  it('checks out the base branch, never the pull request head', () => {
+    const text = directives();
+
+    expect(text, 'the checkout must name the base branch').toMatch(
+      /ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.ref\s*\}\}/,
+    );
+    for (const forbidden of [
+      'github.event.pull_request.head.sha',
+      'github.event.pull_request.head.ref',
+      'refs/pull/${{ github.event.pull_request.number }}/merge',
+    ]) {
+      expect(
+        text,
+        `checking out ${forbidden} under pull_request_target hands a fork the write token`,
+      ).not.toContain(`ref: ${forbidden}`);
+    }
+  });
+
+  it('treats the fork\'s commits as data: fetched into a ref, never checked out or run', () => {
+    // Shell continuations split one command over several lines, so the check
+    // is per command rather than per line -- otherwise the refspec looks like
+    // a bare mention of the ref and this passes for the wrong reason.
+    const commands = directives().replace(/\\\n\s*/g, ' ').split('\n');
+    const mentions = commands.filter((line) => line.includes('refs/commitlore/pr-head'));
+
+    expect(mentions.length, 'the fork ref should appear where it is fetched').toBeGreaterThan(0);
+    for (const command of mentions) {
+      expect(command, `${command.trim()} does more than fetch the fork ref`).toMatch(/git fetch/);
+    }
+  });
+
+  it('never checks out or resets onto the fork ref', () => {
+    const text = directives();
+    for (const pattern of [/git\s+checkout[^\n]*pr-head/, /git\s+reset[^\n]*pr-head/, /git\s+merge[^\n]*pr-head/]) {
+      expect(text, 'the fork ref must not become the working tree').not.toMatch(pattern);
+    }
+  });
+
+  it('runs its build before the fork ref exists in the checkout, not from it', () => {
+    // `npm ci` resolves lifecycle scripts from whatever tree is checked out.
+    // With the base checked out that is this repository's own package.json;
+    // it must never be a fork's.
+    const text = directives();
+    expect(text).toMatch(/run:\s*npm ci/);
+    expect(text, 'no install or build may name the fork ref').not.toMatch(
+      /npm (ci|install|run)[^\n]*pr-head/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #723.

`preserve` ran on `pull_request`, which hands a fork's workflow a **read-only token**. The job read the branch's commits, built the inherited note correctly, and could not publish it:

```
merge-type=squash  records=4  pushed=false
→ the record was attached on the runner and is about to be discarded with it
```

That is what happened to #720 — four records lost at the merge, recovered by hand afterwards, in the repository whose whole claim is that records survive a squash. `contents: write` was already declared; it cannot grant what the event does not carry.

## Why `pull_request_target` is safe *here*

That event is better known for handing an attacker a write token, and the mechanism is specific: it checks out the base by default, and the hole opens when a workflow points the checkout at the fork's head and then runs it.

**This job never has.** It checks out `base.ref` — for an unrelated reason, because `refs/pull/<n>/merge` is gone once the PR closes — installs and builds from that tree, and brings the fork's commits in as `refs/commitlore/pr-head`, read for trailer blocks and nothing else. Data, never scripts.

The change is one line. What makes it safe was already true.

## Being already true is not staying true

So the two rules are asserted rather than requested. `test/preserve-workflow-safety.test.ts` reads the workflow with comment lines stripped — a comment cannot satisfy it — and requires that the checkout names the base branch and that every command mentioning the fork ref is a `git fetch`.

| mutation | fails |
|---|---|
| revert the trigger to `pull_request` | the trigger case |
| `ref: github.event.pull_request.head.sha` | the base-branch case |
| `git checkout refs/commitlore/pr-head -- . && npm ci` | three, incl. *every mention is a fetch* |

## What this does not do

It runs on **close**, so it publishes rather than gates: a merge that cannot carry its records still happens first, and the report is the only thing standing there. Making `preserve` a required check cannot fix that — the close event is after the merge by construction.