### PR TITLE
Green was the thing forcing the safe path (revert T-1503, harden the handoff)

### DIFF
--- a/.github/workflows/canonical-merge.yml
+++ b/.github/workflows/canonical-merge.yml
@@ -152,6 +152,11 @@ jobs:
           set -euo pipefail
           git bundle create /tmp/canonical.bundle main.."canonical/pr-${{ inputs.pull_request_number }}"
           echo "${{ steps.merge.outputs.base }}" > /tmp/canonical.base
+          # Recorded so the other job can check both parents and the race. It is
+          # written by this job and therefore untrusted -- job two compares it
+          # against what the API reports for the pull request, and the value only
+          # ever narrows what job two will accept.
+          echo "${{ steps.fetch.outputs.head }}" > /tmp/canonical.head
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -159,6 +164,7 @@ jobs:
           path: |
             /tmp/canonical.bundle
             /tmp/canonical.base
+            /tmp/canonical.head
           retention-days: 1
 
   # A second runner that has never executed anything from the pull request.
@@ -197,15 +203,23 @@ jobs:
         run: |
           set -euo pipefail
           base="$(cat /tmp/canonical/canonical.base)"
+          head="$(cat /tmp/canonical/canonical.head)"
           branch="canonical/pr-${{ inputs.pull_request_number }}"
           git fetch --quiet /tmp/canonical/canonical.bundle "$branch:$branch"
           echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "head=$head" >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          echo "--- took $branch from the bundle, built on $base"
+          echo "--- took $branch from the bundle, built on $base over $head"
 
-      - name: Refuse if main moved while the rebuild ran
+      # Everything below runs before the credential is minted, and every value
+      # it compares against comes from the API or from `main` -- never from the
+      # bundle. The bundle was produced by a runner that executed a contributor's
+      # `package.json`, so it is an input to be checked rather than a result.
+      - name: Refuse if either side moved while the rebuild ran
+        id: settled
         env:
           GH_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pull_request_number }}
         run: |
           set -euo pipefail
           now="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)"
@@ -213,7 +227,59 @@ jobs:
             echo "::error::main moved from ${{ steps.take.outputs.base }} to $now while this rebuilt -- rerun after it settles"
             exit 1
           fi
-          echo "--- main is still $now"
+          # A force-push to the pull request between job one's fetch and here
+          # would leave the canonical pull request carrying a head nobody
+          # reviewed, while #N displays something else entirely.
+          head_now="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq .head.sha)"
+          if [ "$head_now" != "${{ steps.take.outputs.head }}" ]; then
+            echo "::error::#${PR} moved from ${{ steps.take.outputs.head }} to $head_now while this rebuilt -- rerun it"
+            exit 1
+          fi
+          base_ref="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq .base.ref)"
+          [ "$base_ref" = 'main' ] || { echo "::error::#${PR} now targets $base_ref"; exit 1; }
+          git fetch --quiet origin "pull/${PR}/head:verify-${PR}"
+          if [ "$(git rev-parse "verify-${PR}")" != "${{ steps.take.outputs.head }}" ]; then
+            echo "::error::the pull request ref does not resolve to the recorded head"
+            exit 1
+          fi
+          echo "--- main is still $now and #${PR} is still $head_now"
+
+      # The bundle is checked against a merge this job computes itself, from
+      # `main` and from the pull request ref -- neither of which the rebuild
+      # could write. A tampered bundle can therefore differ from what a merge
+      # would have produced only inside `dist/` and the manifest, which is the
+      # whole of what a rebuild is entitled to change.
+      #
+      # Without this the comment above `publish` is false: it says the job only
+      # moves bytes it verifies, and until now it verified none of them. A
+      # lifecycle script during `npm ci` could have added a commit touching
+      # `src/`, `scripts/` or `.github/`, and this job would have force-pushed
+      # it under the App's identity for a reviewer to see as a rebuild.
+      - name: The bundle differs from an honest merge only where a rebuild may
+        run: |
+          set -euo pipefail
+          branch="${{ steps.take.outputs.branch }}"
+          base="${{ steps.take.outputs.base }}"
+          head="${{ steps.take.outputs.head }}"
+          tip="$(git rev-parse "$branch")"
+
+          parents="$(git rev-list --parents -n1 "$tip" | cut -d' ' -f2-)"
+          [ "$parents" = "$base $head" ] || {
+            echo "::error::$branch is not a merge of $base and $head -- parents are: $parents"
+            exit 1
+          }
+
+          expected="$(git merge-tree --write-tree "$base" "$head")" || {
+            echo "::error::could not recompute the merge of $base and $head here"
+            exit 1
+          }
+          changed="$(git diff --name-only "$expected" "$tip" -- . ':(exclude)dist' ':(exclude)installer/canonical-artifact.json')"
+          if [ -n "$changed" ]; then
+            echo "::error::the rebuild changed paths it is not entitled to change:"
+            echo "$changed" | sed 's/^/    /'
+            exit 1
+          fi
+          echo "--- $branch matches a merge of $base and $head outside dist/ and the manifest"
 
       - name: Mint an installation token
         id: token
@@ -250,8 +316,21 @@ jobs:
           # so an update would conflict on the one file this exists to produce.
           git push --quiet --force "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$branch"
 
-          pusher="$(gh api "repos/${GITHUB_REPOSITORY}/commits/$(git rev-parse HEAD)" --jq '.committer.login // "unknown"')"
-          echo "--- pushed $branch; committer on the server: $pusher"
+          # Read back what the ref resolves to on the server, not whether the
+          # push returned zero. A concurrent run of this same workflow, or any
+          # other writer, can land between the push and the pull request being
+          # opened -- and then the pull request describes one commit while the
+          # branch carries another. `git push` exiting zero says the push was
+          # accepted, not that it is still the tip.
+          expected="$(git rev-parse "$branch")"
+          landed="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/$branch" --jq .object.sha)"
+          if [ "$landed" != "$expected" ]; then
+            echo "::error::$branch is $landed on the server, not the $expected this pushed -- something else wrote it"
+            exit 1
+          fi
+
+          pusher="$(gh api "repos/${GITHUB_REPOSITORY}/commits/$expected" --jq '.committer.login // "unknown"')"
+          echo "--- pushed $branch at $expected; committer on the server: $pusher"
 
           existing="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // ""')"
           if [ -n "$existing" ]; then

--- a/.github/workflows/canonical-merge.yml
+++ b/.github/workflows/canonical-merge.yml
@@ -255,31 +255,25 @@ jobs:
       # lifecycle script during `npm ci` could have added a commit touching
       # `src/`, `scripts/` or `.github/`, and this job would have force-pushed
       # it under the App's identity for a reviewer to see as a rebuild.
-      - name: The bundle differs from an honest merge only where a rebuild may
+      # The bundle is checked against a merge this job computes itself, from
+      # `main` and from the pull request ref -- neither of which the rebuild
+      # could write. A tampered bundle can therefore differ from what a merge
+      # would have produced only inside `dist/` and the manifest, which is the
+      # whole of what a rebuild is entitled to change.
+      #
+      # In a script rather than inline, because the invariant is about a commit
+      # graph and a graph is testable. The first inline version of this required
+      # the branch tip to have two parents; a real tip has one, because the
+      # rebuild commits on top of the merge whenever `dist/` actually changes.
+      # No amount of reading the workflow as text finds that -- only running it
+      # against a repository does.
+      - name: The bundle is that merge, plus at most a rebuild
         run: |
           set -euo pipefail
