### PR TITLE
A pull request may arrive without the artifact (#719, T-1503)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,22 +57,61 @@ jobs:
       # amd64 Node 24 Bookworm container is the one builder that can update it.
       # Build twice and compare every dist byte: matching git only once would
       # not notice a builder that changes its output between invocations.
+      # T-1502 lands the rebuild after merge, so a pull request no longer has to
+      # carry one -- but only a pull request that carries none. A pull request
+      # that does touch `dist/` or the manifest is checked exactly as before,
+      # which keeps the old path intact as the fallback rather than replacing it.
+      #
+      # The decision is made from the commit range, not from the working tree:
+      # `build:canonical` below rewrites `dist/`, so anything read afterwards
+      # describes what this job just built rather than what the author pushed.
+      - name: Decide which artifact contract this run can check
+        id: contract
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          mode=strict
+          if [ "${{ github.event_name }}" = 'pull_request' ]; then
+            carried="$(git diff --name-only "$BASE_SHA"...HEAD -- dist/ installer/canonical-artifact.json)"
+            if [ -z "$carried" ]; then
+              mode=contract-only
+            else
+              echo "--- this pull request carries the artifact, so it is checked in full:"
+              echo "$carried" | sed 's/^/    /'
+            fi
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "--- artifact contract mode: $mode"
+
       - name: Canonical dist is reproducible and matches its manifest
+        env:
+          MODE: ${{ steps.contract.outputs.mode }}
         run: |
           set -euo pipefail
           first="$(mktemp)"
           second="$(mktemp)"
+          verify() {
+            if [ "$MODE" = 'strict' ]; then npm run artifact:verify; else npm run artifact:verify -- --contract-only; fi
+          }
           npm run build:canonical
-          npm run artifact:verify
+          verify
           find dist -type f -print0 | sort -z | xargs -0 sha256sum > "$first"
           npm run build:canonical
-          npm run artifact:verify
+          verify
           find dist -type f -print0 | sort -z | xargs -0 sha256sum > "$second"
+          # Reproducibility is checked in both modes. It asks whether the builder
+          # is deterministic, which has nothing to do with what the author pushed.
           cmp "$first" "$second" || {
             echo "::error::canonical builder produced different dist bytes"
             exit 1
           }
-          git diff --exit-code -- dist/ installer/canonical-artifact.json
+          if [ "$MODE" = 'strict' ]; then
+            git diff --exit-code -- dist/ installer/canonical-artifact.json
+          else
+            echo "--- source-only pull request: the committed bundle is not compared."
+            echo "--- canonical-merge.yml rebuilds it after merge, and the push and tag paths still check it in full."
+          fi
 
       - name: Unit and dogfooding tests
         run: npx vitest run --reporter=default --reporter=json --outputFile=vitest-report.json

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,7 +40,7 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = '473b1fc06750384875d7236986b34b9564b3ff250c3f6da8b4572be50d75c48a';
+export const EXPECTED_CI_WORKFLOW_SHA256 = '24f749bb78ba8e929a6c86d77f1e3269b462b13cf65f038ca350959c2ea7ce84';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore

--- a/scripts/verify-canonical-artifact.mjs
+++ b/scripts/verify-canonical-artifact.mjs
@@ -15,6 +15,32 @@ import {
 } from './canonical-artifact-contract.mjs';
 
 const root = resolve(fileURLToPath(new URL('../', import.meta.url)));
+
+/**
+ * `--contract-only` checks what the manifest *declares* and stops short of what
+ * it *records*.
+ *
+ * The three checksum comparisons below all ask the same question -- does the
+ * committed manifest describe the committed bundle -- and on a pull request that
+ * changes `src/` and nothing else, the honest answer is no, by construction.
+ * CI rebuilds before it verifies, so after `build:canonical` the tree holds a
+ * bundle built from the new source while the committed manifest still describes
+ * the old one. All three fail together and `git diff` is never reached: that is
+ * how #720 failed, and dropping the diff line alone would not have moved it.
+ *
+ * What this mode still refuses is a manifest whose contract has been edited --
+ * the platform, the image, the build command, the runtime asset list, the source
+ * input list. Those do not move when source moves, so a pull request has no
+ * honest reason to touch them.
+ *
+ * What it gives up, and this is the whole cost: on that path nothing checks that
+ * the committed manifest tells the truth about the committed bundle. A bundle
+ * edited by hand passes every check in this mode -- measured on #763, where
+ * `artifact:verify` passed and only the rebuild-and-diff caught it. That
+ * property now lives on the push and tag paths, and on `canonical-merge.yml`,
+ * which regenerates the manifest rather than trusting one.
+ */
+const contractOnly = process.argv.includes('--contract-only');
 const errors = [];
 const fail = (message) => errors.push(message);
 const same = (left, right) => JSON.stringify(left) === JSON.stringify(right);
@@ -41,9 +67,11 @@ if (recorded !== undefined) {
     fail(`runtime asset list must be exactly ${RUNTIME_DIST_ASSETS.join(', ')}`);
   }
   if (!same(recorded.source?.inputs, SOURCE_INPUTS)) fail('manifest source inputs differ from the reviewed source list');
-  if (recorded.source?.sha256 !== actual.source.sha256) fail('source checksum does not match this checkout');
-  if (!same(recorded.artifact?.files, actual.artifact.files)) fail('dist file list or a dist file checksum does not match the canonical manifest');
-  if (recorded.artifact?.sha256 !== actual.artifact.sha256) fail('dist aggregate checksum does not match the canonical manifest');
+  if (!contractOnly) {
+    if (recorded.source?.sha256 !== actual.source.sha256) fail('source checksum does not match this checkout');
+    if (!same(recorded.artifact?.files, actual.artifact.files)) fail('dist file list or a dist file checksum does not match the canonical manifest');
+    if (recorded.artifact?.sha256 !== actual.artifact.sha256) fail('dist aggregate checksum does not match the canonical manifest');
+  }
 }
 
 if (errors.length > 0) {
@@ -57,6 +85,13 @@ if (errors.length > 0) {
 }
 
 const releaseCommit = process.env.RELEASE_COMMIT;
+if (releaseCommit !== undefined && contractOnly) {
+  // A release is the one place the recorded checksums have to be the reason the
+  // release is allowed. Letting the two combine would make the weaker mode
+  // reachable from the path that most needs the stronger one.
+  console.error('ERROR: --contract-only cannot be combined with RELEASE_COMMIT');
+  process.exit(2);
+}
 if (releaseCommit !== undefined) {
   const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
   if (head !== releaseCommit) {
@@ -70,5 +105,12 @@ if (releaseCommit !== undefined) {
   }
   console.log(`canonical artifact provenance: source ${head}, artifact ${actual.artifact.sha256}`);
 } else {
-  console.log(`canonical artifact verified: ${actual.artifact.sha256}`);
+  // Named differently on purpose. A reader scanning a log for "canonical
+  // artifact verified" must not find it on a run that never compared the
+  // recorded checksums.
+  console.log(
+    contractOnly
+      ? `canonical artifact contract intact (checksums not compared): ${actual.artifact.sha256}`
+      : `canonical artifact verified: ${actual.artifact.sha256}`,
+  );
 }

--- a/test/canonical-artifact.test.ts
+++ b/test/canonical-artifact.test.ts
@@ -14,7 +14,11 @@ const CANONICAL_COMMAND = 'docker run --rm --platform linux/amd64 -v "$PWD":/w -
 
 let copy = '';
 
-const run = (script: string) => spawnSync(process.execPath, [script], { cwd: copy, encoding: 'utf8' });
+const run = (script: string, ...args: string[]) =>
+  spawnSync(process.execPath, [script, ...args], { cwd: copy, encoding: 'utf8' });
+
+const runWithEnv = (script: string, env: NodeJS.ProcessEnv, ...args: string[]) =>
+  spawnSync(process.execPath, [script, ...args], { cwd: copy, encoding: 'utf8', env: { ...process.env, ...env } });
 
 beforeAll(() => {
   copy = mkdtempSync(join(tmpdir(), 'commitlore-canonical-artifact-'));
@@ -51,6 +55,67 @@ describe('canonical artifact contract', () => {
 });
 
 describe('canonical artifact CI and release provenance', () => {
+  // T-1503. CI rebuilds before it verifies, so on a pull request that changes
+  // `src/` and nothing else all three checksum comparisons fail together and
+  // `git diff` is never reached -- which is how #720 failed, and why removing
+  // the diff line alone would not have moved it.
+  describe('--contract-only, the mode a source-only pull request is checked in', () => {
+    it('passes when source moved and the committed bundle did not', () => {
+      expect(run(WRITER).status).toBe(0);
+      const source = join(copy, 'src', 'cli.ts');
+      const original = readFileSync(source);
+      writeFileSync(source, `${original.toString()}\n// a source-only change\n`);
+      try {
+        expect(run(VERIFIER).status, 'the strict mode is supposed to reject this').toBe(1);
+        const relaxed = run(VERIFIER, '--contract-only');
+        expect(relaxed.status, relaxed.stderr).toBe(0);
+        // A reader scanning a log for the strict line must not find it here.
+        expect(relaxed.stdout).toContain('checksums not compared');
+        expect(relaxed.stdout).not.toContain('canonical artifact verified');
+      } finally {
+        writeFileSync(source, original);
+      }
+    });
+
+    it('still refuses a manifest whose declared contract was edited', () => {
+      // The platform, image, build command and input lists do not move when
+      // source moves, so a pull request has no honest reason to touch them.
+      // Without this the relaxed mode would be a way to land a manifest that
+      // names a different builder.
+      expect(run(WRITER).status).toBe(0);
+      const path = join(copy, 'installer', 'canonical-artifact.json');
+      const original = readFileSync(path, 'utf8');
+      const edited = JSON.parse(original);
+      edited.builder.platform = 'linux/arm64';
+      writeFileSync(path, JSON.stringify(edited, null, 2));
+      // Source moves too, so the two modes have to disagree about something.
+      // Editing only the manifest leaves strict and relaxed reporting the same
+      // line, and a test both modes pass cannot tell which one ran.
+      const source = join(copy, 'src', 'cli.ts');
+      const sourceOriginal = readFileSync(source);
+      writeFileSync(source, `${sourceOriginal.toString()}\n// a source-only change\n`);
+      try {
+        const result = run(VERIFIER, '--contract-only');
+        expect(result.status, 'a tampered contract passed the relaxed mode').toBe(1);
+        expect(result.stderr).toContain('manifest does not declare linux/amd64');
+        expect(
+          result.stderr,
+          'the relaxed mode reported a checksum it is supposed to skip, so strict ran instead',
+        ).not.toContain('source checksum does not match this checkout');
+      } finally {
+        writeFileSync(path, original);
+        writeFileSync(source, sourceOriginal);
+      }
+    });
+
+    it('refuses to be combined with a release, where the checksums are the reason', () => {
+      expect(run(WRITER).status).toBe(0);
+      const result = runWithEnv(VERIFIER, { RELEASE_COMMIT: 'a'.repeat(40) }, '--contract-only');
+      expect(result.status, 'the weaker mode was reachable from the release path').toBe(2);
+      expect(result.stderr).toContain('cannot be combined with RELEASE_COMMIT');
+    });
+  });
+
   it('builds and compares the canonical artifact twice in CI', () => {
     const ci = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
     expect(ci).toContain('Canonical dist is reproducible and matches its manifest');


### PR DESCRIPTION
T-1502 is proven on a real merge — #761 carried source only, `canonical-merge` rebuilt it, and `e4e5154` landed with `artifact:verify` and `git diff -- dist/` both clean and nobody having built anything by hand. That was T-1503's stated dependency, so this is the next step.

## "Drop the diff line" was wrong, and #761 is the run that shows it

CI builds *before* it verifies. After `build:canonical` the tree holds a bundle made from the new source while the committed manifest still describes the old one, so on a source-only pull request all three checksum comparisons fail together and `git diff` is never reached:

```
ERROR: canonical artifact verification failed:
  - source checksum does not match this checkout
  - dist file list or a dist file checksum does not match the canonical manifest
  - dist aggregate checksum does not match the canonical manifest
```

That is exactly how #720 failed. Removing the diff line would not have moved it.

## The second mode

`--contract-only` keeps what the manifest **declares** and drops what it **records**. Platform, image, build command, runtime asset list, source input list — none of those move when source moves, so a pull request has no honest reason to touch them, and this mode still refuses one that does.

Measured by exit code, read directly rather than through a pipe:

| case | strict | `--contract-only` |
|---|---|---|
| clean tree | 0 | 0 |
| source moved, bundle did not | 1 | **0** |
| manifest's declared platform edited | 1 | **1** |
| with `RELEASE_COMMIT` set | — | **2** |

The success line is worded differently on purpose — `canonical artifact contract intact (checksums not compared)` — so a reader scanning a log for `canonical artifact verified` cannot find it on a run that never compared them.

## What this gives up

**On the source-only path, nothing checks that the committed manifest tells the truth about the committed bundle.**

That is not theoretical. It is the property #763 was built to falsify, and it did: a hand-edited `dist/commitlore.mjs` with `src/` untouched passed `artifact:verify` completely and was caught only by the rebuild-and-diff after it ([the run](https://github.com/MongLong0214/commitlore/actions/runs/32108141891)).

That property now lives on the push and tag paths, and in `canonical-merge.yml`, which regenerates the manifest rather than trusting one.

## The relaxation is conditional, not blanket

A pull request that **does** carry `dist/` or the manifest is checked exactly as before. The old path stays available as a fallback rather than being replaced. The decision is read from the commit range before the build runs, because afterwards the tree describes what the job just built rather than what the author pushed.

Reproducibility — two canonical builds compared byte for byte — runs in both modes. It asks whether the builder is deterministic, which has nothing to do with what the author pushed.

## Verified

Reverting the second mode fails all three new tests; restoring it passes seven.

The tampered-contract test initially passed in **both** directions — with the mode and without it — because editing only the manifest leaves strict and relaxed reporting the same line. It was strengthened by moving source as well, so the two modes have something to disagree about, and it now fails on the negative control like the other two.

`EXPECTED_CI_WORKFLOW_SHA256` re-locked to `24f749bb…`; `test/release-publish-prerequisites.test.ts` passes 29.

## Not in this pull request

T-1503's acceptance — *a pull request touching `src/` with no `dist/` change is green* — needs a pull request that touches `src/`. This one does not, so it will be observed on the next one after this lands.