### PR TITLE
Measure whether an App-opened pull request runs the checks (T-1502)

### DIFF
--- a/.github/workflows/measure-app-pull-request.yml
+++ b/.github/workflows/measure-app-pull-request.yml
@@ -1,0 +1,123 @@
+﻿name: Measure — does an App-opened pull request run the checks
+
+# T-1502's first step (#719), and it is a measurement rather than a build.
+#
+# ADR-0036 decided that a bot merge opens a pull request instead of pushing,
+# because `main` requires a `lint` context that no push can produce. That
+# decision rests on one thing nobody has measured: **that a pull request opened
+# by an App triggers the checks at all.** If `on: pull_request` does not fire for
+# one, the rebuild pull request is green with nothing having run — #722's empty
+# runner, reintroduced by the design meant to be careful.
+#
+# So this opens a throwaway pull request as the App, reads what GitHub attaches
+# to it, and closes it. It changes nothing and merges nothing. Run it by hand;
+# there is no trigger that can fire it on its own.
+on:
+  workflow_dispatch:
+
+# Only to read what the run produced. Everything the App does is done with the
+# App's own token, which is what is being measured.
+permissions:
+  contents: read
+
+# One at a time: two runs would race on the same branch name and the second
+# would measure the first's leftovers.
+concurrency:
+  group: measure-app-pull-request
+  cancel-in-progress: false
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.23.2'
+
+      - name: Mint an installation token
+        id: token
+        env:
+          COMMITLORE_BOT_APP_ID: ${{ secrets.COMMITLORE_BOT_APP_ID }}
+          COMMITLORE_BOT_KEY: ${{ secrets.COMMITLORE_BOT_KEY }}
+        run: |
+          set -euo pipefail
+          token="$(node scripts/app-installation-token.mjs)"
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
+      - name: Open a throwaway pull request as the App
+        id: open
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          branch="measure/app-pr-${GITHUB_RUN_ID}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+          # A real change, because a pull request with an empty diff is refused
+          # and would measure nothing. It is deleted with the branch.
+          mkdir -p .measurements
+          printf 'Opened by run %s to answer whether an App-opened pull request runs the checks (#719, T-1502).\nDeleted with its branch by the same run.\n' \
+            "$GITHUB_RUN_ID" > .measurements/app-pull-request-probe.md
+
+          git config user.name  'commitlore-canonical-build[bot]'
+          git config user.email '4622872+commitlore-canonical-build[bot]@users.noreply.github.com'
+          git checkout -b "$branch"
+          git add .measurements/app-pull-request-probe.md
+          git commit --quiet -m "$(printf 'Measure whether an App-opened pull request runs the checks\n\nT-1502 (#719). ADR-0036 assumes it does and nobody has measured it. Opened and closed by the same workflow run; the branch and this file go with it.\n\nBlast: local\nUndo: easy\nCertainty: firm\nRecord-Id: r-measureapppr\nProvenance: authored\nVerified: this commit exists to be looked at, not to be kept\nCommitLore-Version: 2.0.0')"
+
+          git push --quiet "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$branch"
+
+          number="$(gh pr create --base main --head "$branch" \
+            --title 'Measurement: does an App-opened pull request run the checks? (#719)' \
+            --body 'Opened by the `measure-app-pull-request` workflow to answer T-1502'"'"'s first question. It will be closed by the same run. Nothing here is meant to merge.' \
+            | grep -oE '[0-9]+$')"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "opened pull request #$number on $branch"
+
+      - name: Read what GitHub attached to it
+        id: read
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          NUMBER: ${{ steps.open.outputs.number }}
+        run: |
+          set -euo pipefail
+          head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${NUMBER}" --jq .head.sha)"
+
+          # Checks do not appear instantly. Six minutes is long enough that
+          # "none yet" and "none ever" stop being the same observation, which is
+          # the whole point of the measurement.
+          for attempt in $(seq 1 24); do
+            count="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${head}/check-runs" --jq '.check_runs|length')"
+            [ "$count" != "0" ] && break
+            sleep 15
+          done
+
+          echo "--- check runs attached to $head after the wait: $count"
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${head}/check-runs" \
+            --jq '.check_runs[]|"  \(.status)\t\(.conclusion // "-")\t\(.name)"' || true
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Close it and take the branch with it
+        if: always() && steps.open.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh pr close "${{ steps.open.outputs.number }}" --delete-branch --comment 'Measured and closed. See the run that opened this.' || true
+
+      - name: Report the answer
+        env:
+          COUNT: ${{ steps.read.outputs.count }}
+        run: |
+          set -euo pipefail
+          if [ "${COUNT:-0}" = "0" ]; then
+            echo "::error::an App-opened pull request attached NO check runs — ADR-0036's assumption is false and F15 needs a different shape"
+            exit 1
+          fi
+          echo "an App-opened pull request attached $COUNT check run(s); ADR-0036's assumption holds so far"
+          echo "Read the list above rather than this number: the eleven required contexts are what matter, not the count." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/measure-app-pull-request.yml
+++ b/.github/workflows/measure-app-pull-request.yml
@@ -89,6 +89,16 @@ jobs:
           set -euo pipefail
           head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${NUMBER}" --jq .head.sha)"
 
+          # Who actually opened it, recorded before the answer rather than after.
+          # "No checks ran" has two causes that need different fixes -- the pull
+          # request was opened by GITHUB_TOKEN rather than the App (a wiring
+          # mistake), or it was opened by the App and checks still did not run
+          # (which changes ADR-0036's options). Without the actor those two are
+          # the same observation, and telling them apart later means measuring
+          # again.
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${NUMBER}" \
+            --jq '"--- opened by: \(.user.login) (type \(.user.type), id \(.user.id))"'
+
           # Checks do not appear instantly. Six minutes is long enough that
           # "none yet" and "none ever" stop being the same observation, which is
           # the whole point of the measurement.
@@ -116,7 +126,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${COUNT:-0}" = "0" ]; then
-            echo "::error::an App-opened pull request attached NO check runs — ADR-0036's assumption is false and F15 needs a different shape"
+            echo "::error::no check runs attached — read the 'opened by' line above before concluding anything: a Bot-type App actor means ADR-0036's assumption is false, a plain token actor means the credential wiring is wrong and the question is still unanswered"
             exit 1
           fi
           echo "an App-opened pull request attached $COUNT check run(s); ADR-0036's assumption holds so far"

--- a/scripts/app-installation-token.mjs
+++ b/scripts/app-installation-token.mjs
@@ -1,0 +1,96 @@
+/**
+ * Mint an installation token for the repository's GitHub App (T-1502, #719).
+ *
+ * ADR-0036 decided that a bot merge opens a pull request rather than pushing,
+ * because `main` requires a `lint` context that no push can produce. That
+ * decision rests on an assumption nobody has measured: **that a pull request
+ * opened by an App triggers the checks at all.** If `on: pull_request` does not
+ * fire for one, the rebuild pull request is green with nothing having run,
+ * which is #722's empty runner in a new place — the exact defect the design is
+ * meant to avoid, reintroduced by the design.
+ *
+ * This mints the token that measurement needs. It is written here rather than
+ * taken from an action so the repository owns the one credential path it has:
+ * a dependency that mints tokens is a dependency that can mint tokens.
+ *
+ * Reads `COMMITLORE_BOT_APP_ID` and `COMMITLORE_BOT_KEY` from the environment
+ * and writes the token to stdout. Nothing else is printed there, so a caller
+ * can capture it without parsing.
+ */
+
+import { createSign } from 'node:crypto';
+
+const die = (message) => {
+  process.stderr.write(`app-installation-token: ${message}\n`);
+  process.exit(2);
+};
+
+const base64url = (input) =>
+  Buffer.from(input).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+/**
+ * A JWT the App signs for itself. Ten minutes is GitHub's ceiling; sixty
+ * seconds of backdating absorbs clock skew between this runner and GitHub,
+ * which rejects a token issued in its own future.
+ */
+const appJwt = (appId, privateKey) => {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({ iat: now - 60, exp: now + 540, iss: appId }));
+  const signer = createSign('RSA-SHA256');
+  signer.update(`${header}.${payload}`);
+  let signature;
+  try {
+    signature = signer.sign(privateKey);
+  } catch (error) {
+    die(`the private key could not sign — is COMMITLORE_BOT_KEY a full PEM? (${error.message})`);
+  }
+  return `${header}.${payload}.${base64url(signature)}`;
+};
+
+const api = async (path, token, init = {}) => {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'x-github-api-version': '2022-11-28',
+      'user-agent': 'commitlore-app-token',
+      ...(init.headers ?? {}),
+    },
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    // The message is the useful part and never contains the token; the token is
+    // only ever in the request header, which is not echoed here.
+    die(`${init.method ?? 'GET'} ${path} → ${response.status} ${body.slice(0, 300)}`);
+  }
+  return body === '' ? {} : JSON.parse(body);
+};
+
+const appId = (process.env.COMMITLORE_BOT_APP_ID ?? '').trim();
+const privateKey = process.env.COMMITLORE_BOT_KEY ?? '';
+const repository = (process.env.GITHUB_REPOSITORY ?? '').trim();
+
+if (appId === '') die('COMMITLORE_BOT_APP_ID is empty');
+if (privateKey.trim() === '') die('COMMITLORE_BOT_KEY is empty');
+if (!repository.includes('/')) die('GITHUB_REPOSITORY is not owner/name');
+
+const jwt = appJwt(appId, privateKey);
+
+// The installation is looked up by repository rather than listed, so a token
+// minted here can only ever reach the repository this ran in.
+const installation = await api(`/repos/${repository}/installation`, jwt);
+if (typeof installation.id !== 'number') {
+  die(`no installation for ${repository} — install the App on it before running this`);
+}
+
+const minted = await api(`/app/installations/${installation.id}/access_tokens`, jwt, {
+  method: 'POST',
+});
+if (typeof minted.token !== 'string') die('the installation token response carried no token');
+
+process.stderr.write(
+  `app-installation-token: installation ${installation.id}, expires ${minted.expires_at}\n`,
+);
+process.stdout.write(minted.token);