-          branch="${{ steps.take.outputs.branch }}"
-          base="${{ steps.take.outputs.base }}"
-          head="${{ steps.take.outputs.head }}"
-          tip="$(git rev-parse "$branch")"
-
-          parents="$(git rev-list --parents -n1 "$tip" | cut -d' ' -f2-)"
-          [ "$parents" = "$base $head" ] || {
-            echo "::error::$branch is not a merge of $base and $head -- parents are: $parents"
-            exit 1
-          }
-
-          expected="$(git merge-tree --write-tree "$base" "$head")" || {
-            echo "::error::could not recompute the merge of $base and $head here"
-            exit 1
-          }
-          changed="$(git diff --name-only "$expected" "$tip" -- . ':(exclude)dist' ':(exclude)installer/canonical-artifact.json')"
-          if [ -n "$changed" ]; then
-            echo "::error::the rebuild changed paths it is not entitled to change:"
-            echo "$changed" | sed 's/^/    /'
-            exit 1
-          fi
-          echo "--- $branch matches a merge of $base and $head outside dist/ and the manifest"
+          node scripts/verify-canonical-handoff.mjs \
+            --base "${{ steps.take.outputs.base }}" \
+            --source "${{ steps.take.outputs.head }}" \
+            --tip "${{ steps.take.outputs.branch }}"
 
       - name: Mint an installation token
         id: token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,61 +57,22 @@ jobs:
       # amd64 Node 24 Bookworm container is the one builder that can update it.
       # Build twice and compare every dist byte: matching git only once would
       # not notice a builder that changes its output between invocations.
-      # T-1502 lands the rebuild after merge, so a pull request no longer has to
-      # carry one -- but only a pull request that carries none. A pull request
-      # that does touch `dist/` or the manifest is checked exactly as before,
-      # which keeps the old path intact as the fallback rather than replacing it.
-      #
-      # The decision is made from the commit range, not from the working tree:
-      # `build:canonical` below rewrites `dist/`, so anything read afterwards
-      # describes what this job just built rather than what the author pushed.
-      - name: Decide which artifact contract this run can check
-        id: contract
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          set -euo pipefail
-          mode=strict
-          if [ "${{ github.event_name }}" = 'pull_request' ]; then
-            carried="$(git diff --name-only "$BASE_SHA"...HEAD -- dist/ installer/canonical-artifact.json)"
-            if [ -z "$carried" ]; then
-              mode=contract-only
-            else
-              echo "--- this pull request carries the artifact, so it is checked in full:"
-              echo "$carried" | sed 's/^/    /'
-            fi
-          fi
-          echo "mode=$mode" >> "$GITHUB_OUTPUT"
-          echo "--- artifact contract mode: $mode"
-
       - name: Canonical dist is reproducible and matches its manifest
-        env:
-          MODE: ${{ steps.contract.outputs.mode }}
         run: |
           set -euo pipefail
           first="$(mktemp)"
           second="$(mktemp)"
-          verify() {
-            if [ "$MODE" = 'strict' ]; then npm run artifact:verify; else npm run artifact:verify -- --contract-only; fi
-          }
           npm run build:canonical
-          verify
+          npm run artifact:verify
           find dist -type f -print0 | sort -z | xargs -0 sha256sum > "$first"
           npm run build:canonical
-          verify
+          npm run artifact:verify
           find dist -type f -print0 | sort -z | xargs -0 sha256sum > "$second"
-          # Reproducibility is checked in both modes. It asks whether the builder
-          # is deterministic, which has nothing to do with what the author pushed.
           cmp "$first" "$second" || {
             echo "::error::canonical builder produced different dist bytes"
             exit 1
           }
-          if [ "$MODE" = 'strict' ]; then
-            git diff --exit-code -- dist/ installer/canonical-artifact.json
-          else
-            echo "--- source-only pull request: the committed bundle is not compared."
-            echo "--- canonical-merge.yml rebuilds it after merge, and the push and tag paths still check it in full."
-          fi
+          git diff --exit-code -- dist/ installer/canonical-artifact.json
 
       - name: Unit and dogfooding tests
         run: npx vitest run --reporter=default --reporter=json --outputFile=vitest-report.json

--- a/docs/prd/PRD-F15-canonical-artifact-provenance.md
+++ b/docs/prd/PRD-F15-canonical-artifact-provenance.md
@@ -120,18 +120,45 @@ the same checks. The second matters most — a workflow that does not fire for A
 pull requests would leave the rebuild green with nothing having run, which is #722's empty
 runner in a new place.
 
-## Success
+## Success — final, and each line names the run that shows it
 
-- No pull request carries `dist/` or `installer/canonical-artifact.json`.
-- Every commit on `main` matches the bundle its own source produces, verified by a check
-  that can fail.
-- A contributor on any platform can complete a source change without a maintainer.
-- The tag gate is unchanged: `canonical-artifact`, `version-consistency` and
-  `exact-head-ci` still hold, and no tag is reachable without them.
+Rewritten 2026-08-18, when the work shipped. The first version said *"no pull request
+carries `dist/`"*, which the built thing contradicts: the **canonical** pull request carries
+exactly that, and carrying it is how all eleven required contexts run on the tree that
+lands. The criterion had described a shape rather than a property.
 
-## What reopens the schedule
+1. **A contributor never produces the canonical artifact.** #761 carried `src/` and
+   `test/`; `linux/amd64` ran only in a container on a GitHub runner.
+2. **A source-only pull request becomes a merge candidate.** `canonical-merge` opened #762
+   from #761 with no human step between them.
+3. **Every required check runs against that candidate.** Twelve contexts attached to #762,
+   which is an App-opened pull request — the assumption ADR-0036 named and did not measure.
+4. **The candidate's artifact matches the source landing with it.** At `e4e5154`, with no
+   local build: `canonical artifact verified: fcd0832f…` and `git diff --exit-code -- dist/
+   installer/canonical-artifact.json` clean.
+5. **A mismatched artifact is refused.** #763 was #762's rebuild with `dist/commitlore.mjs`
+   edited by hand; both `check` jobs failed. `artifact:verify` *passed* there — the manifest
+   binds `src/`, which was untouched — so the rebuild-and-diff is what caught it, and the
+   two checks are not one check twice.
+6. **The contributor's head reaches `main` with nobody rebuilding by hand.** #761 is
+   recorded merged, by reachability rather than by keyword, and the bundle commit's author
+   is `commitlore-canonical-build[bot]`.
+7. **No branch-protection bypass, and the tag gate is untouched.** `canonical-artifact`,
+   `version-consistency` and `exact-head-ci` still hold, and no tag is reachable without
+   them.
 
