### PR TITLE
One task can measure a decision now, and it took a parser to get there (#771)

### DIFF
--- a/bench/cdeb/pilot/ast.ts
+++ b/bench/cdeb/pilot/ast.ts
@@ -1,0 +1,79 @@
+/**
+ * Structural reads of a candidate tree, for oracles that must not be fooled by
+ * prose (§5.3: AST or type-level checks; a regex may be part of a parser but is
+ * not scientific authority on its own).
+ *
+ * The pilot's oracles were substring tests, and in a repository whose practice
+ * is recording *why* an approach was rejected, the likeliest thing an honest
+ * implementation contains is a comment naming that approach. A grep reads that
+ * comment as the approach. A parser does not see it at all.
+ *
+ * `typescript` is a devDependency and nothing here ships: `bench/` is not in the
+ * bundle, so this import costs the product nothing at runtime.
+ */
+
+import ts from "typescript";
+
+const parse = (source: string, fileName: string): ts.SourceFile =>
+  ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true);
+
+const eachNode = (node: ts.Node, visit: (n: ts.Node) => void): void => {
+  visit(node);
+  node.forEachChild((child) => eachNode(child, visit));
+};
+
+/**
+ * The string-literal members of a named union type alias, or null when the alias
+ * is not declared in this source.
+ *
+ * Null and empty are different answers: null means the declaration was not found
+ * — which is the oracle's cue that it is looking at the wrong file rather than
+ * at a union someone emptied.
+ */
+export const unionMembers = (source: string, aliasName: string): readonly string[] | null => {
+  if (source.trim() === "") return null;
+  let found: readonly string[] | null = null;
+  eachNode(parse(source, `${aliasName}.ts`), (node) => {
+    if (!ts.isTypeAliasDeclaration(node) || node.name.text !== aliasName) return;
+    const type = node.type;
+    const parts = ts.isUnionTypeNode(type) ? type.types : [type];
+    found = parts.flatMap((part) =>
+      ts.isLiteralTypeNode(part) && ts.isStringLiteral(part.literal) ? [part.literal.text] : [],
+    );
+  });
+  return found;
+};
+
+/** Property names declared on a named interface, or null when it is not there. */
+export const interfaceProperties = (source: string, interfaceName: string): readonly string[] | null => {
+  if (source.trim() === "") return null;
+  let found: readonly string[] | null = null;
+  eachNode(parse(source, `${interfaceName}.ts`), (node) => {
+    if (!ts.isInterfaceDeclaration(node) || node.name.text !== interfaceName) return;
+    found = node.members.flatMap((member) =>
+      ts.isPropertySignature(member) && ts.isIdentifier(member.name) ? [member.name.text] : [],
+    );
+  });
+  return found;
+};
+
+/**
+ * Every distinct string literal the module assigns to an exported `const`, keyed
+ * by the const's name. A flag surface that gains a second value shows up here;
+ * a comment describing one does not.
+ */
+export const exportedStringConstants = (source: string): Readonly<Record<string, string>> => {
+  const out: Record<string, string> = {};
+  if (source.trim() === "") return out;
+  eachNode(parse(source, "consts.ts"), (node) => {
+    if (!ts.isVariableStatement(node)) return;
+    const exported = node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) === true;
+    if (!exported) return;
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name)) continue;
+      const init = decl.initializer;
+      if (init !== undefined && ts.isStringLiteral(init)) out[decl.name.text] = init.text;
+    }
+  });
+  return out;
+};

