### PR TITLE
Release 1.1.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.1.2
+
+Upgrading no longer reports a version it did not install.
+
+`install.sh` printed `current -> v1.1.1` and left `<data-root>/current`
+pointing at the previous release. `commitlore init` records the hook's
+interpreter as `<data-root>/current/dist/commitlore.mjs` precisely so hooks
+follow upgrades, so every repository on that machine kept validating commits
+with the old build while the CLI reported the new one.
+
+The rename was the mechanism. When `current` already exists as a symlink to a
+directory, BSD `mv` follows it and moves the source *into* it, returning 0 — so
+the `&&` held and the success line printed while the temporary link sat inside
+the old release directory. A first install creates the link and cannot reach
+this, which is why it shipped in 1.0.2 and survived two releases.
+
+Two changes, and the second is the one that matters. The rename now says it
+means rename — `-h` on BSD, `-T` on GNU, falling back to unlink-and-rename,
+which is not atomic but fails visibly rather than silently keeping the old
+build. And the success line is printed only after reading the link back,
+because every mechanism above can return zero without moving anything, and that
+line is the only thing an operator reads before trusting the upgrade.
+
+If you upgraded to 1.1.0 or 1.1.1 on macOS, check it:
+
+```
+readlink "$(commitlore --help >/dev/null 2>&1; echo ~/.local/share/commitlore)/current"
+```
+
+`commitlore doctor` reports the same split in its own words, and re-running the
+installer at 1.1.2 repairs it.
+
+Windows CI now exercises the host-detection branches that only a comment was
+holding. A GitHub runner has no coding agents, so those branches never ran
+there; a planted `claude.cmd` and `codex.cmd` make them run, and a leftover
+`.claude.json` with no executable is required to stay `notDetected` — the rule
+1.1.1 documented and nothing enforced.
+
 ## 1.1.1
 
 Host wiring works on Windows. 1.1.0 said plainly that it did not; this is the

--- a/README.ja.md
+++ b/README.ja.md
@@ -83,13 +83,13 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh | sh -s v1.1.2
 ```
 
 **Windows** — PowerShell で同じインストールを行います:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.ps1))) v1.1.2
 ```
 
 Windows での host 配線には **v1.1.1 以降**が必要です。それ以前は検出が `.cmd` shim を見つけられず、インストーラーもそれを実行できなかったため、Windows へのインストールは CLI を置くだけで何も配線しませんでした — 成功としてではなく `ok: false` として報告されます。1.1.1 で Codex、Gemini CLI、Hermes について実機で確認しました。
@@ -131,11 +131,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh
-sh install.sh v1.1.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh
+sh install.sh v1.1.2
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.1.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.2 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -83,13 +83,13 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록하며, 설정이나 cache
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh | sh -s v1.1.2
 ```
 
 **Windows** — PowerShell에서 같은 설치를 한다:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.ps1))) v1.1.2
 ```
 
 Windows에서 host 배선은 **v1.1.1 이상**이 필요하다. 그 전에는 탐지가 `.cmd` shim을 보지 못하고 설치기가 그것을 실행하지도 못해서, Windows 설치는 CLI만 놓고 아무것도 배선하지 않았다 — 성공이 아니라 `ok: false`로 보고됐다. 1.1.1에서 Codex, Gemini CLI, Hermes에 대해 실기로 확인했다.
@@ -131,11 +131,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh
-sh install.sh v1.1.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh
+sh install.sh v1.1.2
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v1.1.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.2 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Prerequisites for either path: Node.js 22.23.2+ and Git. The script checks both 
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh | sh -s v1.1.2
 ```
 
 **Windows** — the same install, in PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.ps1))) v1.1.2
 ```
 
 Host wiring on Windows requires **v1.1.1 or later**. Before it, detection could not see a `.cmd` shim and the installer could not run one, so a Windows install placed the CLI and wired nothing — reported as `ok: false`, never as success. Verified on a real machine at 1.1.1 for Codex, Gemini CLI and Hermes.
@@ -159,11 +159,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh
-sh install.sh v1.1.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh
+sh install.sh v1.1.2
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.1.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.2 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,13 +80,13 @@ commitlore plugin install-codex
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh | sh -s v1.1.2
 ```
 
 **Windows** — 在 PowerShell 中执行同样的安装：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.ps1))) v1.1.2
 ```
 
 在 Windows 上配置 host 需要 **v1.1.1 或更高版本**。在此之前，检测看不到 `.cmd` shim，安装器也无法运行它，因此 Windows 安装只放下 CLI 而不配置任何 host —— 报告为 `ok: false`，而不是成功。已在 1.1.1 上于真实机器验证 Codex、Gemini CLI 与 Hermes。
@@ -128,11 +128,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh
-sh install.sh v1.1.1
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh
+sh install.sh v1.1.2
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.1.1 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.1.2 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.ps1))) v1.1.1
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.ps1))) v1.1.2
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.1/install.sh | sh -s v1.1.1
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.2/install.sh | sh -s v1.1.2
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "652157c6778590cee959d24764e7d17db80b1a7f86335570bff15c24578ff13e"
+    "sha256": "8befa4a047123f61bdb30470aa907e3fde35102f739c87c86aff15be26925a2d"
   },
   "artifact": {
     "sha256": "60cabca7420d9e687418acd7a6b3e62b792afadc2744edfb39c7af9a7a33335b",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Cuts 1.1.2.

## Upgrading no longer reports a version it did not install

`install.sh` printed `current -> v1.1.1` and left `<data-root>/current` on the previous release. `commitlore init` records the hook interpreter as `<data-root>/current/dist/commitlore.mjs` **precisely so hooks follow upgrades** — so every repository on that machine kept validating commits with the old build while the CLI reported the new one.

BSD `mv` follows a destination that is a symlink to a directory and moves the source into it, returning zero. The `&&` held and the success line printed. A first install creates the link and cannot reach this, which is why it shipped in 1.0.2 and survived two releases — **the reproduction needs two installs, and the tests now do that.**

The rename says it means rename (`-h` / `-T`, falling back to unlink-and-rename), and **the success line is printed only after reading the link back.** That second half is the one that matters: every mechanism available here can return zero without moving anything.

The note tells an upgraded user how to check whether they are affected, because this is the kind of state that stays silently wrong.

## Also in

Windows CI now exercises the host-detection branches that only a comment was holding (#722, #734). A planted `claude.cmd` and `codex.cmd` make them run, and a leftover `.claude.json` with no executable is required to stay `notDetected` — the rule 1.1.1 documented and nothing enforced.

## Version surfaces

All twenty-one, asserted before pushing. The four README sentences saying host wiring needs **1.1.1 or later** deliberately do **not** move — they name the release that fixed it, and rounding them forward would make four files claim something false. Confirmed by reading them, not by trusting the script.

`dist/commitlore.mjs` is unchanged; `installer/canonical-artifact.json` moves because `package.json` is one of its four source inputs.

104 cases across `manifest`, `readme`, `check-release-version` and `release-publish-prerequisites`. `artifact:verify` → `60cabca7…`.