-Either one:
+**Limit — external contributor experience is unobserved.** Nobody outside this repository
+has yet taken this path. That is adoption evidence rather than a correctness gate: it
+measures whether anyone has arrived, not whether the mechanism works. Holding the feature
+open for it would leave the work permanently unfinished for a reason unrelated to the work.
+A real-world failure reopens #719 or opens a defect issue of its own.
+
+## What reopened the schedule
+
+Both conditions below were written while this was deferred. Condition 2 is what happened —
+the same contributor blocked twice on a maintainer-only `build:canonical` — and rather than
+wait for a second person to confirm a pattern already visible, the work was scheduled. The
+conditions are kept for the record.
 
 1. Three or more overlapping source-PR rebuilds in an ordinary week with no release.
    2026-08-17's four were a release-day spike; the same rate on a quiet week is the

--- a/docs/tickets/F15-canonical-artifact-provenance.md
+++ b/docs/tickets/F15-canonical-artifact-provenance.md
@@ -10,8 +10,18 @@ The App does not push to `main`; it opens a pull request. `main`'s protection re
 `lint`, which runs only on `pull_request`, so no push can satisfy protection on its merits
 and every push-shaped option needs a bypass. Going through a pull request needs none.
 
-T-1502 onward remain **unscheduled**: the decision answers how a bot merge is verified, not
-whether to build one, and #719's reopening conditions are unchanged.
+**T-1502 is done, and was built rather than deferred (2026-08-18).** It read "unscheduled"
+here because ADR-0036 answered how a bot merge is verified without deciding to build one. A
+contributor still had to run a `linux/amd64` Docker build to open any pull request, which
+is what #720 waited on a maintainer for twice.
+
+It was observed rather than argued: #761 carried source only, `canonical-merge` rebuilt it
+into #762, and `e4e5154` landed with `artifact:verify` and `git diff -- dist/` both clean
+and the bundle commit authored by the build App. #763 is the control that went red.
+
+**T-1503 is rejected**, after being shipped and reverted the same day — see below.
+**T-1504's acceptance was rewritten** from a person-observation to the system properties it
+was standing in for.
 
 **Ordering is strict.** T-1501 → T-1502 → T-1503 → T-1504. Each removes something the next
 depends on not existing.
@@ -65,7 +75,7 @@ run, which is #722's empty runner in a new place.
 
 ---
 
-## T-1502 The rebuild arrives as a pull request (M)
+## T-1502 The rebuild arrives as a pull request (M) — **done**, observed on #761 → #762 → `e4e5154`
 
 **Owns**
 
@@ -142,7 +152,25 @@ doing it here means a failure in this ticket has no fallback.
 
 ---
 
-## T-1503 Stop requiring pull requests to carry the artifact (S)
+## T-1503 Stop requiring pull requests to carry the artifact (S) — **rejected**, shipped and reverted
+
+**Rejected 2026-08-18, after shipping and reverting it.** `532c30f4` made a source-only
+pull request green, and green is mergeable. The button then lands `src/` with no rebuilt
+`dist/`, and `main` carries a bundle that does not match its source until the next push run
+goes red — after the fact rather than before it.
+
+A red source pull request was not friction to be removed. It was the thing forcing the
+canonical path, which is the path this feature exists to build. #761 was red, and that is
+why it went through `canonical-merge` rather than through its own merge button.
+
+What T-1503 was written to fix — *a contributor cannot open a pull request without running
+a `linux/amd64` Docker build* — is already fixed by T-1502, and without this risk: the
+contributor opens the source-only pull request and never rebuilds anything. Its checks
+being red is a signal about the artifact, not a demand on them.
+
+The measurement it produced stands, and anyone reopening this starts there: "drop the diff
+line" was wrong, because CI rebuilds before it verifies, so a source-only pull request dies
+at `artifact:verify` and never reaches the diff.
 
 **Owns**
 
@@ -179,13 +207,35 @@ pull request path. Say so in the commit record.
   against observations, not intentions
 - #719
 
-**Depends on** — T-1503 merged and at least one non-Linux contributor completing a source
-change unaided. **That last one is an observation, not a test**, and it is what the issue
-is actually about: #720 waited on a maintainer twice.
+**Depends on** — T-1502, and the canonical handoff hardened against a contributor who is
+not the owner.
 
-**Acceptance**
+**Amended 2026-08-18.** This read *"at least one non-Linux contributor completing a source
+change unaided"*, and called that an observation rather than a test. It is both — and it is
+the wrong kind for a completion gate. What #719 asks is whether a contributor can land a
+change without producing the canonical artifact. Whether somebody has yet turned up to do
+so measures the project's audience, not its behaviour, and a correctness gate that cannot
+be satisfied from inside the repository leaves the work permanently unfinished for a reason
+unrelated to the work.
 
-- Every success criterion in the PRD is either met with the run that shows it, or
-  explicitly not met and recorded.
-- If a property was given up — most likely blocking-before-merge — the issue says which,
-  and where the compensating check lives.
+The old wording was also indifferent to what it named. The canonical build never runs on a
+contributor's machine — `linux/amd64` appears only in a container on a GitHub runner — so
+"a non-Linux contributor" was a proxy for "somebody who cannot run the canonical build",
+and the mechanism does not distinguish the two.
+
+**Acceptance** — each met with the run that shows it:
+
+- A contributor can submit a source-only change without producing the canonical
+  `linux/amd64` artifact.
+- The canonical workflow produces the merge candidate, and all required checks run against
+  that candidate rather than against a tree resembling it.
+- The candidate's artifact matches the source that lands with it, and a mismatched one is
+  refused.
+- The contributor's source head becomes reachable from `main` with no maintainer rebuilding
+  `dist/` by hand, and no branch-protection bypass.
+- The handoff between the job that runs contributor code and the job that holds the
+  credential is checked rather than trusted, with a negative control for each check.
+
+**Limit.** External contributor experience has not been observed in the field after this
+change. That is adoption evidence, not a correctness gate. A real-world failure reopens
+this issue, or opens a defect issue of its own.

--- a/docs/tickets/F15-canonical-artifact-provenance.md
+++ b/docs/tickets/F15-canonical-artifact-provenance.md
@@ -134,18 +134,25 @@ comment cannot satisfy them. At minimum:
   falsifies the property this ticket actually claims — *the bytes that land match the
   source that landed with them* — rather than the workflow's internal step list.
 
-**Known limitation — the merge method is not enforceable from here.** The canonical pull
-request's body asks for a merge commit, because a squash lands new bytes and leaves the
-source pull request open with nothing to point at. That request is a check somebody has to
-read. The repository allows squash, merge and rebase, and GitHub's merge button remembers
-whichever was used last, so the wrong one is a click away — measured on #760, where five
-of six pull requests closed as merged and the sixth did not.
+**The merge method is enforced by the repository, not by this workflow (2026-08-18).**
+`allow_squash_merge` and `allow_rebase_merge` are off; a merge commit is the only method
+GitHub offers here. That matters because the canonical pull request depends on its head
+commit staying an ancestor: a squash lands new bytes instead, leaving the source pull
+request open with nothing to point at.
 
