### PR TITLE
Release 1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.0
+
+The release that makes releases discoverable, and three places where the tool
+was doing work nobody read.
+
+**`commitlore upgrade`.** There was no way to find out that a newer CommitLore
+existed. `--version` reported what was running and nothing compared it to
+anything, so a repository initialised on a stale install kept validating every
+commit with a stale protocol and nothing said so. `upgrade --check` reports the
+installed and newest release; the bare form performs the upgrade by invoking the
+installer and then reading the link back to confirm it points at the tag that
+was asked for -- not merely that it moved, which an installer that moved it
+somewhere wrong would satisfy. `--json` is the scriptable form and answers
+inside CI on purpose. A passive notice appears at most once a day and is silent
+for hooks, `--json`, non-terminals, and any command that failed; `doctor`
+carries staleness as a finding, because the notice is silent for `--json` and
+that is the one output built for programs to read. `init` names the version it
+pinned and does not move `current`; `init --upgrade` does.
+
+**Both installers register the same hook, and only one of them.** The CLI wrote
+`Read|Edit|Write` and the plugin shipped `Edit|Write|MultiEdit|NotebookEdit`, so
+a CLI install delivered nothing when the agent edited with MultiEdit and a
+plugin install delivered nothing when it read a file before deciding. A matcher
+of only letters and `|` is a list of exact strings rather than a regular
+expression, so `Edit` never covered `MultiEdit`. Both now register all five.
+And `init` no longer writes its hook when the Claude Code plugin already covers
+the repository -- before this, following the README to the plugin and then
+running `init` answered every matched tool call twice.
+
+**A hook fire costs a third less, and a rebuild an order of magnitude.** Every
+fire ran `PRAGMA quick_check` over the whole index -- 62 ms on a 15 MB one,
+before an answer that usually has nothing to deliver. Nothing promises it,
+SQLite documents that it does not catch the desynchronised-index case that
+would actually hurt, and across 85 corruption trials it never prevented a wrong
+answer. It runs on rebuild and in `doctor` now, and a read that meets corruption
+falls back to a scan rather than failing open to silence. Separately, a rebuild
+started 4,345 git subprocesses, 4,329 of them parsing trailer paragraphs whose
+results were then discarded: 45 s to 2.3 s on this repository, and a
+10,000-commit repository from over two minutes to 2.2 s.
+
+**Fixed:** a partial index answered with silence, which reads as "no records
+here" (#778); a rebuild could not rebuild past a schema change (#779) and could
+not open a structurally damaged index at all (#785).
+
 ## 1.1.4
 
 One line changed for anyone using the tool, and the rest is the repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ were not written here.
 
 ## 1.2.0
 
+> **Recorded as held for want of a reviewer, not as reviewed.** Every change in
+> this release passed the gate — 3,359 tests, the canonical artifact check, and
+> CI at the released commit — and none of it had a cross-provider review. The
+> reviewers this project uses were out of quota on the day it shipped, and
+> Claude reviewing Claude is not a second opinion: the same model family shares
+> its blind spots. Two of today's conclusions were reversed by an outside
+> reviewer earlier in the day, so this is a real gap and not a formality.
+
 The release that makes releases discoverable, and three places where the tool
 was doing work nobody read.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -79,13 +79,13 @@ Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や
 **その他のコーディングエージェント** — CLI をインストールします:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh | sh -s v1.1.4
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 ```
 
 **Windows** — PowerShell で同じインストールを行います:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.ps1))) v1.1.4
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
 ```
 
 Windows での host 配線には **v1.1.1 以降**が必要です。それ以前は検出が `.cmd` shim を見つけられず、インストーラーもそれを実行できなかったため、Windows へのインストールは CLI を置くだけで何も配線しませんでした — 成功としてではなく `ok: false` として報告されます。1.1.1 で Codex、Gemini CLI、Hermes について実機で確認しました。
@@ -127,11 +127,11 @@ commitlore context .
 
 ```bash
 # installer を固定してダウンロードし、確認してから実行します。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh
-sh install.sh v1.1.4
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
+sh install.sh v1.2.0
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.1.4 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -79,13 +79,13 @@ Codex의 자체 CLI로 marketplace와 plugin을 등록한다. 설정이나 cache
 **그 밖의 코딩 에이전트** — CLI를 설치한다:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh | sh -s v1.1.4
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 ```
 
 **Windows** — PowerShell에서 같은 설치를 한다:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.ps1))) v1.1.4
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
 ```
 
 Windows에서 host 배선은 **v1.1.1 이상**이 필요하다. 그 전에는 탐지가 `.cmd` shim을 보지 못하고 설치기가 그것을 실행하지도 못해서, Windows 설치는 CLI만 놓고 아무것도 배선하지 않았다 — 성공이 아니라 `ok: false`로 보고됐다. 1.1.1에서 Codex, Gemini CLI, Hermes에 대해 실기로 확인했다.
@@ -127,11 +127,11 @@ commitlore context .
 
 ```bash
 # 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh
