### PR TITLE
gate pinned its own name and left the other half of the pair unpinned

### DIFF
--- a/test/ci-gate.test.ts
+++ b/test/ci-gate.test.ts
@@ -91,6 +91,17 @@ describe('the CI fan-in gate', () => {
     // version bump renames it.
     const demo = workflow('demo-lint.yml');
     expect(demo.jobs.lint, 'demo-lint.yml has no lint job').toBeDefined();
+    // The required context is the check-run NAME, which GitHub takes from an
+    // explicit `name:` when there is one and from the job id otherwise. Renaming
+    // the id is caught here and in action-lint.test.ts; ADDING a `name:` was
+    // not, and it breaks the context exactly as thoroughly -- `lint` would stop
+    // reporting while a job called `lint` still sits in the file. `gate` pins
+    // its name above; this is the same pin, which was missing on the other half
+    // of the required pair.
+    expect(
+      demo.jobs.lint?.name,
+      'lint must not carry an explicit name: the required context is derived from the job id',
+    ).toBeUndefined();
     for (const [file, id] of [['ci.yml', 'gate'], ['demo-lint.yml', 'lint']] as const) {
       const body = readFileSync(join(REPO_ROOT, '.github/workflows', file), 'utf8');
       const job = body.slice(body.indexOf(`  ${id}:`));


### PR DESCRIPTION
Follows #805. Closes the other way a required context can stop reporting.

## The asymmetry

Protection requires `gate` and `lint`. A required context is a check-run **name**, which GitHub takes from an explicit `name:` when a job has one and from the job id otherwise.

`gate` pins its name (`ci-gate.test.ts:37`). `lint` did not. That was mine.

## The reported hole is already caught; the real one was not

A peer reported the risk as *renaming the job id*. Tested by making the rename rather than by reading the assertions — `lint` → `linting` fails two tests, one here and one in `action-lint.test.ts`, because both assert `jobs.lint` exists.

The hole is the other direction:

```
add `name: pr-lint`, leave the job id as `lint`
  → the check-run becomes `pr-lint`
  → the required context `lint` never reports
  → every PR blocks, with no failing check to explain it
  → all 35 assertions in both files still pass
```

Reproduced before closing it. A job called `lint` still sits in the file, which is exactly what both existing assertions look at.

## The shape

The name written in the required list and the place that emits it are **different places**, and only one of them was guarded. Same shape as the matrix-interpolated contexts in #803 and the `branches: [dev]` near-miss another session hit today — a name and its enforcement site drifting apart.

## The assertion

That the job carries **no** `name:` — the property is its absence, not an equality. Asserting `name === 'lint'` would invite someone to add a redundant `name: lint`, which is one edit from wrong.

Negative control: adding `name: pr-lint` fails the assertion; restored byte-identical.

## Limit, in the commit

This pins where the name comes from, not that the check ever runs. A workflow-level failure before job dispatch produces no check run at all, and neither this nor the trigger assertion sees that.

Full suite green, `tsc --noEmit` clean.