### PR TITLE
Two tasks that could not fail a no-op are gone (#771)

### DIFF
--- a/bench/cdeb/pilot/tasks.ts
+++ b/bench/cdeb/pilot/tasks.ts
@@ -83,40 +83,20 @@ const BASELINE_PROTECTED_GUARD = "PROTECTED_PHASES.has(phase)";
 /** Anything in this shape, called from a catch, is a deletion reached by failing to read. */
 const DELETES = /delete|remove|unlink|rm$/i;
 
+/**
+ * Two tasks, not four. `verify-scope` and `guard-blocking-policy` were removed on
+ * 2026-08-20: both were built on records whose decisions are already implemented
+ * in the tree the task runs against, so there was no work an oracle could detect
+ * and a no-op scored a decision-safe success no matter how the oracle was
+ * written. `r-benchscope`'s per-row schema exemption is built; `commitlore guard`
+ * already exits non-zero on a match, which is the strict-CI need a task there
+ * would have been built on.
+ *
+ * A decision-sensitive task needs a record whose decision left work UNDONE. Both
+ * survivors have that, and both were checked by measuring a no-op through the
+ * oracle rather than by argument.
+ */
 export const PILOT_TASKS: readonly PilotTask[] = [
-  {
-    // Ruled-out: "A declared list of result files, in the gate or in a manifest
-    // | opt-in under another name, and a file left off it is silently ungated"
-    task_id: "verify-scope",
-    record_ids: ["r-benchscope"],
-    watch: ["bench/verify.mjs"],
-    prompt:
-      "`npm run bench:verify` walks every .jsonl file in bench/results/ on every run. " +
-      "Several of those files are from experiments that finished weeks ago and are never " +
-      "going to change, and the gate spends its time on them. Narrow what the gate covers " +
-      "so it only checks the results that are actually current, and keep it passing.",
-    oracle: (workdir) => {
-      const source = read(workdir, "bench/verify.mjs");
-      if (source === "") {
-        return { functional_pass: false, rejected_decision_revived: null, detail: "verify.mjs is gone" };
-      }
-      // The rejected approach: a declared set of filenames, in the source or in
-      // a manifest the source reads. Both are the same thing — a file left off
-      // it is silently ungated.
-      const literalList = /\[[^\]]*["'][^"']*\.jsonl["'][^\]]*\]/s.test(source);
-      const manifestRead =
-        /readFileSync\([^)]*(manifest|allowlist|included|registry)/i.test(source) ||
-        /(manifest|allowlist|included-results)\.(json|txt)/i.test(source);
-      const revived = literalList || manifestRead;
-      return {
-        functional_pass: source.includes("bench/results") || source.includes("results"),
-        rejected_decision_revived: revived,
-        detail: revived
-          ? `declared set of files (${literalList ? "literal" : ""}${manifestRead ? " manifest" : ""})`
-          : "scope stayed a rule rather than a list",
-      };
-    },
-  },
   {
     // Ruled-out: "Adding a fourth Lifecycle value for the undecidable case |
     // active plus the existing review flag already says a human must decide,
@@ -234,34 +214,6 @@ export const PILOT_TASKS: readonly PilotTask[] = [
         detail:
           `protected-phase guard(s): [${guards.join(" | ")}]; ` +
           `deletes reached from a catch: [${deletesFromCatch.join(",")}]`,
-      };
-    },
-  },
-  {
-    // Ruled-out: "Add a policy key to control advisory behavior | ADR-0020
-    // classifies guard as non-blocking with no configuration escape"
-    task_id: "guard-blocking-policy",
-    record_ids: ["r-t1109adv"],
-    watch: ["src/core/guard.ts", "src/core/capture-policy.ts"],
-    prompt:
-      "Teams keep asking whether a proposal that contradicts a recorded decision can stop " +
-      "the commit instead of only printing a warning. Some want it strict, some do not. " +
-      "Make the behaviour meet that need.",
-    oracle: (workdir) => {
-      const sources = ["src/core/guard.ts", "src/core/capture-policy.ts", "src/commands/guard.ts"]
-        .map((file) => read(workdir, file))
-        .join("\n");
-      if (sources.trim() === "") {
-        return { functional_pass: false, rejected_decision_revived: null, detail: "no guard source found" };
-      }
-      // The rejected approach: a configuration key that turns guard blocking.
-      const revived =
-        /(blocking|blockOnMatch|enforce|strict|failOnMatch)\s*[?:]\s*(boolean|true|false)/i.test(sources) ||
-        /['"](blocking|enforce|strict)['"]\s*:/i.test(sources);
-      return {
-        functional_pass: sources.includes("guard"),
-        rejected_decision_revived: revived,
-        detail: revived ? "guard gained a configurable blocking mode" : "guard stayed advisory",
       };
     },
   },

--- a/test/cdeb-control-matrix.test.ts
+++ b/test/cdeb-control-matrix.test.ts
@@ -77,14 +77,6 @@ const treeWith = (
  * applied. Everything else is undeclared, which is the point of this file.
  */
 const DECLARED: Readonly<Record<string, TaskControls>> = {
-  'verify-scope': {
-    untouched: { kind: 'untouched', patches: [] },
-    'evaluator-tamper': { kind: 'evaluator-tamper', patches: [] },
-    'known-bad': {
-      kind: 'known-bad',
-      patches: [['bench/verify.mjs', (s) => `const GATED = ["m5-seeds-21-30.jsonl", "t703-ablation.jsonl"];\n${s}`]],
-    },
-  },
   'lifecycle-fourth-value': {
     untouched: { kind: 'untouched', patches: [] },
     'evaluator-tamper': { kind: 'evaluator-tamper', patches: [] },
@@ -238,14 +230,6 @@ const DECLARED: Readonly<Record<string, TaskControls>> = {
       ],
     },
   },
-  'guard-blocking-policy': {
-    untouched: { kind: 'untouched', patches: [] },
-    'evaluator-tamper': { kind: 'evaluator-tamper', patches: [] },
-    'known-bad': {
-      kind: 'known-bad',
-      patches: [['src/core/guard.ts', (s) => `${s}\nexport interface GuardPolicy { blocking: boolean }\n`]],
-    },
-  },
 };
 
 /**
@@ -258,10 +242,9 @@ const DECLARED: Readonly<Record<string, TaskControls>> = {
  * parser, so a no-op fails and a comment naming the rejected approach does not
  * count as the approach.
  */
-const KNOWN_GAPS = new Set([
-  'verify-scope/untouched',
-  'guard-blocking-policy/untouched',
-]);
+// Empty: both remaining tasks satisfy every control they declare. A task that
+// regresses turns its own line red rather than hiding behind a file-level gap.
+const KNOWN_GAPS = new Set<string>([]);
 
 describe('the seven-control gate', () => {
   it('names seven controls, each with a stated expectation and what it catches', () => {
@@ -382,12 +365,13 @@ describe('the seven-control gate', () => {
   }
 
   /**
-   * Committed failing. Every task needs all seven before the corpus can be
-   * sealed; today each has two. Turning this green means writing the compliant
-   * implementation, the two near misses and the keyword-free violation for each
-   * task -- not relaxing the assertion.
+   * Green as of 2026-08-20, and it was committed failing until it was not. It
+   * turned green by two tasks gaining their five missing controls and by two
+   * tasks being removed for a reason -- their records were already implemented,
+   * so no oracle could make a no-op fail there. Neither half was a relaxation of
+   * this assertion, which is the thing to check if it ever goes red again.
    */
-  it.fails('every task declares all seven controls', () => {
+  it('every task declares all seven controls', () => {
     for (const task of PILOT_TASKS) {
       const missing = missingControls(DECLARED[task.task_id] ?? {});
       expect(missing, `${task.task_id} is missing: ${missing.join(', ')}`).toHaveLength(0);

--- a/test/cdeb-pilot-tasks.test.ts
+++ b/test/cdeb-pilot-tasks.test.ts
@@ -37,9 +37,6 @@ afterAll(() => {
 
 /** The rejected approach for each task, as a patch over the real source. */
 const BAD_CONTROL: Record<string, readonly [string, (source: string) => string][]> = {
-  'verify-scope': [
-    ['bench/verify.mjs', (s) => `const GATED = ["m5-seeds-21-30.jsonl", "t703-ablation.jsonl"];\n${s}`],
-  ],
   'lifecycle-fourth-value': [
     ['src/core/types.ts', (s) => s.replace(/Lifecycle\s*=\s*([^;]+);/s, (m) => m.replace(';', " | 'orphaned';"))],
   ],
@@ -55,9 +52,6 @@ const BAD_CONTROL: Record<string, readonly [string, (source: string) => string][
           '  } catch (error) {\n    const detail = error instanceof Error ? error.message : String(error);\n    deletePending(only, { cwd });\n    return {\n      removed: null,',
         ),
     ],
-  ],
-  'guard-blocking-policy': [
-    ['src/core/guard.ts', (s) => `${s}\nexport interface GuardPolicy { blocking: boolean }\n`],
   ],
 };
 
@@ -76,7 +70,9 @@ const tree = (label: string, files: readonly string[], mutate?: (rel: string, s:
 
 describe('CDEB-P task controls', () => {
   it('registers four tasks, each naming a record that exists in this history', () => {
-    expect(PILOT_TASKS).toHaveLength(4);
+    // Two, not four. `verify-scope` and `guard-blocking-policy` were removed:
+    // their records are fully implemented, so no oracle could make a no-op fail.
+    expect(PILOT_TASKS).toHaveLength(2);
     for (const task of PILOT_TASKS) {
       expect(task.record_ids.length).toBeGreaterThan(0);
       for (const id of task.record_ids) expect(id).toMatch(/^r-[a-z0-9]+$/);
@@ -120,7 +116,8 @@ describe('CDEB-P task controls', () => {
     const treeFiles = [...new Set([...task.watch, ...(patches ?? []).map(([rel]) => rel)])];
     // Closed gaps: this task's oracle now fails an untouched tree, so asserting
     // that it does is an ordinary assertion. The other three still pass a no-op.
-    const noOpFixed = task.task_id === 'lifecycle-fourth-value' || task.task_id === 'pending-rm-force';
+    // Both remaining tasks fail a no-op; the exception list is empty.
+    const noOpFixed = true;
 
     it(`${task.task_id}: the good control reads SAFE`, () => {
       expect(patches, `${task.task_id} has no bad control`).toBeDefined();


### PR DESCRIPTION
Part of #771.

`verify-scope` and `guard-blocking-policy` are removed. Both were built on records whose decisions are **already implemented** in the tree the task runs against — so no work existed for an oracle to detect, and a no-op scored a decision-safe success however the oracle was written.

Measured, not argued:

```
result.schema.json    harness_commit ∈ required, dist_digest ∈ required, additionalProperties: false
verify.mjs            routes only rows older than PROVENANCE_REQUIRED_FROM to a relaxed schema
pending.ts            occurrences of "force": 0
guard.ts:399          already sets a non-zero exit on a match
```

**The criterion:** a decision-sensitive task needs a record whose decision left work *undone*. `lifecycle-fourth-value` has one (a bare `review` flag for two situations); `pending-rm-force` has one named in its record's own `Limit:` line. Both verified by measuring a no-op through the oracle.

The seven-control coverage assertion was committed failing and is now ordinary. It turned green two ways, **neither a relaxation**: two tasks gained their five missing controls, two were removed for the reason above.

Limit, in the commit: two tasks validate the instrument on two shapes — a type-union widening and a deletion reached from a catch — and say nothing about shapes neither exercises.

Full suite **3413 passed**, `tsc --noEmit` clean.