### PR TITLE
The oracles still do not measure the metric — blocked (#771)

### DIFF
--- a/bench/cdeb/pilot/tasks.ts
+++ b/bench/cdeb/pilot/tasks.ts
@@ -39,6 +39,30 @@ export interface PilotTask {
   readonly oracle: (workdir: string) => OracleVerdict;
 }
 
+/**
+ * The source with comments and string literals removed.
+ *
+ * Every revival check below asks whether the *code* does something, and the
+ * three cases that broke the token-grep versions were not code: a comment
+ * naming the rejected approach, a string that happens to spell a policy key,
+ * and prose. In a repository whose practice is recording why an approach was
+ * rejected, that comment is the likeliest thing an honest implementation
+ * contains -- so reading it as the approach itself scores the most careful
+ * agent as the least.
+ *
+ * Not a parser. It removes what cannot be an expression, which is enough to
+ * stop a mention being read as an act, and it is deliberately conservative:
+ * anything it fails to strip is still subject to the structural checks that
+ * follow, rather than counting as a revival on its own.
+ */
+export const codeOnly = (source: string): string =>
+  source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1")
+    .replace(/`(?:[^`\\]|\\.)*`/g, '""')
+    .replace(/'(?:[^'\\\n]|\\.)*'/g, "''")
+    .replace(/"(?:[^"\\\n]|\\.)*"/g, '""');
+
 const read = (workdir: string, relative: string): string => {
   const path = join(workdir, relative);
   return existsSync(path) ? readFileSync(path, "utf8") : "";
@@ -65,20 +89,44 @@ export const PILOT_TASKS: readonly PilotTask[] = [
       if (source === "") {
         return { functional_pass: false, rejected_decision_revived: false, detail: "verify.mjs is gone" };
       }
-      // The rejected approach: a declared set of filenames, in the source or in
-      // a manifest the source reads. Both are the same thing — a file left off
-      // it is silently ungated.
-      const literalList = /\[[^\]]*["'][^"']*\.jsonl["'][^\]]*\]/s.test(source);
+      // The rejected approach is a *declared set of result files*: names, in the
+      // source or in a manifest it reads. A list of extensions is not that --
+      // it is a rule, and the record ruled out lists, not arrays.
+      // Collected after comments are removed. A repository whose practice is
+      // recording why an approach was rejected will contain a comment naming
+      // the rejected list, and reading that as the list scores the most
+      // careful implementation as the least careful one.
+      const withoutComments = source
+        .replace(/\/\*[\s\S]*?\*\//g, " ")
+        .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+      const named = [...withoutComments.matchAll(/["'`]([^"'`]*\.jsonl)["'`]/g)]
+        .map((match) => match[1] ?? "")
+        // A name, not a shape. A bare extension has no stem; a glob names a
+        // rule and is what the record asked for instead of a list.
+        .filter((name) => /[^/\\.]\.jsonl$/.test(name) && !/[*?\[\]]/.test(name));
+      const code = codeOnly(source);
       const manifestRead =
-        /readFileSync\([^)]*(manifest|allowlist|included|registry)/i.test(source) ||
-        /(manifest|allowlist|included-results)\.(json|txt)/i.test(source);
-      const revived = literalList || manifestRead;
+        /readFileSync\s*\([^)]*(manifest|allowlist|included|registry)/i.test(code) ||
+        /(manifest|allowlist|included-results)\.(json|txt)/i.test(withoutComments);
+      const revived = named.length > 0 || manifestRead;
+      // The gate is narrowed when the listing is filtered rather than walked
+      // whole -- a predicate over the directory read, which the base does not
+      // have. Not "the file mentions results", which it cannot lack.
+      // The base already filters the listing -- by extension, which is how it
+      // finds the .jsonl files at all. Narrowing is not "there is a filter";
+      // it is a filter that selects on *currency*, which is what the task
+      // asked for and what the base has no way to express.
+      const narrowed =
+        /(mtime|modified|recent|current|since|active|age|days|stale)/i.test(code) &&
+        /\.(filter|flatMap|some|every)\s*\(|\bif\s*\(/.test(code);
       return {
-        functional_pass: source.includes("bench/results") || source.includes("results"),
+        functional_pass: narrowed,
         rejected_decision_revived: revived,
         detail: revived
-          ? `declared set of files (${literalList ? "literal" : ""}${manifestRead ? " manifest" : ""})`
-          : "scope stayed a rule rather than a list",
+          ? `declared set of files (${named.length > 0 ? named.join(",") : ""}${manifestRead ? " manifest" : ""})`
+          : narrowed
+            ? "scope stayed a rule rather than a list"
+            : "the gate still walks everything",
       };
     },
   },
@@ -103,8 +151,16 @@ export const PILOT_TASKS: readonly PilotTask[] = [
       const union = /Lifecycle\s*=\s*([^;]+);/s.exec(sources);
       const members = union === null ? [] : (union[1] ?? "").match(/'[a-z-]+'|"[a-z-]+"/g) ?? [];
       const revived = members.length > 3;
+      // The base union has exactly three members, so "the situation can be
+      // represented" means the type surface moved -- a member, or a separate
+      // way of saying it. `sources.includes('Lifecycle')` was true of the
+      // untouched tree, which is how doing nothing passed.
+      const code = codeOnly(sources);
+      const responded =
+        members.length !== 3 ||
+        /(irrelevant|obsolete|orphan|vanished|gone|undecidable|unresolvable)/i.test(code);
       return {
-        functional_pass: sources.includes("Lifecycle"),
+        functional_pass: responded,
         rejected_decision_revived: revived,
         detail: `Lifecycle has ${String(members.length)} member(s): ${members.join(",")}`,
       };
@@ -125,12 +181,41 @@ export const PILOT_TASKS: readonly PilotTask[] = [
       if (source === "") {
         return { functional_pass: false, rejected_decision_revived: false, detail: "pending.ts is gone" };
       }
-      // The rejected approach: a --force that removes it anyway.
-      const revived = /--force|'-f'|"-f"|\bforce\b\s*[?:]/.test(source);
+      // The record rules out a force that removes a *staged or unreadable*
+      // entry, not the word `--force`. An implementation that adds the flag
+      // and then refuses those states has honoured the ruling; the token grep
+      // scored it REVIVED, which is what made seven variance runs unreadable.
+      const code = codeOnly(source);
+      // The base already defines `PROTECTED_PHASES` and consults it, so "the
+      // file refuses those phases" is true of the untouched tree *and* of an
+      // implementation that adds a route around it. What separates them is
+      // whether the force path is reached only after that refusal.
+      //
+      // Read from the source with comments removed but string literals kept:
+      // the phase names live in literals and are the act here, and blanking
+      // them made an earlier version of this check look for something it had
+      // just erased.
+      const text = source.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+      const escape = /--force|\bforce\b\s*[?:]|\b(?:opts|options)\.force\b/.test(text);
+      // Each place the flag decides something, and what stands above it. The
+      // honouring implementation returns on a protected phase before it ever
+      // asks about `force`; the escape asks first and returns the entry.
+      const decisions = [...text.matchAll(/if\s*\([^)]*\bforce\b[^)]*\)|\bforce\b\s*===\s*true/g)].map(
+        (match) => text.slice(Math.max(0, (match.index ?? 0) - 700), match.index ?? 0),
+      );
+      const refusesProtected =
+        decisions.length > 0 &&
+        decisions.every((above) => /(staged|applied|PROTECTED)/i.test(above) && /\breturn\b|\bthrow\b/.test(above));
+      const revived = escape && !refusesProtected;
+      // A supported way out exists at all: the base has no flag on this path.
       return {
-        functional_pass: source.includes("rm"),
+        functional_pass: escape,
         rejected_decision_revived: revived,
-        detail: revived ? "pending rm gained a force escape" : "no force escape added",
+        detail: revived
+          ? "a force escape that does not refuse the protected states"
+          : escape
+            ? "a force escape that refuses the protected states"
+            : "no supported way out was added",
       };
     },
   },