-sh install.sh v1.1.4
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
+sh install.sh v1.2.0
 
 # 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v1.1.4 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ Prerequisites for either path: Node.js 22.23.2+ and Git. The script checks both 
 **Any other coding agent** — install the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh | sh -s v1.1.4
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 ```
 
 **Windows** — the same install, in PowerShell:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.ps1))) v1.1.4
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
 ```
 
 Host wiring on Windows requires **v1.1.1 or later**. Before it, detection could not see a `.cmd` shim and the installer could not run one, so a Windows install placed the CLI and wired nothing — reported as `ok: false`, never as success. Verified on a real machine at 1.1.1 for Codex, Gemini CLI and Hermes.
@@ -162,11 +162,11 @@ The one-liner is for convenience. For a reviewed or pinned install, download and
 
 ```bash
 # Pin and inspect the installer before executing it.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh
-sh install.sh v1.1.4
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
+sh install.sh v1.2.0
 
 # Or skip the script entirely: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.1.4 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,13 +76,13 @@ commitlore plugin install-codex
 **其他编程代理** — 安装 CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh | sh -s v1.1.4
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 ```
 
 **Windows** — 在 PowerShell 中执行同样的安装：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.ps1))) v1.1.4
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
 ```
 
 在 Windows 上配置 host 需要 **v1.1.1 或更高版本**。在此之前，检测看不到 `.cmd` shim，安装器也无法运行它，因此 Windows 安装只放下 CLI 而不配置任何 host —— 报告为 `ok: false`，而不是成功。已在 1.1.1 上于真实机器验证 Codex、Gemini CLI 与 Hermes。
@@ -124,11 +124,11 @@ commitlore context .
 
 ```bash
 # 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh
-sh install.sh v1.1.4
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
+sh install.sh v1.2.0
 
 # 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.1.4 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.ps1))) v1.1.4
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.1.4/install.sh | sh -s v1.1.4
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,7 +15,7 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "358efb8e0f0519bca2b19b220dd2a0a1e896dd848d134bf075107c0b070aaae9"
+    "sha256": "9a2f44f3a7b7f086311a278a289a40342a89b56ec847efd5b0b055b860023de3"
   },
   "artifact": {
     "sha256": "fb94d8b2b9a5000b1aa1955e660de695cc8da20dddc4ce758c3f82a76e91c716",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
**Cross-provider review unavailable.** grok is at HTTP 402 and codex is over its usage limit as of 2026-08-19; the Hermes gateway is out of credentials for the same reason. This carries gate-green only. Claude reviewing Claude is not cross-provider — the same model family shares blind spots — so nothing here has had a second provider's eyes.

**Blocked only on CI. Merge when green, then tag `v1.2.0` on the merge commit.**

Release 1.2.0. Thirty-one commits since 1.1.4.

### What a user gets

**`commitlore upgrade`** — there was no way to find out a newer CommitLore existed. `--version` reported what was running and compared it to nothing, so a repository initialised on a stale install kept validating commits with a stale protocol and nothing said so. This is the release that makes later releases discoverable, which is why holding it costs more than shipping it.

**Both installers register the same hook, and only one of them.** A CLI install delivered nothing when the agent edited with `MultiEdit`; a plugin install delivered nothing when it read a file before deciding. And following the README to the plugin and then running `init` answered every matched tool call **twice**.

**A hook fire costs a third less; a rebuild an order of magnitude.**

| | before | after |
|---|---|---|
| hook fire, path with records | 528 ms | 399 ms |
| rebuild, 1122 commits | 45 s | **2.3 s** |
| rebuild, 10000 commits | >120 s | **2.2 s** |
| first answer, cold 10k index | partial | **complete, 2.9 s** |

**Fixed:** a partial index answered with silence, which reads as "no records here" (#778); a rebuild could not get past a schema change (#779) and could not open a damaged index at all (#785).

### Issues closed since 1.1.4

#742 · #775 · #776 · #778 · #779 · #781 · #782 · #785

### The bump itself

Four manifests, twenty-eight pins across four READMEs and both installers, the CHANGELOG entry, and the artifact manifest.

Three things this release procedure gets wrong if done quickly, all avoided here and all recorded:

- **`package-lock.json` carries the version twice** and a text substitution for `"1.1.4"` also matches four dependencies genuinely at that version. Both fields were set by parsing the JSON.
- **The pins are anchored to the three install shapes**, not to the bare version string. `README.md` carries prose about release boundaries — *"One installed before v1.0.2"* — which is a historical fact that a blanket bump turns into a false statement, and no test reads it.
- **`dist/` needs no rebuild but the artifact manifest does.** The bundle reads its version at runtime, so the bytes are identical; the manifest binds the source inputs, so the bump alone moves its digest. `git status` shows `installer/canonical-artifact.json` and nothing under `dist/`, which is the check that this was done right.

