### PR TITLE
F15's ticket file still says unscheduled for two tickets that shipped

### DIFF
--- a/docs/tickets/F15-canonical-artifact-provenance.md
+++ b/docs/tickets/F15-canonical-artifact-provenance.md
@@ -10,8 +10,18 @@ The App does not push to `main`; it opens a pull request. `main`'s protection re
 `lint`, which runs only on `pull_request`, so no push can satisfy protection on its merits
 and every push-shaped option needs a bypass. Going through a pull request needs none.
 
-T-1502 onward remain **unscheduled**: the decision answers how a bot merge is verified, not
-whether to build one, and #719's reopening conditions are unchanged.
+**T-1502 and T-1503 are done, and were built rather than deferred (2026-08-18).** They read
+"unscheduled" here because ADR-0036 answered how a bot merge is verified without deciding to
+build one. A contributor still had to run a `linux/amd64` Docker build to open any pull
+request, which is what #720 waited on a maintainer for twice, so they were scheduled.
+
+T-1502 was observed rather than argued: #761 carried source only, `canonical-merge` rebuilt
+it into #762, and `e4e5154` landed with `artifact:verify` and `git diff -- dist/` both clean
+and the bundle commit authored by the build App. The negative control is #763.
+
+**T-1504 remains unscheduled, and not for want of code.** Its last condition is an
+observation about a person -- a non-Linux contributor completing a source change unaided --
+and nothing in this repository can produce one.
 
 **Ordering is strict.** T-1501 → T-1502 → T-1503 → T-1504. Each removes something the next
 depends on not existing.
@@ -65,7 +75,7 @@ run, which is #722's empty runner in a new place.
 
 ---
 
-## T-1502 The rebuild arrives as a pull request (M)
+## T-1502 The rebuild arrives as a pull request (M) — **done**, observed on #761 → #762 → `e4e5154`
 
 **Owns**
 
@@ -142,7 +152,7 @@ doing it here means a failure in this ticket has no fallback.
 
 ---
 
-## T-1503 Stop requiring pull requests to carry the artifact (S)
+## T-1503 Stop requiring pull requests to carry the artifact (S) — **done**, `532c30f4`
 
 **Owns**
 


### PR DESCRIPTION
T-1502 and T-1503 landed today. The file still read *"T-1502 onward remain unscheduled"* — written when ADR-0036 answered how a bot merge is verified without deciding to build one.

A ticket file that says a shipped thing is unscheduled is worse than one that says nothing, because it is the document somebody reads to find out what is left.

- **T-1502** — done, marked against what was observed rather than what was intended: #761 carried source only, `canonical-merge` rebuilt it into #762, and `e4e5154` landed with `artifact:verify` and `git diff -- dist/` both clean, the bundle commit authored by the build App. #763 is the control that went red.
- **T-1503** — done, `532c30f4`.
- **T-1504** — still unscheduled, and the header now says why that is not a scheduling decision. Its remaining condition is an observation about a person — a non-Linux contributor completing a source change unaided — and nothing in this repository can produce one.

Documentation only; the file owns no assertion. 23 tests across the two canonical suites pass unchanged.