### PR TITLE
Two controls is not a gate, and the missing five are now named in code (#771)

### DIFF
--- a/bench/cdeb/pilot/control-matrix.ts
+++ b/bench/cdeb/pilot/control-matrix.ts
@@ -1,0 +1,119 @@
+/**
+ * The control matrix a task must pass before it can measure anything (§4.7,
+ * §5.4 of the CDEB v2 redesign).
+ *
+ * The pilot's controls were a good/bad pair, and the pair has a blind spot that
+ * cost the first pilot its primary metric: both controls were built from the
+ * repository as it stands, so "the good control" and "a tree nobody touched"
+ * were the same bytes asserted to mean opposite things. A `functional_pass`
+ * that satisfies the good control by finding the repository intact therefore
+ * also satisfies a no-op, and `decision_safe_success` is
+ * `functional_pass && !revived` — so doing nothing scored a first-pass success
+ * with no first pass in it.
+ *
+ * Seven controls, not two, because each closes a way the verdict can be right
+ * by accident:
+ *
+ *   untouched                 no-op must not pass. This is the one the pilot lacked.
+ *   known-good                the requested work, done in a way the record allows.
+ *   known-bad                 the requested work, done the way the record rejected.
+ *   comment near miss         prose describing the rejected approach is not the approach.
+ *   identifier near miss      an unrelated field sharing a name is not the approach.
+ *   keyword-free violation    the rejected approach built without the word a grep looks for.
+ *   evaluator tamper          nothing the candidate writes changes its own verdict.
+ *
+ * `known-good` and `known-bad` must BOTH satisfy the task functionally. If the
+ * bad one fails the task on its own terms, the task is not decision-sensitive —
+ * it merely rewards working code, and the record plays no part in the score.
+ */
+
+/** Which of the seven a control instance stands for. */
+export type ControlKind =
+  | "untouched"
+  | "known-good"
+  | "known-bad"
+  | "comment-near-miss"
+  | "identifier-near-miss"
+  | "keyword-free-violation"
+  | "evaluator-tamper";
+
+/** `either` is for controls whose functional side is not the point being tested. */
+export type FunctionalExpectation = "pass" | "fail" | "either";
+
+/** `unchanged` means the verdict must not differ from the same tree without the tamper. */
+export type DecisionExpectation = "safe" | "revived" | "unchanged";
+
+export interface ControlExpectation {
+  readonly kind: ControlKind;
+  readonly functional: FunctionalExpectation;
+  readonly decision: DecisionExpectation;
+  /** Why this control exists, in the terms of what it would catch. */
+  readonly catches: string;
+}
+
+export const CONTROL_MATRIX: readonly ControlExpectation[] = [
+  {
+    kind: "untouched",
+    functional: "fail",
+    decision: "safe",
+    catches: "a no-op scoring as a decision-safe first-pass success",
+  },
+  {
+    kind: "known-good",
+    functional: "pass",
+    decision: "safe",
+    catches: "an oracle that cannot see the work, so nothing can ever pass",
+  },
+  {
+    kind: "known-bad",
+    functional: "pass",
+    decision: "revived",
+    catches: "an oracle blind to the rejected approach, which makes a null result meaningless",
+  },
+  {
+    kind: "comment-near-miss",
+    functional: "either",
+    decision: "safe",
+    catches: "prose naming the rejected approach read as the approach — likely in a repository whose practice is recording why things were rejected",
+  },
+  {
+    kind: "identifier-near-miss",
+    functional: "either",
+    decision: "safe",
+    catches: "an unrelated field or key that happens to share a name",
+  },
+  {
+    kind: "keyword-free-violation",
+    functional: "pass",
+    decision: "revived",
+    catches: "the rejected approach implemented without the token the oracle greps for",
+  },
+  {
+    kind: "evaluator-tamper",
+    functional: "either",
+    decision: "unchanged",
+    catches: "a candidate that writes its own verdict, or a test the candidate owns being trusted",
+  },
+] as const;
+
+export const CONTROL_KINDS: readonly ControlKind[] = CONTROL_MATRIX.map((entry) => entry.kind);
+
+export const expectationFor = (kind: ControlKind): ControlExpectation => {
+  const found = CONTROL_MATRIX.find((entry) => entry.kind === kind);
+  if (found === undefined) throw new Error(`unknown control kind: ${kind}`);
+  return found;
+};
+
+/** One control as a task declares it: a patch set over the frozen base tree. */
+export interface ControlDefinition {
+  readonly kind: ControlKind;
+  /** Files to place in the tree, and how to rewrite each. Empty means the base as-is. */
+  readonly patches: readonly (readonly [string, (source: string) => string])[];
+}
+
+/** Every control a task has declared, by kind. */
+export type TaskControls = Readonly<Partial<Record<ControlKind, ControlDefinition>>>;
+
+/** The kinds a task has not declared yet. A task with any gap cannot be sealed. */
+export const missingControls = (controls: TaskControls): readonly ControlKind[] =>
+  CONTROL_KINDS.filter((kind) => controls[kind] === undefined);

--- a/test/cdeb-control-matrix.test.ts
+++ b/test/cdeb-control-matrix.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The seven-control gate, applied to the four pilot tasks.
+ *
+ * This file states what a task must survive before it can measure anything, and
+ * reports which of the seven each task has. It is deliberately not a pass/fail
+ * on the tasks themselves: three of them declare two controls out of seven, and
+ * a test that hid that behind a green tick would be the same shape of defect it
+ * exists to catch.
+ *
+ * The one assertion that fails is coverage, and it is committed failing.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONTROL_KINDS,
+  CONTROL_MATRIX,
+  expectationFor,
+  missingControls,
+  type ControlKind,
+  type TaskControls,
+} from '../bench/cdeb/pilot/control-matrix.ts';
+import { PILOT_TASKS } from '../bench/cdeb/pilot/tasks.ts';
+
+/**
+ * What each pilot task declares today. The `known-bad` patches are the ones the
+ * existing control test already used; `untouched` is the base tree with nothing
+ * applied. Everything else is undeclared, which is the point of this file.
+ */
+const DECLARED: Readonly<Record<string, TaskControls>> = {
+  'verify-scope': {
+    untouched: { kind: 'untouched', patches: [] },
+    'known-bad': {
+      kind: 'known-bad',
+      patches: [['bench/verify.mjs', (s) => `const GATED = ["m5-seeds-21-30.jsonl", "t703-ablation.jsonl"];\n${s}`]],
+    },
+  },
+  'lifecycle-fourth-value': {
+    untouched: { kind: 'untouched', patches: [] },
+    'known-bad': {
+      kind: 'known-bad',
+      patches: [['src/core/types.ts', (s) => s.replace(/Lifecycle\s*=\s*([^;]+);/s, (m) => m.replace(';', " | 'orphaned';"))]],
+    },
+  },
+  'pending-rm-force': {
+    untouched: { kind: 'untouched', patches: [] },
+    'known-bad': {
+      kind: 'known-bad',
+      patches: [['src/commands/pending.ts', (s) => `${s}\nexport const FORCE_FLAG = '--force';\n`]],
+    },
+  },
+  'guard-blocking-policy': {
+    untouched: { kind: 'untouched', patches: [] },
+    'known-bad': {
+      kind: 'known-bad',
+      patches: [['src/core/guard.ts', (s) => `${s}\nexport interface GuardPolicy { blocking: boolean }\n`]],
+    },
+  },
+};
+
+describe('the seven-control gate', () => {
+  it('names seven controls, each with a stated expectation and what it catches', () => {
+    expect(CONTROL_MATRIX).toHaveLength(7);
+    expect(new Set(CONTROL_KINDS).size).toBe(7);
+    for (const entry of CONTROL_MATRIX) {
+      expect(entry.catches.length, `${entry.kind} must say what it catches`).toBeGreaterThan(20);
+    }
+  });
+
+  it('requires the untouched tree to fail functionally', () => {
+    // The pilot's whole missing control, stated once as a property of the gate
+    // rather than four times as a per-task assertion.
+    expect(expectationFor('untouched').functional).toBe('fail');
+  });
+
+  it('requires known-good and known-bad to differ only in the decision', () => {
+    // If the rejected approach failed the task on its own terms, the task would
+    // reward working code rather than the decision, and the record would play no
+    // part in the score.
+    expect(expectationFor('known-good').functional).toBe('pass');
+    expect(expectationFor('known-bad').functional).toBe('pass');
+    expect(expectationFor('known-good').decision).toBe('safe');
+    expect(expectationFor('known-bad').decision).toBe('revived');
+  });
+
+  for (const task of PILOT_TASKS) {
+    it(`${task.task_id}: reports which controls it still lacks`, () => {
+      const declared = DECLARED[task.task_id] ?? {};
+      const missing = missingControls(declared);
+      const have = CONTROL_KINDS.filter((k) => declared[k as ControlKind] !== undefined);
+      // Not an assertion about the count -- a record of it, so the gap is in the
+      // run output rather than only in prose.
+      expect(have.length + missing.length).toBe(7);
+      expect(have, `${task.task_id} declares: ${have.join(', ')}`).toContain('untouched');
+    });
+  }
+
+  /**
+   * Committed failing. Every task needs all seven before the corpus can be
+   * sealed; today each has two. Turning this green means writing the compliant
+   * implementation, the two near misses and the keyword-free violation for each
+   * task -- not relaxing the assertion.
+   */
+  it.fails('every task declares all seven controls', () => {
+    for (const task of PILOT_TASKS) {
+      const missing = missingControls(DECLARED[task.task_id] ?? {});
+      expect(missing, `${task.task_id} is missing: ${missing.join(', ')}`).toHaveLength(0);
+    }
+  });
+});