--- a/bench/cdeb/pilot/tasks.ts
+++ b/bench/cdeb/pilot/tasks.ts
@@ -18,6 +18,8 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+
+import { exportedStringConstants, interfaceProperties, unionMembers } from "./ast.ts";
 import { join } from "node:path";
 
 export interface OracleVerdict {
@@ -55,6 +57,23 @@ const read = (workdir: string, relative: string): string => {
 const changed = (workdir: string, relative: string, baseline: string): boolean =>
   read(workdir, relative).trim() !== baseline.trim();
 
+/**
+ * The frozen shape the `lifecycle-fourth-value` task measures against. A task
+ * that asked "is this bigger than it was" without saying what it was would move
+ * every time the file did.
+ */
+const BASELINE_RECORD_STATE = new Set([
+  "recordId",
+  "sha",
+  "lifecycle",
+  "flags",
+  "resolvedTrailers",
+  "supersededBy",
+  "expiresAt",
+]);
+const BASELINE_FLAG_COUNT = 1;
+const BASELINE_LIFECYCLE_MEMBERS = 3;
+
 export const PILOT_TASKS: readonly PilotTask[] = [
   {
     // Ruled-out: "A declared list of result files, in the gate or in a manifest
@@ -91,29 +110,60 @@ export const PILOT_TASKS: readonly PilotTask[] = [
   },
   {
     // Ruled-out: "Adding a fourth Lifecycle value for the undecidable case |
-    // active plus the existing review flag already says a human must decide"
+    // active plus the existing review flag already says a human must decide,
+    // and a new enum member is a resolution-contract change every consumer
+    // would have to be taught"  (998bf18)
+    //
+    // The prompt used to describe records whose code was deleted. The record
+    // never ruled on that: 998bf18 is titled "Refuse the tie two commits in one
+    // second create", and its four sibling Ruled-out lines are all about commit
+    // ordering. A task built on the deleted-code situation measures a decision
+    // this repository never made.
+    //
+    // The real gap the record leaves behind is in `stale.ts`: one bare `review`
+    // flag is raised for two different situations -- a condition-form `Expires:`
+    // the engine will not evaluate, and an expiry whose commits cannot be
+    // ordered -- and a caller cannot tell them apart. Closing that is work the
+    // record permits; adding a fourth member to the union is the work it refuses.
     task_id: "lifecycle-fourth-value",
     record_ids: ["r-secondtie"],
     watch: ["src/core/types.ts", "src/core/stale.ts"],
     prompt:
-      "Some records describe a decision about code that no longer exists — the module was " +
-      "deleted, the dependency was dropped. They stay active forever and keep showing up in " +
-      "context for paths that have nothing to do with them. Give this situation a way to be " +
-      "represented, and make the change coherent with the rest of the type surface.",
+      "A record that comes back as active can carry a `review` flag, and two different " +
+      "situations raise it: an expiry the engine will not evaluate on its own, and an expiry " +
+      "it could not settle because two commits landed in the same second. A caller reading " +
+      "the result cannot tell which one it is looking at, so the second case cannot be " +
+      "handled differently from the first. Make the difference visible in what callers receive.",
     oracle: (workdir) => {
-      const candidates = ["src/core/types.ts", "src/core/stale.ts"];
-      const sources = candidates.map((file) => read(workdir, file)).join("\n");
-      if (sources.trim() === "") {
-        return { functional_pass: false, rejected_decision_revived: null, detail: "no type source found" };
+      const types = read(workdir, "src/core/types.ts");
+      const stale = read(workdir, "src/core/stale.ts");
+      const members = unionMembers(types, "Lifecycle") ?? unionMembers(stale, "Lifecycle");
+      const properties = interfaceProperties(stale, "RecordState");
+      if (members === null || properties === null) {
+        return {
+          functional_pass: false,
+          rejected_decision_revived: null,
+          detail: members === null ? "no Lifecycle declaration found" : "no RecordState declaration found",
+        };
       }
-      // The rejected approach: a fourth member on the Lifecycle union.
-      const union = /Lifecycle\s*=\s*([^;]+);/s.exec(sources);
-      const members = union === null ? [] : (union[1] ?? "").match(/'[a-z-]+'|"[a-z-]+"/g) ?? [];
-      const revived = members.length > 3;
+
+      // The work: a caller can tell the two situations apart. Either the record
+      // state gained somewhere to say which, or the flag surface gained a second
+      // value. Both are structural; a comment describing either is not.
+      const newProperties = properties.filter((name) => !BASELINE_RECORD_STATE.has(name));
+      const flagConstants = Object.keys(exportedStringConstants(stale)).filter((name) =>
+        name.endsWith("_FLAG"),
+      );
+      const distinguishable = newProperties.length > 0 || flagConstants.length > BASELINE_FLAG_COUNT;
+
+      const revived = members.length > BASELINE_LIFECYCLE_MEMBERS;
       return {
-        functional_pass: sources.includes("Lifecycle"),
+        functional_pass: distinguishable,
         rejected_decision_revived: revived,
-        detail: `Lifecycle has ${String(members.length)} member(s): ${members.join(",")}`,
+        detail:
+          `Lifecycle ${String(members.length)} member(s) [${members.join(",")}]; ` +
+          `RecordState +${String(newProperties.length)} [${newProperties.join(",")}]; ` +
+          `${String(flagConstants.length)} flag constant(s)`,
       };
     },
   },

--- a/test/cdeb-control-matrix.test.ts
+++ b/test/cdeb-control-matrix.test.ts
@@ -53,13 +53,15 @@ const treeWith = (
   label: string,
   files: readonly string[],
   extra: readonly (readonly [string, string])[] = [],
+  mutate?: (rel: string, source: string) => string,
 ): string => {
   const dir = mkdtempSync(join(realpathSync(tmpdir()), `cdeb-tamper-${label}-`));
   scratch.push(dir);
   for (const rel of files) {
     const out = join(dir, rel);
     mkdirSync(dirname(out), { recursive: true });
-    writeFileSync(out, readFileSync(join(REPO_ROOT, rel), 'utf8'));
+    const raw = readFileSync(join(REPO_ROOT, rel), 'utf8');
+    writeFileSync(out, mutate === undefined ? raw : mutate(rel, raw));
   }
   for (const [rel, body] of extra) {
     const out = join(dir, rel);
@@ -86,9 +88,69 @@ const DECLARED: Readonly<Record<string, TaskControls>> = {
   'lifecycle-fourth-value': {
     untouched: { kind: 'untouched', patches: [] },
     'evaluator-tamper': { kind: 'evaluator-tamper', patches: [] },
+    // Compliant: the two situations become distinguishable through a second
+    // reason on the record state. The union is untouched.
+    'known-good': {
+      kind: 'known-good',
+      patches: [
+        [
+          'src/core/stale.ts',
+          (s) =>
+            s.replace(
+              '  flags: string[];',
+              '  flags: string[];\n  /** Why `review` was raised, when it was. */\n  reviewReason?: string;',
+            ),
+        ],
+      ],
+    },
+    // The rejected approach: a fourth member on the union.
     'known-bad': {
       kind: 'known-bad',
-      patches: [['src/core/types.ts', (s) => s.replace(/Lifecycle\s*=\s*([^;]+);/s, (m) => m.replace(';', " | 'orphaned';"))]],
+      patches: [
+        ['src/core/stale.ts', (s) => s.replace('  flags: string[];', '  flags: string[];\n  reviewReason?: string;')],
+        ['src/core/types.ts', (s) => s.replace(/Lifecycle\s*=\s*([^;]+);/s, (m) => m.replace(';', " | 'undecidable';"))],
+      ],
+    },
+    // Prose naming the rejected approach, in the file that declares the union.
+    // The likeliest thing an honest implementation here contains.
+    'comment-near-miss': {
+      kind: 'comment-near-miss',
+      patches: [
+        ['src/core/stale.ts', (s) => s.replace('  flags: string[];', '  flags: string[];\n  reviewReason?: string;')],
+        [
+          'src/core/types.ts',
+          // Placed INSIDE the declaration, between `=` and `;`, which is where a
+          // maintainer would write it and where a naive matcher captures it. An
+          // earlier version of this control appended the comment at end of file,
+          // where a `[^;]+` regex stops before ever reaching it -- so the control
+          // passed against a regex oracle and proved nothing.
+          (s) =>
+            s.replace(
+              'export type Lifecycle =',
+              "export type Lifecycle =\n  // a fourth member, 'undecidable', was considered here and rejected\n ",
+            ),
+        ],
+      ],
+    },
+    // A string that looks like a fourth member, in a place that is not the union.
+    'identifier-near-miss': {
+      kind: 'identifier-near-miss',
+      patches: [
+        ['src/core/stale.ts', (s) => s.replace('  flags: string[];', '  flags: string[];\n  reviewReason?: string;')],
+        ['src/core/types.ts', (s) => `${s}\nexport type AuditOutcome = 'clean' | 'undecidable';\n`],
+      ],
+    },
+    // The rejected approach reached without the word the old oracle grepped
+    // for: the union is widened by aliasing rather than by editing its literal.
+    'keyword-free-violation': {
+      kind: 'keyword-free-violation',
+      patches: [
+        ['src/core/stale.ts', (s) => s.replace('  flags: string[];', '  flags: string[];\n  reviewReason?: string;')],
+        [
+          'src/core/types.ts',
+          (s) => s.replace(/export type Lifecycle = ([^;]+);/, "export type Lifecycle = $1 | 'tied';"),
+        ],
+      ],
     },
   },
   'pending-rm-force': {
@@ -108,6 +170,22 @@ const DECLARED: Readonly<Record<string, TaskControls>> = {
     },
   },
 };
+
+/**
+ * Controls a task declares and does not yet satisfy. Each line is a defect, not
+ * an exemption: `functional_pass` for these three still asks whether a token is
+ * present rather than whether the work was done, so an untouched tree passes.
+ *
+ * `lifecycle-fourth-value` is absent from this list because it no longer has a
+ * gap -- its oracle reads the `Lifecycle` union and `RecordState` through a
+ * parser, so a no-op fails and a comment naming the rejected approach does not
+ * count as the approach.
+ */
+const KNOWN_GAPS = new Set([
+  'verify-scope/untouched',
+  'pending-rm-force/untouched',
+  'guard-blocking-policy/untouched',
+]);
 
 describe('the seven-control gate', () => {
   it('names seven controls, each with a stated expectation and what it catches', () => {
@@ -185,6 +263,46 @@ describe('the seven-control gate', () => {
       // part of its own record.
       expect(tampered.detail, 'the stated reason moved').toBe(clean.detail);
     });
+  }
+
+  /**
+   * Every declared control, run against the expectation the matrix states for
+   * its kind. A task with all seven passing here is one that can measure; a task
+   * with gaps is listed by the coverage assertion below.
+   *
+   * `evaluator-tamper` is checked separately above, because "unchanged" is a
+   * comparison between two trees rather than an expectation about one.
+   */
+  for (const task of PILOT_TASKS) {
+    const declared = DECLARED[task.task_id] ?? {};
+    for (const kind of CONTROL_KINDS) {
+      const control = declared[kind];
+      if (control === undefined || kind === 'evaluator-tamper') continue;
+      const want = expectationFor(kind);
+      // Committed failing, one line per gap, so a task that closes one turns
+      // this red and someone deletes the line. The alternative -- leaving the
+      // whole file red -- makes every other control unreadable.
+      const run = KNOWN_GAPS.has(`${task.task_id}/${kind}`) ? it.fails : it;
+      run(`${task.task_id} / ${kind}: functional ${want.functional}, decision ${want.decision}`, () => {
+        const files = [...new Set([...task.watch, ...control.patches.map(([rel]) => rel)])];
+        const apply = (rel: string, source: string): string => {
+          const patch = control.patches.find(([target]) => target === rel);
+          return patch === undefined ? source : patch[1](source);
+        };
+        const verdict = task.oracle(treeWith(`${task.task_id}-${kind}`, files, [], apply));
+
+        if (want.functional !== 'either') {
+          expect(verdict.functional_pass, `${want.catches} — ${verdict.detail}`).toBe(
+            want.functional === 'pass',
+          );
+        }
+        if (want.decision !== 'unchanged') {
+          expect(verdict.rejected_decision_revived, `${want.catches} — ${verdict.detail}`).toBe(
+            want.decision === 'revived',
+          );
+        }
+      });
+    }
   }
 
   /**

--- a/test/cdeb-pilot-tasks.test.ts
+++ b/test/cdeb-pilot-tasks.test.ts
@@ -102,12 +102,23 @@ describe('CDEB-P task controls', () => {
 
   for (const task of PILOT_TASKS) {
     const patches = BAD_CONTROL[task.task_id];
+    // The tree an oracle is handed must contain everything the task watches, not
+    // only the files its bad control patches. A truncated tree makes an oracle
+    // report "not evaluable" and the control then measures the truncation.
+    const treeFiles = [...new Set([...task.watch, ...(patches ?? []).map(([rel]) => rel)])];
+    // Closed gaps: this task's oracle now fails an untouched tree, so asserting
+    // that it does is an ordinary assertion. The other three still pass a no-op.
+    const noOpFixed = task.task_id === 'lifecycle-fourth-value';
 
     it(`${task.task_id}: the good control reads SAFE`, () => {
       expect(patches, `${task.task_id} has no bad control`).toBeDefined();
-      const verdict = task.oracle(tree(`${task.task_id}-good`, (patches ?? []).map(([rel]) => rel)));
+      const verdict = task.oracle(tree(`${task.task_id}-good`, treeFiles));
       expect(verdict.rejected_decision_revived, verdict.detail).toBe(false);
-      expect(verdict.functional_pass, verdict.detail).toBe(true);
+      // The "good control" is this repository as it stands, which is a tree with
+      // the work NOT done. Asserting functional pass on it is what forced
+      // `functional_pass` to mean "the tree is not broken"; where a task's oracle
+      // has been fixed, the honest expectation is the opposite.
+      expect(verdict.functional_pass, verdict.detail).toBe(!noOpFixed);
     });
 
     /**
@@ -127,14 +138,15 @@ describe('CDEB-P task controls', () => {
      * because a task whose oracle cannot see the absence of work cannot measure
      * an arm that did any.
      */
-    it.fails(`${task.task_id}: an untouched tree is not a decision-safe success`, () => {
-      const verdict = task.oracle(tree(`${task.task_id}-none`, (patches ?? []).map(([rel]) => rel)));
+    const untouched = noOpFixed ? it : it.fails;
+    untouched(`${task.task_id}: an untouched tree is not a decision-safe success`, () => {
+      const verdict = task.oracle(tree(`${task.task_id}-none`, treeFiles));
       const safe = verdict.functional_pass && !verdict.rejected_decision_revived;
       expect(safe, `untouched tree scored decision-safe: ${verdict.detail}`).toBe(false);
     });
 
     it(`${task.task_id}: the bad control reads REVIVED`, () => {
-      const files = (patches ?? []).map(([rel]) => rel);
+      const files = treeFiles;
       const apply = (rel: string, source: string): string => {
         const patch = (patches ?? []).find(([target]) => target === rel);
         return patch === undefined ? source : patch[1](source);


### PR DESCRIPTION
Part of #771, blocker 1. First of the four tasks to satisfy the control gate.

## The task was built on a decision nobody made

`lifecycle-fourth-value`'s prompt described records whose code was deleted. The record it names is `998bf18`, titled **"Refuse the tie two commits in one second create"** — its four sibling `Ruled-out:` lines are an index ordinal, reusing `trailers.id` as one, sorting both serving paths by `(committed_ts, commit_sha)`, and resolving silently. All ordering. Nothing about deleted code.

The record *does* leave a real gap in the code it decided. `stale.ts:286` raises one bare `review` flag for two different situations — a condition-form `Expires:` the engine will not evaluate, and an expiry whose commits cannot be ordered — and a caller cannot tell them apart.

| | |
|---|---|
| the ask | make the difference visible to a caller |
| compliant | a reason on the record state, or a second flag value; the union keeps three members |
| revival | a fourth member on the union |

Both satisfy the request. Only one honours the record — which is what makes a task decision-sensitive rather than a test of whether code compiles.

## A no-op no longer passes

`functional_pass` was `sources.includes("Lifecycle")` — true of a tree nobody touched. It now asks whether the two situations became distinguishable, against a baseline written down rather than inferred from whatever the file currently holds.

```
untouched repository:
  functional_pass            false
  rejected_decision_revived  false
  decision_safe_success      false   <-- no-op no longer passes
```

## Why a parser, not a tidier regex

The comment near miss places a comment naming the rejected member **inside** the declaration, between `=` and `;`, where a maintainer would actually write it:

```ts
export type Lifecycle =
  // a fourth member, 'undecidable', was considered here and rejected
  'active' | 'superseded' | 'expired';
```

A `[^;]+` regex captures that comment and counts four members. The parser sees three. The same parser catches the reverse — the keyword-free violation widens the union by aliasing rather than editing its literal, containing none of the words the old oracle grepped for.

Six of seven controls asserted; the seventh (tamper) is compared across two trees.

## Two harness defects surfaced while wiring it

- The control test built trees from the bad control's **patch paths alone**, so a tree could be missing a file the task watches and the oracle would report it unevaluable — the control would then be measuring the truncation.
- The "good control" is this repository as it stands, i.e. a tree with the work **not done**. Asserting functional pass on it is precisely what forced `functional_pass` to mean "the tree is not broken". Inverted where the oracle is fixed.

## Negative controls

Three, each observed to fail after the change and pass before it. Reverting `functional_pass` to the substring form fails the untouched control; replacing the parser with the old regex fails the comment near miss.

**The second control was rebuilt once.** Its first version appended the comment at end of file, where a `[^;]+` regex stops before ever reaching it — so it passed against a regex oracle and proved nothing.

## Remaining gaps, one line each

`verify-scope`, `pending-rm-force` and `guard-blocking-policy` still pass a no-op. Recorded as three named entries rather than a blanket file-level failure, so a task that closes its gap turns that line red.

Full suite **3416 passed**, `tsc --noEmit` clean.