### PR TITLE
Specify #719 so the next person starts from the question, not the symptom

### DIFF
--- a/docs/prd/PRD-F15-canonical-artifact-provenance.md
+++ b/docs/prd/PRD-F15-canonical-artifact-provenance.md
@@ -1,0 +1,137 @@
+# PRD F15 — Who is entitled to publish the bytes (#719)
+
+- ADR: 0011 (distribution is a git clone), 0021 §7 is unrelated and must not be cited here
+- Issue: [#719](https://github.com/MongLong0214/commitlore/issues/719)
+- Status: **specified, not scheduled.** The credentials exist; the design problem in
+  "The unsolved question" below does not have an answer yet, and this document does not
+  invent one.
+
+## What this is about, and what it is not
+
+`dist/commitlore.mjs` is committed. The `check` job rebuilds it twice in
+`docker linux/amd64 node:24-bookworm`, compares the two builds to each other, verifies
+both against `installer/canonical-artifact.json`, and then runs
+`git diff --exit-code -- dist/ installer/canonical-artifact.json`.
+
+That last line is easy to read as a formality and is not. `build:canonical` **overwrites
+the worktree**, and every step after it splits into two trees:
+
+| step | runs against |
+|---|---|
+| `node dist/cli.js validate` / `doctor` | the **rebuilt** tree |
+| `git clone --depth 1 "file://$PWD"` — the ADR-0011 test | **HEAD**, the committed bundle |
+| `audit` | the committed bundle, copied, not rebuilt |
+| `install-script` / `install-ps1` / `install-macos` / `install-alpine` | tag the checkout, clone the tag — the committed bundle |
+
+`git diff --exit-code -- dist/` is the only thing making those two trees the same bytes.
+
+So the subject is not merge conflicts. It is **which commit is entitled to be the
+product**, in a repository whose first-class install is a git clone of the checkout
+(ADR-0011). The conflict cost is what that entitlement is currently bought with.
+
+## Goal
+
+Remove the cost of carrying `dist/` in every pull request **without** separating two
+claims that are currently one:
+
+1. this source builds deterministically on `linux/amd64`; and
+2. this checkout **is** the plugin.
+
+## Non-goals
+
+- **Removing the committed bundle.** Not a preference — ADR-0011 already decided it, and
+  rejected the alternative by name: *"Do not commit `dist/` + require a source build |
+  requiring a toolchain during installation breaks the 'one clone and done' promise."*
+  Its opening line is *"Distribution is git clone. Do not use a registry."* Any proposal
+  that starts by removing `dist/` is reopening ADR-0011, which is a different document
+  from this one.
+- Weakening `artifact:verify`. It answers "does the committed manifest describe the
+  committed bundle", and nothing else answers that.
+- Moving the guarantee to the tag gate alone. The tag gate cannot rejoin claims 1 and 2
+  if the PR-level evidence for 2 was never gathered — see "Rejected" below.
+- Any change to what `install.sh` / `install.ps1` fetch. Users still clone a tag.
+- Speeding up the canonical build itself. This is about how many times it must run, not
+  how long one run takes.
+
+## The measured cost
+
+Recorded on 2026-08-17, a day with three releases:
+
+- **Four rebuild cycles** across overlapping source pull requests. `.gitattributes` marks
+  `dist/**` as `-diff -merge`, so git does not attempt a text merge at all — every second
+  pull request must rebuild, at roughly one Docker build plus one 20–32 minute CI cycle.
+- **`Verified:` digests go stale.** Two commit records merged that day carry artifact
+  digests that do not match the merged tree. Both are true of their own commit; a reader
+  who does not know that reads it as drift.
+- **A contributor could not finish their own work.** #720 arrived from a Windows machine
+  with `src/` and `test/` only — correctly, because a Windows host cannot produce a
+  `linux/amd64` Docker build — and waited on a maintainer twice.
+
+The third is the one that changes the threshold. A cost measured in CI minutes is an
+annoyance. A cost measured in *which contributors can complete a change* is not.
+
+## Rejected, with reasons
+
+| proposal | why not |
+|---|---|
+| Drop `git diff --exit-code -- dist/` from the PR path, keep it on push and tags | decouples claims 1 and 2. The clone, audit and install jobs would go on validating the previous bundle, so a change breaking self-containment or a plugin entry point would never be executed by the job ADR-0011 exists to satisfy |
+| Upload `dist/` as a PR artifact and apply it on push | two source pull requests merging in sequence apply the wrong tree: PR-B's artifact was built from `main+B`, not `main+A+B` |
+| A merge queue | serialises without inserting a rebuild into the merge commit; a required check demanding a matching `dist/` fails queued commits forever |
+| A `.gitattributes` merge driver that picks a side | resolves the conflict by discarding the property |
+| CI rebuilds `dist/` and pushes it to the pull request branch | keeps both claims and frees same-repository contributors, but does not remove the conflict, and a `pull_request` token cannot push to a fork — the case that actually hurt |
+
+## The direction
+
+**A privileged merge.** A GitHub App merges the source, runs `build:canonical` and
+`artifact:manifest`, and pushes that tree. Pull requests then carry no `dist/` at all, the
+commit that lands matches its own source from the start, and today's `artifact:verify` and
+`git diff --exit-code` stay exactly where they are on the push side.
+
+Credentials exist as of 2026-08-17: App `4622872`, `contents: read and write` on this
+repository only, with `COMMITLORE_BOT_APP_ID` and `COMMITLORE_BOT_KEY` registered as
+repository secrets.
+
+A weaker variant — rebuild and push on `push` to `main` — keeps `HEAD` consistent but
+leaves one stale parent in history, which must never be tagged. It is recorded so that it
+is rejected deliberately rather than rediscovered.
+
+## The unsolved question
+
+**A commit the App pushes has not been checked.**
+
+For the App to push to `main` it must be in the branch protection bypass list. The commit
+it pushes is the merge result plus a rebuild — a tree no required check ran against. That
+the pull request was green is a statement about a different tree.
+
+So the naive implementation moves the gate from *blocking before* to *reporting after*,
+which is the limitation recorded against `preserve` in #723 — adopted voluntarily this
+time. Any design that ships must answer this. Three shapes are worth evaluating and none
+has been:
+
+1. **Push to a staging ref, let checks run there, fast-forward `main` only on green.**
+   Keeps blocking semantics; costs a second CI cycle, which is the cost being removed.
+2. **Make the rebuild verifiable without re-running checks** — the App pushes, and a
+   required push-event check re-derives the bundle and compares. Still after the fact, but
+   the window is bounded and the failure is loud rather than silent.
+3. **Do not bypass at all**: the App pushes to a branch, opens a pull request containing
+   only the rebuilt artifact, and that pull request passes normally. Preserves every
+   property; adds a second merge per change.
+
+## Success
+
+- No pull request carries `dist/` or `installer/canonical-artifact.json`.
+- Every commit on `main` matches the bundle its own source produces, verified by a check
+  that can fail.
+- A contributor on any platform can complete a source change without a maintainer.
+- The tag gate is unchanged: `canonical-artifact`, `version-consistency` and
+  `exact-head-ci` still hold, and no tag is reachable without them.
+
+## What reopens the schedule
+
+Either one:
+
+1. Three or more overlapping source-PR rebuilds in an ordinary week with no release.
+   2026-08-17's four were a release-day spike; the same rate on a quiet week is the
+   ordinary cadence.
+2. A **second** non-Linux contributor blocked on a maintainer-only `build:canonical`. One
+   contributor twice is an anecdote with a repeat; two people is the pattern.

--- a/docs/tickets/F15-canonical-artifact-provenance.md
+++ b/docs/tickets/F15-canonical-artifact-provenance.md
@@ -1,0 +1,140 @@
+# F15 tickets — Who is entitled to publish the bytes (#719)
+
+> PRD: [PRD-F15-canonical-artifact-provenance.md](../prd/PRD-F15-canonical-artifact-provenance.md)
+> ADR: [0011](../adr/ADR-0011-plugin-first-distribution.md) (distribution is a git clone)
+> Issue: [#719](https://github.com/MongLong0214/commitlore/issues/719)
+> Baseline head: `ad6fee3` (1.1.2).
+
+**T-1501 is a decision, not an implementation, and nothing after it may start until it
+lands.** The credentials are in place; the reason this is unscheduled is that a commit the
+App pushes has not been checked, and no ticket here pretends otherwise.
+
+**Ordering is strict.** T-1501 → T-1502 → T-1503 → T-1504. Each removes something the next
+depends on not existing.
+
+---
+
+## T-1501 Decide how a bot-pushed commit is verified (S) — decision only
+
+**Owns**
+
+- `docs/adr/ADR-00xx-*.md` (new) — the decision and what it costs
+- `docs/prd/PRD-F15-canonical-artifact-provenance.md` — replace "The unsolved question"
+  with the answer
+
+**Depends on** — nothing. This is the gate.
+
+**Problem**
+
+For the App to push to `main` it must be in the branch protection bypass list. The commit
+it pushes is a merge result plus a rebuild: a tree no required check ran against. "The
+pull request was green" is a statement about a different tree.
+
+Shipping the naive form moves the gate from *blocking before* to *reporting after* — the
+limitation recorded against `preserve` in #723, adopted voluntarily.
+
+**Evaluate exactly these three**, and record why the two that lose, lose:
+
+1. **Staging ref + fast-forward.** App pushes to `refs/heads/canonical-staging`, checks run
+   there, `main` fast-forwards only on green. Keeps blocking semantics. Costs the second CI
+   cycle this whole effort exists to remove — so measure that before choosing it.
+2. **Bypass plus a required push-event check.** App pushes to `main`; a push-event job
+   re-derives the bundle and compares. Still after the fact; the window is bounded and the
+   failure is loud. Requires an answer to "what happens to `main` between push and check".
+3. **No bypass.** App pushes a branch containing only the rebuilt artifact and opens a
+   pull request for it, which passes normally. Preserves every property. Costs a second
+   merge per change and needs a rule for what happens when that second pull request fails.
+
+**Acceptance**
+
+- An ADR that names the chosen shape, the property it gives up if any, and the two
+  rejected shapes with their costs.
+- If the answer is that none is acceptable, that is a valid outcome: the ADR says so and
+  #719 stays open with the reason sharpened. **Do not ship a design to close a ticket.**
+
+**Not in scope** — any workflow file, any permission change.
+
+---
+
+## T-1502 Rebuild-and-push, behind whatever T-1501 chose (M)
+
+**Owns**
+
+- `.github/workflows/canonical-merge.yml` (new)
+- `scripts/check-exact-head-ci.mjs` — `EXPECTED_CI_WORKFLOW_SHA256` if `ci.yml` moves
+- `test/canonical-merge-workflow.test.ts` (new)
+
+**Depends on** — T-1501 merged. Branch protection updated by the repository owner, which
+is not a step any agent performs.
+
+**Owns the assertions**, in the shape `test/preserve-workflow-safety.test.ts` established:
+the workflow's safety properties are read from the file with comment lines stripped, so a
+comment cannot satisfy them. At minimum:
+
+- the App token is minted from `COMMITLORE_BOT_APP_ID` / `COMMITLORE_BOT_KEY` and never
+  echoed;
+- the job never checks out or executes a pull request's head — the same rule #723 fixed for
+  `preserve`, and the same reason;
+- the rebuild is `build:canonical`, not a local `npm run build`, or the pushed bytes are
+  not the canonical ones.
+
+**Acceptance**
+
+- A source-only pull request merges and the commit that lands on `main` passes
+  `artifact:verify` and `git diff --exit-code -- dist/` **without anyone rebuilding by
+  hand**.
+- Deliberately breaking the rebuild — e.g. skipping `artifact:manifest` — produces a red
+  check, not a green merge. **A fixture that cannot fail is not evidence** (#722).
+
+**Not in scope** — removing `dist/` from pull request requirements. That is T-1503, and
+doing it here means a failure in this ticket has no fallback.
+
+---
+
+## T-1503 Stop requiring pull requests to carry the artifact (S)
+
+**Owns**
+
+- `.github/workflows/ci.yml` — the `check` job's `git diff --exit-code` line, on the pull
+  request path only
+- `scripts/verify-canonical-artifact.mjs` — a mode that verifies the manifest is
+  self-consistent with this checkout's source, distinct from verifying it against the
+  committed bundle
+- `EXPECTED_CI_WORKFLOW_SHA256`
+
+**Depends on** — T-1502 proven on at least one real merge. Not on a green test run: on a
+merge that actually landed a matching commit.
+
+**The trap.** `artifact:verify` compares the committed manifest's source checksum against
+the checkout. A source change that does not rebuild fails there **before** `git diff` is
+reached — #720 failed exactly this way. So "drop one line" is wrong: the verify script
+needs the second mode, and adding it removes "the committed manifest does not lie" from the
+pull request path. Say so in the commit record.
+
+**Acceptance**
+
+- A pull request touching `src/` with no `dist/` change is green.
+- The same change, merged, lands a commit where `dist/` matches — by T-1502, not by hand.
+- The push and tag paths are untouched: `canonical-artifact`, `version-consistency` and
+  `exact-head-ci` still gate every tag.
+
+---
+
+## T-1504 Close #719, or record why it cannot close (S)
+
+**Owns**
+
+- `docs/prd/PRD-F15-canonical-artifact-provenance.md` — success criteria checked off
+  against observations, not intentions
+- #719
+
+**Depends on** — T-1503 merged and at least one non-Linux contributor completing a source
+change unaided. **That last one is an observation, not a test**, and it is what the issue
+is actually about: #720 waited on a maintainer twice.
+
+**Acceptance**
+
+- Every success criterion in the PRD is either met with the run that shows it, or
+  explicitly not met and recorded.
+- If a property was given up — most likely blocking-before-merge — the issue says which,
+  and where the compensating check lives.


### PR DESCRIPTION
Adds `PRD-F15` and its tickets for #719.

#719 was filed as a merge-conflict complaint and is not one. Two reviews moved it to what it is actually about — **which commit is entitled to be the product** — and that analysis currently lives in issue comments, where a reader has to reconstruct it from a thread.

## What the PRD carries

`build:canonical` overwrites the worktree, so the jobs after it split:

| step | runs against |
|---|---|
| `validate` / `doctor` | the **rebuilt** tree |
| the ADR-0011 clone test, `audit`, four `install-*` jobs | **HEAD**, the committed bundle |

`git diff --exit-code -- dist/` is the only thing making those the same bytes. Removing it from the PR path does not move a gate — it separates *this source is deterministic* from *this checkout is the plugin*, and the tag gate cannot rejoin them.

Five proposals recorded as rejected with reasons, including two that looked right when raised: a PR artifact applied on push uses the wrong tree when two source PRs merge in sequence, and a merge queue serialises without inserting a rebuild.

**ADR-0011 already rejected removing the committed bundle**, in those words — *"requiring a toolchain during installation breaks the 'one clone and done' promise"*. Quoted in the non-goals, because it is the first thing anyone proposes here and proposing it reopens a different document.

## The tickets put the unanswered part first

**T-1501 is a decision, not an implementation.** A commit the App pushes has not been checked; "the PR was green" is a statement about a different tree. Three shapes to evaluate, and its acceptance says concluding **none** is acceptable is a valid outcome — otherwise the ticket pressures someone into shipping a design to close it.

T-1502 → T-1503 → T-1504 follow, each depending on the previous being *observed*, not merely tested. T-1504 depends on a non-Linux contributor completing a source change unaided, which is what the issue is actually about.

## Scope

This specifies. It schedules nothing — the reopening conditions on #719 are unchanged and neither has been met.