### PR TITLE
Stop the checkout from overriding the App it was meant to measure (T-1502)

### DIFF
--- a/.github/workflows/measure-app-pull-request.yml
+++ b/.github/workflows/measure-app-pull-request.yml
@@ -34,6 +34,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # Without this the checkout leaves an `http.<url>.extraheader` holding
+          # the Actions token, and that header beats credentials in a push URL.
+          # The first run of this workflow pushed as `github-actions[bot]` while
+          # carrying a perfectly good App token, and failed with `Permission ...
+          # denied to github-actions[bot]` -- measuring the wiring instead of the
+          # question. The App must be the actor here or the measurement is void.
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -72,6 +79,12 @@ jobs:
           git commit --quiet -m "$(printf 'Measure whether an App-opened pull request runs the checks\n\nT-1502 (#719). ADR-0036 assumes it does and nobody has measured it. Opened and closed by the same workflow run; the branch and this file go with it.\n\nBlast: local\nUndo: easy\nCertainty: firm\nRecord-Id: r-measureapppr\nProvenance: authored\nVerified: this commit exists to be looked at, not to be kept\nCommitLore-Version: 2.0.0')"
 
           git push --quiet "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$branch"
+
+          # The push above is the first thing that can silently use the wrong
+          # identity, so confirm the branch arrived as the App before opening
+          # anything on top of it.
+          pusher="$(gh api "repos/${GITHUB_REPOSITORY}/commits/$(git rev-parse HEAD)" --jq '.committer.login // "unknown"')"
+          echo "--- branch pushed; commit committer on the server: $pusher"
 
           number="$(gh pr create --base main --head "$branch" \
             --title 'Measurement: does an App-opened pull request run the checks? (#719)' \


### PR DESCRIPTION
The first measurement run failed before measuring anything:

```
remote: Permission to MongLong0214/commitlore.git denied to github-actions[bot]
```

It was carrying a **valid App token** at the time. `actions/checkout` defaults to `persist-credentials: true`, leaving an `http.<url>.extraheader` with the Actions token — and that header beats credentials embedded in a push URL. The push went out as `github-actions[bot]`, was refused, and the run measured its own wiring instead of the question.

This is exactly the branch the actor capture was added for one commit earlier. It arrived **before** that capture could run, because the failure landed at the push rather than at the pull request. So the same correction moves one step earlier: after pushing, read back who the server says committed it.

## What the failed run did establish

```
app-installation-token: installation 154501414, expires 2026-08-18T00:00:31Z
```

**The App is installed on this repository and the token path works end to end.** That was an open item on the owner's list — it cannot be checked from a user token, which is why it was there. A failed run answered it.

## Still unmeasured

Whether an App-opened pull request runs the checks. That is the whole point of the workflow and it has not happened yet.