### PR TITLE
Plant a host in Windows CI so the wiring branch actually runs (#722)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,16 +632,25 @@ jobs:
           Set-Content -LiteralPath (Join-Path $fixtureBin 'cursor.cmd') -Value "@echo off`r`nexit /b 0`r`n"
           $env:PATH = "$fixtureBin;$env:PATH"
 
+          # The exit code is part of what is being tested: `install.ps1` returns
+          # this command's status, so a host that failed has to make it non-zero
+          # or an install reports success over a repository with nothing wired.
+          # It is also why this step ends with an explicit `exit 0` -- GitHub's
+          # pwsh shell exits with the last native command's code, and the second
+          # case deliberately produces a failing one.
           function Enumerate([string] $stateHome) {
             New-Item -ItemType Directory -Force -Path $stateHome | Out-Null
             $raw = (& $shim installer-hosts --wrapper $shim --data-root (Join-Path $stateHome 'data') --home $stateHome --json) -join "`n"
+            $code = $LASTEXITCODE
             Write-Host $raw
-            return ($raw | ConvertFrom-Json)
+            return [pscustomobject]@{ summary = ($raw | ConvertFrom-Json); code = $code }
           }
 
           # 1. A detected host with no config yet: written, then live-verified
           #    through a real MCP initialize against the wrapper.
-          $ok = Enumerate (Join-Path $env:RUNNER_TEMP 'cl-host-ok')
+          $okRun = Enumerate (Join-Path $env:RUNNER_TEMP 'cl-host-ok')
+          $ok = $okRun.summary
+          if ($okRun.code -ne 0) { throw "a wired host exited $($okRun.code), want 0" }
           $cursor = $ok.hosts | Where-Object { $_.host -eq 'cursor' }
           if (-not $cursor) { throw 'cursor was not detected — the planted shim did not reach detection' }
           # A `MCP initialize timed out` here is #729's symptom on a runner, not a
@@ -663,7 +672,9 @@ jobs:
           # -NoNewline so the byte comparison below is against what was written,
           # not against Set-Content's trailing newline.
           Set-Content -LiteralPath (Join-Path $badHome '.cursor\mcp.json') -Value '{ not json' -NoNewline
-          $bad = Enumerate $badHome
+          $badRun = Enumerate $badHome
+          $bad = $badRun.summary
+          if ($badRun.code -eq 0) { throw 'a failed host exited 0 — install.ps1 would report success over nothing wired' }
           $cursorBad = $bad.hosts | Where-Object { $_.host -eq 'cursor' }
           if (-not $cursorBad) { throw 'cursor was not detected in the failing case' }
           if ($cursorBad.outcome -ne 'failed') { throw "a broken config reported $($cursorBad.outcome), want failed" }
@@ -676,6 +687,9 @@ jobs:
           }
 
           Write-Host 'planted host: wired when usable, failed when not, config untouched on failure'
+          # Every assertion above throws under $ErrorActionPreference = 'Stop',
+          # so reaching this line means they all held.
+          exit 0
 
       # The documented piped form, under PowerShell 7. `iex` gives a piped script
       # no arguments, so the version arrives through COMMITLORE_VERSION -- which is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -603,6 +603,80 @@ jobs:
           & $shim --help > $null
           if ($LASTEXITCODE -ne 0) { throw "--help exited $LASTEXITCODE" }
 