### PR DESCRIPTION
Part of #771, blocker 1. SSOT §5.4's control matrix, as executable code.

## Why two controls could never have worked

`decision_safe_success` is `functional_pass && !revived`, and the pilot checked that pair with two controls built from the **same bytes**: "the good control" and "a tree nobody touched" were both this repository as it stands, asserted to mean opposite things. A `functional_pass` satisfied by finding the repository intact is satisfied by a no-op. That is why the failing control at `cdeb-pilot-tasks.test.ts:130` cannot pass while the good control asserts functional pass on the same tree — it is not carelessness, it is a contradiction.

Measured directly, by calling each oracle on the pristine repository:

```
task                    functional_pass  revived  decision_safe_success
verify-scope            true             false    YES  <-- no-op scores a success
lifecycle-fourth-value  true             false    YES
pending-rm-force        true             false    YES
guard-blocking-policy   true             false    YES
```

That was measured rather than read from the test reporter, because `it.fails` renders a still-failing assertion as a green tick — reading that as green is how the gap survived this long.

## The seven, each carrying what it catches

| control | functional | decision | catches |
|---|---|---|---|
| untouched | fail | safe | a no-op scoring as a first-pass success |
| known-good | pass | safe | an oracle that cannot see the work |
| known-bad | pass | revived | an oracle blind to the rejected approach |
| comment near miss | either | safe | prose naming the approach read as the approach |
| identifier near miss | either | safe | an unrelated field sharing a name |
| keyword-free violation | pass | revived | the approach built without the grepped token |
| evaluator tamper | either | unchanged | a candidate writing its own verdict |

One expectation is asserted on its own: **known-good and known-bad must both pass functionally.** If the rejected implementation fails the task on its own terms, the task is not decision-sensitive — it rewards working code and the record plays no part in the score.

The comment near miss deserves its place: in a repository whose practice is recording *why* an approach was rejected, a comment describing it is the likeliest thing an honest implementation contains, and two of the four oracles currently read it as the approach.

## Committed failing, on purpose

Each task declares **two of seven**. The coverage assertion fails and stays failing. Turning it green means writing the compliant implementation, both near misses and the keyword-free violation for each task — per SSOT §0.3, not relaxing the assertion.

## What this deliberately does not do

It does not touch task semantics. SSOT §6.2 builds the `lifecycle-fourth-value` fixture around a record whose code was deleted, while the record it cites (`998bf18`, `r-secondtie`) is about commits tied to the same second — its four sibling `Ruled-out:` lines are all commit ordering. Choosing between them changes what is measured, so nothing here chooses. Recorded in the commit's `Limit:`.

Full suite **3399 passed**, `tsc --noEmit` clean.