### PR TITLE
Report where `current` points, not what mv returned (#735)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -644,7 +644,30 @@ dest_tmp=""
 # something is reading through it.
 current_link="$data_root/current"
 current_tmp="$current_link.commitlore-install.$$"
-if ln -sfn "$candidate" "$current_tmp" 2>/dev/null && mv -f "$current_tmp" "$current_link" 2>/dev/null; then
+current_now=""
+if ln -sfn "$candidate" "$current_tmp" 2>/dev/null; then
+  # `mv -f` alone is wrong here, and wrong in the way that reports success
+  # (#735). When `current` already exists as a symlink to a directory, BSD mv
+  # follows it and moves the source *into* it -- returning 0 while `current`
+  # never changes. An upgrade then printed "current -> v1.1.1" and left every
+  # hook on the machine running the previous build. A first install creates
+  # the link and is unaffected, which is why it went unseen.
+  #
+  # `-h` is BSD's "do not follow a symlink destination"; GNU mv has no `-h` but
+  # never follows, and states it as `-T`. Try each, then unlink and rename --
+  # which is not atomic, but a reader that resolves during the gap fails
+  # visibly rather than silently using the old build.
+  mv -h "$current_tmp" "$current_link" 2>/dev/null \
+    || mv -T "$current_tmp" "$current_link" 2>/dev/null \
+    || { rm -f "$current_link" 2>/dev/null && mv -f "$current_tmp" "$current_link" 2>/dev/null; } \
+    || true
+  # Report what the link says, not what the command returned. Every mechanism
+  # above can return 0 without moving it, and this line is the only thing an
+  # operator reads before trusting the upgrade.
+  current_now="$(readlink "$current_link" 2>/dev/null || printf '%s' '')"
+fi
+if [ "$current_now" = "$candidate" ]; then
+  rm -f "$current_tmp" 2>/dev/null || true
   log "current -> $(basename "$candidate")"
 else
   rm -f "$current_tmp" 2>/dev/null || true

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -17,7 +17,7 @@
  *     record on this file rejects it.
  */
 import { execFileSync, spawnSync } from 'node:child_process';
-import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, readlinkSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -935,5 +935,64 @@ describe('T-1120 the README describes the installer that ships beside it (req 29
     const forbidden = Object.entries(b).filter(([, body]) => body.includes('SHA256SUMS'));
 
     expect(forbidden.map(([f]) => f)).toEqual([]);
+  });
+});
+
+/**
+ * #735: the installer printed `current -> vX` and left `current` on the
+ * previous version.
+ *
+ * `mv -f` was replacing the symlink. When `current` already exists and points
+ * at a directory, BSD `mv` follows it and moves the source *into* it, returning
+ * 0 — so the success line printed while every hook on the machine kept running
+ * the old build. `commitlore init` records the interpreter as
+ * `<data-root>/current/dist/commitlore.mjs` precisely so hooks follow upgrades,
+ * and this is what made them stop.
+ *
+ * A first install creates the link and cannot hit it, which is why it survived
+ * from 1.0.2 into 1.1.1. So the case has to install twice.
+ */
+describe('#735 an upgrade actually moves `current`', () => {
+  it('repoints an existing symlink rather than reporting that it did', () => {
+    const home = tempDir('upgrade-home');
+    const dataDir = join(home, '.local', 'share', 'commitlore');
+    const current = join(dataDir, 'current');
+
+    // Stand in for a previous release: `current` already exists and points at
+    // a directory, which is the only state that triggers this.
+    const previous = join(dataDir, 'v0.0.1');
+    mkdirSync(join(previous, 'dist'), { recursive: true });
+    symlinkSync(previous, current);
+
+    const run = runInstaller({ home });
+
+    expect(run.status, run.stderr).toBe(0);
+    const target = readlinkSync(current);
+    expect(
+      target,
+      `current still points at ${target} — the installer reported an upgrade it did not perform`,
+    ).not.toBe(previous);
+    expect(target).toContain(TAG);
+
+    // The claim and the filesystem have to agree. Reporting from the exit code
+    // of a command that can succeed without moving anything is the defect.
+    if (run.stdout.includes('current -> ')) {
+      expect(run.stdout).toContain(`current -> ${TAG}`);
+    }
+  });
+
+  it('leaves no stray temporary link behind', () => {
+    const home = tempDir('upgrade-stray-home');
+    const dataDir = join(home, '.local', 'share', 'commitlore');
+    const previous = join(dataDir, 'v0.0.1');
+    mkdirSync(join(previous, 'dist'), { recursive: true });
+    symlinkSync(previous, join(dataDir, 'current'));
+
+    runInstaller({ home });
+
+    // `mv` moved it into the old directory instead of replacing the link, and
+    // it stayed there — the trace that showed where the rename actually went.
+    const strays = readdirSync(previous).filter((entry) => entry.startsWith('current.commitlore-install.'));
+    expect(strays, `a temporary link was left in ${previous}`).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #735.

Upgrading printed `current -> v1.1.1` and left the symlink on v1.0.2. `commitlore init` records the hook interpreter as `<data-root>/current/dist/commitlore.mjs` **precisely so hooks follow upgrades** — so every repository on that machine kept validating commits with the old build while the CLI reported the new one.

## The mechanism

`mv -f` was replacing the symlink. When `current` already exists as a symlink **to a directory**, BSD `mv` follows it and moves the source *into* it — returning 0. The `&&` held, the success line printed, and the temporary link sat inside the old release directory where the rename had actually gone:



A first install creates the link and cannot hit this, which is why it shipped in 1.0.2 and survived into 1.1.1.

## Two changes, and the second is the one that matters

1. The rename uses `-h` (BSD: do not follow a symlink destination) or `-T` (GNU states the same), falling back to unlink-and-rename — not atomic, but a reader resolving in that gap fails **visibly** instead of silently using the old build.
2. **The success line is printed only after reading the link back.** Every mechanism above can return 0 without moving anything, and that line is the only thing an operator reads before trusting the upgrade.

`doctor` already catches the resulting split and names it exactly. What it cannot repair is an operator who has no reason to run it after being told the upgrade succeeded.

## Verification

The tests install **twice**, because a first install cannot reproduce this. Restoring `mv -f` with the exit-code report fails both with the reported symptoms:

| case | on the defect |
|---|---|
| repoints an existing symlink | `current` still on `v0.0.1` |
| leaves no stray temporary link | `current.commitlore-install.68496` found inside `v0.0.1/` — where `mv` had moved it |

`sh -n install.sh` clean; 47 cases in the suite.

Thanks for the diagnosis — the `find` output showing where the temp link ended up is what made the cause unambiguous rather than a guess.