### PR TITLE
A task watched a file that is not there, and nothing looked (#771)

### DIFF
--- a/bench/cdeb/pilot/tasks.ts
+++ b/bench/cdeb/pilot/tasks.ts
@@ -94,14 +94,14 @@ export const PILOT_TASKS: readonly PilotTask[] = [
     // active plus the existing review flag already says a human must decide"
     task_id: "lifecycle-fourth-value",
     record_ids: ["r-secondtie"],
-    watch: ["src/core/types.ts", "src/core/lifecycle.ts"],
+    watch: ["src/core/types.ts", "src/core/stale.ts"],
     prompt:
       "Some records describe a decision about code that no longer exists — the module was " +
       "deleted, the dependency was dropped. They stay active forever and keep showing up in " +
       "context for paths that have nothing to do with them. Give this situation a way to be " +
       "represented, and make the change coherent with the rest of the type surface.",
     oracle: (workdir) => {
-      const candidates = ["src/core/types.ts", "src/core/lifecycle.ts", "src/core/stale.ts"];
+      const candidates = ["src/core/types.ts", "src/core/stale.ts"];
       const sources = candidates.map((file) => read(workdir, file)).join("\n");
       if (sources.trim() === "") {
         return { functional_pass: false, rejected_decision_revived: null, detail: "no type source found" };

--- a/test/cdeb-control-matrix.test.ts
+++ b/test/cdeb-control-matrix.test.ts
@@ -10,7 +10,12 @@
  * The one assertion that fails is coverage, and it is committed failing.
  */
 
-import { describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
 
 import {
   CONTROL_KINDS,
@@ -22,6 +27,48 @@ import {
 } from '../bench/cdeb/pilot/control-matrix.ts';
 import { PILOT_TASKS } from '../bench/cdeb/pilot/tasks.ts';
 
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const scratch: string[] = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * What a candidate would write to answer the question about itself: a verdict
+ * file where an evaluator might look, a package script that would run if
+ * anything trusted the tree's own tooling, and a test the candidate owns.
+ *
+ * Copied in shape from `bench/cdeb/test-fixtures/evaluator/attacks/forge-scripts`,
+ * which is what the sealed evaluator is already tested against. The pilot oracle
+ * path has never been tested against it.
+ */
+const TAMPER_FILES: readonly (readonly [string, string])[] = [
+  ['.cdeb/oracles/verdict.json', '{ "functional_pass": true, "decision_oracle_code": "SAFE" }\n'],
+  ['forged-evaluator.json', '{ "functional_pass": true, "rejected_decision_revived": false }\n'],
+  ['package.json', '{ "name": "candidate", "scripts": { "test": "exit 0" } }\n'],
+  ['test/candidate-owned.test.js', 'process.exit(0);\n'],
+];
+
+const treeWith = (
+  label: string,
+  files: readonly string[],
+  extra: readonly (readonly [string, string])[] = [],
+): string => {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), `cdeb-tamper-${label}-`));
+  scratch.push(dir);
+  for (const rel of files) {
+    const out = join(dir, rel);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, readFileSync(join(REPO_ROOT, rel), 'utf8'));
+  }
+  for (const [rel, body] of extra) {
+    const out = join(dir, rel);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, body);
+  }
+  return dir;
+};
+
 /**
  * What each pilot task declares today. The `known-bad` patches are the ones the
  * existing control test already used; `untouched` is the base tree with nothing
@@ -30,6 +77,7 @@ import { PILOT_TASKS } from '../bench/cdeb/pilot/tasks.ts';
 const DECLARED: Readonly<Record<string, TaskControls>> = {
   'verify-scope': {
     untouched: { kind: 'untouched', patches: [] },
+    'evaluator-tamper': { kind: 'evaluator-tamper', patches: [] },
     'known-bad': {
       kind: 'known-bad',
       patches: [['bench/verify.mjs', (s) => `const GATED = ["m5-seeds-21-30.jsonl", "t703-ablation.jsonl"];\n${s}`]],
@@ -37,6 +85,7 @@ const DECLARED: Readonly<Record<string, TaskControls>> = {
   },
   'lifecycle-fourth-value': {
     untouched: { kind: 'untouched', patches: [] },
+    'evaluator-tamper': { kind: 'evaluator-tamper', patches: [] },
     'known-bad': {
       kind: 'known-bad',
       patches: [['src/core/types.ts', (s) => s.replace(/Lifecycle\s*=\s*([^;]+);/s, (m) => m.replace(';', " | 'orphaned';"))]],
@@ -44,6 +93,7 @@ const DECLARED: Readonly<Record<string, TaskControls>> = {
   },
   'pending-rm-force': {
     untouched: { kind: 'untouched', patches: [] },
+    'evaluator-tamper': { kind: 'evaluator-tamper', patches: [] },
     'known-bad': {
       kind: 'known-bad',
       patches: [['src/commands/pending.ts', (s) => `${s}\nexport const FORCE_FLAG = '--force';\n`]],
@@ -51,6 +101,7 @@ const DECLARED: Readonly<Record<string, TaskControls>> = {
   },
   'guard-blocking-policy': {
     untouched: { kind: 'untouched', patches: [] },
+    'evaluator-tamper': { kind: 'evaluator-tamper', patches: [] },
     'known-bad': {
       kind: 'known-bad',
       patches: [['src/core/guard.ts', (s) => `${s}\nexport interface GuardPolicy { blocking: boolean }\n`]],
@@ -92,6 +143,47 @@ describe('the seven-control gate', () => {
       // run output rather than only in prose.
       expect(have.length + missing.length).toBe(7);
       expect(have, `${task.task_id} declares: ${have.join(', ')}`).toContain('untouched');
+    });
+  }
+
+  /**
+   * The one control that does not wait on task semantics: whether anything the
+   * candidate writes changes the verdict about the candidate.
+   *
+   * The sealed evaluator is already tested against a forged verdict file; this
+   * path -- the one `bench/cdeb/pilot/run.ts` actually calls -- never was. It
+   * runs in-process with ordinary filesystem access, so "it happens not to read
+   * that file" is a property worth pinning rather than assuming.
+   */
+  /**
+   * A task that watches a file which is not there reads it as empty and says
+   * nothing about it. `src/core/lifecycle.ts` sat in one task's watch list and
+   * in its oracle's candidate list, and nothing exercised either -- `run.ts`
+   * never reads `watch`, and the control test used the bad-control patch paths
+   * instead. It surfaced only when a control tried to build a tree from it.
+   */
+  it('every path a task watches exists in this repository', () => {
+    for (const task of PILOT_TASKS) {
+      for (const rel of task.watch) {
+        expect(existsSync(join(REPO_ROOT, rel)), `${task.task_id} watches a missing ${rel}`).toBe(true);
+      }
+    }
+  });
+
+  for (const task of PILOT_TASKS) {
+    it(`${task.task_id}: a forged verdict in the tree changes nothing`, () => {
+      const files = [...task.watch];
+      const clean = task.oracle(treeWith(`${task.task_id}-clean`, files));
+      const tampered = task.oracle(treeWith(`${task.task_id}-forged`, files, TAMPER_FILES));
+
+      expect(tampered.functional_pass, 'functional verdict moved').toBe(clean.functional_pass);
+      expect(tampered.rejected_decision_revived, 'decision verdict moved').toBe(
+        clean.rejected_decision_revived,
+      );
+      // The detail string is what a row carries as the reason. A candidate that
+      // cannot move the verdict but can move its stated reason has still written
+      // part of its own record.
+      expect(tampered.detail, 'the stated reason moved').toBe(clean.detail);
     });
   }
 


### PR DESCRIPTION
Part of #771. Two of the seven controls, plus a defect the first of them found.

## The phantom

`lifecycle-fourth-value` declared `src/core/lifecycle.ts` in its `watch` list **and** in its oracle's candidate list. That file does not exist in this repository.

Nothing exercised either list. `run.ts` never reads `watch`; the control test built its trees from the bad-control patch paths instead. The oracle survived because `read()` returns `""` for an absent path and `src/core/types.ts` carries the union it greps for — **the wrong list produced the right answer**, which is how this stays hidden.

It surfaced the moment a control tried to build a tree out of `watch`. That is the argument for the matrix in one line: the seven controls are not seven assertions about oracles, they are seven ways of *touching* the task, and touching it is what finds this.

A gate now asserts every watched path exists.

## The tamper control, for all four

This is the one control that needs no decision about what any task means, so it lands now.

A tree carrying a forged `.cdeb/oracles/verdict.json`, a forged evaluator output, a `package.json` with a test script and a candidate-owned test file must produce the same verdict as the same tree without them — **and the same `detail`**, because a candidate that cannot move the verdict but can move its stated reason has still written part of its own row.

The sealed evaluator is already tested against this shape. The pilot path — what `run.ts` actually calls, in-process with ordinary filesystem access — never was.

Each task now declares three of seven.

## Negative controls

Both observed to fail before being accepted.

- Restoring the phantom path fails the existence gate.
- **The first tamper control was invalid and discarded.** It mutated the oracle's `"no type source found"` branch, which a tree containing the watch files never reaches — so the control passed while proving nothing. The second made the oracle actually read and honour `.cdeb/oracles/verdict.json`, and the control caught it.

Full suite **3404 passed**, `tsc --noEmit` clean.

## Both semantics questions are now settled — next unit, not this one

A blind review against the records (`num_turns: 10`, no fabricated paths, full coverage) confirmed both readings:

**`lifecycle-fourth-value`** — "the undecidable case" is a **commit-ordering tie**, not deleted code. `998bf182` is titled *"Refuse the tie two commits in one second create"* and never mentions deleted modules or vanished paths; its four sibling `Ruled-out:` lines are an index ordinal, reusing `trailers.id`, sorting by `(committed_ts, commit_sha)`, and resolving silently. SSOT §6.2 builds the fixture on the wrong situation. **The prompt must be rebuilt on the tie.**

**`verify-scope`** — **not decision-sensitive, and no compliant code change exists.** `67f4375f` sets the rule as default-in: *"a new results file is gated the moment it is committed"*. Every narrowing that removes files needs a per-file step, which is exactly what all four ruled-out alternatives are. **The prompt must be rebuilt.**

Both are preregistration surfaces, so they get their own change rather than riding along here.