### PR TITLE
Two lines the register pass could not have seen

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -402,7 +402,7 @@ lifecycle(`Supersedes:`와 `Expires:`, 그리고 위 표의 마지막 행을 참
 
 ## record 프로토콜
 
-record는 평범한 Git commit trailer 묶음이고, 대개는 작은 것으로 충분합니다:
+record는 평범한 Git commit trailer 묶음이고, 대개는 작은 것으로 충분하다:
 
 ```text
 Fix expired-token refresh
@@ -411,7 +411,7 @@ Ruled-out: Extend token TTL to 24h | security policy violation
 Warn: Do not narrow the 4xx handler without verifying upstream behavior
 ```
 
-어휘 전체를 쓰는 완전한 예제, 모든 trailer key 표, 그리고 CommitLore 없이 순수 Git으로 읽는 방법은 [docs/protocol.md](docs/protocol.md)에 있습니다. 규범적 정의는 [SPEC §3](spec/SPEC.md)입니다.
+어휘 전체를 쓰는 완전한 예제, 모든 trailer key 표, 그리고 CommitLore 없이 순수 Git으로 읽는 방법은 [docs/protocol.md](docs/protocol.md)에 있다. 규범적 정의는 [SPEC §3](spec/SPEC.md)이다.
 
 ## 저장소가 증명하는 것
 


### PR DESCRIPTION
#753 converged `README.ko.md` on 한다체 with six exceptions following one rule: **address the reader and it stays polite, describe the product and it does not.**

Two lines break it, and **neither was in that branch's diff.** #751 wrote them — replacing the protocol section with a pointer — and the two branches never saw each other.

```
- record는 … 대개는 작은 것으로 충분합니다:
+ record는 … 대개는 작은 것으로 충분하다:

- … 방법은 docs/protocol.md에 있습니다. 규범적 정의는 SPEC §3입니다.
+ … 방법은 docs/protocol.md에 있다. 규범적 정의는 SPEC §3이다.
```

Both describe where a document is. Nobody is addressed, so both take the plain form the surrounding paragraphs use.

## My own count was wrong, and the reason is worth recording

The review counted fourteen polite lines. I counted twenty-five.

`아니다` contains `니다`. A pattern matching that syllable alone reports **every plain-form negation** as polite — and this document has many, because refusing an overclaim is what it does:

```
:182  … 모든 commit에 record가 생긴다는 뜻이 아니다.
:303  이것은 전달을 잰 것이지 효과를 잰 것이 아니다.
:377  또 하나의 메모리 데이터베이스가 아니다.
```

The precise pattern gives fourteen, and all fourteen are documented exceptions:

```
17-30    the hero paragraph — addressed to the reader
46-47    contents links — anchor text for the two headings below
105      the CTA
192      "설치하기 전에 읽어보세요"
277,290  headings — anchor targets, and ja/zh parity
```

## Limit

**Nothing checks this.** The rule lives in the PR that established it and in a comment. The next section written in the wrong register will land the same way these did — from a branch that never touched the file the rule was recorded on.