### PR TITLE
Let installer fixtures express executable modes (#716)

### DIFF
--- a/test/installer-hosts.test.ts
+++ b/test/installer-hosts.test.ts
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { resolveCommand } from '../src/commands/installer-hosts.js';
+
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const ENTRY = join(ROOT, 'dist', 'commitlore.mjs');
@@ -26,14 +28,14 @@ interface Run {
   summary: { schema: string; runtimeIdentity: { version: string; entrypoint: string; packageRoot: string; indexSchemaVersion: number }; ok: boolean; hosts: Array<{ host: string; outcome: string; healthy: boolean }> };
 }
 
-const wrapper = (root: string, name = 'commitlore'): string => {
+const wrapper = (root: string, name = 'commitlore', mode = 0o755): string => {
   const isWindows = process.platform === 'win32';
   const path = join(root, 'bin', `${name}${isWindows ? '.cmd' : ''}`);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, isWindows
     ? `@echo off\r\n"${process.execPath}" "${ENTRY}" %*\r\n`
     : `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(ENTRY)} "$@"\n`);
-  if (!isWindows) chmodSync(path, 0o755);
+  if (!isWindows) chmodSync(path, mode);
   return path;
 };
 
@@ -150,6 +152,31 @@ describe('installer-hosts accepts only live CommitLore registrations', () => {
     expect(result.status).toBe(0);
     expect(result.summary.hosts).toContainEqual(expect.objectContaining({ host: 'cursor', outcome: 'custom-preserved', healthy: true }));
     expect(readFileSync(config, 'utf8')).toBe(before);
+  });
+});
+
+describe('#716 executable search fixtures', () => {
+  it.runIf(process.platform !== 'win32')('skips a non-executable command shadow earlier on PATH', () => {
+    // Given
+    const shadowRoot = temporary();
+    const executableRoot = temporary();
+    const shadow = wrapper(shadowRoot, 'claude', 0o644);
+    const executable = wrapper(executableRoot, 'claude', 0o755);
+    const previousPath = process.env['PATH'];
+    process.env['PATH'] = `${dirname(shadow)}${delimiter}${dirname(executable)}`;
+
+    // When
+    const resolved = (() => {
+      try {
+        return resolveCommand('claude');
+      } finally {
+        if (previousPath === undefined) delete process.env['PATH'];
+        else process.env['PATH'] = previousPath;
+      }
+    })();
+
+    // Then
+    expect(resolved).toEqual({ path: executable, usesCommandInterpreter: false });
   });
 });
 

--- a/test/installer-windows-command.test.ts
+++ b/test/installer-windows-command.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, join } from 'node:path';
+import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -56,35 +56,6 @@ describe('#716 Windows command resolution', () => {
 
     // Then
     expect(resolved).toEqual({ path: shim, usesCommandInterpreter: true });
-  });
-
-  it.runIf(process.platform !== 'win32')('skips a non-executable command shadow earlier on PATH', () => {
-    // Given
-    const root = temporary();
-    const shadowBin = join(root, 'shadow');
-    const executableBin = join(root, 'executable');
-    const shadow = join(shadowBin, 'claude');
-    const executable = join(executableBin, 'claude');
-    mkdirSync(shadowBin);
-    mkdirSync(executableBin);
-    writeFileSync(shadow, '#!/bin/sh\nexit 1\n');
-    writeFileSync(executable, '#!/bin/sh\nexit 0\n');
-    chmodSync(shadow, 0o644);
-    chmodSync(executable, 0o755);
-    const previousPath = process.env['PATH'];
-    process.env['PATH'] = `${shadowBin}${delimiter}${executableBin}`;
-
-    // When
-    const resolved = (() => {
-      try {
-        return resolveCommand('claude');
-      } finally {
-        restoreEnvironment('PATH', previousPath);
-      }
-    })();
-
-    // Then
-    expect(resolved).toEqual({ path: executable, usesCommandInterpreter: false });
   });
 
   it('uses the same resolver for a concrete batch wrapper path', () => {


### PR DESCRIPTION
Relays #725 so it can merge. **The change and its authorship are @plutoparty1's**; the only thing added here is a merge from `main`.

#725 sits on a fork, and after #730 landed, `main` carries a change to `.github/workflows/demo-preserve.yml`. Branch protection requires up-to-date before merge, and every route this token has to update a fork branch is refused:

```
refusing to allow an OAuth App to create or update workflow
`.github/workflows/demo-preserve.yml` without `workflow` scope
```

That is GitHub protecting workflow files from a token that was not granted the scope — correct behaviour, and not something to route around. Pushing the same branch to this repository is allowed, so it goes through here instead.

## The change

`wrapper()` in `test/installer-hosts.test.ts` hard-coded `chmodSync(path, 0o755)`, so **no fixture in that suite could be non-executable** — meaning no defect involving executability could be caught there at all. The missing `X_OK` in #720 was the instance that happened to land, not the last one that could.

It now takes a mode, and the mode-0644 shadow assertion moves beside the helper instead of being hand-built in another file. The duplicate is removed.

## Verification

`artifact:verify` → `14ff6168…`, unchanged by the merge: the canonical source inputs are `package-lock.json`, `package.json`, `tsconfig.json` and `src`, and this touches only `test/`. No rebuild was required.

#725 will be closed pointing here once this merges.