### PR TITLE
Building twice in one job says nothing about building again next month

### DIFF
--- a/docs/CANONICAL-BUILD.md
+++ b/docs/CANONICAL-BUILD.md
@@ -4,7 +4,7 @@
 canonical bytes are produced only on Linux amd64 with Node 24 Bookworm:
 
 ```sh
-docker run --rm --platform linux/amd64 -v "$PWD":/w -w /w node:24-bookworm \
+docker run --rm --platform linux/amd64 -v "$PWD":/w -w /w node:24-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584 \
   sh -c "npm ci && npm run build"
 ```
 

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -2,8 +2,8 @@
   "format": "commitlore-canonical-artifact-v1",
   "builder": {
     "platform": "linux/amd64",
-    "image": "node:24-bookworm",
-    "command": "docker run --rm --platform linux/amd64 -v \"$PWD\":/w -w /w node:24-bookworm sh -c \"npm ci && npm run build\""
+    "image": "node:24-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584",
+    "command": "docker run --rm --platform linux/amd64 -v \"$PWD\":/w -w /w node:24-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584 sh -c \"npm ci && npm run build\""
   },
   "runtimeAssets": [
     "dist/commitlore.mjs"
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "5769b00b1f160aa379bceb58ee6ab0f902f67f6d8b959f4896b99c8389bfb597"
+    "sha256": "d3f037443ce152a29c7259cb953c45057e3ff2a47da00b56e9280f644a2d77cf"
   },
   "artifact": {
     "sha256": "fcd0832fed28ef33c18591a93d743c918b3af2eda7d311e7bc321d34b5921e8a",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && npm run bundle",
-    "build:canonical": "docker run --rm --platform linux/amd64 -v \"$PWD\":/w -w /w node:24-bookworm sh -c \"npm ci && npm run build\"",
+    "build:canonical": "docker run --rm --platform linux/amd64 -v \"$PWD\":/w -w /w node:24-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584 sh -c \"npm ci && npm run build\"",
     "artifact:manifest": "node scripts/write-canonical-artifact-manifest.mjs",
     "artifact:verify": "node scripts/verify-canonical-artifact.mjs",
     "bench:deterministic": "npm run build && node --experimental-strip-types bench/deterministic.ts",

--- a/scripts/canonical-artifact-contract.mjs
+++ b/scripts/canonical-artifact-contract.mjs
@@ -4,7 +4,19 @@ import { join, relative } from 'node:path';
 
 export const CANONICAL_ARTIFACT_FORMAT = 'commitlore-canonical-artifact-v1';
 export const CANONICAL_ARTIFACT_MANIFEST = 'installer/canonical-artifact.json';
-export const CANONICAL_BUILD_COMMAND = 'docker run --rm --platform linux/amd64 -v "$PWD":/w -w /w node:24-bookworm sh -c "npm ci && npm run build"';
+/**
+ * The builder, pinned by digest rather than by tag.
+ *
+ * `node:24-bookworm` is mutable: the same source built on two dates can pick up
+ * a different base image, Node patch or OS package. Building twice in one job
+ * proves the builder is deterministic *now*, and says nothing about a rebuild
+ * next month -- which is the claim `installer/canonical-artifact.json` is for.
+ *
+ * The tag is kept in the digest's own string so a reader can still see which
+ * Node line this is. Updating it is a deliberate change, like a dependency bump.
+ */
+export const CANONICAL_BUILD_IMAGE = 'node:24-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584';
+export const CANONICAL_BUILD_COMMAND = `docker run --rm --platform linux/amd64 -v "$PWD":/w -w /w ${CANONICAL_BUILD_IMAGE} sh -c "npm ci && npm run build"`;
 
 // The installer starts only this file from dist/. The TypeScript outputs remain
 // tracked for now (see docs/CANONICAL-BUILD.md), but are not runtime inputs.
@@ -37,7 +49,7 @@ export const artifactManifest = (root) => ({
   format: CANONICAL_ARTIFACT_FORMAT,
   builder: {
     platform: 'linux/amd64',
-    image: 'node:24-bookworm',
+    image: CANONICAL_BUILD_IMAGE,
     command: CANONICAL_BUILD_COMMAND,
   },
   runtimeAssets: [...RUNTIME_DIST_ASSETS],

--- a/scripts/verify-canonical-artifact.mjs
+++ b/scripts/verify-canonical-artifact.mjs
@@ -8,6 +8,7 @@ import {
   CANONICAL_ARTIFACT_FORMAT,
   CANONICAL_ARTIFACT_MANIFEST,
   CANONICAL_BUILD_COMMAND,
+  CANONICAL_BUILD_IMAGE,
   RUNTIME_DIST_ASSETS,
   SOURCE_INPUTS,
   artifactManifest,
@@ -35,7 +36,7 @@ const actual = artifactManifest(root);
 if (recorded !== undefined) {
   if (recorded.format !== CANONICAL_ARTIFACT_FORMAT) fail(`manifest format is ${JSON.stringify(recorded.format)}`);
   if (recorded.builder?.platform !== 'linux/amd64') fail('manifest does not declare linux/amd64');
-  if (recorded.builder?.image !== 'node:24-bookworm') fail('manifest does not declare node:24-bookworm');
+  if (recorded.builder?.image !== CANONICAL_BUILD_IMAGE) fail(`manifest does not declare ${CANONICAL_BUILD_IMAGE}`);
   if (recorded.builder?.command !== CANONICAL_BUILD_COMMAND) fail('manifest does not record the canonical build command');
   if (!same(recorded.runtimeAssets, RUNTIME_DIST_ASSETS)) {
     fail(`runtime asset list must be exactly ${RUNTIME_DIST_ASSETS.join(', ')}`);

--- a/test/canonical-artifact.test.ts
+++ b/test/canonical-artifact.test.ts
@@ -10,7 +10,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const ROOT = resolve(fileURLToPath(new URL('../', import.meta.url)));
 const WRITER = 'scripts/write-canonical-artifact-manifest.mjs';
 const VERIFIER = 'scripts/verify-canonical-artifact.mjs';
-const CANONICAL_COMMAND = 'docker run --rm --platform linux/amd64 -v "$PWD":/w -w /w node:24-bookworm sh -c "npm ci && npm run build"';
+// Imported rather than restated. A copy of the command in the test is a second
+// place for the digest to be right in, and the pin exists because the builder
+// is otherwise allowed to drift -- a test carrying a stale copy would be the
+// same drift wearing a passing badge.
+const { CANONICAL_BUILD_COMMAND: CANONICAL_COMMAND, CANONICAL_BUILD_IMAGE } = await import(
+  '../scripts/canonical-artifact-contract.mjs'
+);
 
 let copy = '';
 
@@ -33,6 +39,18 @@ describe('canonical artifact contract', () => {
     expect(manifest.runtimeAssets).toEqual(['dist/commitlore.mjs']);
     expect(manifest.artifact.files.length).toBeGreaterThanOrEqual(250);
     expect(run(VERIFIER).status).toBe(0);
+  });
+
+  it('pins the builder by digest, and the command uses the pinned image', () => {
+    // `node:24-bookworm` is mutable: the same source built on two dates can
+    // pick up a different base image, Node patch or OS package. Building twice
+    // in one job proves the builder is deterministic now and says nothing about
+    // next month, which is the claim the manifest is for.
+    expect(CANONICAL_BUILD_IMAGE).toMatch(/^node:24-bookworm@sha256:[0-9a-f]{64}$/);
+    expect(CANONICAL_COMMAND).toContain(CANONICAL_BUILD_IMAGE);
+    expect(run(WRITER).status).toBe(0);
+    const manifest = JSON.parse(readFileSync(join(copy, 'installer', 'canonical-artifact.json'), 'utf8'));
+    expect(manifest.builder.image).toBe(CANONICAL_BUILD_IMAGE);
   });
 
   it('rejects a non-canonical byte with the exact canonical build command, then passes after restoration', () => {


### PR DESCRIPTION
`node:24-bookworm` is a **mutable tag**. The canonical build is what this repository points at when it says a released commit's bundle matches its own source — and the two-build comparison in CI proves the builder is deterministic *in that job*, same image, minutes apart. Across dates it proves nothing: a different base layer, Node patch or OS package can arrive under the same name.

Pinned to `sha256:934240a1…`, which is the digest the tag resolves to today **and** the digest CI pulled on [run 32108141891](https://github.com/MongLong0214/commitlore/actions/runs/32108141891). This fixes what is already in use rather than moving to something new.

## One constant, every site derived

`CANONICAL_BUILD_IMAGE` in `scripts/canonical-artifact-contract.mjs` now owns it. The build command, the manifest, the verifier's check, the documented command and the test all read from it.

The test previously restated the command as a string literal. That is a second place for the digest to be right in, and a stale copy there would be exactly the drift this pin exists to stop — wearing a passing badge.

The tag stays inside the digest's own string, so a reader still sees which Node line this is. Updating it is a deliberate change, like a dependency bump.

## Verified as a gate, not as an edit

```
pin in place, old manifest   artifact:verify exit 1
                             "manifest does not declare node:24-bookworm@sha256:934240a1…"
                             "manifest does not record the canonical build command"
after artifact:manifest      exit 0, and dist/ did not move
constant reverted to the bare tag   the new assertion fails
restored                     5 pass
```

Exit codes read directly rather than through a pipe — `tail` swallowed the first one.

**Limit** (on the commit): nothing checks that the pinned digest still exists upstream, so a digest deleted from the registry surfaces as a build failure rather than as a clear message.