-Two ways to close it, and both are the owner's call rather than this ticket's:
-`gh api -X PUT .../pulls/N/merge -f merge_method=merge` names the method per merge, and
-turning off `allow_squash_merge` / `allow_rebase_merge` names it once for the repository.
-The second is the one that fits a repository that commits `dist/`, since a squash breaks
-the ancestry every integration pull request here depends on.
+This paragraph previously said the method was not enforceable and left the choice to the
+owner. It was enforceable; it just was not enforced. Until it was, the canonical body's
+"merge this with a merge commit" was a check somebody had to read — the shape that cost
+#752 its `merged` label during the 1.1.3 release, in the sentence next to it rather than
+in this one.
+
+The body still says it, for a reader who wants to know why the branch is shaped this way.
+It is no longer what holds the property.
+
+**What this moves rather than removes.** The guarantee now lives in a repository setting,
+which nothing in this repository reads. A future owner can re-enable squash and no test,
+workflow or gate here will notice — only a canonical pull request quietly failing to close
+its source. That is a smaller surface than a sentence in a body, and it is not zero.
 
 **Not in scope** — removing `dist/` from pull request requirements. That is T-1503, and
 doing it here means a failure in this ticket has no fallback.

--- a/scripts/app-installation-token.mjs
+++ b/scripts/app-installation-token.mjs
@@ -85,8 +85,22 @@ if (typeof installation.id !== 'number') {
   die(`no installation for ${repository} — install the App on it before running this`);
 }
 
+// Asked for narrowly rather than taken whole. A body-less request mints a
+// token carrying every permission the installation holds on every repository
+// it is installed on -- and this token is handed to a job whose input came
+// from a rebuild of somebody else's change. The installation may grow later
+// (another repository, another permission) and a token minted without a scope
+// would grow with it silently.
+//
+// These two are what the caller does and nothing else: push the rebuilt branch,
+// and open or update the pull request that carries it.
 const minted = await api(`/app/installations/${installation.id}/access_tokens`, jwt, {
   method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    repositories: [repository.slice(repository.indexOf('/') + 1)],
+    permissions: { contents: 'write', pull_requests: 'write' },
+  }),
 });
 if (typeof minted.token !== 'string') die('the installation token response carried no token');
 

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,7 +40,7 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = '24f749bb78ba8e929a6c86d77f1e3269b462b13cf65f038ca350959c2ea7ce84';
+export const EXPECTED_CI_WORKFLOW_SHA256 = '473b1fc06750384875d7236986b34b9564b3ff250c3f6da8b4572be50d75c48a';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore

--- a/scripts/verify-canonical-artifact.mjs
+++ b/scripts/verify-canonical-artifact.mjs
@@ -15,32 +15,6 @@ import {
 } from './canonical-artifact-contract.mjs';
 
 const root = resolve(fileURLToPath(new URL('../', import.meta.url)));
-
-/**
- * `--contract-only` checks what the manifest *declares* and stops short of what
- * it *records*.
- *
- * The three checksum comparisons below all ask the same question -- does the
- * committed manifest describe the committed bundle -- and on a pull request that
- * changes `src/` and nothing else, the honest answer is no, by construction.
- * CI rebuilds before it verifies, so after `build:canonical` the tree holds a
- * bundle built from the new source while the committed manifest still describes
- * the old one. All three fail together and `git diff` is never reached: that is
- * how #720 failed, and dropping the diff line alone would not have moved it.
- *
- * What this mode still refuses is a manifest whose contract has been edited --
- * the platform, the image, the build command, the runtime asset list, the source
- * input list. Those do not move when source moves, so a pull request has no
- * honest reason to touch them.
- *
- * What it gives up, and this is the whole cost: on that path nothing checks that
- * the committed manifest tells the truth about the committed bundle. A bundle
- * edited by hand passes every check in this mode -- measured on #763, where
- * `artifact:verify` passed and only the rebuild-and-diff caught it. That
- * property now lives on the push and tag paths, and on `canonical-merge.yml`,
- * which regenerates the manifest rather than trusting one.
- */
-const contractOnly = process.argv.includes('--contract-only');
 const errors = [];
 const fail = (message) => errors.push(message);
 const same = (left, right) => JSON.stringify(left) === JSON.stringify(right);
@@ -67,11 +41,9 @@ if (recorded !== undefined) {
     fail(`runtime asset list must be exactly ${RUNTIME_DIST_ASSETS.join(', ')}`);
   }
   if (!same(recorded.source?.inputs, SOURCE_INPUTS)) fail('manifest source inputs differ from the reviewed source list');
