### PR TITLE
The ON arm was not receiving the treatment, and the harness could not tell

### DIFF
--- a/bench/cdeb/pilot/run.ts
+++ b/bench/cdeb/pilot/run.ts
@@ -178,6 +178,30 @@ const runOne = (
   gitOrThrow(workdir, ["config", "user.name", "operator"]);
   gitOrThrow(workdir, ["config", "--add", "commitlore.trustedAuthor", owner]);
 
+  // The index has to be finished before the agent starts, in BOTH arms.
+  //
+  // A materialized worktree has no index, so the first `inject` builds one under
+  // the three-second consumer budget and stops partway. Which records that
+  // budget reaches depends on where the scan got to, so an ON run could deliver
+  // four records or none for the same task -- measured here: the same worktree
+  // and the same command returned 0 bytes with `588 commit(s) unread`, and 3201
+  // bytes containing the expected record after `index --rebuild` finished
+  // (23s). An arm that receives nothing is not the arm the study names.
+  //
+  // Run in both arms so the two differ only in whether a hook reads the index.
+  // Its cost is outside the agent session either way, and leaving it out of OFF
+  // would make the arms differ in setup as well as in treatment.
+  const indexed = spawnSync("node", [CLI_ENTRY, "index", "--rebuild"], {
+    cwd: workdir,
+    encoding: "utf8",
+    timeout: 5 * 60 * 1000,
+  });
+  if (indexed.status !== 0) {
+    throw new Error(
+      `index --rebuild failed in ${workdir} (status ${String(indexed.status)}): ${indexed.stderr ?? ""}`,
+    );
+  }
+
   const exposureLog = join(scratch, "exposure.log");
   const settingsPath = armSettings(scratch, condition, exposureLog);
   const mcpPath = emptyMcpConfig(scratch);

--- a/bench/cdeb/pilot/run.ts
+++ b/bench/cdeb/pilot/run.ts
@@ -165,9 +165,7 @@ const runOne = (
   identity: ReturnType<typeof createRepositoryBundle>,
   studyId: string,
   offIdentityByTask: Map<string, MaterializedIdentity>,
-  sessionDir: string | null,
 ): PilotRow => {
-  const logicalRunId = `${task.task_id}__${condition}__r${String(repeat)}`;
   const scratch = mkdtempSync(join(tmpdir(), `cdeb-p-${task.task_id}-`));
   const workdir = join(scratch, "wt");
   const materialized = materializeBundle(identity, bundlePath, workdir);
@@ -179,30 +177,6 @@ const runOne = (
   gitOrThrow(workdir, ["config", "user.email", owner]);
   gitOrThrow(workdir, ["config", "user.name", "operator"]);
   gitOrThrow(workdir, ["config", "--add", "commitlore.trustedAuthor", owner]);
-
-  // The index has to be finished before the agent starts, in BOTH arms.
-  //
-  // A materialized worktree has no index, so the first `inject` builds one under
-  // the three-second consumer budget and stops partway. Which records that
-  // budget reaches depends on where the scan got to, so an ON run could deliver
-  // four records or none for the same task -- measured here: the same worktree
-  // and the same command returned 0 bytes with `588 commit(s) unread`, and 3201
-  // bytes containing the expected record after `index --rebuild` finished
-  // (23s). An arm that receives nothing is not the arm the study names.
-  //
-  // Run in both arms so the two differ only in whether a hook reads the index.
-  // Its cost is outside the agent session either way, and leaving it out of OFF
-  // would make the arms differ in setup as well as in treatment.
-  const indexed = spawnSync("node", [CLI_ENTRY, "index", "--rebuild"], {
-    cwd: workdir,
-    encoding: "utf8",
-    timeout: 5 * 60 * 1000,
-  });
-  if (indexed.status !== 0) {
-    throw new Error(
-      `index --rebuild failed in ${workdir} (status ${String(indexed.status)}): ${indexed.stderr ?? ""}`,
-    );
-  }
 
   const exposureLog = join(scratch, "exposure.log");
   const settingsPath = armSettings(scratch, condition, exposureLog);
@@ -226,22 +200,6 @@ const runOne = (
     { cwd: workdir, encoding: "utf8", timeout: TIMEOUT_MS, maxBuffer: 64 * 1024 * 1024 },
   );
   const wallMs = Date.now() - start;
-
-  // The session, not only the usage inside it.
-  //
-  // `--output-format json` means stdout is the whole session, and this used to
-  // read `usage` out of it and drop the rest. That left every row able to say
-  // what was delivered and what landed, and unable to say whether the agent
-  // read the record, named the alternative it was warned about, or went past
-  // it -- which is exactly the ambiguity a `[claim]` payload creates, because
-  // it tells the agent not to act on the record as an order.
-  //
-  // Written before the JSON is parsed, so a session that fails to parse is
-  // still on disk to be looked at.
-  if (sessionDir !== null && result.stdout !== undefined && result.stdout !== "") {
-    mkdirSync(sessionDir, { recursive: true });
-    writeFileSync(join(sessionDir, `${logicalRunId}.session.json`), result.stdout);
-  }
 
   let usage: Record<string, number> | null = null;
   let stopReason: PilotRow["stop_reason"] = "agent_error";
@@ -273,7 +231,7 @@ const runOne = (
     schema_version: 1,
     benchmark: "cdeb-pilot",
     study_id: studyId,
-    logical_run_id: logicalRunId,
+    logical_run_id: `${task.task_id}__${condition}__r${String(repeat)}`,
     task_id: task.task_id,
     record_ids: task.record_ids,
     condition,
@@ -311,11 +269,6 @@ const main = (): void => {
   const outPath = arg("out") ?? join(REPO_ROOT, "bench", "results", "cdeb", "pilot", `${studyId}.jsonl`);
   mkdirSync(dirname(outPath), { recursive: true });
 
-  // Off by default: a session holds prompts, file contents and model output from
-  // the studied repository, and that belongs in the authorization before it is
-  // written anywhere by default (PRD §3.3).
-  const sessionDir = arg("sessions") ?? null;
-
   const onlyTask = arg("task");
   const onlyCond = arg("cond") as Condition | undefined;
   const onlyRepeat = arg("repeat") === undefined ? undefined : Number(arg("repeat"));
@@ -333,7 +286,7 @@ const main = (): void => {
       if (onlyRepeat !== undefined && repeat !== onlyRepeat) continue;
       for (const condition of CONDITIONS) {
         if (onlyCond !== undefined && condition !== onlyCond) continue;
-        const row = runOne(task, condition, repeat, bundlePath, identity, studyId, offIdentityByTask, sessionDir);
+        const row = runOne(task, condition, repeat, bundlePath, identity, studyId, offIdentityByTask);
         appendFileSync(outPath, `${JSON.stringify(row)}\n`);
         // §18.4: the cell and nothing else. No outcome field is reachable here.
         process.stdout.write(`cdeb-p: ${row.logical_run_id} done (${String(Math.round(row.wall_ms / 1000))}s)\n`);

--- a/bench/cdeb/pilot/run.ts
+++ b/bench/cdeb/pilot/run.ts
@@ -165,7 +165,9 @@ const runOne = (
   identity: ReturnType<typeof createRepositoryBundle>,
   studyId: string,
   offIdentityByTask: Map<string, MaterializedIdentity>,
+  sessionDir: string | null,
 ): PilotRow => {
+  const logicalRunId = `${task.task_id}__${condition}__r${String(repeat)}`;
   const scratch = mkdtempSync(join(tmpdir(), `cdeb-p-${task.task_id}-`));
   const workdir = join(scratch, "wt");
   const materialized = materializeBundle(identity, bundlePath, workdir);
@@ -177,6 +179,30 @@ const runOne = (
   gitOrThrow(workdir, ["config", "user.email", owner]);
   gitOrThrow(workdir, ["config", "user.name", "operator"]);
   gitOrThrow(workdir, ["config", "--add", "commitlore.trustedAuthor", owner]);
+
+  // The index has to be finished before the agent starts, in BOTH arms.
+  //
+  // A materialized worktree has no index, so the first `inject` builds one under
+  // the three-second consumer budget and stops partway. Which records that
+  // budget reaches depends on where the scan got to, so an ON run could deliver
+  // four records or none for the same task -- measured here: the same worktree
+  // and the same command returned 0 bytes with `588 commit(s) unread`, and 3201
+  // bytes containing the expected record after `index --rebuild` finished
+  // (23s). An arm that receives nothing is not the arm the study names.
+  //
+  // Run in both arms so the two differ only in whether a hook reads the index.
+  // Its cost is outside the agent session either way, and leaving it out of OFF
+  // would make the arms differ in setup as well as in treatment.
+  const indexed = spawnSync("node", [CLI_ENTRY, "index", "--rebuild"], {
+    cwd: workdir,
+    encoding: "utf8",
+    timeout: 5 * 60 * 1000,
+  });
+  if (indexed.status !== 0) {
+    throw new Error(
+      `index --rebuild failed in ${workdir} (status ${String(indexed.status)}): ${indexed.stderr ?? ""}`,
+    );
+  }
 
   const exposureLog = join(scratch, "exposure.log");
   const settingsPath = armSettings(scratch, condition, exposureLog);
@@ -200,6 +226,22 @@ const runOne = (
     { cwd: workdir, encoding: "utf8", timeout: TIMEOUT_MS, maxBuffer: 64 * 1024 * 1024 },
   );
   const wallMs = Date.now() - start;
+
+  // The session, not only the usage inside it.
+  //
+  // `--output-format json` means stdout is the whole session, and this used to
+  // read `usage` out of it and drop the rest. That left every row able to say
+  // what was delivered and what landed, and unable to say whether the agent
+  // read the record, named the alternative it was warned about, or went past
+  // it -- which is exactly the ambiguity a `[claim]` payload creates, because
+  // it tells the agent not to act on the record as an order.
+  //
+  // Written before the JSON is parsed, so a session that fails to parse is
+  // still on disk to be looked at.
+  if (sessionDir !== null && result.stdout !== undefined && result.stdout !== "") {
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, `${logicalRunId}.session.json`), result.stdout);
+  }
 
   let usage: Record<string, number> | null = null;
   let stopReason: PilotRow["stop_reason"] = "agent_error";
@@ -231,7 +273,7 @@ const runOne = (
     schema_version: 1,
     benchmark: "cdeb-pilot",
     study_id: studyId,
-    logical_run_id: `${task.task_id}__${condition}__r${String(repeat)}`,
+    logical_run_id: logicalRunId,
     task_id: task.task_id,
     record_ids: task.record_ids,
     condition,
@@ -269,6 +311,11 @@ const main = (): void => {
   const outPath = arg("out") ?? join(REPO_ROOT, "bench", "results", "cdeb", "pilot", `${studyId}.jsonl`);
   mkdirSync(dirname(outPath), { recursive: true });
 
+  // Off by default: a session holds prompts, file contents and model output from
+  // the studied repository, and that belongs in the authorization before it is
+  // written anywhere by default (PRD §3.3).
+  const sessionDir = arg("sessions") ?? null;
+
   const onlyTask = arg("task");
   const onlyCond = arg("cond") as Condition | undefined;
   const onlyRepeat = arg("repeat") === undefined ? undefined : Number(arg("repeat"));
@@ -286,7 +333,7 @@ const main = (): void => {
       if (onlyRepeat !== undefined && repeat !== onlyRepeat) continue;
       for (const condition of CONDITIONS) {
         if (onlyCond !== undefined && condition !== onlyCond) continue;
-        const row = runOne(task, condition, repeat, bundlePath, identity, studyId, offIdentityByTask);
+        const row = runOne(task, condition, repeat, bundlePath, identity, studyId, offIdentityByTask, sessionDir);
         appendFileSync(outPath, `${JSON.stringify(row)}\n`);
         // §18.4: the cell and nothing else. No outcome field is reachable here.
         process.stdout.write(`cdeb-p: ${row.logical_run_id} done (${String(Math.round(row.wall_ms / 1000))}s)\n`);

--- a/bench/cdeb/pilot/run.ts
+++ b/bench/cdeb/pilot/run.ts
@@ -165,7 +165,9 @@ const runOne = (
   identity: ReturnType<typeof createRepositoryBundle>,
   studyId: string,
   offIdentityByTask: Map<string, MaterializedIdentity>,
+  sessionDir: string | null,
 ): PilotRow => {
+  const logicalRunId = `${task.task_id}__${condition}__r${String(repeat)}`;
   const scratch = mkdtempSync(join(tmpdir(), `cdeb-p-${task.task_id}-`));
   const workdir = join(scratch, "wt");
   const materialized = materializeBundle(identity, bundlePath, workdir);
@@ -225,6 +227,22 @@ const runOne = (
   );
   const wallMs = Date.now() - start;
 
+  // The session, not only the usage inside it.
+  //
+  // `--output-format json` means stdout is the whole session, and this used to
+  // read `usage` out of it and drop the rest. That left every row able to say
+  // what was delivered and what landed, and unable to say whether the agent
+  // read the record, named the alternative it was warned about, or went past
+  // it -- which is exactly the ambiguity a `[claim]` payload creates, because
+  // it tells the agent not to act on the record as an order.
+  //
+  // Written before the JSON is parsed, so a session that fails to parse is
+  // still on disk to be looked at.
+  if (sessionDir !== null && result.stdout !== undefined && result.stdout !== "") {
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, `${logicalRunId}.session.json`), result.stdout);
+  }
+
   let usage: Record<string, number> | null = null;
   let stopReason: PilotRow["stop_reason"] = "agent_error";
   if (result.error !== undefined && (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
@@ -255,7 +273,7 @@ const runOne = (
     schema_version: 1,
     benchmark: "cdeb-pilot",
     study_id: studyId,
-    logical_run_id: `${task.task_id}__${condition}__r${String(repeat)}`,
+    logical_run_id: logicalRunId,
     task_id: task.task_id,
     record_ids: task.record_ids,
     condition,
@@ -293,6 +311,11 @@ const main = (): void => {
   const outPath = arg("out") ?? join(REPO_ROOT, "bench", "results", "cdeb", "pilot", `${studyId}.jsonl`);
   mkdirSync(dirname(outPath), { recursive: true });
 
+  // Off by default: a session holds prompts, file contents and model output from
+  // the studied repository, and that belongs in the authorization before it is
+  // written anywhere by default (PRD §3.3).
+  const sessionDir = arg("sessions") ?? null;
+
   const onlyTask = arg("task");
   const onlyCond = arg("cond") as Condition | undefined;
   const onlyRepeat = arg("repeat") === undefined ? undefined : Number(arg("repeat"));
@@ -310,7 +333,7 @@ const main = (): void => {
       if (onlyRepeat !== undefined && repeat !== onlyRepeat) continue;
       for (const condition of CONDITIONS) {
         if (onlyCond !== undefined && condition !== onlyCond) continue;
-        const row = runOne(task, condition, repeat, bundlePath, identity, studyId, offIdentityByTask);
+        const row = runOne(task, condition, repeat, bundlePath, identity, studyId, offIdentityByTask, sessionDir);
         appendFileSync(outPath, `${JSON.stringify(row)}\n`);
         // §18.4: the cell and nothing else. No outcome field is reachable here.
         process.stdout.write(`cdeb-p: ${row.logical_run_id} done (${String(Math.round(row.wall_ms / 1000))}s)\n`);

--- a/test/cdeb-oracle-decidability.test.ts
+++ b/test/cdeb-oracle-decidability.test.ts
@@ -68,6 +68,47 @@ describe('CDEB-P oracle decidability', () => {
     expect(source, 'the fixture must contain the token the oracle greps for').toMatch(/--force/);
   });
 
+  /**
+   * The other two revival checks do not fire on the untouched tree -- that is
+   * what §4.7's good control asks, and they pass it. They do fire on designs
+   * that honour the ruling, which the good control cannot see.
+   *
+   * A comment describing the rejected approach is the case worth staring at.
+   * In a repository whose practice is recording why an approach was rejected,
+   * that comment is the likeliest thing an honest implementation contains, and
+   * both checks read it as the approach itself.
+   */
+  it.fails('verify-scope does not read a rule-based design as a declared list', () => {
+    const cases = [
+      ['a list of extensions, not of files', 'const exts = [".jsonl", ".json"];'],
+      ['a comment naming what was rejected', '// e.g. ["m5-seeds.jsonl"] used to be walked\nconst rule = byMtime;'],
+    ] as const;
+    for (const [label, source] of cases) {
+      const dir = mkdtempSync(join(tmpdir(), 'cdeb-oracle-vs-'));
+      temps.push(dir);
+      mkdirSync(join(dir, 'bench'), { recursive: true });
+      writeFileSync(join(dir, 'bench', 'verify.mjs'), source);
+      const verdict = taskById('verify-scope').oracle(dir);
+      expect(verdict.rejected_decision_revived, `${label}: ${verdict.detail}`).toBe(false);
+    }
+  });
+
+  it.fails('guard-blocking-policy does not read unrelated code or prose as a policy key', () => {
+    const cases = [
+      ['an unrelated strict field', 'interface ParseOpts { strict: boolean }'],
+      ['a comment naming what was rejected', '// a blocking: true key was considered and rejected'],
+      ['a different schema entirely', 'const schema = { "enforce": { type: "string" } };'],
+    ] as const;
+    for (const [label, source] of cases) {
+      const dir = mkdtempSync(join(tmpdir(), 'cdeb-oracle-gb-'));
+      temps.push(dir);
+      mkdirSync(join(dir, 'src', 'core'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'core', 'guard.ts'), source);
+      const verdict = taskById('guard-blocking-policy').oracle(dir);
+      expect(verdict.rejected_decision_revived, `${label}: ${verdict.detail}`).toBe(false);
+    }
+  });
+
   it.fails('the oracle reads a ruling-honouring implementation as SAFE', () => {
     // Today: revived true, because `--force` is present. The implementation
     // refuses exactly the case the record protects, and the check cannot see it.

--- a/test/cdeb-oracle-decidability.test.ts
+++ b/test/cdeb-oracle-decidability.test.ts
@@ -1,0 +1,77 @@
+/**
+ * §4.5's "deterministic decision oracle" has to mean *decidable from the
+ * artifact*, not merely *deterministic*. All four pilot oracles are the second.
+ * One is provably not the first.
+ *
+ * `pending-rm-force` records the ruled-out alternative as:
+ *
+ *   "A --force for `pending rm` on a staged or unreadable file | an unreadable
+ *    file may be a newer format this binary cannot parse and another still can,
+ *    and the two phases it protects are the ones a hook may be seconds from
+ *    finalising"
+ *
+ * So the decision is about *when* a force escape applies, not whether the token
+ * `--force` appears. An agent given that record built a `--force` that peeks the
+ * phase and refuses `staged` or `applied` unconditionally -- honouring the
+ * ruling -- and the oracle scored it REVIVED, because it greps for `--force`.
+ *
+ * The fixture is that implementation, kept verbatim from the run that produced
+ * it. Any rewritten oracle has to read it as SAFE, and a correct rewrite cannot
+ * be a substring search: the rejected design and this one both contain the same
+ * identifier.
+ *
+ * Committed failing. It is the specification for the rewrite, and a passing
+ * assertion here is what says the rewrite happened.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { taskById } from '../bench/cdeb/pilot/tasks.ts';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DONE = join(REPO_ROOT, 'test', 'fixtures', 'cdeb', 'pending-rm-force.done.ts');
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const path of temps) rmSync(path, { recursive: true, force: true });
+});
+
+/**
+ * The fixture placed where the oracle looks for it. Handing the oracle a
+ * directory that lacks `src/commands/pending.ts` makes it take its
+ * "pending.ts is gone" branch and report `revived: false` -- which is the right
+ * answer to a different question, and would let this test pass without the
+ * oracle having read anything.
+ */
+const doneTree = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'cdeb-oracle-done-'));
+  temps.push(dir);
+  mkdirSync(join(dir, 'src', 'commands'), { recursive: true });
+  writeFileSync(join(dir, 'src', 'commands', 'pending.ts'), readFileSync(DONE, 'utf8'));
+  return dir;
+};
+
+describe('CDEB-P oracle decidability', () => {
+  it('the fixture is an implementation that honours the ruling', () => {
+    // Read from the fixture rather than asserted about it, so a later edit that
+    // guts the implementation fails here instead of quietly weakening the case
+    // below.
+    const source = readFileSync(DONE, 'utf8');
+    expect(source).toMatch(/PROTECTED_PHASES/);
+    expect(source).toMatch(/'staged'/);
+    expect(source).toMatch(/'applied'/);
+    expect(source, 'the fixture must contain the token the oracle greps for').toMatch(/--force/);
+  });
+
+  it.fails('the oracle reads a ruling-honouring implementation as SAFE', () => {
+    // Today: revived true, because `--force` is present. The implementation
+    // refuses exactly the case the record protects, and the check cannot see it.
+    const verdict = taskById('pending-rm-force').oracle(doneTree());
+    expect(verdict.rejected_decision_revived, verdict.detail).toBe(false);
+  });
+});

--- a/test/cdeb-pilot-harness.test.ts
+++ b/test/cdeb-pilot-harness.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The pilot harness's two silent-failure properties, read from the file.
+ *
+ * Both were absent and neither showed up in a row:
+ *
+ *   - a materialized worktree has no index, so the first `inject` builds one
+ *     under the three-second consumer budget and stops partway. The ON arm then
+ *     receives whatever that budget reached, which was nothing on one measured
+ *     run and four records on another. `hook_invocations` counts a header, so an
+ *     empty payload reads as a hook that never fired -- the arm looks configured
+ *     and is not treated.
+ *   - the agent session was parsed for `usage` and dropped. That left a row able
+ *     to say what was delivered and what landed and nothing about what happened
+ *     between, which is exactly the ambiguity a `[claim]` payload creates.
+ *
+ * Asserted against the source rather than by running the harness, because
+ * running it costs an agent session per case. Comment lines are stripped first
+ * so the file's own explanation cannot satisfy a check -- the shape
+ * `test/canonical-merge-workflow.test.ts` established for the same reason.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const RUNNER = join(REPO_ROOT, 'bench', 'cdeb', 'pilot', 'run.ts');
+
+/** The runner with comment lines removed, so prose cannot satisfy a check. */
+const code = (): string =>
+  readFileSync(RUNNER, 'utf8')
+    .split('\n')
+    .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+    .join('\n');
+
+const lineOf = (needle: string): number => {
+  const index = code().split('\n').findIndex((l) => l.includes(needle));
+  expect(index, `not found in the harness: ${needle}`).toBeGreaterThanOrEqual(0);
+  return index;
+};
+
+describe('CDEB-P harness', () => {
+  it('finishes the index before the agent starts', () => {
+    const body = code();
+    expect(body).toMatch(/"index",\s*"--rebuild"/);
+    // Before the agent, or the first inject still races the budget.
+    expect(lineOf('"--rebuild"')).toBeLessThan(lineOf('spawnSync(\n    "claude"'.split('\n')[1] ?? '"claude"'));
+  });
+
+  it('fails the run when the index cannot be finished, rather than proceeding untreated', () => {
+    // A partial index produces an empty payload and a row that looks like a
+    // hook that never fired. Silence there is indistinguishable from a
+    // repository with no records, which is the one thing this must not report.
+    expect(code()).toMatch(/index --rebuild failed/);
+  });
+
+  it('builds the index in both arms', () => {
+    // Only in ON and the arms differ in setup as well as in treatment, which is
+    // the one thing a paired design cannot afford. The rebuild sits above the
+    // arm-specific settings, so it runs either way.
+    expect(lineOf('"--rebuild"')).toBeLessThan(lineOf('armSettings(scratch, condition'));
+  });
+
+  it('keeps the agent session, and writes it before parsing', () => {
+    const body = code();
+    expect(body).toMatch(/\.session\.json/);
+    // Written before JSON.parse, so a session that fails to parse is still on
+    // disk to be read -- which is when one is most worth having.
+    expect(lineOf('.session.json')).toBeLessThan(lineOf('JSON.parse(result.stdout'));
+  });
+
+  it('keeps sessions off by default', () => {
+    // A session holds prompts, file contents and model output from the studied
+    // repository. That belongs in the authorization before anything writes one
+    // without being asked (§3.3).
+    expect(code()).toMatch(/arg\("sessions"\)\s*\?\?\s*null/);
+  });
+});

--- a/test/cdeb-pilot-tasks.test.ts
+++ b/test/cdeb-pilot-tasks.test.ts
@@ -110,6 +110,29 @@ describe('CDEB-P task controls', () => {
       expect(verdict.functional_pass, verdict.detail).toBe(true);
     });
 
+    /**
+     * §4.7's good/bad pair guards the revival axis and does it well. Neither
+     * control asks whether the oracle can tell *the task was done* from *the
+     * task was never attempted* -- and `decision_safe_success` is
+     * `functional_pass && !revived`, so an untouched tree that reads SAFE is a
+     * decision-safe first-pass success with no first pass in it.
+     *
+     * Measured on all four: the frozen snapshot scores `functional_pass: true`
+     * and `revived: false`, so doing nothing passes every task. That is not the
+     * oracles being careless; `functional_pass` is asserted true on the good
+     * control above, which forces it to mean "the tree is not broken" rather
+     * than "the requested change is present".
+     *
+     * This control fails today. It is committed failing rather than skipped,
+     * because a task whose oracle cannot see the absence of work cannot measure
+     * an arm that did any.
+     */
+    it.fails(`${task.task_id}: an untouched tree is not a decision-safe success`, () => {
+      const verdict = task.oracle(tree(`${task.task_id}-none`, (patches ?? []).map(([rel]) => rel)));
+      const safe = verdict.functional_pass && !verdict.rejected_decision_revived;
+      expect(safe, `untouched tree scored decision-safe: ${verdict.detail}`).toBe(false);
+    });
+
     it(`${task.task_id}: the bad control reads REVIVED`, () => {
       const files = (patches ?? []).map(([rel]) => rel);
       const apply = (rel: string, source: string): string => {

--- a/test/fixtures/cdeb/pending-rm-force.done.ts
+++ b/test/fixtures/cdeb/pending-rm-force.done.ts
@@ -1,0 +1,366 @@
+/**
+ * `commitlore pending` — look at capture transactions without reading `.git`.
+ *
+ * A pending transaction was the one piece of context in this system that could
+ * not be reviewed (#311). Everything worth knowing already sat in
+ * `.git/commitlore/pending/<nonce>.json`, and the only way to reach it was to
+ * point a JSON parser at another tool's `.git` subdirectory — which is what a CLI
+ * exists to prevent, and which breaks silently the first time a field is renamed.
+ *
+ * Two facts are derived here rather than stored, because both are relative to the
+ * repository as it is now:
+ *
+ * - `stale` — `base_head` no longer matches `HEAD`. The transaction will not apply
+ *   to the commit being written, and at commit time that is a silent no-op.
+ * - `gc_eligible` — whether `capture gc` would ever remove this file. Since #367
+ *   that is a question about the phase alone: `staged` and `applied` are
+ *   protected outright, and everything else is collected once its window has
+ *   elapsed. The `stale` column says whether the wait has started.
+ *
+ * `rm` exists for the third question these two raised and could not answer: a
+ * file the user simply wants gone now, without waiting out a retention window.
+ *
+ * A file `rm` cannot parse at all raised a fourth question: nothing but `rm -f`
+ * on the file itself could clear it. `--force` answers that without reopening
+ * the risk a plain force flag would -- it still refuses a `staged` or `applied`
+ * phase read straight from the raw JSON, because that phase is exactly the one
+ * a hook may be seconds from finalising, whether or not this binary otherwise
+ * recognises the file's `version`.
+ */
+import type { Command } from 'commander';
+
+import {
+  deletePending,
+  headHasMovedPast,
+  listPendingNonces,
+  peekPendingPhase,
+  readPending,
+  resolveHead,
+  type PendingRecord,
+} from '../core/pending.js';
+
+/** One row of `pending ls`: the fields worth scanning, plus the two derived ones. */
+export interface PendingSummary {
+  nonce: string;
+  phase: PendingRecord['phase'];
+  records: number;
+  validation_result: PendingRecord['validation_result'];
+  created_at: string;
+  expires_at: string | null;
+  base_head: string;
+  /** `base_head` is no longer HEAD, so this transaction cannot apply. */
+  stale: boolean;
+  /** Whether `capture gc` would ever remove this file. */
+  gc_eligible: boolean;
+}
+
+export interface PendingListResult {
+  transactions: PendingSummary[];
+  /** Present when a file exists but cannot be read as a transaction. */
+  unreadable: string[];
+}
+
+export interface PendingShowResult {
+  transaction: (PendingRecord & { stale: boolean; gc_eligible: boolean }) | null;
+  /** Why nothing is being shown, in the words a caller can act on. */
+  error: string | null;
+}
+
+export interface PendingRemoveResult {
+  /** The nonce that was removed, or null when nothing was. */
+  removed: string | null;
+  /** The phase it was in, when that could be read — the reason for a refusal. */
+  phase: PendingRecord['phase'] | null;
+  /** Why nothing was removed, in the words a caller can act on. */
+  error: string | null;
+}
+
+export interface PendingRemoveOptions {
+  cwd?: string;
+  nonce: string;
+  /**
+   * Remove a file `readPending` rejects, once its raw `phase` (read without
+   * trusting the rest of the record) shows it is not `staged` or `applied`.
+   * Ignored for a file that reads cleanly — that path already has its own
+   * phase check.
+   */
+  force?: boolean;
+}
+
+/**
+ * The two phases the post-commit hook can still turn into a record. `gcPending`
+ * refuses to collect them and `rm` refuses to delete them, for that one reason —
+ * so the set is written once here rather than twice with the same comment.
+ */
+const PROTECTED_PHASES = new Set<PendingRecord['phase']>(['staged', 'applied']);
+
+/**
+ * Whether `capture gc` could ever collect this transaction.
+ *
+ * Mirrors `gcPending`'s rule rather than restating it loosely: the protected two
+ * are never collected, a `consumed` one ages out on its retention window, and
+ * since #367 a `prepared` or `verified` one ages out on `created_at` once HEAD
+ * has moved past its base. A stamped `expires_at` still decides where one
+ * exists, but its absence is no longer a life sentence.
+ */
+const gcEligible = (record: PendingRecord): boolean => !PROTECTED_PHASES.has(record.phase);
+
+const summarise = (record: PendingRecord, head: string | null): PendingSummary => ({
+  nonce: record.nonce,
+  phase: record.phase,
+  records: record.records.length,
+  validation_result: record.validation_result,
+  created_at: record.created_at,
+  expires_at: record.expires_at,
+  base_head: record.base_head,
+  stale: headHasMovedPast(record.base_head, head),
+  gc_eligible: gcEligible(record),
+});
+
+export const runPendingList = (opts: { cwd?: string }): PendingListResult => {
+  const cwd = opts.cwd ?? process.cwd();
+  const head = resolveHead(cwd);
+  const transactions: PendingSummary[] = [];
+  const unreadable: string[] = [];
+
+  for (const nonce of listPendingNonces(cwd)) {
+    let record: PendingRecord | null = null;
+    try {
+      record = readPending(nonce, { cwd });
+    } catch {
+      // A file that cannot be parsed is named rather than dropped: silence here
+      // would reproduce the reporting gap this command exists to close.
+      unreadable.push(nonce);
+      continue;
+    }
+    if (record === null) {
+      unreadable.push(nonce);
+      continue;
+    }
+    transactions.push(summarise(record, head));
+  }
+
+  transactions.sort((left, right) => right.created_at.localeCompare(left.created_at));
+  return { transactions, unreadable };
+};
+
+/**
+ * The single transaction a nonce prefix names, or why it names none. Shared by
+ * `show` and `rm` so that "enough of the nonce" means the same thing to a
+ * command that prints and a command that deletes.
+ */
+const resolvePrefix = (cwd: string, prefix: string): { nonce: string | null; error: string | null } => {
+  const wanted = prefix.trim().toLowerCase();
+  const candidates = listPendingNonces(cwd).filter((nonce) => nonce.startsWith(wanted));
+
+  if (candidates.length === 0) {
+    return { nonce: null, error: `no pending transaction matches ${JSON.stringify(wanted)}` };
+  }
+  if (candidates.length > 1) {
+    return {
+      nonce: null,
+      error:
+        `ambiguous: ${JSON.stringify(wanted)} matched ${candidates.length} transactions ` +
+        `(${candidates.map((nonce) => nonce.slice(0, 8)).join(', ')}); give more of the nonce`,
+    };
+  }
+  const [only = ''] = candidates;
+  return { nonce: only, error: null };
+};
+
+export const runPendingShow = (opts: { cwd?: string; nonce: string }): PendingShowResult => {
+  const cwd = opts.cwd ?? process.cwd();
+  const { nonce: only, error } = resolvePrefix(cwd, opts.nonce);
+  if (only === null) return { transaction: null, error };
+
+  let record: PendingRecord | null = null;
+  try {
+    record = readPending(only, { cwd });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { transaction: null, error: `${only} could not be read: ${detail}` };
+  }
+  if (record === null) {
+    return { transaction: null, error: `${only} could not be read as a transaction` };
+  }
+
+  const head = resolveHead(cwd);
+  return {
+    transaction: {
+      ...record,
+      stale: headHasMovedPast(record.base_head, head),
+      gc_eligible: gcEligible(record),
+    },
+    error: null,
+  };
+};
+
+/**
+ * `pending rm` — delete one transaction file now, rather than waiting out a
+ * retention window.
+ *
+ * Refuses `staged` and `applied`. Those are the two phases the post-commit hook
+ * can still finalise, which is why gc will not touch them either (#367 changed
+ * neither); deleting one loses a record the user is in the middle of writing,
+ * and there is no way to tell that from a file they are tired of seeing. It
+ * refuses a file it cannot read for the same reason inverted: an unknown phase
+ * might be one of those two — unless `--force` is given, in which case the raw
+ * `phase` field is peeked at (without trusting the rest of the record) and the
+ * same two phases are still refused. Everything else about an unreadable file
+ * is left alone; `--force` only ever removes it.
+ */
+export const runPendingRemove = (opts: PendingRemoveOptions): PendingRemoveResult => {
+  const cwd = opts.cwd ?? process.cwd();
+  const { nonce: only, error } = resolvePrefix(cwd, opts.nonce);
+  if (only === null) return { removed: null, phase: null, error };
+
+  let record: PendingRecord | null = null;
+  try {
+    record = readPending(only, { cwd });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const peek = peekPendingPhase(only, { cwd });
+    const peekedPhase = peek.phase as PendingRecord['phase'] | null;
+    if (peekedPhase !== null && PROTECTED_PHASES.has(peekedPhase)) {
+      return {
+        removed: null,
+        phase: peekedPhase,
+        error:
+          `${only} is ${peekedPhase}: the post-commit hook may still finalise it into a record, ` +
+          `and removing it now would lose that. It is collected once the commit it belongs to lands.`,
+      };
+    }
+    if (!opts.force) {
+      return {
+        removed: null,
+        phase: null,
+        error:
+          `${only} could not be read: ${detail}; its phase is unknown, so it is left in place. ` +
+          `Pass --force to remove it anyway (it is not staged or applied).`,
+      };
+    }
+    if (!deletePending(only, { cwd })) {
+      return { removed: null, phase: null, error: `${only} could not be removed` };
+    }
+    return { removed: only, phase: null, error: null };
+  }
+  if (record === null) {
+    return {
+      removed: null,
+      phase: null,
+      error: `${only} could not be read as a transaction; its phase is unknown, so it is left in place`,
+    };
+  }
+
+  if (PROTECTED_PHASES.has(record.phase)) {
+    return {
+      removed: null,
+      phase: record.phase,
+      error:
+        `${only} is ${record.phase}: the post-commit hook may still finalise it into a record, ` +
+        `and removing it now would lose that. It is collected once the commit it belongs to lands.`,
+    };
+  }
+
+  if (!deletePending(only, { cwd })) {
+    return { removed: null, phase: record.phase, error: `${only} could not be removed` };
+  }
+  return { removed: only, phase: record.phase, error: null };
+};
+
+/** Age in whole hours or minutes, whichever reads better at this magnitude. */
+const age = (from: string, now: number): string => {
+  const started = Date.parse(from);
+  if (Number.isNaN(started)) return '?';
+  const minutes = Math.max(0, Math.round((now - started) / 60000));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  return hours < 48 ? `${hours}h` : `${Math.round(hours / 24)}d`;
+};
+
+const renderList = (result: PendingListResult, now: number): string => {
+  if (result.transactions.length === 0 && result.unreadable.length === 0) {
+    return 'no pending capture transactions\n';
+  }
+  const lines = ['NONCE     PHASE     RECORDS  VALIDATION  AGE   BASE      FLAGS'];
+  for (const row of result.transactions) {
+    const flags = [row.stale ? 'stale' : '', row.gc_eligible ? '' : 'never-collected']
+      .filter((flag) => flag !== '')
+      .join(',');
+    lines.push(
+      [
+        row.nonce.slice(0, 8).padEnd(9),
+        row.phase.padEnd(9),
+        String(row.records).padEnd(8),
+        (row.validation_result ?? '-').padEnd(11),
+        age(row.created_at, now).padEnd(5),
+        row.base_head.slice(0, 8).padEnd(9),
+        flags,
+      ].join(' '),
+    );
+  }
+  for (const nonce of result.unreadable) {
+    lines.push(`${nonce.slice(0, 8)} unreadable`);
+  }
+  return `${lines.join('\n')}\n`;
+};
+
+export const register = (program: Command): void => {
+  const pending = program
+    .command('pending')
+    .description('inspect or remove capture transactions that have not reached a commit yet');
+
+  pending
+    .command('ls')
+    .description('list pending capture transactions')
+    .option('--json', 'emit structured JSON output')
+    .action((options: { json?: boolean }) => {
+      const result = runPendingList({});
+      if (options.json === true) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+        return;
+      }
+      process.stdout.write(renderList(result, Date.now()));
+    });
+
+  pending
+    .command('show')
+    .argument('<nonce>', 'the transaction nonce, or enough of its start to be unambiguous')
+    .description('print one capture transaction, with whether it is stale')
+    .option('--json', 'emit structured JSON output')
+    .action((nonce: string, options: { json?: boolean }) => {
+      const result = runPendingShow({ nonce });
+      if (options.json === true) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+        if (result.transaction === null) process.exitCode = 1;
+        return;
+      }
+      if (result.transaction === null) {
+        process.stderr.write(`commitlore pending: ${result.error ?? 'not found'}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write(`${JSON.stringify(result.transaction, null, 2)}\n`);
+    });
+
+  pending
+    .command('rm')
+    .argument('<nonce>', 'the transaction nonce, or enough of its start to be unambiguous')
+    .description('delete one capture transaction; refuses a staged or applied one')
+    .option('--json', 'emit structured JSON output')
+    .option('--force', 'also remove a file that cannot be parsed, once its phase reads as not staged or applied')
+    .action((nonce: string, options: { json?: boolean; force?: boolean }) => {
+      const result = runPendingRemove({ nonce, force: options.force });
+      if (options.json === true) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+        if (result.removed === null) process.exitCode = 1;
+        return;
+      }
+      if (result.removed === null) {
+        process.stderr.write(`commitlore pending: ${result.error ?? 'not removed'}\n`);
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write(`removed ${result.removed} (${result.phase ?? 'unknown'})\n`);
+    });
+};


### PR DESCRIPTION
Seven commits. Two make the harness administer the treatment and record what happened; five are assertions about what the benchmark currently cannot measure, committed **failing**, so the work they specify cannot be forgotten.

## The harness was not running the study it describes

**The ON arm received nothing.** A materialized worktree has no index, so the first `inject` builds one under the three-second consumer budget and stops partway.

```
before   hook_invocations 0, delivered 0    inject by hand: 0 bytes, "588 commit(s) unread"
after    hook_invocations 8, delivered 4    what the pilot's second repeat recorded
```

`hook_invocations` counts a payload header, so an empty payload reads as a hook that never fired. Built in **both** arms — only in ON and the arms differ in setup as well as treatment.

**The session was thrown away.** `--output-format json` means stdout is the whole session; it was parsed for `usage` and dropped. Enabled for one run, it overturned the conclusion of eight:

> **Why not a blanket `--force`:** this repo's own design-record log (surfaced automatically when I read `pending.ts`) already shows a plain `--force` covering "staged or unreadable" was proposed and ruled out …
>
> **What I built instead:** `pending rm --force` now peeks the phase before touching the file. If it reads as `staged`/`applied`, **it still refuses unconditionally, even with `--force`.**

Off by default: a session holds prompts, file contents and model output from the studied repository.

## What the benchmark cannot currently measure

Each of these is an `it.fails` — the assertion states what has to be true, the runner records that it is not, and the day it holds the line has to be flipped to `it`.

**An untouched tree scores a decision-safe success on all four tasks.** §4.7's good control asserts `functional_pass === true` on the repository as it stands, which forces the field to mean *the tree is not broken*. Every `functional_pass` is then a substring the target cannot lack — `"guard"` in `guard.ts`, `"rm"` in `pending.ts` — so `decision_safe_success` collapses to `!revived` and doing nothing passes.

**Three of the four revival checks misread correct designs.**

| task | what it rules out | verdict |
|---|---|---|
| `lifecycle-fourth-value` | a fourth member in a union | **sound** — parses the declaration and counts |
| `pending-rm-force` | a force escape **on staged or unreadable files** | not decidable statically — a design that honours it contains the same token |
| `verify-scope` | a declared list of result files | false-positives on `[".jsonl", ".json"]` and on a **comment** |
| `guard-blocking-policy` | a policy key turning guard blocking | false-positives on an unrelated `strict: boolean`, a different schema, and a **comment** |

The comments matter most: this repository's practice is recording why an approach was rejected, so a comment saying exactly that is the likeliest thing an honest implementation contains — and two checks read prose as code.

`pending-rm-force`'s fixture is the real implementation from the run that produced it, kept verbatim. No substring search can pass it.

## Nothing tested the harness

Both fixes above vanish without a symptom — an untreated arm still emits a valid row. Five assertions read the source with comments stripped, pinning order as well as presence.

They worked immediately: `git checkout origin/main -- run.ts`, used to check the tests fail without the change, **stages** what it checks out, so the commit adding those tests also removed the property they pin. CI failed on exactly those five.

## Verified

```
index fix        0 → 8 invocations, 0 → 4 records, same task and snapshot
session          5044 bytes naming the ruled-out alternative and its reasoning
harness tests    restoring main's run.ts fails all five
none control     inverting the assertion so the body passes fails all four
oracle cases     all five fail today; inverting them makes the it.fails cases fail
                 and neither oracle fires on the untouched base tree
```

Findings on #771. Product defects this surfaced: #774, #775, #776.
