### PR TITLE
Say whose two seconds ran out, not that git failed

### DIFF
--- a/src/hooks/pre-push.ts
+++ b/src/hooks/pre-push.ts
@@ -106,6 +106,26 @@ export const installPrePushHook = (cwd = process.cwd()): PrePushHookResult => {
 const oneLine = (detail: string): string => detail.replace(/\s+/g, ' ').trim();
 
 /**
+ * The transport budget is ours, so its expiry has to be reported as ours.
+ *
+ * `spawnSync` reports a timeout as `spawnSync git ETIMEDOUT`, and that reached
+ * operators unchanged: it names the call that returned and not the thing that
+ * happened, so it reads as git failing rather than as this hook declining to
+ * wait. Measured while pushing a release tag — the line said `ETIMEDOUT` and
+ * the records were fine, needing only `commitlore sync`, which the rest of the
+ * sentence already said. #746 is the same shape in the commit-msg hook: a
+ * message accurate about the mechanism and wrong about the situation costs
+ * more than a vague one, because it sends somebody looking.
+ *
+ * The budget is interpolated rather than written out, so the sentence cannot
+ * drift from `PRE_PUSH_NOTES_SYNC_TIMEOUT_MS`.
+ */
+const saidWhy = (detail: string): string =>
+  /\bETIMEDOUT\b/.test(detail)
+    ? `the ${PRE_PUSH_NOTES_SYNC_TIMEOUT_MS / 1000}s this hook waits for the remote ran out`
+    : oneLine(detail);
+
+/**
  * One fail-open line per unsuccessful remote. Successful sync stays quiet.
  *
  * The line has to answer what the operator will actually ask, which is not
@@ -125,7 +145,7 @@ export const describeSync = (results: readonly SyncResult[]): string[] =>
     .map((result) =>
       result.outcome === 'diverged'
         ? `commitlore: notes mirror (${result.remote}) diverged: ${oneLine(result.detail)}. The branch was pushed. Your records and the remote's both exist and neither one fast-forwards, so a later push will not settle it — run "commitlore sync" to merge them.`
-        : `commitlore: notes mirror (${result.remote}) failed: ${oneLine(result.detail)}. The branch was pushed; the records for these commits are still only local. The next push retries this automatically, or run "commitlore sync" to send them now.`,
+        : `commitlore: notes mirror (${result.remote}) failed: ${saidWhy(result.detail)}. The branch was pushed; the records for these commits are still only local. The next push retries this automatically, or run "commitlore sync" to send them now.`,
     );
 
 /**
@@ -160,7 +180,7 @@ export const register = (program: Command): void => {
         // and the line must still say where the records ended up, for the same
         // reason `describeSync` does (#632).
         process.stderr.write(
-          `commitlore: notes mirror failed: ${oneLine(error instanceof Error ? error.message : String(error))}. The branch was pushed; the records for these commits are still only local. The next push retries this automatically, or run "commitlore sync" to send them now.\n`,
+          `commitlore: notes mirror failed: ${saidWhy(error instanceof Error ? error.message : String(error))}. The branch was pushed; the records for these commits are still only local. The next push retries this automatically, or run "commitlore sync" to send them now.\n`,
         );
       }
     });

--- a/test/pre-push-hook.test.ts
+++ b/test/pre-push-hook.test.ts
@@ -208,6 +208,14 @@ describe('the pre-push hook publishes the mirror without re-entering itself', ()
     expect(lines).toHaveLength(1);
     expect(lines[0], 'the operator is told the branch went out').toContain('The branch was pushed');
     expect(lines[0], 'and what became of the records, and whether to act').toContain('retries this automatically');
+    // The budget is this hook's, so the line has to own it. `spawnSync git
+    // ETIMEDOUT` names the call that returned rather than the decision that was
+    // made, and it reads as git having failed -- which sends an operator to look
+    // at a transport that is fine. #746 is the same shape in the commit-msg hook.
+    expect(lines[0], 'the line still leaks the raw child-process code').not.toMatch(/ETIMEDOUT|spawnSync/);
+    expect(lines[0], 'and it does not say whose budget ran out').toContain(
+      `the ${PRE_PUSH_NOTES_SYNC_TIMEOUT_MS / 1000}s this hook waits for the remote ran out`,
+    );
   }, 60_000);
 
   it('disables terminal credential prompts and still lets the branch push through', async () => {


### PR DESCRIPTION
Pushing the `v1.1.3` tag printed this:

```
commitlore: notes mirror (origin) failed: spawnSync git ETIMEDOUT. The branch was
pushed; the records for these commits are still only local. The next push retries
this automatically, or run "commitlore sync" to send them now.
```

Nothing was wrong with the transport. `commitlore sync` immediately reported `in-sync`. But the line names the call that returned rather than the decision that was made, so it reads as git having failed — and it sends whoever gets it to look at a remote that is fine.

The two seconds are ours. `PRE_PUSH_NOTES_SYNC_TIMEOUT_MS` exists so an offline push does not feel stuck, and declining to wait is the hook working as designed. `spawnSync` has no way to say that; the raw code reached the operator unchanged.

Now:

```
commitlore: notes mirror (origin) failed: the 2s this hook waits for the remote ran
out. The branch was pushed; …
```

The value is interpolated from the constant, so the sentence cannot drift from what it describes. Every other detail is untouched — a refused connection still reports as a refused connection, because that one really is about the transport.

This is #746 in a second hook: a message accurate about the mechanism and wrong about the situation costs more than a vague one.

---

## This pull request carries source only, on purpose

No `dist/`, no `installer/canonical-artifact.json`. **Its own checks are expected to be red** — `artifact:verify` fails first because the committed manifest no longer matches `src/`, which is the trap recorded in T-1503 from #720.

That is the state T-1502 exists to handle, and this is the pull request it will be proven on: #754's `canonical-merge` workflow rebuilds the artifact after merge and opens a second pull request carrying the result, so all eleven required contexts run on the tree that actually lands rather than one that resembles it.

**Do not merge this directly.** It merges through the canonical pull request, which is the observation T-1502 asks for.

## Verified

With `dist/` unrebuilt the extended timeout test fails naming the string it still matched; after the rebuild all six pre-push tests pass.

The assertions first landed in the wrong test in the same file — a string replace bound to the first of two identical lines — and the name filter skipped the one they landed in, so a deliberately impossible expectation still reported green. That is how it was caught, and it is why the negative control above is stated as a real failure message rather than as a passing run.