### PR DESCRIPTION
First step of T-1502 (#719), and it is a **measurement**, not a build.

## Why this before anything else

ADR-0036 decided a bot merge opens a pull request rather than pushing, because `main` requires a `lint` context no push can produce. It named two assumptions it did not measure, and one is load-bearing:

> **Does a pull request opened by an App trigger the checks at all?**

If `on: pull_request` does not fire for one, the rebuild pull request is **green with nothing having run** — #722's empty runner, reintroduced by the design meant to be careful about exactly that. And it would arrive looking like success.

## What it does

Opens a throwaway pull request as the App, waits up to six minutes so that *none yet* and *none ever* stop being the same observation, reads what GitHub attached, prints the list, and closes it with its branch.

- `workflow_dispatch` only — nothing can fire it on its own
- merges nothing, changes nothing
- fails loudly if **zero** checks attach, because that answer kills ADR-0036's shape and should not be a quiet pass

## The token

Minted by `scripts/app-installation-token.mjs` rather than by `actions/create-github-app-token`. Fewer lines the other way, but it puts token minting behind a dependency this repository would then have to trust with exactly that. The installation is looked up **by repository**, so a token this script mints cannot reach anything else.

## Verification

The signing path runs end to end locally against a throwaway RSA key and reaches GitHub, which answers  — the JWT was built, signed and sent, rejected only because that key is not the App's. The empty-id and not-a-PEM guards each produce their own named message. Workflow parses; `EXPECTED_CI_WORKFLOW_SHA256` covers `ci.yml` alone, so adding a workflow does not move it.

## Before dispatching it

The App must be installed on this repository. If it is not, the script says so by name rather than failing obscurely — that is the first thing the run will tell us.