+      # #722. Every other assertion about host wiring on this runner is vacuous:
+      # a GitHub runner has no coding agents, so detection short-circuits and the
+      # summary is `"hosts":[]` on every run. An assertion reading that list
+      # passes whether the wiring code works, is broken, or has been deleted --
+      # which is why #714 had to exist as a standing record and why both Windows
+      # defects in #716 were found by a person on a real machine instead.
+      #
+      # A planted `cursor.cmd` removes the vacancy. Detection looks for the
+      # command on PATH; nothing here executes Cursor, because Cursor plays no
+      # part in wiring -- what gets written is its config and what gets probed
+      # is CommitLore's own wrapper. So the fixture is a file, and the branch it
+      # unlocks is the real one.
+      #
+      # Two cases, and the second is what makes the first mean anything. A
+      # fixture that can only succeed proves the installer reports what the
+      # fixture told it, which is the empty runner again with more steps.
+      - name: A planted host is wired, and a broken one is reported failed
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $shim = Join-Path $env:LOCALAPPDATA 'commitlore\bin\commitlore.cmd'
+
+          $fixtureBin = Join-Path $env:RUNNER_TEMP 'commitlore-host-fixture'
+          New-Item -ItemType Directory -Force -Path $fixtureBin | Out-Null
+          # Extensionless on purpose as well: PATHEXT is what #716's second cause
+          # could not consult, so the fixture is only findable if it is honoured.
+          Set-Content -LiteralPath (Join-Path $fixtureBin 'cursor.cmd') -Value "@echo off`r`nexit /b 0`r`n"
+          $env:PATH = "$fixtureBin;$env:PATH"
+
+          function Enumerate([string] $stateHome) {
+            New-Item -ItemType Directory -Force -Path $stateHome | Out-Null
+            $raw = (& $shim installer-hosts --wrapper $shim --data-root (Join-Path $stateHome 'data') --home $stateHome --json) -join "`n"
+            Write-Host $raw
+            return ($raw | ConvertFrom-Json)
+          }
+
+          # 1. A detected host with no config yet: written, then live-verified
+          #    through a real MCP initialize against the wrapper.
+          $ok = Enumerate (Join-Path $env:RUNNER_TEMP 'cl-host-ok')
+          $cursor = $ok.hosts | Where-Object { $_.host -eq 'cursor' }
+          if (-not $cursor) { throw 'cursor was not detected — the planted shim did not reach detection' }
+          # A `MCP initialize timed out` here is #729's symptom on a runner, not a
+          # loose assertion. Do not weaken this to make it pass -- an outcome that
+          # accepts a failed probe is the vacancy this whole step exists to remove.
+          if ($cursor.outcome -ne 'installed') { throw "cursor outcome $($cursor.outcome), want installed: $($cursor.detail)" }
+          if (-not $cursor.healthy) { throw "cursor is not healthy: $($cursor.detail)" }
+          if ($ok.notDetected -contains 'cursor') { throw 'cursor is in both hosts and notDetected' }
+          $written = Join-Path (Join-Path $env:RUNNER_TEMP 'cl-host-ok') '.cursor\mcp.json'
+          if (-not (Test-Path -LiteralPath $written)) { throw "no config at $written" }
+          if (-not ((Get-Content -LiteralPath $written -Raw | ConvertFrom-Json).mcpServers.commitlore)) {
+            throw 'the config carries no commitlore registration'
+          }
+
+          # 2. The same host, with a config it cannot use. This must fail, and
+          #    the summary must say so rather than rounding up.
+          $badHome = Join-Path $env:RUNNER_TEMP 'cl-host-bad'
+          New-Item -ItemType Directory -Force -Path (Join-Path $badHome '.cursor') | Out-Null
+          # -NoNewline so the byte comparison below is against what was written,
+          # not against Set-Content's trailing newline.
+          Set-Content -LiteralPath (Join-Path $badHome '.cursor\mcp.json') -Value '{ not json' -NoNewline
+          $bad = Enumerate $badHome
+          $cursorBad = $bad.hosts | Where-Object { $_.host -eq 'cursor' }
+          if (-not $cursorBad) { throw 'cursor was not detected in the failing case' }
+          if ($cursorBad.outcome -ne 'failed') { throw "a broken config reported $($cursorBad.outcome), want failed" }
+          if ($cursorBad.healthy) { throw 'a broken config was reported healthy' }
+          if ($bad.ok) { throw 'ok stayed true while a requested host failed' }
+          # #716: the reason has to name the file it was about.
+          if ($cursorBad.detail -notmatch 'mcp\.json') { throw "the failure does not name its file: $($cursorBad.detail)" }
+          if ((Get-Content -LiteralPath (Join-Path $badHome '.cursor\mcp.json') -Raw) -ne '{ not json') {
+            throw 'a config that could not be used was modified anyway'
+          }
+
+          Write-Host 'planted host: wired when usable, failed when not, config untouched on failure'
+
       # The documented piped form, under PowerShell 7. `iex` gives a piped script
       # no arguments, so the version arrives through COMMITLORE_VERSION -- which is
       # why that variable exists. This step is also the only check that a leading

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,7 +40,7 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = '87f33a8cea5b04369e118f68d64798f46dcf7dd7d549af374c5ee29b89c9352e';
+export const EXPECTED_CI_WORKFLOW_SHA256 = '89b92db6ac4d1fa33d5d856ff8bd94b32cac65bb19a99ab03a690961b637e679';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,7 +40,7 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = '89b92db6ac4d1fa33d5d856ff8bd94b32cac65bb19a99ab03a690961b637e679';
+export const EXPECTED_CI_WORKFLOW_SHA256 = '2d33e8811f8ab845939cf6c265343e51e2866c0013650a062cb0d40f9bd37205';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore


### PR DESCRIPTION
Closes #722.

A GitHub runner has no coding agents, so detection short-circuits and the Windows job has printed `"hosts":[]` on **every run it has ever made**. Every branch that wires a host is unexecuted there — not under-tested, unreachable — and an assertion reading that list passes whether the wiring code works, is broken, or has been deleted.

That vacancy is why #714 existed as a standing record, and why both Windows defects in #716 were found by a person on a real machine rather than by any job here.

## What changes

A planted `cursor.cmd` on `PATH`. Detection looks for the command; **nothing executes Cursor** — Cursor plays no part in wiring, since what gets written is its config and what gets probed is CommitLore's own wrapper. So the fixture is a file, and the branch it unlocks is the real one: detection → atomic config write → live MCP `initialize`.

## Two cases, and the second is the point

| case | asserts |
|---|---|
| detected host, no config yet | `outcome: installed`, `healthy`, not in `notDetected`, and the registration present in `.cursor/mcp.json` afterwards |
| same host, unparseable config | `outcome: failed`, `ok: false`, **the file named in the reason** (#716), and the config byte-identical afterwards |

A fixture that can only succeed proves the installer reports what the fixture told it — the empty runner again with more steps. The failing case is what makes the passing one mean anything.

## Notes for review

- `EXPECTED_CI_WORKFLOW_SHA256` is re-locked to the edited file. That digest is what stops a workflow body changing unreviewed, so it moves deliberately with the job contract; 29 release-prerequisite cases pass against it.
- **This step has never run.** It needs `windows-latest`, which is the whole point, so its first execution is this PR's own `install-ps1` job.
- If the live probe times out there, that is #729's symptom on a runner — not a reason to loosen the assertion. A comment in the step says so.

## Scope

One host of seven, on one platform. `gemini-cli`, `windsurf` and `opencode` take the same JSON path and are not planted; `codex`, `hermes` and `claude-code` take different ones and are not covered.

The suggestion and its framing — *so this class can't hide behind an empty runner again* — came from kantorcodes1 in a public discussion, and it is a better answer than the one I was giving.