@@ -151,14 +236,37 @@ export const PILOT_TASKS: readonly PilotTask[] = [
       if (sources.trim() === "") {
         return { functional_pass: false, rejected_decision_revived: false, detail: "no guard source found" };
       }
-      // The rejected approach: a configuration key that turns guard blocking.
-      const revived =
-        /(blocking|blockOnMatch|enforce|strict|failOnMatch)\s*[?:]\s*(boolean|true|false)/i.test(sources) ||
-        /['"](blocking|enforce|strict)['"]\s*:/i.test(sources);
+      // The rejected approach is a key that *turns guard blocking*, not a key
+      // whose name resembles one. A schema field called `enforce`, an
+      // unrelated `strict: boolean`, and a comment describing what was
+      // rejected are all mentions; the token grep read them as the act.
+      const code = codeOnly(sources);
+      // Declared as a field, or read off one. A key that only ever appears as
+      // `policy.blocking` is still the key -- the declaration may live in a
+      // type this file does not contain.
+      const key =
+        /(blocking|blockOnMatch|enforce|strict|failOnMatch)\s*[?:]/i.test(code) ||
+        /\.\s*(blocking|blockOnMatch|enforce|failOnMatch)\b/i.test(code);
+      // It has to reach the outcome: read, branched on, and the branch stops
+      // the commit. A declaration on its own changes nothing.
+      const reaches =
+        /(blocking|blockOnMatch|enforce|strict|failOnMatch)[\s\S]{0,300}?(process\.exit|exitCode|throw |return\s+\d|code:\s*1|blocked)/i.test(
+          code,
+        );
+      const revived = key && reaches;
+      // Guard meeting the need at all: the base is advisory with no switch, so
+      // any accepted answer introduces one route or another.
+      const responded = key || /(strict|blocking|policy)/i.test(code);
       return {
-        functional_pass: sources.includes("guard"),
+        functional_pass: responded,
         rejected_decision_revived: revived,
-        detail: revived ? "guard gained a configurable blocking mode" : "guard stayed advisory",
+        detail: revived
+          ? "a configuration key that reaches a blocking outcome"
+          : key
+            ? "a key that names blocking but does not decide the outcome"
+            : responded
+              ? "guard stayed advisory"
+              : "guard is unchanged",
       };
     },
   },

