### PR TITLE
Guard the detection decision that only a comment was holding (#722)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,6 +691,86 @@ jobs:
           # so reaching this line means they all held.
           exit 0
 
+      # The planted host above covers the JSON path. The three hosts where real
+      # defects actually landed take different ones, and none of them executes
+      # here: codex reached `codex mcp add failed` (#716 cause 2), and
+      # claude-code came back `notDetected` with its config on disk, which #728
+      # resolved as the rule working rather than a bug.
+      #
+      # That resolution is currently held by a comment. Nothing fails if someone
+      # gives claude-code a config-directory fallback "for symmetry" -- and the
+      # installer would then report `failed` with `ok: false` on any machine
+      # carrying a leftover `.claude.json`, which is the false failure #728
+      # refused. This is where that decision gets enforced.
+      - name: Detection reaches the CLI-driven hosts, and stops where it should
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $shim = Join-Path $env:LOCALAPPDATA 'commitlore\bin\commitlore.cmd'
+
+          function Enumerate([string] $stateHome, [string] $extraBin) {
+            New-Item -ItemType Directory -Force -Path $stateHome | Out-Null
+            $previous = $env:PATH
+            if ($extraBin) { $env:PATH = "$extraBin;$env:PATH" }
+            try {
+              $raw = (& $shim installer-hosts --wrapper $shim --data-root (Join-Path $stateHome 'data') --home $stateHome --json) -join "`n"
+            } finally { $env:PATH = $previous }
+            Write-Host $raw
+            return ($raw | ConvertFrom-Json)
+          }
+
+          function PlantShim([string] $name) {
+            $bin = Join-Path $env:RUNNER_TEMP "cl-bin-$name"
+            New-Item -ItemType Directory -Force -Path $bin | Out-Null
+            # Exits 0 for anything. Enough to prove the branch was reached and
+            # the shim was executed -- not that the real host would agree.
+            Set-Content -LiteralPath (Join-Path $bin "$name.cmd") -Value "@echo off`r`nexit /b 0`r`n"
+            return $bin
+          }
+
+          # 1. #728, the case with nothing else guarding it. A leftover config
+          #    and no executable must stay notDetected. A config-directory
+          #    fallback added here would fail this.
+          $leftover = Join-Path $env:RUNNER_TEMP 'cl-claude-leftover'
+          New-Item -ItemType Directory -Force -Path $leftover | Out-Null
+          Set-Content -LiteralPath (Join-Path $leftover '.claude.json') -Value '{}' -NoNewline
+          New-Item -ItemType Directory -Force -Path (Join-Path $leftover '.claude') | Out-Null
+          $left = Enumerate $leftover ''
+          if ($left.notDetected -notcontains 'claude-code') {
+            throw 'a leftover .claude.json made claude-code detected — #728 says an executable check is what ignores it'
+          }
+          if ($left.hosts | Where-Object { $_.host -eq 'claude-code' }) {
+            throw 'claude-code appears in hosts with no claude executable present'
+          }
+
+          # 2. The other half: with the executable there, PATHEXT must find it
+          #    and the branch must run. #716 cause 2 was that it could not.
+          $withClaude = Enumerate (Join-Path $env:RUNNER_TEMP 'cl-claude-present') (PlantShim 'claude')
+          if ($withClaude.notDetected -contains 'claude-code') {
+            throw 'claude.cmd is on PATH and claude-code was still notDetected — PATHEXT is not being consulted'
+          }
+          if (-not ($withClaude.hosts | Where-Object { $_.host -eq 'claude-code' })) {
+            throw 'claude-code is in neither hosts nor notDetected — it was dropped'
+          }
+
+          # 3. codex takes the CLI path, which is what `codex mcp add failed`
+          #    was. A shim that runs at all is enough to prove it is reached.
+          $withCodex = Enumerate (Join-Path $env:RUNNER_TEMP 'cl-codex-present') (PlantShim 'codex')
+          if ($withCodex.notDetected -contains 'codex') {
+            throw 'codex.cmd is on PATH and codex was still notDetected'
+          }
+          if (-not ($withCodex.hosts | Where-Object { $_.host -eq 'codex' })) {
+            throw 'codex is in neither hosts nor notDetected — it was dropped'
+          }
+
+          # Hermes is deliberately not planted. Its wiring runs our own wrapper
+          # rather than a hermes binary, so a shim proves nothing about it, and
+          # driving the real `commitlore hermes install` here would test Hermes
+          # rather than this enumeration. Its trailing-backslash argument path
+          # is covered by unit cases instead.
+          Write-Host 'claude-code: ignored a leftover config, found a planted shim; codex: reached its CLI path'
+          exit 0
+
       # The documented piped form, under PowerShell 7. `iex` gives a piped script
       # no arguments, so the version arrives through COMMITLORE_VERSION -- which is
       # why that variable exists. This step is also the only check that a leading

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,7 +40,7 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = '2d33e8811f8ab845939cf6c265343e51e2866c0013650a062cb0d40f9bd37205';
+export const EXPECTED_CI_WORKFLOW_SHA256 = 'f84cd550b55320c433cf53656b27eeb38f906f040795a39862c09f32b47bb4e5';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore


### PR DESCRIPTION
Extends the planted-host fixture to the two branches where real defects landed.

The first fixture covers the **JSON path** — the one where nothing ever broke. The hosts that actually failed on a real Windows machine take different paths, and neither executed in CI:

- **codex** reached `codex mcp add failed` (#716 cause 2)
- **claude-code** came back `notDetected` with `.claude.json` on disk

## Why claude-code is the important one

#728 resolved that as **the rule working**, not a bug: detection asks what the wiring operation needs, and claude-code's wiring runs the host's own CLI, so a leftover config is exactly what an executable check exists to ignore.

**That resolution is currently held by a comment.** Nothing fails if someone adds a config-directory fallback there for symmetry — and the installer would then report `failed` with `ok: false` on any machine carrying a leftover `.claude.json`. That is the false *failure* #728 refused, and it would ship green.

## Three cases, each tied to something that happened

| fixture | must |
|---|---|
| leftover `.claude.json`, no executable | stay `notDetected` |
| `claude.cmd` on `PATH` | be found, and its branch run |
| `codex.cmd` on `PATH` | reach the CLI path |

The last two are the same `PATHEXT` question #716's cause 2 answered wrongly, asked on the branches the first fixture does not touch.

## Not planted, on purpose

**Hermes.** Its wiring runs our own wrapper rather than a hermes binary, so a shim proves nothing about it, and driving the real `commitlore hermes install` here would test Hermes instead of this enumeration. Its trailing-backslash argument path is covered by unit cases.

**gemini-cli, windsurf, opencode** still rest on the cursor fixture's shape rather than their own rows.

## Notes

A shim that exits 0 for everything proves a branch was **reached**, not that the real host would agree — these are detection assertions, not integration ones.

`EXPECTED_CI_WORKFLOW_SHA256` is re-locked to the edited file; 29 release-prerequisite cases pass. As with the first fixture, **this step has never run** — `windows-latest` is the point — so its first execution is this PR's own `install-ps1` job.