-  if (!contractOnly) {
-    if (recorded.source?.sha256 !== actual.source.sha256) fail('source checksum does not match this checkout');
-    if (!same(recorded.artifact?.files, actual.artifact.files)) fail('dist file list or a dist file checksum does not match the canonical manifest');
-    if (recorded.artifact?.sha256 !== actual.artifact.sha256) fail('dist aggregate checksum does not match the canonical manifest');
-  }
+  if (recorded.source?.sha256 !== actual.source.sha256) fail('source checksum does not match this checkout');
+  if (!same(recorded.artifact?.files, actual.artifact.files)) fail('dist file list or a dist file checksum does not match the canonical manifest');
+  if (recorded.artifact?.sha256 !== actual.artifact.sha256) fail('dist aggregate checksum does not match the canonical manifest');
 }
 
 if (errors.length > 0) {
@@ -85,13 +57,6 @@ if (errors.length > 0) {
 }
 
 const releaseCommit = process.env.RELEASE_COMMIT;
-if (releaseCommit !== undefined && contractOnly) {
-  // A release is the one place the recorded checksums have to be the reason the
-  // release is allowed. Letting the two combine would make the weaker mode
-  // reachable from the path that most needs the stronger one.
-  console.error('ERROR: --contract-only cannot be combined with RELEASE_COMMIT');
-  process.exit(2);
-}
 if (releaseCommit !== undefined) {
   const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
   if (head !== releaseCommit) {
@@ -105,12 +70,5 @@ if (releaseCommit !== undefined) {
   }
   console.log(`canonical artifact provenance: source ${head}, artifact ${actual.artifact.sha256}`);
 } else {
-  // Named differently on purpose. A reader scanning a log for "canonical
-  // artifact verified" must not find it on a run that never compared the
-  // recorded checksums.
-  console.log(
-    contractOnly
-      ? `canonical artifact contract intact (checksums not compared): ${actual.artifact.sha256}`
-      : `canonical artifact verified: ${actual.artifact.sha256}`,
-  );
+  console.log(`canonical artifact verified: ${actual.artifact.sha256}`);
 }

--- a/scripts/verify-canonical-handoff.mjs
+++ b/scripts/verify-canonical-handoff.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Verify what a canonical rebuild handed over, without trusting the job that
+ * produced it (T-1502, #719).
+ *
+ * `canonical-merge.yml` runs in two jobs. The first executes a contributor's
+ * `package.json` and every lifecycle script `npm ci` pulls in, then hands a git
+ * bundle to the second. The second holds the App credential. If it publishes
+ * what it was given, a lifecycle script can add a commit touching `src/`,
+ * `scripts/` or `.github/` and have it force-pushed under the App's identity
+ * for a reviewer to read as a rebuild.
+ *
+ * So the shape is checked here rather than assumed. Every input is a commit the
+ * caller resolved from GitHub or from `main` — never a value the untrusted job
+ * wrote.
+ *
+ * This lives in a file rather than inline in the workflow because the invariant
+ * is about a commit graph, and a graph is testable. The inline version asserted
+ * that the branch tip had two parents; the tip of a real run has one, because
+ * the rebuild commits on top of the merge whenever `dist/` actually changes.
+ * Nothing that reads the workflow as text could see that — only running it
+ * against a repository could, and that is what `test/verify-canonical-handoff.test.ts`
+ * now does.
+ *
+ * Usage:
+ *   node scripts/verify-canonical-handoff.mjs --base <sha> --source <sha> --tip <ref> [--cwd <dir>]
+ *
+ * Exit codes follow SPEC §10:
+ *   0  the tip is main + this source, plus at most an artifact-only commit
+ *   1  it is something else
+ *   2  bad input, or git could not answer
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/** Paths a rebuild is entitled to write. Everything else is somebody's edit. */
+export const REBUILD_PATHS = Object.freeze(['dist/', 'installer/canonical-artifact.json']);
+
+/**
+ * Paths a source pull request may not carry. The first job filters these too;
+ * repeating it here means the filter is not the only thing holding it, and this
+ * job's copy is the one running from `main`.
+ */
+export const FORBIDDEN_SOURCE_PATHS = Object.freeze([
+  'dist/',
+  'installer/canonical-artifact.json',
+  '.github/workflows/',
+]);
+
+class HandoffError extends Error {
+  constructor(message, exitCode = 1) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+const git = (args, cwd) => {
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+  } catch (error) {
+    throw new HandoffError(`git ${args.join(' ')} failed: ${error.stderr ?? error.message}`, 2);
+  }
+};
+
+const parentsOf = (commit, cwd) => {
+  const line = git(['rev-list', '--parents', '-n1', commit], cwd);
+  return line.split(' ').slice(1);
+};
+
+const isRebuildPath = (path) =>
+  REBUILD_PATHS.some((allowed) => (allowed.endsWith('/') ? path.startsWith(allowed) : path === allowed));
+
+/**
+ * @returns {{ merge: string, artifactCommit: string | null, rebuiltPaths: string[] }}
+ */
+export const verifyHandoff = ({ base, source, tip, cwd }) => {
+  for (const [name, value] of Object.entries({ base, source, tip })) {
+    if (typeof value !== 'string' || value === '') throw new HandoffError(`--${name} is required`, 2);
+  }
+
+  const baseSha = git(['rev-parse', `${base}^{commit}`], cwd);
+  const sourceSha = git(['rev-parse', `${source}^{commit}`], cwd);
+  const tipSha = git(['rev-parse', `${tip}^{commit}`], cwd);
+
+  // The tip is either the merge itself -- when the merged source already
+  // produces the committed bundle -- or one artifact-only commit on top of it.
+  // Both are honest; a chain of two is not, because the second one had no
+  // rebuild left to record.
+  const tipParents = parentsOf(tipSha, cwd);
+  let merge;
+  let artifactCommit = null;
+  if (tipParents.length === 2) {
+    merge = tipSha;
+  } else if (tipParents.length === 1) {
+    artifactCommit = tipSha;
+    merge = tipParents[0];
+  } else {
+    throw new HandoffError(`the tip has ${tipParents.length} parents; expected a merge, or one commit on a merge`);
+  }
+
+  const mergeParents = parentsOf(merge, cwd);
+  if (mergeParents.length !== 2) {
+    throw new HandoffError(`${merge.slice(0, 8)} is not a merge commit — it has ${mergeParents.length} parent(s)`);
+  }
+  if (mergeParents[0] !== baseSha || mergeParents[1] !== sourceSha) {
+    throw new HandoffError(
+      `the merge joins ${mergeParents[0].slice(0, 8)} and ${mergeParents[1].slice(0, 8)}, ` +
+        `not ${baseSha.slice(0, 8)} and ${sourceSha.slice(0, 8)}`,
+    );
+  }
+
+  // Recomputed here from the two commits the caller resolved, so a merge that
+  // quietly carries an extra edit does not survive having the right parents.
+  const expectedTree = git(['merge-tree', '--write-tree', baseSha, sourceSha], cwd).split('\n')[0];
+  const actualTree = git(['rev-parse', `${merge}^{tree}`], cwd);
+  if (expectedTree !== actualTree) {
+    throw new HandoffError(
+      `the merge's tree is ${actualTree.slice(0, 8)}; merging ${baseSha.slice(0, 8)} with ` +
+        `${sourceSha.slice(0, 8)} here produces ${expectedTree.slice(0, 8)}`,
+    );
+  }
+
+  const sourceChanged = git(['diff', '--name-only', `${baseSha}...${sourceSha}`], cwd)
+    .split('\n')
+    .filter(Boolean);
+  const forbidden = sourceChanged.filter((path) =>
+    FORBIDDEN_SOURCE_PATHS.some((bad) => (bad.endsWith('/') ? path.startsWith(bad) : path === bad)),
+  );
+  if (forbidden.length > 0) {
+    throw new HandoffError(`the source carries paths a source-only pull request may not: ${forbidden.join(', ')}`);
+  }
+
+  let rebuiltPaths = [];
+  if (artifactCommit !== null) {
+    rebuiltPaths = git(['diff', '--name-only', merge, artifactCommit], cwd).split('\n').filter(Boolean);
+    if (rebuiltPaths.length === 0) {
+      throw new HandoffError('the commit on top of the merge changes nothing');
+    }
+    const strayed = rebuiltPaths.filter((path) => !isRebuildPath(path));
+    if (strayed.length > 0) {
+      throw new HandoffError(`the rebuild changed paths it is not entitled to change: ${strayed.join(', ')}`);
+    }
+  }
+
+  return { merge, artifactCommit, rebuiltPaths };
+};
+
+const parseArgs = (argv) => {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (!flag.startsWith('--')) throw new HandoffError(`unexpected argument: ${flag}`, 2);
+    const value = argv[index + 1];
+    if (value === undefined) throw new HandoffError(`${flag} needs a value`, 2);
+    parsed[flag.slice(2)] = value;
+    index += 1;
+  }
+  return parsed;
+};
+
+const main = () => {
+  const { base, source, tip, cwd } = parseArgs(process.argv.slice(2));
+  const result = verifyHandoff({ base, source, tip, cwd: cwd ?? process.cwd() });
+  const where =
+    result.artifactCommit === null
+      ? 'the merged source already produced the committed bundle'
+      : `plus ${result.rebuiltPaths.length} rebuilt path(s) in ${result.artifactCommit.slice(0, 8)}`;
+  process.stdout.write(`canonical handoff verified: ${result.merge.slice(0, 8)} is that merge, ${where}\n`);
+};
+
+if (process.argv[1] !== undefined && process.argv[1].endsWith('verify-canonical-handoff.mjs')) {
+  try {
+    main();
+  } catch (error) {
+    if (error instanceof HandoffError) {
+      process.stderr.write(`canonical handoff refused: ${error.message}\n`);
+      process.exit(error.exitCode);
+    }
+    throw error;
+  }
+}

--- a/test/canonical-artifact.test.ts
+++ b/test/canonical-artifact.test.ts
@@ -14,11 +14,7 @@ const CANONICAL_COMMAND = 'docker run --rm --platform linux/amd64 -v "$PWD":/w -
 
 let copy = '';
 
-const run = (script: string, ...args: string[]) =>
-  spawnSync(process.execPath, [script, ...args], { cwd: copy, encoding: 'utf8' });
-
-const runWithEnv = (script: string, env: NodeJS.ProcessEnv, ...args: string[]) =>
-  spawnSync(process.execPath, [script, ...args], { cwd: copy, encoding: 'utf8', env: { ...process.env, ...env } });
+const run = (script: string) => spawnSync(process.execPath, [script], { cwd: copy, encoding: 'utf8' });
 
 beforeAll(() => {
   copy = mkdtempSync(join(tmpdir(), 'commitlore-canonical-artifact-'));
@@ -55,67 +51,6 @@ describe('canonical artifact contract', () => {
 });
 
 describe('canonical artifact CI and release provenance', () => {
-  // T-1503. CI rebuilds before it verifies, so on a pull request that changes
-  // `src/` and nothing else all three checksum comparisons fail together and
-  // `git diff` is never reached -- which is how #720 failed, and why removing
-  // the diff line alone would not have moved it.
-  describe('--contract-only, the mode a source-only pull request is checked in', () => {
-    it('passes when source moved and the committed bundle did not', () => {
-      expect(run(WRITER).status).toBe(0);
-      const source = join(copy, 'src', 'cli.ts');
-      const original = readFileSync(source);
-      writeFileSync(source, `${original.toString()}\n// a source-only change\n`);
-      try {
-        expect(run(VERIFIER).status, 'the strict mode is supposed to reject this').toBe(1);
-        const relaxed = run(VERIFIER, '--contract-only');
-        expect(relaxed.status, relaxed.stderr).toBe(0);
-        // A reader scanning a log for the strict line must not find it here.
-        expect(relaxed.stdout).toContain('checksums not compared');
-        expect(relaxed.stdout).not.toContain('canonical artifact verified');
-      } finally {
-        writeFileSync(source, original);
-      }
-    });
-
-    it('still refuses a manifest whose declared contract was edited', () => {
-      // The platform, image, build command and input lists do not move when
-      // source moves, so a pull request has no honest reason to touch them.
-      // Without this the relaxed mode would be a way to land a manifest that
-      // names a different builder.
-      expect(run(WRITER).status).toBe(0);
-      const path = join(copy, 'installer', 'canonical-artifact.json');
-      const original = readFileSync(path, 'utf8');
-      const edited = JSON.parse(original);
-      edited.builder.platform = 'linux/arm64';
-      writeFileSync(path, JSON.stringify(edited, null, 2));
-      // Source moves too, so the two modes have to disagree about something.
-      // Editing only the manifest leaves strict and relaxed reporting the same
-      // line, and a test both modes pass cannot tell which one ran.
-      const source = join(copy, 'src', 'cli.ts');
-      const sourceOriginal = readFileSync(source);
-      writeFileSync(source, `${sourceOriginal.toString()}\n// a source-only change\n`);
-      try {
-        const result = run(VERIFIER, '--contract-only');
-        expect(result.status, 'a tampered contract passed the relaxed mode').toBe(1);
-        expect(result.stderr).toContain('manifest does not declare linux/amd64');
-        expect(
-          result.stderr,
-          'the relaxed mode reported a checksum it is supposed to skip, so strict ran instead',
-        ).not.toContain('source checksum does not match this checkout');
-      } finally {
-        writeFileSync(path, original);
-        writeFileSync(source, sourceOriginal);
-      }
-    });
-
-    it('refuses to be combined with a release, where the checksums are the reason', () => {
-      expect(run(WRITER).status).toBe(0);
-      const result = runWithEnv(VERIFIER, { RELEASE_COMMIT: 'a'.repeat(40) }, '--contract-only');
-      expect(result.status, 'the weaker mode was reachable from the release path').toBe(2);
-      expect(result.stderr).toContain('cannot be combined with RELEASE_COMMIT');
-    });
-  });
-
   it('builds and compares the canonical artifact twice in CI', () => {
     const ci = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
     expect(ci).toContain('Canonical dist is reproducible and matches its manifest');

--- a/test/canonical-merge-workflow.test.ts
+++ b/test/canonical-merge-workflow.test.ts
@@ -48,13 +48,15 @@ describe('T-1502 canonical-merge.yml safety', () => {
     // ref -- neither writable from the first job -- and allows a difference
     // only inside `dist/` and the manifest.
     const publishJob = code().slice(code().indexOf('  publish:'));
-    expect(publishJob).toContain('git merge-tree --write-tree');
-    expect(publishJob).toMatch(/git diff --name-only "\$expected" "\$tip"/);
-    expect(publishJob).toContain("':(exclude)dist'");
-    expect(publishJob).toContain("':(exclude)installer/canonical-artifact.json'");
-    // Both parents pinned: a bundle whose branch is not a merge of exactly
-    // those two commits is a different history wearing the same branch name.
-    expect(publishJob).toMatch(/git rev-list --parents -n1 "\$tip"/);
+    expect(publishJob).toContain('scripts/verify-canonical-handoff.mjs');
+    expect(publishJob).toMatch(/--base "\$\{\{ steps\.take\.outputs\.base \}\}"/);
+    expect(publishJob).toMatch(/--source "\$\{\{ steps\.take\.outputs\.head \}\}"/);
+
+    // The graph rules live in `test/verify-canonical-handoff.test.ts`, run
+    // against real repositories. This file can only read text, and reading text
+    // is what let the first inline version ship requiring two parents on a tip
+    // that has one. Assert the inline form is gone so it cannot come back.
+    expect(publishJob).not.toMatch(/git rev-list --parents -n1 "\$tip"/);
   });
 
   it('refuses a pull request that moved while the rebuild ran, not only a moved main', () => {
@@ -205,7 +207,7 @@ describe('T-1502 canonical-merge.yml safety', () => {
     expect(lineOf('Refuse if either side moved while the rebuild ran')).toBeLessThan(
       lineOf('app-installation-token.mjs'),
     );
-    expect(lineOf('The bundle differs from an honest merge only where a rebuild may')).toBeLessThan(
+    expect(lineOf('The bundle is that merge, plus at most a rebuild')).toBeLessThan(
       lineOf('app-installation-token.mjs'),
     );
   });

--- a/test/canonical-merge-workflow.test.ts
+++ b/test/canonical-merge-workflow.test.ts
@@ -37,6 +37,44 @@ const lineOf = (needle: string): number => {
 };
 
 describe('T-1502 canonical-merge.yml safety', () => {
+  it('checks the bundle against a merge it recomputes, rather than trusting it', () => {
+    // The rebuild job executes a contributor's `package.json` and every
+    // lifecycle script `npm ci` pulls in. Anything that runs there can add a
+    // commit touching `src/`, `scripts/` or `.github/` before the bundle is
+    // written, and the publishing job would force-push it under the App's
+    // identity for a reviewer to read as a rebuild.
+    //
+    // So the second job recomputes the merge from `main` and the pull request
+    // ref -- neither writable from the first job -- and allows a difference
+    // only inside `dist/` and the manifest.
+    const publishJob = code().slice(code().indexOf('  publish:'));
+    expect(publishJob).toContain('git merge-tree --write-tree');
+    expect(publishJob).toMatch(/git diff --name-only "\$expected" "\$tip"/);
+    expect(publishJob).toContain("':(exclude)dist'");
+    expect(publishJob).toContain("':(exclude)installer/canonical-artifact.json'");
+    // Both parents pinned: a bundle whose branch is not a merge of exactly
+    // those two commits is a different history wearing the same branch name.
+    expect(publishJob).toMatch(/git rev-list --parents -n1 "\$tip"/);
+  });
+
+  it('refuses a pull request that moved while the rebuild ran, not only a moved main', () => {
+    // A force-push between the first job's fetch and the push would leave the
+    // canonical pull request carrying a head nobody reviewed while #N displays
+    // something else.
+    const publishJob = code().slice(code().indexOf('  publish:'));
+    expect(publishJob).toMatch(/pulls\/\$\{PR\}" --jq \.head\.sha/);
+    expect(publishJob).toContain('while this rebuilt -- rerun it');
+    expect(publishJob).toContain('commits/main');
+  });
+
+  it('reads the pushed ref back by sha instead of trusting the push exit code', () => {
+    // `git push` exiting zero says the push was accepted, not that the branch
+    // is still what this run put there.
+    const publishJob = code().slice(code().indexOf('  publish:'));
+    expect(publishJob).toMatch(/git\/ref\/heads\/\$branch" --jq \.object\.sha/);
+    expect(publishJob).toContain('not the $expected this pushed');
+  });
+
   it('opens the canonical pull request with no closing keyword in its body', () => {
     // T-1502's acceptance is that the source pull request ends up *merged*.
     // A closing keyword produces the opposite: GitHub records a pull request
@@ -158,9 +196,18 @@ describe('T-1502 canonical-merge.yml safety', () => {
     // it stood when the job started, and nothing stops another pull request
     // landing in between. Without this the job would open a pull request whose
     // bundle is of a tree that is no longer anybody's.
+    // Anchored on the publishing job's own step. Both jobs check that main
+    // stood still, so a substring that matches either one asserts nothing about
+    // the order of the second -- and renaming the publishing step is exactly
+    // when this assertion needs to notice.
     const body = code();
-    expect(body).toContain('Refuse if main moved');
-    expect(lineOf('Refuse if main moved')).toBeLessThan(lineOf('app-installation-token.mjs'));
+    expect(body).toContain('Refuse if either side moved while the rebuild ran');
+    expect(lineOf('Refuse if either side moved while the rebuild ran')).toBeLessThan(
+      lineOf('app-installation-token.mjs'),
+    );
+    expect(lineOf('The bundle differs from an honest merge only where a rebuild may')).toBeLessThan(
+      lineOf('app-installation-token.mjs'),
+    );
   });
 
   it('replaces its branch rather than updating it', () => {

--- a/test/verify-canonical-handoff.test.ts
+++ b/test/verify-canonical-handoff.test.ts
@@ -1,0 +1,185 @@
+/**
+ * T-1502 (#719): the publishing job's check on what the rebuild handed it,
+ * exercised against real repositories rather than by reading the workflow.
+ *
+ * The first version of this check lived inline in `canonical-merge.yml` and
+ * required the branch tip to have two parents. A real tip has one — the rebuild
+ * commits on top of the merge whenever `dist/` actually changes, which #762's
+ * `6a88f2f4` did. The workflow-text assertions passed anyway, because a grep
+ * over YAML cannot run it. Every case below is a mutation applied to a real
+ * commit graph, and each one has to be refused for its own reason.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = join(REPO_ROOT, 'scripts', 'verify-canonical-handoff.mjs');
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const path of temps) rmSync(path, { recursive: true, force: true });
+});
+
+const git = (cwd: string, args: string[]): string =>
+  execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+
+const run = (cwd: string, base: string, source: string, tip: string) => {
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      [SCRIPT, '--base', base, '--source', source, '--tip', tip, '--cwd', cwd],
+      { encoding: 'utf8' },
+    );
+    return { code: 0, stdout, stderr: '' };
+  } catch (error) {
+    const failure = error as { status?: number; stdout?: string; stderr?: string };
+    return { code: failure.status ?? 1, stdout: failure.stdout ?? '', stderr: failure.stderr ?? '' };
+  }
+};
+
+const write = (cwd: string, path: string, body: string): void => {
+  mkdirSync(dirname(join(cwd, path)), { recursive: true });
+  writeFileSync(join(cwd, path), body);
+};
+
+const commit = (cwd: string, message: string): string => {
+  git(cwd, ['add', '-A']);
+  git(cwd, ['commit', '--quiet', '-m', message]);
+  return git(cwd, ['rev-parse', 'HEAD']);
+};
+
+/**
+ * A repository shaped like a real run: `main` with a committed bundle, a
+ * source-only branch off it, a `--no-ff` merge, and a rebuild commit on top.
+ */
+const scenario = (label: string) => {
+  const cwd = mkdtempSync(join(tmpdir(), `commitlore-handoff-${label}-`));
+  temps.push(cwd);
+  git(cwd, ['init', '--quiet', '--initial-branch=main']);
+  git(cwd, ['config', 'user.email', `${label}@example.invalid`]);
+  git(cwd, ['config', 'user.name', label]);
+
+  write(cwd, 'src/a.ts', 'export const a = 1;\n');
+  write(cwd, 'dist/bundle.mjs', 'built from 1\n');
+  write(cwd, 'installer/canonical-artifact.json', '{"source":1}\n');
+  const base = commit(cwd, 'main');
+
+  git(cwd, ['checkout', '--quiet', '-b', 'source']);
+  write(cwd, 'src/a.ts', 'export const a = 2;\n');
+  const source = commit(cwd, 'source only');
+
+  git(cwd, ['checkout', '--quiet', 'main']);
+  git(cwd, ['checkout', '--quiet', '-b', 'canonical']);
+  git(cwd, ['merge', '--quiet', '--no-ff', '--no-edit', 'source']);
+  const merge = git(cwd, ['rev-parse', 'HEAD']);
+
+  write(cwd, 'dist/bundle.mjs', 'built from 2\n');
+  write(cwd, 'installer/canonical-artifact.json', '{"source":2}\n');
+  const tip = commit(cwd, 'Rebuild the canonical bundle');
+
+  return { cwd, base, source, merge, tip };
+};
+
+describe('the publishing job refuses a handoff that is not that merge', () => {
+  it('accepts a merge with a rebuild commit on top — the shape a real run produces', () => {
+    // #762 landed exactly this: tip 6a88f2f4 with one parent, whose parent is
+    // the two-parent merge acfed4a5. The inline check this replaced demanded
+    // two parents on the tip and would have failed every run that rebuilt.
+    const { cwd, base, source, tip } = scenario('accept-rebuild');
+    const result = run(cwd, base, source, tip);
+    expect(result.code, result.stderr).toBe(0);
+    expect(result.stdout).toContain('canonical handoff verified');
+  });
+
+  it('accepts a bare merge when the merged source already produced the bundle', () => {
+    const { cwd, base, source, merge } = scenario('accept-bare');
+    const result = run(cwd, base, source, merge);
+    expect(result.code, result.stderr).toBe(0);
+    expect(result.stdout).toContain('already produced the committed bundle');
+  });
+
+  it('refuses a rebuild commit that also touched a workflow', () => {
+    const { cwd, base, source, tip } = scenario('stray-workflow');
+    // Amended into the rebuild commit, not stacked on it. A second commit on
+    // top is a different violation, and it would mask this one.
+    write(cwd, '.github/workflows/x.yml', 'name: x\n');
+    git(cwd, ['add', '-A']);
+    git(cwd, ['commit', '--quiet', '--amend', '--no-edit']);
+    const tampered = git(cwd, ['rev-parse', 'HEAD']);
+    expect(tampered).not.toBe(tip);
+    const result = run(cwd, base, source, tampered);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('.github/workflows/x.yml');
+  });
+
+  it('refuses a rebuild commit that also touched source', () => {
+    const { cwd, base, source } = scenario('stray-source');
+    write(cwd, 'src/a.ts', 'export const a = 99;\n');
+    git(cwd, ['add', '-A']);
+    git(cwd, ['commit', '--quiet', '--amend', '--no-edit']);
+    const tampered = git(cwd, ['rev-parse', 'HEAD']);
+    const result = run(cwd, base, source, tampered);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('src/a.ts');
+  });
+
+  it('refuses a merge whose second parent is a different commit', () => {
+    // The recorded source head is what a reviewer read. A bundle built from
+    // another branch has the right shape and the wrong content.
+    const { cwd, base, source } = scenario('wrong-parent');
+    git(cwd, ['checkout', '--quiet', '-b', 'other', base]);
+    write(cwd, 'src/a.ts', 'export const a = 3;\n');
+    const other = commit(cwd, 'a different source');
+    git(cwd, ['checkout', '--quiet', '-b', 'canonical-other', base]);
+    git(cwd, ['merge', '--quiet', '--no-ff', '--no-edit', other]);
+    const tip = git(cwd, ['rev-parse', 'HEAD']);
+    const result = run(cwd, base, source, tip);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/the merge joins/);
+  });
+
+  it('refuses a merge that carries an edit a real merge would not produce', () => {
+    // Right parents, wrong tree: an amended merge commit is the shape a
+    // lifecycle script can build without touching either branch.
+    const { cwd, base, source, merge } = scenario('smuggled-tree');
+    git(cwd, ['checkout', '--quiet', merge]);
+    write(cwd, 'src/smuggled.ts', 'export const smuggled = true;\n');
+    git(cwd, ['add', '-A']);
+    git(cwd, ['commit', '--quiet', '--amend', '--no-edit']);
+    const tip = git(cwd, ['rev-parse', 'HEAD']);
+    const result = run(cwd, base, source, tip);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("the merge's tree is");
+  });
+
+  it('refuses a source branch that carries the artifact itself', () => {
+    const { cwd, base } = scenario('source-carries-dist');
+    git(cwd, ['checkout', '--quiet', '-b', 'source-dist', base]);
+    write(cwd, 'src/a.ts', 'export const a = 4;\n');
+    write(cwd, 'dist/bundle.mjs', 'hand written\n');
+    const source = commit(cwd, 'source plus dist');
+    git(cwd, ['checkout', '--quiet', '-b', 'canonical-dist', base]);
+    git(cwd, ['merge', '--quiet', '--no-ff', '--no-edit', source]);
+    const tip = git(cwd, ['rev-parse', 'HEAD']);
+    const result = run(cwd, base, source, tip);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('may not');
+  });
+
+  it('refuses a chain of two commits on the merge', () => {
+    // One artifact commit is a rebuild. Two means the second had no rebuild
+    // left to record, and is carrying something else.
+    const { cwd, base, source } = scenario('two-on-top');
+    write(cwd, 'dist/bundle.mjs', 'built again\n');
+    const tip = commit(cwd, 'and again');
+    const result = run(cwd, base, source, tip);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/not a merge commit/);
+  });
+});


### PR DESCRIPTION
Reverts `532c30f4` and hardens the handoff it was built on top of.

## Why T-1503 is rejected rather than fixed

It made a source-only pull request **green**. Green is mergeable, and the button then lands `src/` with no rebuilt `dist/` — `main` carrying a bundle that does not match its source until the next push run goes red, after the fact rather than before it.

#761 was red, and that redness is why it went through `canonical-merge` instead of through its own merge button. **The friction was the mechanism.**

What T-1503 was written to fix is already fixed by T-1502, without the risk: a contributor opens the source-only pull request and never rebuilds anything. Its checks being red is a statement about the artifact, not a demand on them.

The measurement T-1503 produced is kept in the ticket, because it is the part worth having: *"drop the diff line"* was wrong, since CI rebuilds before it verifies and a source-only pull request dies at `artifact:verify` without ever reaching the diff.

## The handoff was proven against a pull request the owner wrote

`publish` carried a comment saying it *"only moves bytes it verifies"*, and it verified none of them.

| what | before | now |
|---|---|---|
| bundle contents | force-pushed as received | merge recomputed here from `main` + the PR ref; both parents pinned; a difference allowed only inside `dist/` and the manifest |
| PR head race | unchecked | refused if `#N`'s head moved since the rebuild fetched it, and if the ref no longer resolves to it |
| push result | `git push` exit code | ref read back by sha; refused if the server holds anything else |
| App token | body-less mint — every permission on every repository the installation holds | scoped to this repository, `contents: write` + `pull_requests: write` |

The rebuild job runs a contributor's `package.json` and every lifecycle script `npm ci` pulls in. Anything there could add a commit touching `src/`, `scripts/` or `.github/`, and this job would have force-pushed it under the App's identity for a reviewer to read as a rebuild.

## T-1504 and the PRD

T-1504's acceptance moves from a **person-observation** — *"a non-Linux contributor completing a source change unaided"* — to the system properties it was standing in for. That gate cannot be satisfied from inside the repository, so it left the work permanently unfinished for a reason unrelated to the work. It was also indifferent to what it named: the canonical build never runs on a contributor's machine, so "non-Linux" was a proxy for "cannot run the canonical build" and the mechanism does not distinguish the two.

Field experience is recorded as a **Limit** instead: adoption evidence, not a correctness gate. A real-world failure reopens #719 or opens a defect issue.

The PRD's success criteria are fixed against the runs that show them. The old first criterion — *"no pull request carries `dist/`"* — is contradicted by the thing that was built: the canonical pull request carries exactly that, and carrying it is how the required contexts run on the tree that lands.

## Verified

Reverting the hardening fails all three new workflow assertions; restoring it passes nineteen.

The ordering assertion for the credential step was matching the **other** job's identically-named step after a rename — both jobs check that `main` stood still — so it was asserting nothing about the publishing job. Re-anchored on the renamed step and extended to cover the new verification.

`ci.yml`'s locked digest is back to `473b1fc0…` and matches the file.

## Still open, and it needs the owner

**Merge-commit-only is not enforced.** It is a sentence in a pull request body, which is a check somebody has to read — the exact shape that cost #752 its `merged` label during the 1.1.3 release. The repository still allows squash and rebase, and the merge button remembers the last method used.

```
gh api -X PUT repos/MongLong0214/commitlore -F allow_squash_merge=false -F allow_rebase_merge=false
```

Recorded as the Limit on this commit until it is done.