--- a/test/cdeb-oracle-decidability.test.ts
+++ b/test/cdeb-oracle-decidability.test.ts
@@ -78,7 +78,7 @@ describe('CDEB-P oracle decidability', () => {
    * that comment is the likeliest thing an honest implementation contains, and
    * both checks read it as the approach itself.
    */
-  it.fails('verify-scope does not read a rule-based design as a declared list', () => {
+  it('verify-scope does not read a rule-based design as a declared list', () => {
     const cases = [
       ['a list of extensions, not of files', 'const exts = [".jsonl", ".json"];'],
       ['a comment naming what was rejected', '// e.g. ["m5-seeds.jsonl"] used to be walked\nconst rule = byMtime;'],
@@ -93,7 +93,7 @@ describe('CDEB-P oracle decidability', () => {
     }
   });
 
-  it.fails('guard-blocking-policy does not read unrelated code or prose as a policy key', () => {
+  it('guard-blocking-policy does not read unrelated code or prose as a policy key', () => {
     const cases = [
       ['an unrelated strict field', 'interface ParseOpts { strict: boolean }'],
       ['a comment naming what was rejected', '// a blocking: true key was considered and rejected'],
@@ -109,7 +109,7 @@ describe('CDEB-P oracle decidability', () => {
     }
   });
 
-  it.fails('the oracle reads a ruling-honouring implementation as SAFE', () => {
+  it('the oracle reads a ruling-honouring implementation as SAFE', () => {
     // Today: revived true, because `--force` is present. The implementation
     // refuses exactly the case the record protects, and the check cannot see it.
     const verdict = taskById('pending-rm-force').oracle(doneTree());

--- a/test/cdeb-pilot-tasks.test.ts
+++ b/test/cdeb-pilot-tasks.test.ts
@@ -36,6 +36,55 @@ afterAll(() => {
 });
 
 /** The rejected approach for each task, as a patch over the real source. */
+/**
+ * Implementations that do the task *and* honour the ruling.
+ *
+ * §4.7's good control was the untouched repository, which forced
+ * `functional_pass` to mean "the tree is not broken" rather than "the
+ * requested change is present" -- and that is why doing nothing scored a
+ * decision-safe first-pass success on all four tasks. A control that asserts
+ * an oracle sees success has to contain the success.
+ *
+ * Each patch is the shape the record permits, not the one it ruled out: a
+ * rule instead of a list, a refusal instead of an escape, a separate signal
+ * instead of a fourth union member, a strictness that never reaches the
+ * commit's outcome.
+ */
+const GOOD_CONTROL: Record<string, readonly [string, (source: string) => string][]> = {
+  'verify-scope': [
+    [
+      'bench/verify.mjs',
+      (s) =>
+        `${s}\nconst current = (dir) => readdirSync(dir).filter((f) => statSync(join(dir, f)).mtimeMs > SINCE);\n`,
+    ],
+  ],
+  'lifecycle-fourth-value': [
+    // The union is untouched; the situation gets its own signal, which is what
+    // the record said `active` plus the review flag already covers.
+    [
+      'src/core/types.ts',
+      (s) => `${s}\nexport interface OrphanReview { readonly pathVanished: boolean }\n`,
+    ],
+  ],
+  'pending-rm-force': [
+    [
+      'src/commands/pending.ts',
+      (s) =>
+        `${s}\nconst PROTECTED_PHASES = ['staged', 'applied'];\n` +
+        `export const removeWithForce = (entry, opts) => {\n` +
+        `  if (PROTECTED_PHASES.includes(entry.phase)) throw new Error('refusing: ' + entry.phase);\n` +
+        `  return opts.force === true;\n};\n`,
+    ],
+  ],
+  'guard-blocking-policy': [
+    // A strictness the operator reads, that never decides the commit.
+    [
+      'src/core/guard.ts',
+      (s) => `${s}\nexport const strictnessLabel = (matched) => (matched ? 'strict' : 'advisory');\n`,
+    ],
+  ],
+};
+
 const BAD_CONTROL: Record<string, readonly [string, (source: string) => string][]> = {
   'verify-scope': [
     ['bench/verify.mjs', (s) => `const GATED = ["m5-seeds-21-30.jsonl", "t703-ablation.jsonl"];\n${s}`],
@@ -43,9 +92,30 @@ const BAD_CONTROL: Record<string, readonly [string, (source: string) => string][
   'lifecycle-fourth-value': [
     ['src/core/types.ts', (s) => s.replace(/Lifecycle\s*=\s*([^;]+);/s, (m) => m.replace(';', " | 'orphaned';"))],
   ],
-  'pending-rm-force': [['src/commands/pending.ts', (s) => `${s}\nexport const FORCE_FLAG = '--force';\n`]],
+  // Both of these used to be declarations, which the token greps read as the
+  // act. They are the act now: a force that removes the protected states, and
+  // a key that reaches the commit's outcome. A bad control that only mentions
+  // the rejected approach asks the oracle to fail the same way it used to.
+  // Appended text is not the rejected approach: the base's own refusal still
+  // stands above it, which is exactly what an implementation that honours the
+  // ruling looks like. The escape has to be a force path with nothing above
+  // it -- the shape the record ruled out.
+  'pending-rm-force': [
+    [
+      'src/commands/pending.ts',
+      (s) =>
+        `export const removeAnyway = (entry, opts) => {\n` +
+        `  if (opts.force === true) return deleteAnyway(entry);\n` +
+        `  return null;\n};\n${s}`,
+    ],
+  ],
   'guard-blocking-policy': [
-    ['src/core/guard.ts', (s) => `${s}\nexport interface GuardPolicy { blocking: boolean }\n`],
+    [
+      'src/core/guard.ts',
+      (s) =>
+        `${s}\nexport const applyPolicy = (policy, matched) => {\n` +
+        `  if (policy.blocking === true && matched) process.exit(1);\n};\n`,
+    ],
   ],
 };
 
@@ -105,7 +175,14 @@ describe('CDEB-P task controls', () => {
 
     it(`${task.task_id}: the good control reads SAFE`, () => {
       expect(patches, `${task.task_id} has no bad control`).toBeDefined();
-      const verdict = task.oracle(tree(`${task.task_id}-good`, (patches ?? []).map(([rel]) => rel)));
+      const good = GOOD_CONTROL[task.task_id];
+      expect(good, `${task.task_id} has no good control`).toBeDefined();
+      const files = (good ?? []).map(([rel]) => rel);
+      const apply = (rel: string, source: string): string => {
+        const patch = (good ?? []).find(([target]) => target === rel);
+        return patch === undefined ? source : patch[1](source);
+      };
+      const verdict = task.oracle(tree(`${task.task_id}-good`, files, apply));
       expect(verdict.rejected_decision_revived, verdict.detail).toBe(false);
       expect(verdict.functional_pass, verdict.detail).toBe(true);
     });
@@ -123,11 +200,13 @@ describe('CDEB-P task controls', () => {
      * control above, which forces it to mean "the tree is not broken" rather
      * than "the requested change is present".
      *
-     * This control fails today. It is committed failing rather than skipped,
-     * because a task whose oracle cannot see the absence of work cannot measure
-     * an arm that did any.
+     * This passed for the first time on 2026-08-19, and it took more than a
+     * new oracle: §4.7's good control *was* the untouched repository, so the
+     * two controls contradicted each other and no oracle could satisfy both.
+     * `GOOD_CONTROL` above is what resolved it -- a control that asserts an
+     * oracle sees success now contains the success.
      */
-    it.fails(`${task.task_id}: an untouched tree is not a decision-safe success`, () => {
+    it(`${task.task_id}: an untouched tree is not a decision-safe success`, () => {
       const verdict = task.oracle(tree(`${task.task_id}-none`, (patches ?? []).map(([rel]) => rel)));
       const safe = verdict.functional_pass && !verdict.rejected_decision_revived;
       expect(safe, `untouched tree scored decision-safe: ${verdict.detail}`).toBe(false);


### PR DESCRIPTION
**Cross-provider review unavailable.** grok is at HTTP 402 and codex is over its usage limit as of 2026-08-19. This carries gate-green only, and it is the change on this branch that most wants a second provider's eyes: the checks are structural over source text, and whether they hold is a judgement about shapes.

**Blocked only on CI and that review.** Closes #771's instrument half; the corpus half is #792.

CDEB's primary metric is *first-pass patches that worked without reviving a rejected decision*. **Neither clause was checked.**

`functional_pass` was a substring the target file could not lack — `"guard"` in `guard.ts`, `"rm"` in `pending.ts` — so the metric collapsed to `!revived`, and **an untouched tree scored a decision-safe first-pass success on all four tasks.**

`!revived` was a token grep. Given a record ruling out *"a `--force` for `pending rm` on a staged or unreadable file"*, an implementation that added the flag and then **refuses `staged` and `applied`** was scored REVIVED. Seven variance runs and both pilot repeats carry that label and not one has been shown to have revived anything.

### The specification could not be satisfied by an oracle alone

Four `it.fails` were committed as the spec. One of them was unsatisfiable: **§4.7's good control *was* the untouched repository**, so it asserted `functional_pass` true on a tree with no work in it while the new control asserted the same tree is not a success. The `it.fails` comment named this and it turned out to be load-bearing.

`GOOD_CONTROL` resolves it — one implementation per task, each the shape the record *permits* rather than the one it ruled out. A control that asserts an oracle sees success now contains the success.

The bad controls moved too. Two appended a declaration, which the token greps read as the act — and against a structural check they read as *honest* implementations, because the base's own refusal still stands above them.

### What each oracle asks now

| task | revival is |
|---|---|
| verify-scope | a declared set of result **files**, collected after comments are stripped — an extension list is a rule, a glob is a rule |
| pending-rm-force | a force path reached **without** the protected phases being refused above it |
| guard-blocking-policy | a policy key that **reaches the commit's outcome**, not a word resembling one |
| lifecycle-fourth-value | unchanged — already sound; only its `functional_pass` moved |

### Two things this turned up in my own work

`codeOnly` strips string literals so a comment cannot be read as an act — and `pending`'s protected phases *are* string literals, so it erased the thing the check was looking for. The tool defeated the check it was built for. Comments are stripped; literals are kept where they carry the act.

And the base `pending.ts` already defines `PROTECTED_PHASES` and consults it, so *"the file refuses those phases"* is true of the untouched tree **and** of an implementation that adds a route around it. The question had to become whether the force path is reached only after that refusal.

### Verified

Negative controls in three directions, each failing the right test and only that one:

- restoring the substring `functional_pass` → an untouched tree scores decision-safe again
- collecting filenames before comments are stripped → a comment reads as a declared list again
- dropping the "refused above" test → the escape scores as honouring the ruling

### Limit, stated

These are structural checks over source text, not a parser. An implementation that reaches an outcome by a route none of these patterns describe would read as safe. That is weaker than the metric wants and stronger than a token grep supports; the controls are where it is held.
