### PR TITLE
The context protection is about to depend on reports from one trigger line

### DIFF
--- a/test/ci-gate.test.ts
+++ b/test/ci-gate.test.ts
@@ -66,6 +66,25 @@ describe('the CI fan-in gate', () => {
     expect(gate).not.toMatch(/=\s*"failure"/);
   });
 
+  it('lint reports on pull requests, which is the only place protection can see it', () => {
+    // `lint` does not report on `main` commits and is not supposed to: a squash
+    // produces a commit carrying no `lint` context, which is why the release
+    // gate requires ten jobs and not eleven. It reports on PR heads, and a PR
+    // head is what branch protection evaluates.
+    //
+    // So the `pull_request` trigger is load-bearing for protection. Remove it
+    // and `lint` becomes a required context that can never report on a pull
+    // request, and every pull request blocks -- the same shape as requiring a
+    // context from a workflow that only runs on another branch, reached from
+    // the other direction. Nothing else guards this.
+    const body = readFileSync(join(REPO_ROOT, '.github/workflows/demo-lint.yml'), 'utf8');
+    const on = (load(body) as { on?: Record<string, unknown> }).on ?? {};
+    expect(
+      Object.keys(on),
+      'demo-lint.yml must trigger on pull_request while `lint` is a required context',
+    ).toContain('pull_request');
+  });
+
   it('lint stays a separate required context, and is not matrix-interpolated', () => {
     // `lint` lives in another workflow and cannot be a `needs:` from ci.yml, so
     // protection requires two contexts. Neither may carry a matrix value, or a


### PR DESCRIPTION
Follows #803. Guards the assumption branch protection now rests on.

## What was unguarded

`lint` is one of the two contexts protection requires, and it reports on **pull requests only**. That is correct rather than a gap — a squash produces a commit carrying no `lint` context, which is why `check-exact-head-ci.mjs` requires ten jobs and not eleven.

Measured on both surfaces before writing this:

```
c622db42 (main)        gate reported     lint absent
#803 head commit       gate reported     lint reported
```

Protection evaluates the **pull request head**, so both are there when it looks.

The part with nothing behind it is *why* `lint` reaches that head at all: a bare `pull_request:` trigger in `demo-lint.yml`. Delete that line and `lint` becomes a required context that can never report on a pull request — **every PR blocks, with no failing check to explain it.**

## One trigger line, two directions

Another session nearly shipped the mirror image today: requiring, on `main`, contexts from a workflow triggered only on `dev`. There the workflow could not report on the protected **branch**; here it would not report on the protected **event**. Same failure, opposite direction, and nothing in this repository noticed either.

The assertion reads the parsed trigger set, not the file text, so reformatting does not move it and removal does.

## This PR is also the enforcement evidence

Protection was tightened between #803 and this PR: `enforce_admins` true, required contexts `gate` + `lint`, pull request required. That was verified by re-reading the settings, which is not the same as watching them refuse something. **This PR is the first to run under them** — if `gate` and `lint` both report and the merge is allowed only after they do, that is the demonstration the settings change did not have.

## Negative control

Removing the `pull_request` trigger fails the assertion; restored byte-identical.

Full suite **3423 passed**, `tsc --noEmit` clean.

## Limit, recorded in the commit

This guards the **trigger**, not the job name. Renaming the `lint` job leaves the trigger intact and still breaks the required context, and nothing here catches that.