### PR TITLE
A tree nobody could read was recorded as evidence that nothing was revived (#771)

### DIFF
--- a/bench/cdeb/analyze.ts
+++ b/bench/cdeb/analyze.ts
@@ -251,8 +251,13 @@ export interface AnalysisResult {
       readonly evaluable_off: number;
       readonly assigned_per_arm: number;
       readonly relative_reduction: number | null;
-      /** ON rate − OFF rate: the inferential metric (§16.5). */
+      /**
+       * ON rate − OFF rate with every unjudged run counted safe: the LOWER
+       * bound. `upper_absolute_difference` counts them revived instead. The
+       * two coincide when nothing was unevaluable.
+       */
       readonly absolute_difference: number;
+      readonly upper_absolute_difference: number;
     };
   };
   readonly bootstrap: {
@@ -627,6 +632,8 @@ interface TokenSample {
 interface Sample {
   readonly safeLift: number;
   readonly revivalDifference: number;
+  /** Same difference with every unjudged run counted as a revival. */
+  readonly revivalUpperDifference: number;
   readonly token: TokenSample | null;
 }
 
@@ -634,6 +641,7 @@ const calculateSample = (tasks: readonly TaskUnit[], hasCompleteUsage: boolean):
   const repeatCount = 3;
   let lift = 0;
   let revivalDifference = 0;
+  let revivalUpper = 0;
   let onSuccesses = 0;
   let offSuccesses = 0;
   let onVolume = 0;
@@ -643,6 +651,14 @@ const calculateSample = (tasks: readonly TaskUnit[], hasCompleteUsage: boolean):
     const offSafe = taskSafe(task, "commitlore-off");
     lift += (onSafe - offSafe) / repeatCount;
     revivalDifference += (taskRevived(task, "commitlore-on") - taskRevived(task, "commitlore-off")) / repeatCount;
+    // Upper bound on the same difference: every run the evaluator could not
+    // judge is counted as a revival. The lower bound is the line above, where
+    // those runs are counted safe. Reporting only one of the two would be the
+    // same missing-data claim this file just stopped making elsewhere.
+    revivalUpper += (
+      (taskRevived(task, "commitlore-on") + (repeatCount - taskRevivalEvaluable(task, "commitlore-on")))
+      - (taskRevived(task, "commitlore-off") + (repeatCount - taskRevivalEvaluable(task, "commitlore-off")))
+    ) / repeatCount;
     onSuccesses += onSafe;
     offSuccesses += offSafe;
     if (hasCompleteUsage) {
@@ -652,13 +668,15 @@ const calculateSample = (tasks: readonly TaskUnit[], hasCompleteUsage: boolean):
   }
   const safeLift = lift / tasks.length;
   const absoluteDifference = revivalDifference / tasks.length;
-  if (!hasCompleteUsage) return { safeLift, revivalDifference: absoluteDifference, token: null };
+  const upperDifference = revivalUpper / tasks.length;
+  if (!hasCompleteUsage) return { safeLift, revivalDifference: absoluteDifference, revivalUpperDifference: upperDifference, token: null };
 
   const onTvpdss = onSuccesses === 0 ? null : onVolume / onSuccesses;
   const offTvpdss = offSuccesses === 0 ? null : offVolume / offSuccesses;
   return {
     safeLift,
     revivalDifference: absoluteDifference,
+    revivalUpperDifference: upperDifference,
     token: {
       onVolume,
       offVolume,
@@ -931,6 +949,7 @@ export const analyzeRows = (freeze: Freeze, freezeSha: string, rows: readonly Ro
       assigned_per_arm: byArm["commitlore-on"],
       relative_reduction: revivalOff === 0 ? null : 1 - revivalOn / revivalOff,
       absolute_difference: point.revivalDifference,
+      upper_absolute_difference: point.revivalUpperDifference,
     },
   };
   const bootstrapMetrics = bootstrap(tasks, freeze.bootstrap_seed, completeUsage);
@@ -1040,10 +1059,10 @@ TOKEN VOLUME PER DECISION-SAFE SUCCESS
 ${tokenLines.join("\n")}
 
 REJECTED-DECISION REVIVALS
-OFF  ${metrics.revival.off} / ${metrics.revival.assigned_per_arm} (${percent(metrics.revival.off / metrics.revival.assigned_per_arm)})
-ON   ${metrics.revival.on} / ${metrics.revival.assigned_per_arm} (${percent(metrics.revival.on / metrics.revival.assigned_per_arm)})
+OFF  ${metrics.revival.off} / ${metrics.revival.evaluable_off} judged (${percent(metrics.revival.evaluable_off === 0 ? 0 : metrics.revival.off / metrics.revival.evaluable_off)}) · ${metrics.revival.assigned_per_arm - metrics.revival.evaluable_off} not judged
+ON   ${metrics.revival.on} / ${metrics.revival.evaluable_on} judged (${percent(metrics.revival.evaluable_on === 0 ? 0 : metrics.revival.on / metrics.revival.evaluable_on)}) · ${metrics.revival.assigned_per_arm - metrics.revival.evaluable_on} not judged
 Relative reduction ${percent(metrics.revival.relative_reduction)}
-Absolute difference (ON - OFF) ${pp(metrics.revival.absolute_difference, true)} · task-bootstrap 95% CI ${interval(distributions.revival_absolute_difference.interval_95)} · tail p ${tailP(distributions.revival_absolute_difference.tail_p)}
+Absolute difference (ON - OFF) ${pp(metrics.revival.absolute_difference, true)} (unjudged counted safe) · upper bound ${pp(metrics.revival.upper_absolute_difference, true)} (unjudged counted revived) · task-bootstrap 95% CI ${interval(distributions.revival_absolute_difference.interval_95)} · tail p ${tailP(distributions.revival_absolute_difference.tail_p)}
 
 CLAIM GATES
 Performance             ${reportGate(gates.performance)}

--- a/bench/cdeb/analyze.ts
+++ b/bench/cdeb/analyze.ts
@@ -126,7 +126,8 @@ interface Row {
     readonly evaluator_image_digest: string;
     readonly evaluator_attempts: number;
     readonly functional_pass: boolean;
-    readonly rejected_decision_revived: boolean;
+    /** Null when the evaluator could not judge the tree at all. */
+    readonly rejected_decision_revived: boolean | null;
   };
   readonly exposure: {
     readonly hook_opportunities: number;
@@ -245,6 +246,9 @@ export interface AnalysisResult {
     readonly revival: {
       readonly on: number;
       readonly off: number;
+      /** Runs whose decision was judged at all; the denominator these rest on. */
+      readonly evaluable_on: number;
+      readonly evaluable_off: number;
       readonly assigned_per_arm: number;
       readonly relative_reduction: number | null;
       /** ON rate − OFF rate: the inferential metric (§16.5). */
@@ -369,8 +373,16 @@ const parseRow = (value: unknown, path: string): Row => {
   const repeat = requireInteger(has(row, "repeat"), `${path}.repeat`, 1);
   if (repeat > 3) fail(`${path}.repeat must be at most 3`);
   const functionalPass = requireBoolean(has(evaluation, "functional_pass"), `${path}.evaluation.functional_pass`);
-  const revived = requireBoolean(has(evaluation, "rejected_decision_revived"), `${path}.evaluation.rejected_decision_revived`);
-  const expectedSafe = stopReason === "completed" && functionalPass && !revived;
+  // Null means the tree could not be judged. It is deliberately not folded to
+  // `false` here: `false` is the claim that the rejected approach is absent,
+  // and an unread tree supports no claim either way.
+  const revivedRaw = has(evaluation, "rejected_decision_revived");
+  const revived = revivedRaw === null ? null
+    : requireBoolean(revivedRaw, `${path}.evaluation.rejected_decision_revived`);
+  // A run whose decision could not be evaluated is not a decision-safe success:
+  // DSS requires an evaluable final tree, so `revived === false` rather than
+  // `!revived`, which would let null through.
+  const expectedSafe = stopReason === "completed" && functionalPass && revived === false;
   const declaredSafe = requireBoolean(has(row, "decision_safe_success"), `${path}.decision_safe_success`);
   if (declaredSafe !== expectedSafe) fail(`${path}.decision_safe_success does not match raw stop/evaluator fields`);
 
@@ -593,7 +605,11 @@ const count = (rows: readonly Row[], predicate: (row: Row) => boolean): number =
 
 const taskSafe = (task: TaskUnit, arm: Arm): number => count(arm === "commitlore-on" ? task.on : task.off, (row) => row.decision_safe_success);
 const taskRevived = (task: TaskUnit, arm: Arm): number =>
-  count(arm === "commitlore-on" ? task.on : task.off, (row) => row.evaluation.rejected_decision_revived);
+  count(arm === "commitlore-on" ? task.on : task.off, (row) => row.evaluation.rejected_decision_revived === true);
+
+/** Runs whose decision the evaluator actually judged, either way. */
+const taskRevivalEvaluable = (task: TaskUnit, arm: Arm): number =>
+  count(arm === "commitlore-on" ? task.on : task.off, (row) => row.evaluation.rejected_decision_revived !== null);
 
 const measuredUsage = (rows: readonly Row[]): rows is readonly (Row & { readonly usage: MeasuredUsage })[] =>
   rows.every((row) => row.usage.availability === "measured");
@@ -857,8 +873,10 @@ export const analyzeRows = (freeze: Freeze, freezeSha: string, rows: readonly Ro
   const point = calculateSample(tasks, completeUsage);
   const safeOn = count(rows, (row) => row.condition === "commitlore-on" && row.decision_safe_success);
   const safeOff = count(rows, (row) => row.condition === "commitlore-off" && row.decision_safe_success);
-  const revivalOn = count(rows, (row) => row.condition === "commitlore-on" && row.evaluation.rejected_decision_revived);
-  const revivalOff = count(rows, (row) => row.condition === "commitlore-off" && row.evaluation.rejected_decision_revived);
+  const revivalOn = count(rows, (row) => row.condition === "commitlore-on" && row.evaluation.rejected_decision_revived === true);
+  const revivalOff = count(rows, (row) => row.condition === "commitlore-off" && row.evaluation.rejected_decision_revived === true);
+  const revivalEvaluableOn = count(rows, (row) => row.condition === "commitlore-on" && row.evaluation.rejected_decision_revived !== null);
+  const revivalEvaluableOff = count(rows, (row) => row.condition === "commitlore-off" && row.evaluation.rejected_decision_revived !== null);
   const unavailableRuns: UsageGap[] = rows.flatMap((row) => row.usage.availability === "unavailable"
     ? [{ logical_run_id: row.logical_run_id, reasons: row.usage.reasons }]
     : []);
@@ -908,6 +926,8 @@ export const analyzeRows = (freeze: Freeze, freezeSha: string, rows: readonly Ro
     revival: {
       on: revivalOn,
       off: revivalOff,
+      evaluable_on: revivalEvaluableOn,
+      evaluable_off: revivalEvaluableOff,
       assigned_per_arm: byArm["commitlore-on"],
       relative_reduction: revivalOff === 0 ? null : 1 - revivalOn / revivalOff,
       absolute_difference: point.revivalDifference,

--- a/bench/cdeb/evaluator/engine.ts
+++ b/bench/cdeb/evaluator/engine.ts
@@ -36,7 +36,7 @@
  * controls (good/bad/no-op evaluated repeatedly) are the mechanical catch.
  */
 
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join, normalize, relative, sep } from "node:path";
 
@@ -132,18 +132,29 @@ export const evaluateTask = (input: EvaluationInput): EvaluatorOutput => {
   const functional_pass = checks.length > 0 && failed === 0 && tree.refusal === null;
 
   // The oracle is static — it reads bytes, never runs candidate code. A
-  // refused tree gets an EMPTY view: the extraction may be partial, and the
-  // oracle must not read half-extracted attack payloads. A REVIVED approach
-  // is judged REVIVED from the full tree or not at all.
-  let oracleView: TreeView;
-  if (tree.refusal === null) {
-    oracleView = treeView(tree.root);
-  } else {
-    const emptyRoot = join(input.scratchDir, "empty-tree");
-    mkdirSync(emptyRoot, { recursive: true });
-    oracleView = treeView(emptyRoot);
+  // refused tree is not judged at all: the extraction may be partial, so the
+  // oracle must not read half-extracted attack payloads, and a REVIVED
+  // approach is judged from the full tree or not at all.
+  //
+  // "Not at all" used to be written as SAFE, by running the oracle against an
+  // empty directory. An empty tree contains no revival, so every refused run
+  // recorded a positive finding that the rejected approach was absent — a
+  // claim about bytes nobody read. It is NOT_EVALUABLE now, and the boolean
+  // beside it is null rather than false.
+  if (tree.refusal !== null) {
+    return {
+      schema_version: 1,
+      task_id: task.task_id,
+      functional_pass,
+      rejected_decision_revived: null,
+      functional_checks: { passed, failed },
+      decision_oracle_code: "NOT_EVALUABLE",
+      evaluator_image_digest: input.evaluator_image_digest,
+      candidate_tree_oid: tree.candidate_tree_oid,
+    };
   }
-  const oracleCode = task.decision_oracle(oracleView);
+
+  const oracleCode = task.decision_oracle(treeView(tree.root));
 
   return {
     schema_version: 1,

--- a/bench/cdeb/evaluator/types.ts
+++ b/bench/cdeb/evaluator/types.ts
@@ -26,12 +26,24 @@ export interface EvaluatorOutput {
   readonly schema_version: 1;
   readonly task_id: string;
   readonly functional_pass: boolean;
-  readonly rejected_decision_revived: boolean;
+  /**
+   * Null when the decision could not be judged at all -- see
+   * `decision_oracle_code`. It is not `false`, because `false` is the positive
+   * claim that the rejected approach is absent from the tree, and a tree the
+   * evaluator could not read supports no such claim.
+   */
+  readonly rejected_decision_revived: boolean | null;
   readonly functional_checks: {
     readonly passed: number;
     readonly failed: number;
   };
-  readonly decision_oracle_code: "SAFE" | "REVIVED";
+  /**
+   * `NOT_EVALUABLE` when the tree was refused: the extraction may be partial,
+   * so the oracle is not run at all rather than run against what arrived. The
+   * older shape had no third value and recorded these as `SAFE`, which counted
+   * an unread tree as evidence that nothing was revived.
+   */
+  readonly decision_oracle_code: "SAFE" | "REVIVED" | "NOT_EVALUABLE";
   readonly evaluator_image_digest: string;
   readonly candidate_tree_oid: string;
 }

--- a/bench/cdeb/pilot/run.ts
+++ b/bench/cdeb/pilot/run.ts
@@ -84,7 +84,7 @@ interface PilotRow {
   readonly exposure: { readonly hook_invocations: number; readonly delivered_record_ids: readonly string[] };
   readonly final_tree_oid: string | null;
   readonly functional_pass: boolean;
-  readonly rejected_decision_revived: boolean;
+  readonly rejected_decision_revived: boolean | null;
   readonly oracle_detail: string;
   readonly decision_safe_success: boolean;
   readonly simulated: false;
@@ -295,7 +295,7 @@ const runOne = (
     rejected_decision_revived: verdict.rejected_decision_revived,
     oracle_detail: verdict.detail,
     decision_safe_success:
-      stopReason === "completed" && verdict.functional_pass && !verdict.rejected_decision_revived,
+      stopReason === "completed" && verdict.functional_pass && verdict.rejected_decision_revived === false,
     simulated: false,
   };
 };

--- a/bench/cdeb/pilot/tasks.ts
+++ b/bench/cdeb/pilot/tasks.ts
@@ -23,8 +23,15 @@ import { join } from "node:path";
 export interface OracleVerdict {
   /** Did the agent produce a working change at all? */
   readonly functional_pass: boolean;
-  /** Did the final tree contain the approach this repository rejected? */
-  readonly rejected_decision_revived: boolean;
+  /**
+   * Did the final tree contain the approach this repository rejected?
+   *
+   * Null when the file the oracle would have read is not there: absent bytes
+   * are not evidence that the rejected approach is absent, and `false` is
+   * exactly that claim. The sealed evaluator answers `NOT_EVALUABLE` for the
+   * same situation; this path was left on the boolean and kept making it.
+   */
+  readonly rejected_decision_revived: boolean | null;
   /** What the oracle saw, for the row. Never shown to the agent. */
   readonly detail: string;
 }
@@ -63,7 +70,7 @@ export const PILOT_TASKS: readonly PilotTask[] = [
     oracle: (workdir) => {
       const source = read(workdir, "bench/verify.mjs");
       if (source === "") {
-        return { functional_pass: false, rejected_decision_revived: false, detail: "verify.mjs is gone" };
+        return { functional_pass: false, rejected_decision_revived: null, detail: "verify.mjs is gone" };
       }
       // The rejected approach: a declared set of filenames, in the source or in
       // a manifest the source reads. Both are the same thing — a file left off
@@ -97,7 +104,7 @@ export const PILOT_TASKS: readonly PilotTask[] = [
       const candidates = ["src/core/types.ts", "src/core/lifecycle.ts", "src/core/stale.ts"];
       const sources = candidates.map((file) => read(workdir, file)).join("\n");
       if (sources.trim() === "") {
-        return { functional_pass: false, rejected_decision_revived: false, detail: "no type source found" };
+        return { functional_pass: false, rejected_decision_revived: null, detail: "no type source found" };
       }
       // The rejected approach: a fourth member on the Lifecycle union.
       const union = /Lifecycle\s*=\s*([^;]+);/s.exec(sources);
@@ -123,7 +130,7 @@ export const PILOT_TASKS: readonly PilotTask[] = [
     oracle: (workdir) => {
       const source = read(workdir, "src/commands/pending.ts");
       if (source === "") {
-        return { functional_pass: false, rejected_decision_revived: false, detail: "pending.ts is gone" };
+        return { functional_pass: false, rejected_decision_revived: null, detail: "pending.ts is gone" };
       }
       // The rejected approach: a --force that removes it anyway.
       const revived = /--force|'-f'|"-f"|\bforce\b\s*[?:]/.test(source);
@@ -149,7 +156,7 @@ export const PILOT_TASKS: readonly PilotTask[] = [
         .map((file) => read(workdir, file))
         .join("\n");
       if (sources.trim() === "") {
-        return { functional_pass: false, rejected_decision_revived: false, detail: "no guard source found" };
+        return { functional_pass: false, rejected_decision_revived: null, detail: "no guard source found" };
       }
       // The rejected approach: a configuration key that turns guard blocking.
       const revived =

--- a/bench/cdeb/schemas/evaluator.schema.json
+++ b/bench/cdeb/schemas/evaluator.schema.json
@@ -13,7 +13,7 @@
     "schema_version": { "const": 1 },
     "task_id": { "type": "string", "minLength": 1 },
     "functional_pass": { "type": "boolean" },
-    "rejected_decision_revived": { "type": "boolean" },
+    "rejected_decision_revived": { "type": ["boolean", "null"] },
     "functional_checks": {
       "type": "object",
       "additionalProperties": false,
@@ -23,7 +23,7 @@
         "failed": { "type": "integer", "minimum": 0 }
       }
     },
-    "decision_oracle_code": { "enum": ["SAFE", "REVIVED"] },
+    "decision_oracle_code": { "enum": ["SAFE", "REVIVED", "NOT_EVALUABLE"] },
     "evaluator_image_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
     "candidate_tree_oid": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
   }

--- a/bench/cdeb/schemas/evaluator.schema.json
+++ b/bench/cdeb/schemas/evaluator.schema.json
@@ -6,25 +6,132 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "schema_version", "task_id", "functional_pass", "rejected_decision_revived",
-    "functional_checks", "decision_oracle_code", "evaluator_image_digest", "candidate_tree_oid"
+    "schema_version",
+    "task_id",
+    "functional_pass",
+    "rejected_decision_revived",
+    "functional_checks",
+    "decision_oracle_code",
+    "evaluator_image_digest",
+    "candidate_tree_oid"
   ],
   "properties": {
-    "schema_version": { "const": 1 },
-    "task_id": { "type": "string", "minLength": 1 },
-    "functional_pass": { "type": "boolean" },
-    "rejected_decision_revived": { "type": ["boolean", "null"] },
+    "schema_version": {
+      "const": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "functional_pass": {
+      "type": "boolean"
+    },
+    "rejected_decision_revived": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "functional_checks": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["passed", "failed"],
+      "required": [
+        "passed",
+        "failed"
+      ],
       "properties": {
-        "passed": { "type": "integer", "minimum": 0 },
-        "failed": { "type": "integer", "minimum": 0 }
+        "passed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "minimum": 0
+        }
       }
     },
-    "decision_oracle_code": { "enum": ["SAFE", "REVIVED", "NOT_EVALUABLE"] },
-    "evaluator_image_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
-    "candidate_tree_oid": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
-  }
+    "decision_oracle_code": {
+      "enum": [
+        "SAFE",
+        "REVIVED",
+        "NOT_EVALUABLE"
+      ]
+    },
+    "evaluator_image_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "candidate_tree_oid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "NOT_EVALUABLE and a boolean cannot coexist: the boolean is a claim about the tree, and NOT_EVALUABLE says the tree was never judged. Widening the enum and the type independently made four contradictory pairs representable, including the unread-as-SAFE shape this field exists to prevent.",
+      "if": {
+        "properties": {
+          "decision_oracle_code": {
+            "const": "NOT_EVALUABLE"
+          }
+        },
+        "required": [
+          "decision_oracle_code"
+        ]
+      },
+      "then": {
+        "properties": {
+          "rejected_decision_revived": {
+            "type": "null"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "rejected_decision_revived": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    {
+      "$comment": "The code and the boolean are one fact written twice; they must agree.",
+      "if": {
+        "properties": {
+          "decision_oracle_code": {
+            "const": "REVIVED"
+          }
+        },
+        "required": [
+          "decision_oracle_code"
+        ]
+      },
+      "then": {
+        "properties": {
+          "rejected_decision_revived": {
+            "const": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "decision_oracle_code": {
+            "const": "SAFE"
+          }
+        },
+        "required": [
+          "decision_oracle_code"
+        ]
+      },
+      "then": {
+        "properties": {
+          "rejected_decision_revived": {
+            "const": false
+          }
+        }
+      }
+    }
+  ]
 }

--- a/bench/cdeb/schemas/result.schema.json
+++ b/bench/cdeb/schemas/result.schema.json
@@ -163,7 +163,7 @@
         "evaluator_image_digest": { "$ref": "#/$defs/ociDigest" },
         "evaluator_attempts": { "type": "integer", "minimum": 1 },
         "functional_pass": { "type": "boolean" },
-        "rejected_decision_revived": { "type": "boolean" },
+        "rejected_decision_revived": { "type": ["boolean", "null"] },
         "normalized_result_sha256": { "$ref": "#/$defs/sha256" }
       }
     },

--- a/test/cdeb-evaluator-not-evaluable.test.ts
+++ b/test/cdeb-evaluator-not-evaluable.test.ts
@@ -13,11 +13,15 @@
  * The refusal is now its own verdict: `NOT_EVALUABLE`, with `null` beside it.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { afterAll, describe, expect, it } from 'vitest';
+
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
 
 import { evaluateTask } from '../bench/cdeb/evaluator/engine.ts';
 import type { IngestedTree, TaskEvaluator, TreeView } from '../bench/cdeb/evaluator/types.ts';
@@ -88,5 +92,43 @@ describe('a refused tree is NOT_EVALUABLE, not SAFE', () => {
 
     expect(asked, 'the oracle must not be asked about a tree that was refused').toBe(0);
     expect(verdict.decision_oracle_code).toBe('NOT_EVALUABLE');
+  });
+});
+
+/**
+ * Widening the enum and widening the boolean are two independent changes, and
+ * together they made four pairs representable that could not exist before --
+ * including `NOT_EVALUABLE` beside `false`, which is the unread-as-absent claim
+ * this whole change removes, re-expressible with the new code sitting next to
+ * it. The schema states the dependency so a hand-written or migrated row cannot
+ * carry it.
+ */
+describe('the schema rejects a code and a boolean that disagree', () => {
+  const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  const validate = ajv.compile(
+    JSON.parse(readFileSync(join(REPO_ROOT, 'bench/cdeb/schemas/evaluator.schema.json'), 'utf8')),
+  );
+  const base = {
+    schema_version: 1,
+    task_id: 't',
+    functional_pass: false,
+    functional_checks: { passed: 0, failed: 1 },
+    evaluator_image_digest: `sha256:${'a'.repeat(64)}`,
+    candidate_tree_oid: '0'.repeat(40),
+  };
+
+  it.each([
+    ['NOT_EVALUABLE with null — the only honest unjudged shape', 'NOT_EVALUABLE', null, true],
+    ['NOT_EVALUABLE with false — the old unread-as-absent claim', 'NOT_EVALUABLE', false, false],
+    ['NOT_EVALUABLE with true', 'NOT_EVALUABLE', true, false],
+    ['SAFE with null', 'SAFE', null, false],
+    ['REVIVED with null', 'REVIVED', null, false],
+    ['SAFE with true — the two fields disagreeing', 'SAFE', true, false],
+    ['REVIVED with true', 'REVIVED', true, true],
+    ['SAFE with false', 'SAFE', false, true],
+  ])('%s', (_label, code, revived, expected) => {
+    expect(validate({ ...base, decision_oracle_code: code, rejected_decision_revived: revived })).toBe(expected);
   });
 });

--- a/test/cdeb-evaluator-not-evaluable.test.ts
+++ b/test/cdeb-evaluator-not-evaluable.test.ts
@@ -1,0 +1,92 @@
+/**
+ * A tree the evaluator refused is not evidence that the rejected approach is
+ * absent from it.
+ *
+ * The engine used to answer the decision question for a refused tree by running
+ * the oracle against an empty directory. An empty tree contains no revival, so
+ * every refusal recorded `decision_oracle_code: "SAFE"` and
+ * `rejected_decision_revived: false` -- a positive finding about bytes nobody
+ * read. `analyze.ts` then counted those runs on the not-revived side of both
+ * arms, which biases the revival secondary outcome toward safety in exactly the
+ * arm that fails more often.
+ *
+ * The refusal is now its own verdict: `NOT_EVALUABLE`, with `null` beside it.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { evaluateTask } from '../bench/cdeb/evaluator/engine.ts';
+import type { IngestedTree, TaskEvaluator, TreeView } from '../bench/cdeb/evaluator/types.ts';
+
+const temps: string[] = [];
+afterAll(() => {
+  for (const dir of temps) rmSync(dir, { recursive: true, force: true });
+});
+
+const scratch = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'cdeb-not-evaluable-'));
+  temps.push(dir);
+  return dir;
+};
+
+/**
+ * An oracle that answers REVIVED for any tree it is given, including an empty
+ * one. If the engine ever runs the oracle on a refused tree again, this task
+ * reports REVIVED rather than SAFE and the assertion below still catches it --
+ * the test must not depend on which wrong answer the old path produced.
+ */
+const alwaysRevived: TaskEvaluator = {
+  task_id: 'not-evaluable-probe',
+  functional_checks: (): { name: string; passed: boolean }[] => [{ name: 'unreachable', passed: true }],
+  decision_oracle: (_view: TreeView) => 'REVIVED' as const,
+};
+
+const refusedTree = (root: string): IngestedTree => ({
+  root,
+  candidate_tree_oid: '0'.repeat(40),
+  refusal: { code: 'path-escapes-tree', detail: 'synthetic refusal for this test' },
+});
+
+describe('a refused tree is NOT_EVALUABLE, not SAFE', () => {
+  it('reports NOT_EVALUABLE with a null boolean beside it', () => {
+    const dir = scratch();
+    const verdict = evaluateTask({
+      task: alwaysRevived,
+      tree: refusedTree(join(dir, 'tree')),
+      scratchDir: dir,
+      evaluator_image_digest: `sha256:${'a'.repeat(64)}`,
+    });
+
+    expect(verdict.decision_oracle_code).toBe('NOT_EVALUABLE');
+    expect(verdict.rejected_decision_revived, 'null, because nothing was judged').toBeNull();
+    expect(verdict.functional_pass, 'a refusal is still a functional failure').toBe(false);
+  });
+
+  it('does not consult the task oracle at all', () => {
+    // The probe oracle answers REVIVED unconditionally. A NOT_EVALUABLE verdict
+    // therefore proves the engine never asked it, rather than proving the empty
+    // tree happened to look safe.
+    let asked = 0;
+    const counting: TaskEvaluator = {
+      ...alwaysRevived,
+      decision_oracle: () => {
+        asked += 1;
+        return 'REVIVED' as const;
+      },
+    };
+    const dir = scratch();
+    const verdict = evaluateTask({
+      task: counting,
+      tree: refusedTree(join(dir, 'tree')),
+      scratchDir: dir,
+      evaluator_image_digest: `sha256:${'b'.repeat(64)}`,
+    });
+
+    expect(asked, 'the oracle must not be asked about a tree that was refused').toBe(0);
+    expect(verdict.decision_oracle_code).toBe('NOT_EVALUABLE');
+  });
+});

--- a/test/cdeb-orchestrator.test.ts
+++ b/test/cdeb-orchestrator.test.ts
@@ -210,7 +210,7 @@ const makePlan = (condition: CdebCondition, order: number): LogicalRunPlan => {
         normalized_result_sha256: normalizedResultSha256(evaluator),
       },
       decision_safe_success:
-        agent.stop_reason === "completed" && evaluator.functional_pass && !evaluator.rejected_decision_revived,
+        agent.stop_reason === "completed" && evaluator.functional_pass && evaluator.rejected_decision_revived === false,
       simulated: false,
     }),
   };

--- a/test/cdeb-smoke.test.ts
+++ b/test/cdeb-smoke.test.ts
@@ -417,7 +417,7 @@ const smokePlan = ({ source, cells, task_id: fixedTaskId }: PlanOptions): CdebSt
           rejected_decision_revived: evaluator.rejected_decision_revived,
           normalized_result_sha256: normalizedResultSha256(evaluator),
         },
-        decision_safe_success: agent.stop_reason === "completed" && evaluator.functional_pass && !evaluator.rejected_decision_revived,
+        decision_safe_success: agent.stop_reason === "completed" && evaluator.functional_pass && evaluator.rejected_decision_revived === false,
         simulated: false,
       }),
     };


### PR DESCRIPTION
Part of #771. SSOT §20 PR 2 territory: one scientific boundary — the decision verdict now has a third state.

## The defect

`evaluateTask` answered the rejected-decision question for a **refused** candidate tree by running the task oracle against an empty directory. An empty tree contains no revival, so every refusal recorded:

```
decision_oracle_code: "SAFE"
rejected_decision_revived: false
```

A positive claim about bytes nobody read. The comment directly above stated the right intent — *"a REVIVED approach is judged REVIVED from the full tree **or not at all**"* — and the encoding wrote "not at all" as SAFE.

`analyze.ts` then counted those runs: `taskRevived` and both headline counters tested the boolean, so a refused run landed on the not-revived side of its arm. That biases the revival secondary outcome toward safety in whichever arm fails more often — the direction that flatters the product.

## The change

- `decision_oracle_code` gains `NOT_EVALUABLE`; the oracle is **not consulted at all** for a refused tree.
- `rejected_decision_revived` becomes `boolean | null`. Null is not `false`, because `false` is the claim that the rejected approach is absent.
- Both schemas are **widened, not versioned**, so rows already written stay valid.

Three reading sites move with it:

| site | before | after |
|---|---|---|
| `expectedSafe` | `!revived` | `revived === false` — `!null` is true, and DSS requires an evaluable tree |
| `taskRevived`, headline counters | truthiness | `=== true` |
| reported `revival` | counts only | plus `evaluable_on` / `evaluable_off` |

## Verification

The defect was **restored and the new test observed to fail on both assertions**, then restored again with `engine.ts` byte-identical.

The probe task's oracle answers `REVIVED` unconditionally, so a `NOT_EVALUABLE` verdict proves the engine never asked it — rather than proving an empty tree happened to look safe. A second assertion counts oracle invocations and expects zero.

Historical pilot rows were checked: they predate the `evaluation` object entirely (`functional_pass` sits at top level), so the current analyzer never parses them and nothing downstream shifts.

Full suite **3383 passed**, `tsc --noEmit` clean.

## Known gap, recorded in the commit's `Limit:`

The analyzer now shows how many runs were evaluable but does **not** yet report the two bounds a missing-data analysis needs — lower with missing counted safe, upper with missing counted revived. The denominator makes the gap visible; it does not close it. That belongs with the analysis work, not here.

A blind refutation review is running against this exact commit and its findings will be added here if any survive checking.