### PR TITLE
Run the upgrade on the platform whose mv diverges (#747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,11 +397,11 @@ jobs:
           # the same tree under a different name is not enough:
           # `verify_incoming_smoke` runs the incoming bundle's `--version` and
           # dies when the tag and the report disagree (install.sh:577-589).
-          older="v0.0.1-upgradetest"
+          older="v0.0.1-ci"
           node -e '
             const fs = require("node:fs");
             const m = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            m.version = "0.0.1-upgradetest";
+            m.version = "0.0.1-ci";
             fs.writeFileSync("package.json", JSON.stringify(m, null, 2) + "\n");
           '
           git add package.json
@@ -437,9 +437,13 @@ jobs:
 
           # The #735 symptom itself: `mv` moved the temporary link into the old
           # release directory instead of replacing the link, and left it there.
-          strays="$(ls -A "$previous" | grep -E '^current' || true)"
-          test -z "$strays" || {
-            echo "::error::the swap left $strays inside $previous -- the rename went into the old release"
+          #
+          # The same `current.commitlore-install.` prefix `test/install-script.test.ts`
+          # filters on for the GNU leg, so the two assert one contract rather
+          # than two that happen to agree.
+          stray="$(find "$previous" -name 'current.commitlore-install.*' -print -quit)"
+          test -z "$stray" || {
+            echo "::error::the swap left $stray inside $previous -- the rename went into the old release"
             exit 1
           }
           echo "--- no stray link in the previous release directory"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,91 @@ jobs:
           "$wrapper" doctor >/dev/null
           "$wrapper" context src/app.js >/dev/null
 
+      # #747. Everything above is a fresh install, and `current` never
+      # pre-exists on a fresh install -- so the branch #735 shipped in is
+      # unreachable here, on the one platform whose `mv` diverges.
+      #
+      # The other side of that gap is what the upgrade in `install-script`
+      # asserts. It runs on `ubuntu-latest`, where GNU `mv` never follows a
+      # symlink, and it reads `wrapper --version` -- and the wrapper binds
+      # `$candidate/dist/commitlore.mjs`, the versioned path, so it reported the
+      # new release throughout the incident while every installed hook kept
+      # executing the old build through `current`. A regression of the 1.1.2
+      # rename would pass both.
+      #
+      # Isolated on Darwin, the mechanism is this:
+      #
+      #     $ ln -s v1.0.2 current && ln -s v1.1.1 current.tmp
+      #     $ mv current.tmp current; echo $?
+      #     0
+      #     $ readlink current
+      #     v1.0.2
+      #     $ ls v1.0.2
+      #     current.tmp
+      #
+      # Exit 0, link unchanged, the temporary link swallowed by the old release
+      # directory. So this leg installs a fake older release, installs the real
+      # one over it, and asserts through the path hooks actually record rather
+      # than through the wrapper.
+      - name: Upgrade over an existing install, and read the link hooks use
+        run: |
+          set -euo pipefail
+          export HOME="$RUNNER_TEMP/upgrade-home"
+          mkdir -p "$HOME"
+          export COMMITLORE_INSTALL_SOURCE="$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+
+          # A tag whose `package.json` really carries the lower version. Tagging
+          # the same tree under a different name is not enough:
+          # `verify_incoming_smoke` runs the incoming bundle's `--version` and
+          # dies when the tag and the report disagree (install.sh:577-589).
+          older="v0.0.1-upgradetest"
+          node -e '
+            const fs = require("node:fs");
+            const m = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            m.version = "0.0.1-upgradetest";
+            fs.writeFileSync("package.json", JSON.stringify(m, null, 2) + "\n");
+          '
+          git add package.json
+          older_commit="$(git -c user.name=ci -c user.email=ci@example.invalid commit-tree "$(git write-tree)" -p HEAD -m 'older release fixture')"
+          git tag -f "$older" "$older_commit"
+          # From HEAD, not from the index. `git add` above staged the lowered
+          # version, and `git checkout -- <path>` restores from the index -- so
+          # the plain form leaves the workspace on the fixture version, and
+          # `COMMITLORE_INSTALL_SOURCE` points at this workspace.
+          git reset -q HEAD package.json
+          git checkout HEAD -- package.json
+
+          sh install.sh "$older"
+          data_root="$HOME/.local/share/commitlore"
+          test -L "$data_root/current"
+          previous="$(cd "$data_root/current" && pwd -P)"
+          echo "--- installed $older; current -> $previous"
+
+          # The upgrade. `current` now pre-exists as a symlink to a directory,
+          # which is the only state that reaches the branch under test.
+          sh install.sh "$COMMITLORE_CI_VERSION"
+
+          # Through the link, not through the wrapper. `commitlore.bin` is
+          # recorded as `<data-root>/current/dist/commitlore.mjs`, so this is
+          # the interpreter every installed hook actually runs.
+          node_bin="$(command -v node)"
+          through_link="$("$node_bin" "$data_root/current/dist/commitlore.mjs" --version)"
+          echo "--- through the link: $through_link"
+          test "$through_link" = "${COMMITLORE_CI_VERSION#v}" || {
+            echo "::error::current still resolves to $through_link -- the installer reported an upgrade it did not perform (#735)"
+            exit 1
+          }
+
+          # The #735 symptom itself: `mv` moved the temporary link into the old
+          # release directory instead of replacing the link, and left it there.
+          strays="$(ls -A "$previous" | grep -E '^current' || true)"
+          test -z "$strays" || {
+            echo "::error::the swap left $strays inside $previous -- the rename went into the old release"
+            exit 1
+          }
+          echo "--- no stray link in the previous release directory"
+
   # The musl row claimed execution on two architectures. Only one of them can
   # run natively here; the other goes through QEMU, which is what makes the
   # claim true rather than smaller.

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,7 +40,7 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = '0994471669cf24bd14d16f0c8f8b7509789e13f74c0cc3e5e2368a2c99c6c114';
+export const EXPECTED_CI_WORKFLOW_SHA256 = '473b1fc06750384875d7236986b34b9564b3ff250c3f6da8b4572be50d75c48a';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,7 +40,7 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = 'b3cf70f2017579462071980215dcd5ee0a65702a05dde409e25b3a18113751bc';
+export const EXPECTED_CI_WORKFLOW_SHA256 = '0994471669cf24bd14d16f0c8f8b7509789e13f74c0cc3e5e2368a2c99c6c114';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore


### PR DESCRIPTION
Closes #747.

The 1.1.2 fix for #735 changed the swap and the success line. **The control flow that broke still runs in no CI job.**

| job | runner | upgrades over an existing `current`? | oracle |
|---|---|---|---|
| `install-macos` | macos-latest | **no** — fresh `$RUNNER_TEMP/home`, so the BSD branch is unreachable | wrapper |
| `install-script` | ubuntu-latest | yes — but GNU `mv` never follows a symlink | `wrapper --version` |

The wrapper cannot see this class by construction: `install.sh:616` binds `$candidate/dist/commitlore.mjs`, the **versioned** path, so it reported the new release throughout the incident while every installed hook kept executing the old build through `current`. A regression of the rename would pass both jobs.

## The mechanism, isolated on Darwin

```
$ mkdir -p v1.0.2 v1.1.1 && ln -s v1.0.2 current && ln -s v1.1.1 current.tmp
$ mv current.tmp current; echo "exit=$?"
exit=0
$ readlink current
v1.0.2
$ ls v1.0.2
current.tmp
```

Exit 0, link unchanged, the temporary link swallowed by the old release directory. **Exit codes and the wrapper are both blind to it.**

## So the assertions go through the link

`commitlore.bin` is recorded as `<data-root>/current/dist/commitlore.mjs` — that is the interpreter every installed hook actually runs.

```
node "$data_root/current/dist/commitlore.mjs" --version   ==  the new version
ls "$previous" | grep '^current'                          ==  empty
```

The second is **the symptom itself**, not a consequence of it.

## Two things building it found

**The fixture has to lower `package.json`, not just tag the tree.** `verify_incoming_smoke` runs the incoming bundle's `--version` and dies when the tag and the report disagree (`install.sh:577-589`). A tag-only fixture fails before reaching the swap — and would have looked like the leg working.

**`git checkout -- package.json` restores from the index, not HEAD.** `git add` above stages the lowered version, so the plain form leaves the workspace on the fixture version — and `COMMITLORE_INSTALL_SOURCE` points at that workspace. Verified against a clone: the tag carries `0.0.1-upgradetest` while the workspace returns to `1.1.2`.

## No ubuntu twin

The suggestion rested on a claim in #719's body that does not hold: *"`test/install-script.test.ts` reads `install.sh` as text; cannot execute the swap."* It spawns the real installer, plants a `current` symlink, and asserts `readlinkSync` plus the absence of a stray link (`:955-995`). **The GNU path is already pinned end to end**, and the gap was one platform, not two.