### PR TITLE
Three translations described a product the English page had stopped describing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,132 +1,59 @@
+<!-- README:BRAND -->
 <p align="center">
-  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore はリポジトリの意思決定の権威を次の編集へ運ぶ: src/pricing.ts でまだ有効な決定が、それが退けた代替案とともに届き、置き換えられた以前のより広い limit は現在の指針として先へ進まない。">
+  <img src="./assets/readme/commitlore-logo.svg" width="440" alt="CommitLore">
+</p>
+
+<h1 align="center">CommitLore</h1>
+
+<h3 align="center">あなたのコーディングエージェントは、チームがすでに却下した案を何度も提案します。</h3>
+
+<p align="center">
+  <strong>Git が所有する、コーディングエージェントの意思決定の権威。</strong><br>
+  制約、却下した代替案、警告を Git に残し、今も有効なものだけを届けます。
+  それならエージェントは、リポジトリがすでに覆した決定を現在の指針として受け取りません。
 </p>
 
 <p align="center">
-  <a href="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="LICENSE"><img alt="ライセンス: MIT" src="https://img.shields.io/badge/license-MIT-3f6b52"></a>
-  <a href="package.json"><img alt="Node.js 22.23.2 以上" src="https://img.shields.io/badge/Node.js-%3E%3D22.23.2-3f6b52"></a>
+  <strong>CommitLore にホスティングサービスはありません。record はリポジトリが所有します。</strong>
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> · <a href="README.ko.md">한국어</a> · <strong>日本語</strong> · <a href="README.zh-CN.md">简体中文</a>
+  <a href="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml">
+    <img alt="CI" src="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml/badge.svg">
+  </a>
+  <a href="https://github.com/MongLong0214/commitlore/releases">
+    <img alt="最新リリース" src="https://img.shields.io/github/v/release/MongLong0214/commitlore?display_name=tag">
+  </a>
+  <a href="spec/SPEC.md">
+    <img alt="プロトコル 2.0 stable" src="https://img.shields.io/badge/protocol-2.0%20stable-3FB950">
+  </a>
+  <a href="package.json">
+    <img alt="Node.js 22.23.2 以上" src="https://img.shields.io/badge/node-22.23.2%2B-3FB950">
+  </a>
+  <a href="LICENSE">
+    <img alt="MIT ライセンス" src="https://img.shields.io/badge/license-MIT-3FB950">
+  </a>
 </p>
 
-# CommitLore
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <strong>日本語</strong> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
 
-**あなたのコーディングエージェントは、チームがすでに却下した案を何度も提案します。**
-
-CommitLore はその決定を Git に残し、ファイルを編集する前に、まだ有効なものだけを
-エージェントに渡します。
-
-CommitLore にホスティングサービスはなく、record は Git に保管します。MCP サーバー
-または hook がコンテキストを返した後は、host が自身のポリシーでそのコンテキストを
-扱います。CommitLore はそのデータフローを制御しません。
-
-**半分は自動で、もう半分はそうではありません。** *delivery* — エージェントがパスを
-編集する前に、まだ有効な決定を渡すこと — はインストールすれば自動で行われます。
-*capture* — 新しい決定を書き残すこと — は、変更に diff では示せない理由があると
-エージェントが判断したときに行われます。通常の `git commit` はこれを開始できません。
-hook には diff があり、capture にはセッションが必要だからです。
-
-<details>
-<summary><strong>目次</strong></summary>
-
-- [インストール](#インストール)
-- [エージェントが受け取るもの](#実際に動かす)
-- [自動になること、ならないこと](#自動になることならないこと)
-- [これが役に立たない場合](#これが役に立たない場合)
-- [一つの例で見る問題](#コードは残った決定は残らなかった)
-- [詳しく言うと何なのか](#詳しく言うと何なのか)
-- [パス問い合わせを見る](#パス問い合わせを見る)
-- [このリポジトリ自体がデモ](#このリポジトリ自体がデモです)
-- [パス範囲と検索](#検索はレコードを見つけられるパス範囲は覆された意思決定を除外する)
-- [仕組み](#仕組み)
-- [別のリポジトリからの現場報告](#実際のリポジトリでの見え方)
-- [何が違うのか](#違い)
-- [どこで効くか](#どこで効くか)
-- [record の作られ方](#record-が作られる方法)
-- [完全な record](#完全な-record)
-- [リポジトリが証明すること](#リポジトリが証明すること)
-- [根拠](#evidence-より狭い製品上の主張)
-- [アンインストール](#アンインストール) · [ドキュメント](#ドキュメント) · [コントリビュート](#コントリビュート)
-
-</details>
-
-## インストール
-
-一度インストールします。host integration を入れ、使うリポジトリを初期化します。
-
-**Claude Code** — プラグイン一つで MCP サーバー、編集前のコンテキストフック、スキルが登録されます:
-
-```
-/plugin marketplace add MongLong0214/commitlore
-/plugin install commitlore@commitlore
-```
-
-プラグインが持つのはここまでで、MCP サーバー、編集前フック、スキルです。`commitlore` を `PATH` に置くことはないので、以下の `commitlore …` コマンドは `install.sh` / `install.ps1` から来るものであり、そのインストールも必要です。
-
-**Codex** — ネイティブプラグインは一つのコマンドでインストールします:
-
-```bash
-commitlore plugin install-codex
-```
-
-Codex 自身の CLI を通じて marketplace と plugin を登録し、設定や cache を直接編集しません。下の標準 installer も Codex を検出すれば同じコマンドを実行します。インストール後は新しい Codex session を開始してください — plugin の skill と MCP server はインストール時ではなく session 開始時に読み込まれます。下の CLI が repository command を提供します。
-
-どちらの経路も前提条件は Node.js 22.23.2+ と Git です。スクリプトは何かを書き込む前に両方を確認します。
-
-**その他のコーディングエージェント** — CLI をインストールします:
+<p align="center">
+  <strong>一度インストールします。</strong> その後、使いたい各リポジトリを初期化します。
+</p>
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 ```
 
-**Windows** — PowerShell で同じインストールを行います:
-
-```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
-```
-
-Windows での host 配線には **v1.1.1 以降**が必要です。それ以前は検出が `.cmd` shim を見つけられず、インストーラーもそれを実行できなかったため、Windows へのインストールは CLI を置くだけで何も配線しませんでした — 成功としてではなく `ok: false` として報告されます。1.1.1 で Codex、Gemini CLI、Hermes について実機で確認しました。
-
-**Hermes** — CLI をインストールした後、host integration を設定します:
-
-```bash
-commitlore hermes install
-```
-
-どの host に対応しているか、各インストール経路が何を必要とするか: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
-
-**前のエージェントが得た判断を、次のエージェントに渡しましょう。**
-
-### 次に、各リポジトリで
-
-検証フック、ローカル index、リポジトリ所有の agent procedure を使う各リポジトリで、
-続けて `commitlore init` を実行します。installer は対応するコーディングエージェントを
-検出し、安全に可能な場所でローカル MCP server を登録します。
-
-```bash
-cd your-repository
-commitlore init
-commitlore context .
-```
-
-そのあとは:
-
-- 普段どおりコミットします。ほとんどのコミットには record がありません。
-- record がある場合、commit-msg hook が検証します。record を作成することはありません。
-- delivery と capture は別の layer です。次の節で host ごとの二つの layer を正確に説明します。
-
-コーディングエージェントとの作業を続けます。変更に diff が保存できない意思決定コンテキストがあるときは、エージェントに CommitLore record をコミットへ含めるよう頼んでください。
-
 <details>
-<summary>インストールを確認または固定したいですか？</summary>
-
-この一行は利便性のためです。レビュー済みまたは固定されたインストールが必要なら、まず `install.sh` をダウンロードして確認するか、リポジトリを clone してください。スクリプトは固定タグのソースチェックアウトと、`node <checkout>/dist/commitlore.mjs` を実行する薄い wrapper だけをインストールします — コンパイル済み成果物のダウンロードもビルド手順もないため、マシンに置かれるのは読めるソースです。
+<summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-# installer を固定してダウンロードし、確認してから実行します。
 curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
 sh install.sh v1.2.0
 
@@ -135,338 +62,344 @@ git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
+固定されたソースチェックアウトと、`node <checkout>/dist/commitlore.mjs` を実行する wrapper を
+インストールします。コンパイル済みダウンロードもビルド手順もありません。
+
 </details>
 
-### アップグレード
+<p align="center">
+  <img
+    src="./assets/readme/demo.gif"
+    width="900"
+    alt="commitlore のデモは src/pricing.ts に記録された二つの決定を出力し、limit と退けた代替案を持つ active な一つだけを届け、superseded な決定は Git には残るが現在の指針としては届けないことを示します。"
+  >
+</p>
 
-インストーラーを再実行し、エージェントのセッションを開き直します。
+---
 
-フックはインストール時に書かれるファイルなので、世代が三つあります。**v1.0.2 より前**にインストールされたフックは、特定のリリースを直接指します。**v1.0.2 から v1.1.2** の間にインストールされたフックは `current` を追いますが、当時の封じ込め stub が通常のアップグレードを認識できず、git がフックに渡す `PATH` ではコミットを拒否します。**v1.1.3 以降**にインストールされたフックは、通常のアップグレードを自動で追います。
+> **コードは残る。判断は残らない。**
 
-前の二世代は、リポジトリごとに一度だけ次を実行してください。
+エージェントがある手法を提案します。チームは自明でない制約のために却下します。最終コードは
+結果を残しても、その代替案をなぜ退けたかはたいてい残しません。後のエージェントはコードだけを見て、
+同じ案をもう一度提案します。
+
+CommitLore はその判断をコードのそばに残します。
+
+## CommitLore がすること
+
+| | 振る舞い | 製品上の経路 |
+|---|---|---|
+| **Capture** | diff が示せない制約、却下した代替案、警告を保存します。候補を session transcript と staged diff に照合します。 | `commitlore capture` |
+| **Preserve** | ホスト型メモリデータベースではなく、承認済み record を Git trailer または notes に保存します。 | commit hook · `refs/notes/commitlore` |
+| **lifecycle を追跡** | active、superseded、expired の決定を区別します。 | `commitlore stale` |
+| **範囲を絞る** | エージェントがこれから編集する path の決定を選びます。 | `commitlore context` |
+| **信頼を等級付け** | record を directive、claim、または保留された内容として届けます。 | 既定 / signed mode |
+| **Delivery** | 対応エージェントに編集前の現在のコンテキストを渡します。 | plugin hook · MCP |
+
+ほとんどの commit に record は不要です。CommitLore はすべての変更を説明するためではなく、
+コードが保存できない判断のためにあります。
+
+<!-- README:QUICKSTART -->
+## 60 秒で decision-aware agent にする
+
+### 1. CLI をインストール
+
+macOS と Linux:
 
 ```bash
-commitlore hooks install
-commitlore doctor
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 ```
 
-インストーラーはこれを代行できません。どのリポジトリにフックがあるかを知る手段がなく、リポジトリの `.git` に触れないことは欠落ではなく方針です。実行中のセッションは開始時に読み込んだランタイムを保持するため、再起動が別途必要です。どのリポジトリで必要かは `commitlore doctor` が挙げます。
+Windows:
 
-## 実際に動かす
-
-`src/pricing.ts` を編集する前に、エージェントは説明ではなく record そのものである
-この payload を受け取ります:
-
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
 ```
+
+Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。
+
+### 2. エージェントを接続
+
+Claude Code:
+
+```text
+/plugin marketplace add MongLong0214/commitlore
+/plugin install commitlore@commitlore
+```
+
+Codex:
+
+```bash
+commitlore plugin install-codex
+```
+
+plugin は `commitlore` を `PATH` に置かないため、下のコマンドには CLI のインストールも必要です。
+インストーラーは安全にできる範囲で対応 MCP host を検出して配線します。正確な表は下にあります。
+
+### 3. リポジトリを初期化
+
+```bash
+cd your-repository
+commitlore init
+commitlore context .
+```
+
+plugin をインストールまたは更新した後は、新しいエージェント session を始めます。実行中の session は
+読み込んだ runtime を保持します。
+
+その後は普段どおり作業して commit します。対応する skill integration では、通常の commit 要求中に
+CommitLore が検討され、残す価値がなければ黙っています。毎回 CommitLore を名指しする必要はありません。
+
+record ごとの確認なしに承認済み record を stage したい場合、リポジトリは一度
+`commitlore auto on` を選べます。この方針はリポジトリが所有してチームに適用されるため、
+このページが勝手に有効にはしません。
+
+<!-- README:PAYLOAD -->
+## エージェントが受け取るもの
+
+`src/pricing.ts` を編集する前に:
+
+```text
 commitlore: active records for src/pricing.ts
 
 Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+  [claim] r-price01  calculatePrice owns final checkout pricing only
 
 Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
+  [claim] r-price01  Reuse it for admin quotes |
+                     eligibility and rounding semantics differ
 ```
 
-`[claim]` には意味があります。この record の author string は、リポジトリが
-directive 用に設定した文字列と一致しないため、エージェントは命令ではなく情報として
-評価するよう伝えられます。既定の author-string mode の `[directive]` は、その文字列を
-制約として扱うというリポジトリの選択であり、身元の証明ではありません。commit author が
-文字列を選ぶため、commit を書ける者は誰でも偽装できます。
-`commitlore.requireSignedDirective=true` では、検証者の trust store で Git が検証した
-signature と、Git が報告する `%GF` fingerprint が repository-local の
-`commitlore.trustedSigner` allowlist にあることも必要です。allowlist が未設定、空、または
-読めない場合は誰も認可されません。その signature も権限や record の真実を証明しません。
-delivery はコンテキストを渡すものであり、編集を止めるものではありません。
+`[claim]` は「情報として吟味する」という意味です。リポジトリは、より強い signed-authority mode を
+選べます。delivery はエージェントにコンテキストを渡すだけで、編集を止めません。
 
-## 自動になること、ならないこと
+[セキュリティモデル →](SECURITY.md)
 
-**Delivery** は path を編集する前に record がエージェントへ届くことです。
-**Capture** は決定が検証済みの commit-time flow に入れることです。二つは別の layer です:
+## なぜ Git なのか
 
-| Host | Delivery | Capture |
-|---|---|---|
-| Claude Code | **はい — plugin により自動です。** | **はい — plugin により可能です。** |
-| Codex | **はい — plugin により自動です。** | **はい — plugin により可能です。** |
-| Hermes | **はい — `commitlore hermes install`.** | **はい — `commitlore hermes install`.** |
-| Gemini CLI, Cursor, Windsurf, opencode | **はい — 両方のインストーラーが MCP server を配線します。** それぞれ独自にではなく、共有された一つの手順を通ります。 | **procedure であり自動ではありません。** server が接続ごとに prepare → verify → stage の手順を伝えます。host が従う場合も従わない場合もあります。 |
-| その他の `AGENTS.md` convention host | **procedure であり自動ではありません。** `commitlore init --agents-md` が repository に書きます。 | **procedure であり自動ではありません。** 同じファイル、同じ但し書きです。 |
+**リポジトリは、そのコードの背後にある判断を所有すべきです。**
 
-「はい」は layer がインストールされるという意味であり、すべての commit に record が
-付くという意味ではありません。自動 integration は最初の三行だけです。その他の
-`AGENTS.md` host では二つの手順は hook ではなく instruction です。host が capture を
-開始し、candidate が検証を通ってから commit hook が付加します。commit-msg hook は
-record があれば検証しますが、新しく作ることはありません。
+CommitLore は record を通常の Git trailer と notes に保存します。だから record は、説明するコードと
+一緒に branch、merge、clone、review を通り、provider が変わっても残ります。
 
-## これが役に立たない場合
+SQLite は再構築可能な index にすぎません。消しても record は Git に残ります。
 
-インストールする前に読んでください。
+## 古い決定を見つけるだけでは足りない
 
-- **測定されたのは弱いほうの等級です。** 1,160 回の研究ではすべてのレコードが
-  `[claim]` として描画され、これはエージェントに命令ではなく情報として扱うよう
-  伝えます。`[directive]` 等級はその後に到達可能になり、ここでは測定されていません
-  —— 研究自身の判定文が、この数値は「強いほうへは転移しない」と述べています。
-  directive がより良いか悪いか同等かは、**どちらの方向にも測定されていません**。
-- **モデル 1 つ、ハーネス 1 つ、構成されたフィクスチャ 10 個です。** オラクルは
-  最終的な実装状態を読みます。したがってレコードを受け取ったエージェントのほうが
-  排除済みの手法を提案しにくかったことは示しますが、そのいずれかが何かを読んだ
-  ことは示しません。
-- cryptographic author verification、repository-wide record coverage、symbol anchor、interactive record builder は未実装です: [#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
-- M4 は guard の効果を検証していません。row に `guard_exposure` がないため treatment exposure を検証できません: [#122](https://github.com/MongLong0214/commitlore/issues/122)。
-- Guard（ruled-out alternative matching）は実験的参考情報です: precision 44.8%（95% Wilson CI 32.7%–57.5%）、recall 22.0%、417-decision corpus 基準（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空の guard 結果は、提案がすべての ruled-out alternative を回避したという保証ではありません — recall 22% では、見逃しが一般的です。
+一般的な memory または retrieval system はこう尋ねます。
 
-完全な方法、除外、arm ごとの truncation split は [bench/VERDICT-M5.md](bench/VERDICT-M5.md) と
-[示していないこと](docs/evidence.md) にあります。delivery の方法と retrieval の根拠は
-[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md) にあります。
+> どの古い text が関係ありそうか？
 
-## コードは残った。決定は残らなかった。
+CommitLore はこう尋ねます。
 
-*同じ悪い案を二度レビューしない。*
+> 記録された決定のうち、今この path に適用されるものはどれか？
 
-**CommitLore なしの場合。** 新しいセッションが入力の似た2つの関数を見て、一方を再利用します。
-
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
-```
-
-チームにはフラグが1つ、ラッパーが1つ、そしてその関数が担うつもりのなかったユースケースを
-守る互換ブランチが1つ増えます。レビュアーは「それは既に却下した」と2度目を書きます。
-
-**CommitLore ありの場合。** 編集の前に、エージェントは上で示した active record を
-受け取り、レビューコメントから再構成した指示を受け取るのではありません。
-
-モジュール境界が、レビューコメントとして後から届くのではなく、エージェントが変更を提案する
-**前に**その目の前に置かれます。
-
-1,160 回の登録済み実行で、却下済みの案を再提案する割合は **18.8%** から **2.8%**
-になりました。この数字が示さないことは、上の
-[これが役に立たない場合](#これが役に立たない場合)にあります。
-
-## 詳しく言うと、何なのか
-
-**コーディングエージェントのための Git ネイティブな decision layer。**
-
-新しいエージェントは実装を受け継ぎます。しかし制約も、チームが却下した代替案も、警告も、
-検証のギャップも受け継ぎません — 何かが運ばないかぎり、それらはコードと一緒には動きません。
-
-CommitLore はその工学的判断を Git に保存し、次の編集の前に**今も有効な決定だけ**を届けます。
-のちに置き換えられた決定や期限切れの決定が、まだ有効であるかのようにエージェントへ届くことは
-ありません。
-
-**リポジトリ所有 · lifecycle 認識 · 根拠検証 · エージェント非依存**
-
-Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
-
-ホスト型メモリサービスも、ベンダー固有のチャット履歴もありません。リポジトリが所有する、
-レビュー可能な意思決定コンテキストだけです。commit trailer は commit と共に移動しますが、
-notes-backed record は通常の clone には来ません。Git は既定で `refs/notes/*` を
-fetch しないため、clone の後に notes fetch を構成する必要があります。
-
-## パス問い合わせを見る
-
-
-
-**新しいエージェント、チャット履歴はゼロ。それでも明白な修正案がなぜ除外されたかを手渡されます。** 変更する前に path を照会します。
-
-```bash
-commitlore context install.sh
-```
-
-出力には、installer の欠陥の修正として `-musl` target を公開する案を除外した active record とその理由が含まれます。hook はコンテキストを返すものであり、編集を止めるとは主張しません。
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-この `PreToolUse` hook path をそのまま再現する方法と、その他すべてのコマンドは [docs/cli.md](docs/cli.md) にあります。
-
-## このリポジトリ自体がデモです
-
-解決済みの問いをエージェントが再び決めないようにすると主張するツールなら、自身で何を捕まえたかも示せるべきです。このツールはその一覧を公開で保ち、このプロジェクトがすでに公開していたもののうち、後から誤りだと分かった項目も含めています。
-
-- **どのインストールでも、README の主張が前提とした信頼 tier を生み出せなかった。** record はエージェントに `directive` または `claim` として届きます。インストール済みのどの surface も directive author string を構成していなかったため、grade は全員に対して `claim` へ fail-closed しましたが、注入された凡例は誰も到達できない tier を示していました。以前の二つの benchmark は `claim` 等級の配信を測定していました ([#415](https://github.com/MongLong0214/commitlore/issues/415)).
-- **登録された benchmark 分析は、一度に四つの異なる実験を読んでしまうところでした。** しかも停止規則が行数だったため、その混入によって研究は自身の完全性ゲートを*通過*していたでしょう ([#441](https://github.com/MongLong0214/commitlore/issues/441)).
-- **result-schema gate は何からも実行されていませんでした。** そのため schema は runner より五フィールド遅れ、二日間誰も気付きませんでした ([#392](https://github.com/MongLong0214/commitlore/issues/392)).
-- **出荷済みの pre-push hook はすべての `git push` を停止させました。** 40 秒間に hook が 1,240 回呼ばれました。関数は十一回テストされていたのに、hook path は一度もテストされていなかったからです ([#422](https://github.com/MongLong0214/commitlore/issues/422)).
-
-これらはすべて、このプロジェクトがインストールを勧める hook で検証されるコミット trailer の `Ruled-out:`、`Warn:`、`Limit:` の行であり、どこでも実行できるのと同じ `commitlore context` で読めます。
-
-**それぞれが支払った代償を含む完全な一覧: [docs/SELF-AUDIT.md](docs/SELF-AUDIT.md)。**
-
-## 検索はレコードを見つけられる。パス範囲は覆された意思決定を除外する。
-
-エージェントが最初の編集を行う前に、リポジトリが持つ「今も有効な意思決定」のうち実際にどれだけがエージェントへ届くのか。このリポジトリで、フックが既定で使う 800 トークン予算のもとでは:
-
-| ルート | 予算 | 届いた有効な決定 | 届いた覆された決定 | トークン |
-|---|---:|---:|---:|---:|
-| コードのみ | — | 0.0% | 0 | 0 |
-| そのパスの `git log` | 800 | 42.0% | 7 | 673,134 |
-| **CommitLore パス範囲** | **800** | **81.7%** | **0** | **511,412** |
-| CommitLore、上限なし | なし | 92.3% | 0 | 741,429 |
-
-上限を外すと、パス範囲はリポジトリ全体のダンプが回収するのと同じ 2,217 組のうち 2,047 組を回収します。ダンプの 92,175,612 トークンの一部しか使わず、ダンプが一緒に運ぶ覆された 7,322 件は一つも届けません。**範囲は何も損なっていません。** 上限が 10.6 ポイントを消費します。残る 170 組は信頼グレーダーが保留したレコードです。
-
-**これは配信を測ったものであり、効果ではありません。** エージェントは走っていないので、回収し*得る*量の上限であって、実際に回収する量ではありません。そして検索指標は、それが予測すべき結果が悪化する間にも上がり得ます。SWE-bench はコンテキスト予算を増やすと BM25 の recall が 29.58 から 51.06 へ上がることを測定した上で、「BM25 の最大コンテキストを増やせば oracle ファイルに対する recall が上がる場合でも性能は落ちる … モデルが問題のコードを特定するのが単に不得手だからだ」と報告しています ([arXiv:2310.06770](https://arxiv.org/abs/2310.06770))。コーパス一つ、リポジトリ一つです。置き換えられたレコードは 7 件、期限切れは 0 件なので、「覆された決定の配信ゼロ」は期限切れについてはまだ何も語りません。手法と全表: [bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)。
-
-**`git log` のベースラインは、自分で自分を測って出た値ではありません。** 同じ測定を、このプロジェクトが書いていない四つのリポジトリ — Django、SymPy、scikit-learn、Requests — に固定コミットで適用すると、あるパスの履歴のうち 800 トークンの切り詰めを生き残る割合は **37.4% から 55.6%** に収まります。上の 42.0% はその帯の中にあります。固定予算が一つのファイルの履歴の半分近くを落とすのは、大きく長命なリポジトリで `git log` が一般に行うことであり、このリポジトリ固有の性質ではありません。**転移しなかったのは仕組みのほうです。** 私たちのパスは中央値 1 コミットで 687 トークン、Django は 8 コミットで 213 トークン。つまり長いコミットメッセージは、固定予算のもとで通常の Git ベースラインをより悪くします — このプロジェクト自身の慣行が払っているコストです。[bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md) はそれらのリポジトリでの配信値も報告しますが、まず §9.0 と §9.5 を読んでください。そこでのレコードは revert コミットからプログラムが生成したものであり、見出しの数値は検索の結果ではなく付与述語が強制する値です。
-
-レコードを一つ取り逃がせば、モデルはコンテキストを失います。すでに覆された意思決定を渡せば、正しさを損ないます。この[検索測定](bench/retrieval/result.md)では、ノイズが 0 件から 10,000 件までのすべてのサイズで、BM25、embedding top-k、hybrid RRF、パスフィルター付き embedding がそれぞれ廃止済みのレコードを一つ返しました。lifecycle を伴う CommitLore のパス範囲は古いレコードをゼロにし、現在の二つのレコード (2/2) を返しました。
-
-再現率は補助的な結果です。検索はおおむねどちらでも同じレコードを見つけますが、どの意思決定がまだ有効かを知るルートは一つだけです。意思決定が覆されたときに違いが現れます。これはまさにこの製品が存在するケースです。
-
-別の #167 の露出実行も重要です。10,002 件のうちモデルに届いたレコードは 2 件だけでした。
-
-| ルート | モデルに見えるレコード | 関連レコード | モデルに見えるトークン |
-|---|---:|---:|---:|
-| すべて注入 | 10,002 | 2/2 | 1,004,554 |
-| top-k 語彙検索 | 2 | 1/2 | 190 |
-| CommitLore パス範囲 | 2 | 2/2 | 335 |
-
-これは固定した 2 レコードの出力予算における露出と再現率の測定であり、トークンコスト、請求コスト、正確さ、エージェントの振る舞いを測るものではありません。これは一つのコーパス、一つのクエリ、一つの固定された embedding モデルによる結果です。再現率が並ぶ地点と、ほかに何が測定され何が測定されていないかは [docs/evidence.md](docs/evidence.md) にあります。
+superseded な決定は大いに関係があり得ても、現在の指針としては誤りです。関連性と権威は
+別の問いです。
 
 ## 仕組み
 
-1. **Capture** — diff からは分からない決定コンテキストだけをエージェントが起草します。
-2. **Verify** — CommitLore がその草稿をセッションと staged diff に照合します。
-3. **Preserve** — 検証済みレコードが identity と lifecycle を持って Git に残ります。
-4. **Deliver** — 次のエージェントはパスを編集する前に、**今も有効な決定だけ**を受け取ります。
+<p align="center">
+  <img src="./assets/readme/hero.svg" width="720" alt="src/pricing.ts では Git 履歴の active な決定が、次の編集前に届けられるコンテキストへ進み、その limit と退けた代替案を伴います。管理者見積もりも対象だった以前の決定は superseded となり、履歴には残っても現在の指針としては進みません。">
+</p>
 
-## 実際のリポジトリでの見え方
+1. **Capture** — エージェントは diff では示せない決定コンテキストだけを起草します。
+2. **Verify** — CommitLore は草稿を session と staged diff に照合します。
+3. **Preserve** — 承認された record は identity と lifecycle を持って Git に残ります。
+4. **Deliver** — 後の編集の前には、その path の active な record だけを返します。
 
-コミット約768個の Swift MCP サーバーのフィールドレポートより、インストール翌日。
-ファイルパスを一つ指定しただけで、エンジニアが存在を知らなかったマージ済み PR が現れ、
-残っていたコードの意味が変わった。
+ほとんどの commit に record はありません。commit hook は record があるときに検証しますが、発明はしません。
 
-> **そのコミットの存在を知らなかった。** 2週間前にマージされた PR で、これらのサイトの
-> うち8か所を既に削除し、それぞれを accessibility-native な等価物に置き換えていた —
-> すべて fail-closed で実機検証済み。
->
-> どれもチャット履歴にはなかった。リポジトリにあり、ファイルパスを指定して得た。
+既存の hook は上書きしません。 `commitlore init` は `core.hooksPath` を尊重し、すでにある hook を
+`<hook>.commitlore-chained` へ移してから先に呼びます。 `commitlore hooks uninstall` は元に戻します。
 
-代替手段は2週間分のマージ済み PR を読むことだった。エージェントが自発的にやることでは
-なく、人が編集のたびにやることでもない。同じレポートの導入コスト: コマンド1つ、コミット
-768個のインデックスに7.4秒。履歴も作業ツリーも触らない。コンソール出力とレポート全文は
-[docs/evidence.md](docs/evidence.md) にあります。
+<!-- README:CAPABILITY -->
+## 自動になること、ならないこと
 
-それはコミット768個のリポジトリでした。**コミット10万件では、インデックスを使った
-`context` 問い合わせが p50 496 ms で応答します。** 背後で動くフックは `commit-msg` が
-p50 185.85 ms、注入フックが p50 102.40 ms です。大きなリポジトリにこれを入れたままに
-するかを決めるのはこれらの数値であり、主張ではなく測定です。同じ実行には見栄えの悪い
-数値も含まれています。インデックスなしで同じ問い合わせをコミット10万件に対して行うと
-86,673 ms かかります。インデックスは動いている問い合わせに乗せた最適化ではなく、その
-規模で問い合わせを可能にするもの自体です。だから `init` がそれを作り、`doctor` が
-それを確認します。
+| Host | 編集前 delivery | 検証済み capture workflow | 毎 commit で決定的な capture |
+|---|---|---|---|
+| Claude Code | plugin を通じて自動 | plugin skill で利用可能 | **certified ではない** |
+| Codex | plugin を通じて自動 | plugin skill で利用可能 | **certified ではない** |
+| Hermes | `commitlore hermes install` 後に利用可能 | host install 後に利用可能 | **certified ではない** |
+| Gemini CLI, Cursor, Windsurf, opencode | host が登録を使う場合の MCP delivery | MCP で公開される procedure | いいえ |
+| `AGENTS.md` host | procedure のみ | procedure のみ | いいえ |
 
-**ホスト型のチャット履歴製品が提供できない3つの性質**、そして権威をサービスではなく Git に
-置いた理由:
+「利用可能」は prepare → verify → stage workflow が存在することを意味します。すべての適格 commit が
+自動で評価されるという意味ではありません。
 
-| ツール | 覚えているもの |
-|---|---|
-| `CLAUDE.md` / `AGENTS.md` | エージェントがどう働くべきか |
-| ADR | 大きなアーキテクチャ決定を文書として |
-| Chat memory / RAG | 過去の関連テキスト |
-| [Lore](https://arxiv.org/abs/2603.15566) | 同じ発想、先に公表された — git trailer に載せた決定レコード |
-| **CommitLore** | **このコードパスに今も適用される決定** |
+対応 skill host の利用者は、毎回「これを CommitLore に記録して」と言う必要はありません。
+残る制約は record ごとのユーザー命令ではなく、host が開始するかどうかです。
 
-類似検索は関連する決定を見つけられます。CommitLore はさらに、その決定が今も有効か、
-置き換えられたか、期限切れかを知っていて — 最初のものだけを示します。
+## 現場報告であって測定ではない
 
-**三行目について。** [Lore](https://arxiv.org/abs/2603.15566)（2026年3月）は、この
-リポジトリができる四か月前に、native な git trailer へ決定レコードを載せる方式を提案して
-います。語彙はこちらとほぼ一対一で対応します。**プロトコルの発想はここで新しいものでは
-なく**、そうでないと言っても論文を読む人の前では持ちません。Lore に対応物がないのは
-lifecycle — `Supersedes:` と `Expires:`、そして上の表の最終行を真にするフィルタリング —
-と信頼グレーディングであり、論文自身が「empirical validation path を*示す*」と書いていて
-実験は行っていません。その検証を、失敗した部分も含めて持っていることが、このプロジェクト
-が論文に対して持つものです
-（[ADR-0029](docs/adr/ADR-0029-lore-is-prior-art-and-this-is-what-differs.md)）。
+無関係な一つのリポジトリで、初めて v1.2.0 を入れた人の一回の実行です。ここでは何も測定されず、
+evidence log にもありません。上の段落が表で扱っていない loop を主張しているため、このページにあります。
 
-## 違い
+その人は agent に丸めの不具合を直すよう頼み、decimal library はすでに検討して却下したと付け加え、
+最後に「commit して」と言いました。CommitLore は一度も名指しされませんでした。commit が持った一部です。
 
-- **CLAUDE.md はエージェントに作業方法を伝える。CommitLore はこのコードがなぜ存在するかを伝える。**
-- **ADR はアーキテクチャを文書化する。CommitLore は diff の中に隠れた意思決定を文書化する。**
-- **もう一つの memory database ではない。Git に組み込まれた decision protocol です。**
-
-権威ある原本は通常の commit trailer と `refs/notes/commitlore` です。index と report はこれらの Git record から派生し、再構築できます。
-
-## どこで効くか
-
-**モジュール境界を守る。** *「`calculatePrice` は最終 checkout 価格のみを担当する。管理者プレビューに再利用しない」*
-
-**却下された回避策を残す。** *「タイムアウトを上げると接続リークが隠れる。cleanup 経路を直すこと」*
-
-**一時的な互換コードに印を付ける。** *「この caller は一時的で、サポート対象の契約には含まれない」*
-
-**検証ギャップを伝える。** *「単一ユーザーの挙動はテスト済み。同時リフレッシュは未検証」*
-
-どれも diff が運べない一文であり、無ければレビュアーが二度言うことになる文です。
-
-## record が作られる方法
-
-すべてのコミットに trailer を手書きする必要はありません。ほとんどのコミットには record がないべきです。外部制約、除外した代案、warning、verification gap のように、diff だけでは復元できない意思決定にだけ record を追加します。
-
-エージェントには、普段どおりコミットし、diff では説明できない意思決定コンテキストだけを残すよう頼みます。
-
-> この変更をコミットしてください。diff で重要な制約、除外した代案、warning、または verification gap を復元できない場合にだけ、CommitLore record を追加してください。
-
-エージェント向けの指針は `skills/commitlore-commits/` にあり、commit-msg hook はエージェントが追加した record を検証するだけで、record を発明したり黙って追加したりしません。`harvest` の経路、`capture` トランザクション、そして人が trailer を手書きする逃げ道は、いずれも [docs/capture.md](docs/capture.md) にあります。
-
-## record プロトコル
-
-record は普通の Git commit trailer の集まりで、たいていは小さいもので足ります:
-
-```text
-Fix expired-token refresh
-
-Ruled-out: Extend token TTL to 24h | security policy violation
-Warn: Do not narrow the 4xx handler without verifying upstream behavior
+```
+Ruled-out: adopting a decimal library such as Decimal.js | the backend is a
+  number contract, so it is meaningless
+Warn: do not revert the test file to console.assert: it exits 0 even on
+  failure, so CI passes silently
+Provenance: drafted
 ```
 
-語彙をすべて使う完全な例、すべての trailer key の表、そして CommitLore なしで素の Git から読む方法は [docs/protocol.md](docs/protocol.md) にあります。規範的な定義は [SPEC §3](spec/SPEC.md) です。
+`Warn` は agent に口述したものではありません。作業中に罠に出会い、次の人のために残しました。
+`Provenance: drafted` は人が record を読まなかったことを記し、`claim` に格付けします。
+つまり命令ではなく、吟味する報告として届けられます。
 
-## リポジトリが証明すること
+共有履歴のない後の session は、結局 decimal library を採用するよう頼まれました。採用せず、その理由として
+record を挙げました。また grade も読みました。 `claim` は指示ではないため、同意する前に記された理由を
+コードと照合しました。
 
-- テスト済みの Git workflow では、意思決定の履歴は rebase、remote transfer、path rename を経ても残る。squash merge は通常の trailer と同じく trailer block を捨てるため、`commitlore squash-preserve` かその GitHub Action が記録を引き継ぐ — テストはその経路を含む。
-- すべての route は同じ trust grading を使い、信頼されない text は instruction ではなく information として渡す。
-- free-form trailer 内の injection に似た text は model-readable route から保留される。
-- 読める repository に record がない状態は、不完全な history や fetch されていない notes mirror と区別される。
+## メモリ保存とは異なる
 
-これは Git に結び付けられ、人間が検証できる意思決定履歴についての製品上の主張です。CommitLore が agent performance を改善するという主張には依存しません。
+| | 一般 memory / RAG | **CommitLore** |
+|---|---|---|
+| 主な問い | どの古い text が関連するか？ | 今ここにどの決定が適用されるか？ |
+| 権威 | memory store または provider | Git |
+| 範囲 | 意味的な類似 | repository path |
+| lifecycle | 多くは append-first | active · superseded · expired |
+| 信頼 | 取得した text | directive · claim · blocked |
+| capture | transcript または note の保存 | 根拠照合済みの決定 record |
+| 可搬性 | backend に依存 | 通常の Git |
 
-## Evidence: より狭い製品上の主張
+CommitLore は意図的に狭いものです。一般の user-memory system、会話 archive、vector database の
+代替ではありません。
 
-112 回の実験は記録されましたが、M4 には run ごとの `guard_exposure` 記録がありません。treatment があったか検証できないため、agent behavior の主張を検証も支持も反証もしていません。上記のより狭い製品上の主張は独立して検証可能な動作に基づきます。クリーンなデータセットと撤回については [M4 verdict](bench/VERDICT-M4.md) を読んでください。
+<!-- README:EVIDENCE -->
+## 根拠: 検索はレコードを見つけられる
 
-何が測定されたか — 検索、露出、レイテンシと規模、hook overhead — そして何が測定されていないか — 損益分岐、そしてエージェントの振る舞いへの効果 — は [docs/evidence.md](docs/evidence.md) にまとめてあります。
+| 問い | 測定結果 | 境界 |
+|---|---|---|
+| 登録された研究で claim grade のコンテキストは再提案を変えたか？ | CommitLore ありで **2.8%** (16/580)、なしで **18.8%** (109/579) | モデル一つ、harness 一つ、構成した task |
+| lifecycle filtering は測定した active projection で retired record を届けたか？ | **retired record 0 件** | superseded record はあり、expiry はなし |
+| index 付き lookup は規模に対応するか？ | **100k commit で p50 496 ms** | index なし fallback はずっと遅い |
 
+index の構築時間は commit 数ではなく *record* 数に従います。高コストの処理は record ごとに一度だけ走るので、
+record が少ない長い履歴は、record が密な短い履歴より早く構築されます。
 
-## アンインストール
+path scope が大きな履歴を model に届けないようにします。#167 corpus では、10,002 件の record のうち
+届いたのは 2 件だけでした。
 
-```bash
-commitlore uninstall
-```
+| route | モデルに見えるレコード | 関連レコード | モデルに見える token |
+|---|---:|---:|---:|
+| すべてを inject | 10,002 | 2/2 | 1,004,554 |
+| top-k lexical | 2 | 1/2 | 190 |
+| CommitLore path scope | 2 | 2/2 | 335 |
 
-`install.sh` または `install.ps1` が書いたものを削除します — wrapper、固定された
-checkout、そして各 agent config に追加した MCP エントリ。自分が書いていないものは
-削除せず、残すものを明示します: リポジトリごとの hook、agent hook、Claude Code
-plugin。`--dry-run` は何も変更せずに報告します。それぞれを何が外すか、そして source
-チェックアウトから実行する方法は [docs/install.md](docs/install.md) にあります。
+これは固定した二 record 予算での exposure と recall の測定です。token cost、請求額、正確さ、agent の
+振る舞いは測りません。一つの corpus、一つの query、一つの固定 embedding model です。
 
+agent study は普遍的な model 効果を確立しません。delivery は model が record を読んだ、または従った
+証拠ではありません。
+
+[手法、全表、除外、negative result →](docs/evidence.md)
+
+<!-- README:LIMITS -->
+## これが役に立たない場合
+
+- **Capture は補助されるもので決定的ではありません。** 対応 skill は通常の commit 要求を検討しますが、
+  すべての適格 commit を評価する host は certified ではありません。
+- **既定の directive mode は authentication ではありません。** commit author header を照合しますが、
+  commit を書ける人なら誰でもその header を設定できます。だから既定 mode の `[directive]` は identity の
+  証明ではなく policy metadata です。signature mode には Git 自身の verified status と repository-local
+  `commitlore.trustedSigner` allowlist の一致も必要です。signer allowlist がない、空、または読めない場合は
+  誰も認可されないため、この mode は fail-closed です。
+- **Guard は実験的な参考情報**であり安全網ではありません: precision 44.8% (95% Wilson CI 32.7%–57.5%)、
+  recall 22.0%、417-decision corpus に基づきます。空の guard 結果は安全判定ではありません。
+- **Delivery は一致する tool call ごとに token を使います。** 編集前 hook は `Read` のほか `Edit`、`Write`、
+  `MultiEdit`、`NotebookEdit` でも走るので、editing agent が commit するよりずっと頻繁に実行されます。
+  一回につき既定で 800 token まで payload を使い、`--budget` で変えます。record のないリポジトリは何も使わず、
+  これはインストールではなく採用とともに生じるコストです。
+- **答えは部分的な場合があります。** coverage は開示され、部分結果にないことは record がない証明ではありません。
+  repository-wide coverage、symbol anchor、interactive record builder は未解決です:
+  [#32](https://github.com/MongLong0214/commitlore/issues/32)、
+  [#33](https://github.com/MongLong0214/commitlore/issues/33)。
+- **commit trailer は clone とともに来ますが、notes は来ません。** Git は既定で `refs/notes/*` を fetch しないため、
+  `refs/notes/commitlore` の record は `commitlore init` がその mirror を構成するまで通常の clone にはありません。
+- **ホスト型 backend はありません。** ただし server または hook がコンテキストを返した後は、host が自身のポリシーで
+  それを扱います。CommitLore はそのデータフローを制御しません。
+
+[セキュリティ](SECURITY.md) ·
+[互換性](docs/COMPATIBILITY.md) ·
+[根拠](docs/evidence.md)
+
+<details>
+<summary><strong>セキュリティと信頼モデル</strong></summary>
+
+record は grade が付くまで信頼できません。既定の author matching は authentication ではなく policy metadata です。
+signed directive mode には Git verification と repository-local signer allowlist が必要で、allowlist がないか読めない場合は
+誰も認可されません。injection の形をした payload は model-readable route から保留されます。
+
+[完全なセキュリティモデル →](SECURITY.md)
+
+</details>
+
+<details>
+<summary><strong>インストール、アップグレード、古い hook 世代</strong></summary>
+
+CLI installer は知らないリポジトリ内の hook を書き換えられず、実行中の host session は読み込んだ runtime を保ちます。
+`commitlore doctor` は両方の状態と修復を示し、`commitlore upgrade` は新しい release があるかを報告します。
+
+[インストールとアップグレード →](docs/install.md)
+
+</details>
+
+<details>
+<summary><strong>プロトコルと Git storage</strong></summary>
+
+record は通常の Git trailer または notes です。Protocol 2.0 は lifecycle、trust grade、validation、compatibility を定義します。
+
+[人向けガイド →](docs/protocol.md) ·
+[規範仕様 →](spec/SPEC.md)
+
+</details>
+
+<details>
+<summary><strong>根拠と negative result</strong></summary>
+
+リポジトリは手法、除外、失敗した測定、元の benchmark や診断が誤っていた事例を公開します。
+
+[根拠 →](docs/evidence.md) ·
+[self-audit →](docs/SELF-AUDIT.md)
+
+</details>
+
+<hr>
+
+<p align="center">
+  <strong>履歴のあるリポジトリで試してください。</strong><br>
+  <sub>path scope、lifecycle、capture、installation が壊れる場所を教えてください。</sub>
+</p>
+
+<p align="center">
+  <a href="https://github.com/MongLong0214/commitlore/issues/new">失敗事例を報告</a>
+  ·
+  <a href="docs/SELF-AUDIT.md">self-audit を読む</a>
+</p>
+
+<hr>
+
+<!-- README:DOCS -->
 ## ドキュメント
 
-- [docs/install.md](docs/install.md) — インストール経路、各経路が書くもの、取り消し方
-- [docs/cli.md](docs/cli.md) — すべてのコマンドとフラグ
-- [docs/capture.md](docs/capture.md) — record が書かれるまで
-- [docs/protocol.md](docs/protocol.md) — record の形式と、Git だけで読む方法
-- [docs/evidence.md](docs/evidence.md) — 何が測定され、何が測定されていないか
-- [spec/SPEC.md](spec/SPEC.md) — 規範プロトコル
+- [インストール、アップグレード、アンインストール](docs/install.md)
+- [CLI リファレンス](docs/cli.md)
+- [Capture workflow](docs/capture.md)
+- [Record protocol](docs/protocol.md)
+- [セキュリティモデル](SECURITY.md)
+- [根拠と制約](docs/evidence.md)
+- [本番契約](docs/PRODUCTION-READINESS-SSOT.md)
+- [ドキュメント索引](docs/README.md)
 
 ## コントリビュート
 
-[spec](spec/SPEC.md)、[ADR](docs/adr/)、[`CONTRIBUTING.md`](CONTRIBUTING.md) を読んでください。CommitLore は [MIT License](LICENSE) の下で永久に無料のオープンソースです。
+[CONTRIBUTING.md](CONTRIBUTING.md) は、このリポジトリが自ら守る record protocol、release gate、
+根拠の再現方法を説明しています。
+
+## ライセンス
+
+MIT — [LICENSE](LICENSE) を参照してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,110 +1,142 @@
+<!-- README:BRAND -->
 <p align="center">
-  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore는 저장소의 결정 권위를 다음 편집으로 나른다: src/pricing.ts에서 아직 유효한 결정이 그것이 기각한 대안과 함께 전달되고, 대체된 이전의 더 넓은 limit은 현재 지침으로 넘어가지 않는다.">
+  <img src="./assets/readme/commitlore-logo.svg" width="440" alt="CommitLore">
+</p>
+
+<h1 align="center">CommitLore</h1>
+
+<h3 align="center">코딩 에이전트가 팀에서 이미 기각한 방안을 계속 다시 제안합니다.</h3>
+
+<p align="center">
+  <strong>Git이 소유하는 코딩 에이전트의 결정 권위.</strong><br>
+  제약, 기각한 대안, 경고를 Git에 보관하고 아직 유효한 것만 전달합니다.
+  그러면 에이전트는 저장소가 이미 뒤집은 결정을 다시 지침으로 받지 않습니다.
 </p>
 
 <p align="center">
-  <a href="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="LICENSE"><img alt="라이선스: MIT" src="https://img.shields.io/badge/license-MIT-3f6b52"></a>
-  <a href="package.json"><img alt="Node.js 22.23.2 이상" src="https://img.shields.io/badge/Node.js-%3E%3D22.23.2-3f6b52"></a>
+  <strong>CommitLore에는 호스팅 서비스가 없습니다. record는 저장소가 소유합니다.</strong>
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> · <strong>한국어</strong> · <a href="README.ja.md">日本語</a> · <a href="README.zh-CN.md">简体中文</a>
+  <a href="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml">
+    <img alt="CI" src="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml/badge.svg">
+  </a>
+  <a href="https://github.com/MongLong0214/commitlore/releases">
+    <img alt="최신 릴리스" src="https://img.shields.io/github/v/release/MongLong0214/commitlore?display_name=tag">
+  </a>
+  <a href="spec/SPEC.md">
+    <img alt="프로토콜 2.0 안정" src="https://img.shields.io/badge/protocol-2.0%20stable-3FB950">
+  </a>
+  <a href="package.json">
+    <img alt="Node.js 22.23.2 이상" src="https://img.shields.io/badge/node-22.23.2%2B-3FB950">
+  </a>
+  <a href="LICENSE">
+    <img alt="MIT 라이선스" src="https://img.shields.io/badge/license-MIT-3FB950">
+  </a>
 </p>
 
-# CommitLore
+<p align="center">
+  <a href="README.md">English</a> ·
+  <strong>한국어</strong> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
 
-**코딩 에이전트가 팀에서 이미 기각한 방안을 계속 다시 제안합니다.**
-
-CommitLore는 그런 결정을 Git에 보관하고, 파일을 편집하기 전에 아직 유효한 결정만
-에이전트에게 전달합니다.
-
-CommitLore에는 호스팅 서비스가 없고 record를 Git에 보관합니다. MCP 서버나 hook이
-맥락을 반환한 뒤에는 host가 자신의 정책에 따라 그 맥락을 처리합니다. CommitLore는 그
-데이터 흐름을 제어하지 않습니다.
-
-**두 절반이 있고, 자동인 것은 하나입니다.** *delivery*, 곧 에이전트가 경로를 편집하기
-전에 아직 유효한 결정을 건네주는 일은 설치하면 알아서 됩니다. *capture*, 곧 새
-결정을 기록하는 일은 변경에 diff가 보여줄 수 없는 이유가 있을 때 에이전트가
-합니다. 평범한 `git commit`은 이것을 시작할 수 없습니다. hook에는 diff가 있고
-capture에는 세션이 필요하기 때문입니다.
-
-<details>
-<summary><strong>목차</strong></summary>
-
-- [설치](#설치)
-- [에이전트가 받는 것](#실제로-보기)
-- [자동으로 되는 것과 아닌 것](#자동으로-되는-것과-아닌-것)
-- [도움이 되지 않는 경우](#이것이-도움이-되지-않는-경우)
-- [한 가지 예로 보는 문제](#코드는-남았다-결정은-남지-않았다)
-- [CommitLore란 무엇인가](#commitlore를-자세히-보면)
-- [경로 질의 보기](#경로-질의-보기)
-- [이 저장소 자체가 데모](#이-저장소-자체가-데모입니다)
-- [경로 범위와 검색](#검색은-레코드를-찾을-수-있습니다-경로-범위는-뒤집힌-결정을-걸러냅니다)
-- [동작 방식](#어떻게-동작하나)
-- [다른 저장소의 현장 보고](#실제-저장소에서는-이렇게-보인다)
-- [차이점](#무엇이-다른가)
-- [효과가 있는 곳](#어디서-값을-하나)
-- [record 생성 방식](#record가-만들어지는-방법)
-- [완전한 record](#완전한-record)
-- [저장소가 증명하는 것](#저장소가-증명하는-것)
-- [근거](#근거-더-좁은-제품-주장)
-- [제거](#제거) · [문서](#문서) · [기여하기](#기여하기)
-
-</details>
-
-## 설치
-
-한 번 설치한다. host integration을 설치하고, 사용할 저장소를 초기화한다.
-
-**Claude Code** — 플러그인 하나가 MCP 서버, 편집 전 컨텍스트 훅, 스킬을 함께 등록한다:
-
-```
-/plugin marketplace add MongLong0214/commitlore
-/plugin install commitlore@commitlore
-```
-
-플러그인이 담는 것은 여기까지다: MCP 서버, 편집 전 훅, 스킬. `commitlore`를 `PATH`에 올리지는 않으므로, 아래의 `commitlore …` 명령은 `install.sh` / `install.ps1`에서 오고 그 설치까지 필요하다.
-
-**Codex** — 네이티브 플러그인은 한 명령으로 설치한다:
-
-```bash
-commitlore plugin install-codex
-```
-
-Codex의 자체 CLI로 marketplace와 plugin을 등록한다. 설정이나 cache를 직접 고치지 않는다. 아래의 표준 설치 스크립트도 Codex를 감지하면 같은 명령을 실행한다. 설치 뒤에는 새 Codex session을 시작한다 — plugin의 skill과 MCP server는 설치 시점이 아니라 session 시작 시점에 로드된다. 아래 CLI가 repository command를 제공한다.
-
-두 경로 모두의 전제 조건: Node.js 22.23.2+ 와 Git. 스크립트는 무엇이든 쓰기 전에 둘을 확인한다.
-
-**그 밖의 코딩 에이전트** — CLI를 설치한다:
+<p align="center">
+  <strong>한 번 설치한다.</strong> 그런 다음 사용할 각 저장소를 초기화합니다.
+</p>
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 ```
 
-**Windows** — PowerShell에서 같은 설치를 한다:
+<details>
+<summary>먼저 설치기를 읽어 보고 싶나요?</summary>
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
+sh install.sh v1.2.0
+
+# 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
+git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
+node commitlore/dist/commitlore.mjs --version
+```
+
+고정된 소스 체크아웃과 `node <checkout>/dist/commitlore.mjs`를 실행하는 wrapper를
+설치합니다. 컴파일된 다운로드도, 빌드 단계도 없습니다.
+
+</details>
+
+<p align="center">
+  <img
+    src="./assets/readme/demo.gif"
+    width="900"
+    alt="commitlore 데모는 src/pricing.ts에 기록된 결정 두 개를 출력하고, limit과 기각한 대안을 가진 활성 결정만 전달하며, 대체된 결정은 Git에는 남지만 현재 지침으로 전달하지 않는다고 보여 줍니다."
+  >
+</p>
+
+---
+
+> **코드는 남는다. 판단은 남지 않는다.**
+
+에이전트가 한 접근을 제안합니다. 팀은 쉽게 드러나지 않는 제약 때문에 이를 기각합니다.
+최종 코드는 결과를 남기지만, 대안을 왜 기각했는지는 대개 남기지 않습니다. 나중의 에이전트는
+코드만 보고 같은 생각을 다시 제안합니다.
+
+CommitLore는 그 판단을 코드 곁에 보관합니다.
+
+## CommitLore가 하는 일
+
+| | 동작 | 제품 경로 |
+|---|---|---|
+| **Capture** | diff가 보여 줄 수 없는 제약, 기각한 대안, 경고를 보존합니다. 후보는 세션 transcript와 staged diff에 대조합니다. | `commitlore capture` |
+| **Preserve** | 호스팅 메모리 데이터베이스 대신 Git trailer 또는 notes에 승인된 record를 저장합니다. | commit hook · `refs/notes/commitlore` |
+| **수명 주기 추적** | 활성, 대체됨, 만료된 결정을 구분합니다. | `commitlore stale` |
+| **범위 지정** | 에이전트가 곧 편집할 path에 맞는 결정을 고릅니다. | `commitlore context` |
+| **신뢰 등급** | record를 directive, claim, 또는 보류된 내용으로 전달합니다. | 기본 / signed mode |
+| **Delivery** | 지원하는 에이전트가 편집 전에 현재 맥락을 받게 합니다. | plugin hook · MCP |
+
+대부분의 commit에는 record가 없어야 합니다. CommitLore는 모든 변경을 설명하는 도구가 아니라,
+코드가 보존할 수 없는 판단을 위한 도구입니다.
+
+<!-- README:QUICKSTART -->
+## 60초 만에 decision-aware agent 만들기
+
+### 1. CLI 설치
+
+macOS와 Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
+```
+
+Windows:
 
 ```powershell
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
 ```
 
-Windows에서 host 배선은 **v1.1.1 이상**이 필요하다. 그 전에는 탐지가 `.cmd` shim을 보지 못하고 설치기가 그것을 실행하지도 못해서, Windows 설치는 CLI만 놓고 아무것도 배선하지 않았다 — 성공이 아니라 `ok: false`로 보고됐다. 1.1.1에서 Codex, Gemini CLI, Hermes에 대해 실기로 확인했다.
+Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.
 
-**Hermes** — CLI를 설치한 뒤 host integration을 설정한다:
+### 2. 에이전트 연결
 
-```bash
-commitlore hermes install
+Claude Code:
+
+```text
+/plugin marketplace add MongLong0214/commitlore
+/plugin install commitlore@commitlore
 ```
 
-어떤 host를 지원하는지, 각 설치 경로가 무엇을 요구하는지: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
+Codex:
 
-**지난 에이전트가 얻어낸 판단을, 다음 에이전트에게 물려주세요.**
+```bash
+commitlore plugin install-codex
+```
 
-### 그런 다음, 각 저장소에서
+plugin은 `commitlore`를 `PATH`에 넣지 않으므로, 아래 명령에는 CLI 설치도 필요합니다.
+설치기는 안전하게 할 수 있는 범위에서 지원하는 MCP host를 감지하고 배선합니다. 정확한 표는 아래에 있습니다.
 
-검증 훅, 로컬 인덱스, 저장소 소유 agent procedure를 쓸 각 저장소에서 이어서
-`commitlore init`을 실행한다. 설치기는 지원되는 코딩 에이전트를 감지하고,
-안전하게 가능한 곳에 로컬 MCP 서버를 등록한다.
+### 3. 저장소 초기화
 
 ```bash
 cd your-repository
@@ -112,214 +144,146 @@ commitlore init
 commitlore context .
 ```
 
-그다음에는:
+plugin을 설치하거나 업데이트한 뒤에는 새 에이전트 session을 시작합니다. 실행 중인 session은
+처음 불러온 runtime을 계속 사용합니다.
 
-- 평소처럼 커밋한다. 대부분의 커밋에는 record가 없다.
-- record가 있으면 commit-msg hook이 검증한다. record를 만들지는 않는다.
-- delivery와 capture는 다른 layer다. 다음 섹션에서 host별 두 layer를 정확히 설명한다.
+그다음에는 평소처럼 작업하고 commit합니다. 지원되는 skill integration에서는 보통의 commit 요청에도
+CommitLore를 고려하고, 보존할 것이 없으면 조용히 지나갑니다. 매 commit마다 CommitLore를 말할 필요가 없습니다.
 
-코딩 에이전트와 계속 작업한다. 변경에 diff가 보존할 수 없는 결정 맥락이 있으면, 에이전트에게 커밋에 CommitLore record를 넣어 달라고 요청한다.
+record마다 확인하지 않고 승인된 record를 stage하고 싶다면 저장소에서 한 번
+`commitlore auto on`을 선택할 수 있습니다. 이 정책은 저장소가 소유하고 팀 전체에 적용되므로,
+이 페이지가 조용히 켜지지는 않습니다.
 
-<details>
-<summary>설치 내용을 살펴보거나 버전을 고정하고 싶나요?</summary>
+<!-- README:PAYLOAD -->
+## 에이전트가 받는 것
 
-한 줄 명령은 편의를 위한 것이다. 검토하거나 고정한 설치가 필요하면 먼저 `install.sh`를 내려받아 살펴보거나, 저장소를 clone한다. 스크립트는 고정된 태그의 소스 체크아웃과 `node <checkout>/dist/commitlore.mjs`를 실행하는 얇은 wrapper만 설치한다 — 컴파일된 산출물을 내려받지 않고 빌드 단계도 없으므로, 기계에 놓이는 것은 읽을 수 있는 소스다.
+`src/pricing.ts`를 편집하기 전에:
 
-```bash
-# 설치기를 고정해 내려받고 살펴본 뒤 실행한다.
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
-sh install.sh v1.2.0
-
-# 또는 스크립트를 건너뛴다. 스크립트가 만드는 체크아웃은 직접 만들 수 있는 것과 같다.
-git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
-node commitlore/dist/commitlore.mjs --version
-```
-
-</details>
-
-### 업그레이드
-
-설치 스크립트를 다시 실행하고, 에이전트 세션을 새로 시작한다.
-
-훅은 설치 시점에 쓰인 파일이라 세대가 셋이다. **v1.0.2 이전**에 설치된 훅은 릴리스 하나를 직접 가리킨다. **v1.0.2 ~ v1.1.2**에 설치된 훅은 `current`를 따라가지만, 그 시절 격리 stub이 통상 업그레이드를 알아보지 못해 git이 훅에 주는 `PATH`에서 커밋을 거부한다. **v1.1.3 이후**에 설치된 훅은 통상 업그레이드를 알아서 따라간다.
-
-앞의 두 세대는 저장소마다 한 번씩 아래를 실행해야 한다.
-
-```bash
-commitlore hooks install
-commitlore doctor
-```
-
-설치 프로그램은 이걸 대신 못 한다. 어느 저장소에 훅이 있는지 알 방법이 없고, 저장소의 `.git`을 건드리지 않는 것은 누락이 아니라 정책이다. 실행 중인 세션은 시작할 때 읽은 런타임을 그대로 들고 있으므로 재시작이 따로 필요하다.
-
-## 실제로 보기
-
-`src/pricing.ts`를 편집하기 전에 에이전트는 설명이 아니라 record 자체인 이 payload를 받는다:
-
-```
+```text
 commitlore: active records for src/pricing.ts
 
 Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+  [claim] r-price01  calculatePrice owns final checkout pricing only
 
 Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
+  [claim] r-price01  Reuse it for admin quotes |
+                     eligibility and rounding semantics differ
 ```
 
-`[claim]`에는 의미가 있다. 이 record의 작성자 문자열이 저장소가 directive용으로
-설정한 문자열과 일치하지 않으므로, 에이전트는 명령이 아니라 정보로 평가해야 한다.
-기본 author-string 모드에서 `[directive]`는 저장소가 그 문자열을 제약으로 취급하기로
-정했다는 뜻일 뿐 신원 증명은 아니다. commit 작성자가 문자열을 고르므로 commit을 쓸 수
-있는 누구나 위조할 수 있다. `commitlore.requireSignedDirective=true`를 설정하면 Git이
-검증자의 trust store에 대해 확인한 서명이 있어야 하고, Git이 보고한 `%GF` 지문이
-repository-local `commitlore.trustedSigner` allowlist에 있어야 한다. allowlist가 없거나 비어 있거나 읽을 수
-없으면 누구도 권한을 얻지 않는다. 그 서명 역시 권한이나 record의 진실을 증명하지는 않는다.
-delivery는 맥락을 준다. 편집을 막지는 않는다.
+`[claim]`은 "정보로서 평가하라"는 뜻입니다. 저장소는 더 강한 signed-authority mode를
+선택할 수 있습니다. delivery는 맥락을 줄 뿐, 편집을 막지 않습니다.
 
+[보안 모델 →](SECURITY.md)
+
+## 왜 Git인가?
+
+**저장소가 코드 뒤에 있는 판단을 소유해야 합니다.**
+
+CommitLore는 record를 평범한 Git trailer와 notes에 저장합니다. 그러므로 record는 그 코드를
+설명하는 방식 그대로 branch, merge, clone, review를 거치고 provider가 바뀌어도 살아남습니다.
+
+SQLite는 다시 만들 수 있는 index일 뿐입니다. 지워도 record는 Git에 남습니다.
+
+## 오래된 결정 하나를 찾는 것만으로는 충분하지 않습니다
+
+일반 memory 또는 retrieval system은 이렇게 묻습니다.
+
+> 어떤 오래된 텍스트가 관련 있어 보이는가?
+
+CommitLore는 이렇게 묻습니다.
+
+> 기록된 결정 중 지금 이 path에 적용되는 것은 무엇인가?
+
+대체된 결정은 매우 관련 있어 보여도 현재 지침으로는 틀릴 수 있습니다. 관련성과 권위는
+서로 다른 질문입니다.
+
+## 어떻게 동작하나
+
+<p align="center">
+  <img src="./assets/readme/hero.svg" width="720" alt="src/pricing.ts에서 Git 이력의 활성 결정은 다음 편집 전에 전달되는 맥락으로 이동하며, 그 limit과 기각한 대안을 함께 지닙니다. 관리자 견적도 다루던 이전 결정은 대체되어 이력에는 남지만 현재 지침으로는 전달되지 않습니다.">
+</p>
+
+1. **Capture** — 에이전트는 diff가 보여 줄 수 없는 결정 맥락만 초안으로 씁니다.
+2. **Verify** — CommitLore는 초안을 세션과 staged diff에 대조합니다.
+3. **Preserve** — 승인된 record는 identity와 lifecycle을 갖고 Git에 남습니다.
+4. **Deliver** — 나중의 편집 전에는 그 path의 활성 record만 반환합니다.
+
+대부분의 commit에는 record가 없습니다. commit hook은 record가 있을 때 검증하지만 발명하지는 않습니다.
+
+기존 hook을 덮어쓰지 않습니다. `commitlore init`은 `core.hooksPath`를 따르고, 이미 설치된 hook을
+`<hook>.commitlore-chained`로 옮긴 뒤 먼저 호출합니다. `commitlore hooks uninstall`은 이를 되돌립니다.
+
+<!-- README:CAPABILITY -->
 ## 자동으로 되는 것과 아닌 것
 
-**Delivery**는 path를 편집하기 전에 record가 에이전트에 도달한다는 뜻이다.
-**Capture**는 결정이 검증된 commit-time flow에 들어갈 수 있다는 뜻이다. 둘은 다른 layer다:
+| Host | 편집 전 delivery | 검증된 capture 워크플로 | 모든 commit에서 결정적으로 capture |
+|---|---|---|---|
+| Claude Code | plugin을 통해 자동 | plugin skill로 사용 가능 | **인증되지 않음** |
+| Codex | plugin을 통해 자동 | plugin skill로 사용 가능 | **인증되지 않음** |
+| Hermes | `commitlore hermes install` 뒤 사용 가능 | host 설치 뒤 사용 가능 | **인증되지 않음** |
+| Gemini CLI, Cursor, Windsurf, opencode | host가 등록을 사용할 때 MCP delivery | MCP로 노출된 procedure | 아니요 |
+| `AGENTS.md` host | procedure만 | procedure만 | 아니요 |
 
-| Host | Delivery | Capture |
+"사용 가능"은 prepare → verify → stage workflow가 있다는 뜻입니다. 모든 적격 commit이
+자동으로 평가된다는 뜻은 아닙니다.
+
+지원되는 skill host 사용자는 매 commit마다 "이것을 CommitLore에 기록해"라고 말할 필요가 없습니다.
+남는 한계는 record마다 필요한 사용자 명령이 아니라 host가 시작하는가입니다.
+
+## 현장 보고이지 측정은 아닙니다
+
+관련 없는 한 저장소에서 v1.2.0을 처음 설치한 사람이 한 번 실행한 사례입니다. 여기서는 아무것도
+측정하지 않았고 evidence log에도 없습니다. 위 문단이 표로 다루지 않는 loop를 주장하기 때문에
+이 페이지에 있습니다.
+
+그 사람은 agent에게 반올림 버그를 고쳐 달라고 했고, decimal library를 이미 검토했다가 기각했다는
+말을 덧붙인 뒤 "commit해"라고 끝냈습니다. CommitLore라는 이름은 한 번도 나오지 않았습니다.
+commit이 실은 일부는 다음과 같습니다.
+
+```
+Ruled-out: adopting a decimal library such as Decimal.js | the backend is a
+  number contract, so it is meaningless
+Warn: do not revert the test file to console.assert: it exits 0 even on
+  failure, so CI passes silently
+Provenance: drafted
+```
+
+`Warn`은 agent에게 받아쓰게 한 것이 아닙니다. 작업 중 함정을 만나고 다음 사람을 위해 남긴 것입니다.
+`Provenance: drafted`는 사람이 record를 읽지 않았음을 나타내며, 이는 `claim`으로 등급을 매깁니다.
+즉 명령이 아니라 평가할 보고서로 전달됩니다.
+
+공유 이력이 없는 나중 session은 결국 decimal library를 도입하라는 요청을 받았습니다. 도입하지 않고
+그 이유로 record를 들었습니다. 또 등급도 읽었습니다. `claim`은 지시가 아니므로 동의하기 전에
+명시된 이유를 코드와 대조했습니다.
+
+## 메모리 저장소와 달리
+
+| | 일반 memory / RAG | **CommitLore** |
 |---|---|---|
-| Claude Code | **예 — plugin을 통해 자동으로 된다.** | **예 — plugin을 통해 된다.** |
-| Codex | **예 — plugin을 통해 자동으로 된다.** | **예 — plugin을 통해 된다.** |
-| Hermes | **예 — `commitlore hermes install`.** | **예 — `commitlore hermes install`.** |
-| Gemini CLI, Cursor, Windsurf, opencode | **된다 — 두 설치기 모두 MCP server를 배선한다.** 각자가 아니라 공유된 한 단계를 거친다. | **procedure이며 자동이 아니다.** server가 연결마다 prepare → verify → stage 절차를 알린다. host가 따를 수도, 따르지 않을 수도 있다. |
-| 그 밖의 `AGENTS.md` convention host | **procedure이며 자동이 아니다.** `commitlore init --agents-md`가 저장소에 적는다. | **procedure이며 자동이 아니다.** 같은 파일, 같은 단서. |
+| 주된 질문 | 어떤 오래된 텍스트가 관련 있는가? | 지금 여기에 어떤 결정이 적용되는가? |
+| 권위 | memory store 또는 provider | Git |
+| 범위 | 의미적 유사도 | repository path |
+| lifecycle | 흔히 append-first | 활성 · 대체됨 · 만료됨 |
+| 신뢰 | 검색된 text | directive · claim · blocked |
+| capture | transcript 또는 note 저장 | 근거를 대조한 결정 record |
+| 이식성 | backend에 종속 | 평범한 Git |
 
-“예”는 layer가 설치되었다는 뜻이지 모든 commit에 record가 생긴다는 뜻이 아니다.
-대부분의 commit에는 record가 없어야 한다. 자동 integration은 첫 세 행에만 있다. 다른
-`AGENTS.md` host에서는 두 단계 모두 hook이 아니라 instruction이다. host가 capture를
-시작해야 하고, candidate는 commit hook이 붙이기 전에 검증을 통과해야 한다. commit-msg
-hook은 record가 있으면 검증하지만, 새로 만들지는 않는다.
+CommitLore는 의도적으로 더 좁습니다. 일반 사용자 memory system, 대화 archive, vector database를
+대체하는 도구가 아닙니다.
 
+<!-- README:EVIDENCE -->
+## 근거: 검색은 레코드를 찾을 수 있습니다
 
+| 질문 | 측정 결과 | 경계 |
+|---|---|---|
+| 등록된 연구에서 claim 등급 맥락이 재제안에 변화를 주었는가? | CommitLore 사용 시 **2.8%** (16/580), 미사용 시 **18.8%** (109/579) | 모델 하나, harness 하나, 구성한 task |
+| lifecycle filtering이 측정된 활성 projection에서 은퇴한 record를 전달했는가? | **은퇴한 record 0개** | 대체된 record는 있었고 만료는 없었음 |
+| index된 조회는 확장되는가? | **commit 100k에서 p50 496 ms** | index 없는 fallback은 훨씬 느림 |
 
-## 이것이 도움이 되지 않는 경우
+index 구축 시간은 commit 수가 아니라 *record* 수를 따릅니다. 비용이 큰 단계는 record마다 한 번만
+실행되므로, 기록이 적은 긴 이력은 record가 빽빽한 짧은 이력보다 더 빨리 구축됩니다.
 
-설치하기 전에 읽어보세요.
-
-- **측정된 것은 약한 쪽 등급이다.** 1,160회 연구에서 모든 레코드는 `[claim]`으로
-  렌더링되었고, 이는 에이전트에게 명령이 아니라 정보로 다루라고 말한다.
-  `[directive]` 등급은 그 뒤에야 도달 가능해졌고 여기서 측정되지 않았다 —
-  연구 자신의 판정문이 이 수치는 "강한 쪽으로 전이되지 않는다"고 적는다.
-  directive가 더 나은지 못한지 같은지는 **양방향 모두 측정되지 않았다**.
-- **모델 하나, 하니스 하나, 구성된 픽스처 열 개다.** 오라클은 최종 구현
-  상태를 읽는다. 따라서 레코드를 받은 에이전트가 배제된 접근을 덜 제안했다는
-  것은 보여주지만, 그중 누군가가 무언가를 읽었다는 것은 보여주지 않는다.
-- 암호학적 작성자 검증, 저장소 전체 record coverage, symbol anchor, interactive record builder는 아직 구현되지 않았다: [#28](https://github.com/MongLong0214/commitlore/issues/28), [#32](https://github.com/MongLong0214/commitlore/issues/32), [#33](https://github.com/MongLong0214/commitlore/issues/33), [#34](https://github.com/MongLong0214/commitlore/issues/34).
-- M4는 guard 효과를 시험하지 못했다. row에 `guard_exposure`가 없어 treatment exposure를 검증할 수 없다: [#122](https://github.com/MongLong0214/commitlore/issues/122).
-- Guard(ruled-out alternative matching)는 실험적 참고 자료이다: precision 44.8%(95% Wilson CI 32.7%–57.5%), recall 22.0%, 417-decision corpus 기준([ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)). 빈 guard 결과는 제안이 모든 ruled-out alternative를 피했다는 보장이 아니다 — recall 22%에서 누락이 일반적이다.
-
-전체 방법, 제외 항목, arm별 truncation split은 [bench/VERDICT-M5.md](bench/VERDICT-M5.md)와
-[보여 주지 않는 것](docs/evidence.md)에 있다. delivery 방법과 retrieval 근거는
-[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)에 있다.
-
-## 코드는 남았다. 결정은 남지 않았다.
-
-*같은 나쁜 아이디어를 다시 리뷰하지 않는다.*
-
-**CommitLore 없이.** 새 세션이 입력이 비슷한 함수 둘을 보고 하나를 재사용한다.
-
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
-```
-
-이제 팀에는 flag 하나, wrapper 하나, compatibility branch 하나가 더 생겼다. 그 branch가
-지키는 사용처는 애초에 그 함수가 맡을 생각이 없던 것이다. 리뷰어는 "이건 이미 기각했다"를 두 번째로 쓴다.
-
-**CommitLore와 함께.** 편집 전에 에이전트는 위에 보인 active record를 받아,
-리뷰 코멘트에서 재구성한 지시를 받지 않는다.
-
-모듈 경계가 리뷰 코멘트로 뒤늦게가 아니라, 에이전트가 변경을 제안하기 **전에** 그 앞에
-놓인다.
-
-등록된 실행 1,160회에서 이는 기각된 방안을 다시 제안하는 비율을 **18.8%**에서
-**2.8%**로 낮췄다. 이 수치가 보여 주지 않는 것은 위의
-[이것이 도움이 되지 않는 경우](#이것이-도움이-되지-않는-경우)에 있다.
-
-## CommitLore를 자세히 보면
-
-**코딩 에이전트를 위한 Git 네이티브 decision layer.**
-
-새 에이전트는 구현을 물려받는다. 하지만 제약도, 팀이 기각한 대안도, 경고도, 검증 공백도
-물려받지 못한다 — 무언가가 실어 나르지 않는 한 코드와 함께 이동하지 않는다.
-
-CommitLore는 그 엔지니어링 판단을 Git에 보존하고, 다음 편집 전에 **지금도 유효한 결정만**
-전달한다. 이후 대체되거나 만료된 결정은 여전히 유효한 것처럼 에이전트에게 도달하지
-않는다.
-
-**저장소 소유 · lifecycle 인식 · 근거 검증 · 에이전트 비종속**
-
-Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
-
-호스팅 메모리 서비스도, 벤더 전용 채팅 기록도 없다. 저장소가 소유하는, 검토 가능한
-결정 맥락만 있다. commit trailer는 commit과 함께 이동하지만 notes-backed record는
-ordinary clone에 오지 않는다. Git은 기본으로 `refs/notes/*`를 fetch하지 않으므로,
-clone 뒤 notes fetch를 구성해야 한다.
-
-## 경로 질의 보기
-
-
-
-**새 에이전트, 채팅 이력은 0개. 그래도 뻔한 수정안이 왜 제외됐는지를 건네받는다.** 바꾸기 전에 path를 조회한다.
-
-```bash
-commitlore context install.sh
-```
-
-출력에는 installer 결함의 수정안으로 `-musl` target을 배포하는 방안을 제외한 활성 record와 그 이유가 들어 있다. hook은 맥락을 제공한다. 편집을 막는다고 주장하지는 않는다.
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-이 PreToolUse hook path를 그대로 재현하는 방법과 나머지 모든 명령은 [docs/cli.md](docs/cli.md)에 있다.
-
-## 이 저장소 자체가 데모입니다
-
-이미 결론 난 질문을 에이전트가 다시 결정하지 못하게 한다고 주장하는 도구라면, 스스로에게서 무엇을 잡아냈는지도 보여줄 수 있어야 한다. 이 도구는 그 목록을 공개로 유지한다. 이 프로젝트가 이미 공개한 내용 중 나중에 틀렸음이 밝혀진 것들도 포함한다.
-
-- **어떤 설치도 README의 주장이 근거한 신뢰 등급을 만들 수 없었다.** record는 에이전트에게 `directive` 또는 `claim` 등급으로 전달된다. 설치된 어느 표면도 신뢰된 작성자를 구성하지 않았으므로, 등급은 모두 `claim`으로 fail-closed 되었지만 주입된 범례는 누구도 도달할 수 없는 등급을 알리고 있었다. 두 이전 benchmark는 `claim` 등급 전달을 측정했다 ([#415](https://github.com/MongLong0214/commitlore/issues/415)).
-- **등록된 benchmark 분석은 한 번에 서로 다른 네 실험을 읽었을 것이며**, 중단 규칙이 행 수였기 때문에 그 오염은 연구가 자체 완전성 관문을 *통과*하게 만들었을 것이다 ([#441](https://github.com/MongLong0214/commitlore/issues/441)).
-- **result-schema gate는 아무것도 실행하지 않았다.** 그래서 schema는 runner보다 다섯 필드 뒤처졌고 이틀 동안 아무도 알아차리지 못했다 ([#392](https://github.com/MongLong0214/commitlore/issues/392)).
-- **배포된 pre-push hook은 모든 `git push`를 멈추게 했다.** 40초에 hook 호출 1,240회였다. 함수는 열한 번 시험했지만 hook path는 한 번도 시험하지 않았기 때문이다 ([#422](https://github.com/MongLong0214/commitlore/issues/422)).
-
-이들 모두는 커밋 trailer의 `Ruled-out:`, `Warn:`, `Limit:` 줄이다. 이 프로젝트가 설치를 권하는 hook이 그 줄을 검증한다. 다른 곳에서 실행하는 것과 같은 `commitlore context`로 읽을 수 있다.
-
-**각 항목이 치른 대가를 포함한 전체 목록: [docs/SELF-AUDIT.md](docs/SELF-AUDIT.md).**
-
-## 검색은 레코드를 찾을 수 있습니다. 경로 범위는 뒤집힌 결정을 걸러냅니다.
-
-에이전트가 첫 편집을 하기 전에, 저장소가 가진 아직 유효한 결정 중 실제로 몇 퍼센트가 에이전트에게 도달할까요? 이 저장소에서, 훅이 기본으로 쓰는 800토큰 예산 기준:
-
-| 경로 | 예산 | 전달된 유효 결정 | 전달된 뒤집힌 결정 | 토큰 |
-|---|---:|---:|---:|---:|
-| 코드만 | — | 0.0% | 0 | 0 |
-| 해당 경로의 `git log` | 800 | 42.0% | 7 | 673,134 |
-| **CommitLore 경로 범위** | **800** | **81.7%** | **0** | **511,412** |
-| CommitLore, 상한 해제 | 없음 | 92.3% | 0 | 741,429 |
-
-상한을 풀면 경로 범위는 저장소 전체 덤프가 회수하는 것과 정확히 같은 2,217쌍 중 2,047쌍을 회수한다. 덤프의 92,175,612 토큰 중 일부만 쓰고, 덤프가 함께 실어 나르는 뒤집힌 레코드 7,322개는 하나도 전달하지 않는다. **범위는 아무 대가도 치르지 않는다.** 상한이 10.6포인트를 쓴다. 남은 170쌍은 신뢰 등급자가 보류한 레코드다.
-
-**이것은 전달을 잰 것이지 효과를 잰 것이 아니다.** 에이전트를 돌리지 않았으므로 회수할 수 *있는* 양의 상한이지 실제로 회수하는 양이 아니다. 그리고 검색 지표는 예측해야 할 결과가 나빠지는 동안에도 올라갈 수 있다. SWE-bench는 컨텍스트 예산을 늘릴 때 BM25 recall이 29.58에서 51.06으로 오르는 것을 측정하고도, "BM25의 최대 컨텍스트 크기를 늘리면 oracle 파일에 대한 recall이 올라가는 경우에도 성능은 떨어진다 … 모델이 문제 코드를 국소화하는 데 그저 서툴기 때문"이라고 보고했다 ([arXiv:2310.06770](https://arxiv.org/abs/2310.06770)). 코퍼스 하나, 저장소 하나다. 대체된 레코드는 7개, 만료된 레코드는 0개이므로 "뒤집힌 결정 0건 전달"은 만료에 대해서는 아직 아무것도 말하지 않는다. 방법과 전체 표: [bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md).
-
-**`git log` 기준선은 우리가 우리를 재서 나온 값이 아니다.** 같은 측정을 이 프로젝트가 쓰지 않은 저장소 넷(Django, SymPy, scikit-learn, Requests)에 고정 커밋으로 적용하면, 한 경로의 이력 중 800토큰 절단에서 살아남는 비율이 **37.4%에서 55.6%** 사이이다. 위의 42.0%가 그 구간 안에 들어간다. 고정 예산이 한 파일 이력의 절반 가까이를 잘라내는 것은 크고 오래된 저장소에서 `git log`가 일반적으로 하는 일이지, 이 저장소만의 특이점이 아니다. **이전되지 않은 것은 메커니즘이다.** 우리 경로는 중앙값 1커밋에 687토큰인데 Django는 8커밋에 213토큰이라, 긴 커밋 메시지가 고정 예산에서 평범한 Git 기준선을 더 나쁘게 만든다 — 이 프로젝트 자체 관행이 치르는 비용이다. [bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md)는 그 저장소들에 대한 전달 수치도 보고하지만 §9.0과 §9.5를 먼저 읽으십시오. 거기 레코드는 revert 커밋에서 프로그램이 생성한 것이고, 헤드라인 숫자는 검색 결과가 아니라 부착 술어가 강제하는 값이다.
-
-레코드 하나를 놓치면 모델은 맥락을 잃는다. 이미 뒤집힌 결정을 건네면 정확성을 잃는다. 이 [검색 측정](bench/retrieval/result.md)에서 방해 레코드가 0개부터 10,000개까지인 모든 크기에서 BM25, 임베딩 top-k, 하이브리드 RRF, 경로 필터를 적용한 임베딩은 각각 대체되어 폐기된 레코드 하나를 반환했다. 수명 주기를 적용한 CommitLore 경로 범위는 오래된 레코드를 0개 반환하고 현재 레코드 둘(2/2)을 모두 반환했다.
-
-재현율은 보조 결과다. 검색은 대체로 어느 쪽이든 같은 레코드를 찾지만, 현재 유효한 결정을 아는 경로는 하나뿐이다. 결정이 뒤집혔을 때 차이가 나타난다. 이 제품은 바로 그 경우를 위해 존재한다.
-
-별도의 #167 노출 실행도 중요하다. 10,002개 레코드 중 모델에 닿은 것은 2개뿐이다.
+path 범위가 큰 이력이 model에 닿지 않게 합니다. #167 corpus에서는 10,002개 record 중 2개만 닿았습니다.
 
 | 경로 | 모델에 보인 레코드 | 관련 레코드 | 모델에 보인 토큰 |
 |---|---:|---:|---:|
@@ -327,140 +291,120 @@ warnings
 | top-k 어휘 검색 | 2 | 1/2 | 190 |
 | CommitLore 경로 범위 | 2 | 2/2 | 335 |
 
-이는 고정된 두 레코드 출력 예산에서 노출과 재현율을 측정한 것이다. 토큰 비용, 청구 비용, 정확도나 에이전트 행동은 측정하지 않는다. 코퍼스 하나, 쿼리 하나, 고정된 임베딩 모델 하나의 결과다. 재현율이 동률인 지점과 그 밖에 무엇이 측정됐고 무엇이 측정되지 않았는지는 [docs/evidence.md](docs/evidence.md)에 있다.
+이는 고정된 두 record 예산에서의 노출과 재현율을 측정한 것입니다. token 비용, 청구 비용, 정확도,
+agent 행동은 측정하지 않습니다. corpus 하나, query 하나, 고정된 embedding model 하나입니다.
 
-## 어떻게 동작하나
+agent 연구는 보편적인 model 효과를 증명하지 않습니다. delivery는 model이 record를 읽거나
+따랐다는 증거가 아닙니다.
 
-1. **Capture** — 에이전트가 diff로는 알 수 없는 결정 맥락만 초안으로 쓴다.
-2. **Verify** — CommitLore가 그 초안을 세션과 staged diff에 대조한다.
-3. **Preserve** — 검증된 record가 identity와 lifecycle을 갖고 Git에 남는다.
-4. **Deliver** — 다음 에이전트는 경로를 편집하기 전에 **지금도 유효한 결정만** 받는다.
+[방법, 전체 표, 제외 항목, 부정적 결과 →](docs/evidence.md)
 
-## 실제 저장소에서는 이렇게 보인다
+<!-- README:LIMITS -->
+## 이것이 도움이 되지 않는 경우
 
-커밋 약 768개인 Swift MCP 서버의 필드리포트에서, 설치 다음 날. 파일 경로 하나를 댔더니
-엔지니어가 존재조차 몰랐던 merge된 PR이 나왔고, 남아 있던 코드의 의미가 달라졌다.
+- **Capture는 보조되며 결정적이지 않습니다.** 지원되는 skill은 보통의 commit 요청을 고려하지만,
+  모든 적격 commit을 평가하는 host는 인증되지 않았습니다.
+- **기본 directive mode는 인증이 아닙니다.** commit author header를 대조하고, commit을 쓸 수 있는
+  누구나 그 header를 정할 수 있습니다. 따라서 기본 mode의 `[directive]`는 identity 증명이 아니라
+  policy metadata입니다. signature mode에는 Git 자체의 verified status와 repository-local
+  `commitlore.trustedSigner` allowlist의 일치가 추가로 필요합니다. signer allowlist가 없거나 비었거나
+  읽을 수 없으면 아무도 권한을 얻지 않으므로 이 mode는 fail-closed입니다.
+- **Guard는 실험적 참고 자료**이며 안전망이 아닙니다: precision 44.8% (95% Wilson CI 32.7%–57.5%),
+  recall 22.0%, 417-decision corpus 기준입니다. 빈 guard 결과는 안전 판정이 아닙니다.
+- **Delivery는 일치하는 모든 tool call에서 token을 씁니다.** 편집 전 hook은 `Read`뿐 아니라 `Edit`,
+  `Write`, `MultiEdit`, `NotebookEdit`에서도 실행되어 editing agent가 commit하는 횟수보다 훨씬 많이
+  실행됩니다. 한 번 실행할 때 기본 800 token까지 payload를 사용하며 `--budget`으로 바꿉니다.
+  record 없는 저장소는 아무것도 쓰지 않으므로, 이는 설치가 아니라 채택과 함께 생기는 비용입니다.
+- **답은 일부만 담을 수 있습니다.** coverage는 공개되며, 일부 결과에 없다고 record가 없다는 증거는
+  아닙니다. repository-wide coverage, symbol anchor, interactive record builder는 아직 열려 있습니다:
+  [#32](https://github.com/MongLong0214/commitlore/issues/32),
+  [#33](https://github.com/MongLong0214/commitlore/issues/33).
+- **commit trailer는 clone과 함께 오지만 notes는 그렇지 않습니다.** Git은 기본으로 `refs/notes/*`를
+  fetch하지 않으므로 `refs/notes/commitlore`의 record는 `commitlore init`이 mirror를 구성하기 전까지
+  ordinary clone에 없습니다.
+- **호스팅 backend는 없습니다.** 하지만 server 또는 hook이 맥락을 반환하면 host는 자신의 정책에 따라
+  그 맥락을 처리합니다. CommitLore는 그 데이터 흐름을 제어하지 않습니다.
 
-> **그 커밋이 있는 줄 몰랐다.** 2주 전 merge된 PR이고, 이미 이 사이트 여덟 곳을 제거하고
-> 각각을 accessibility-native 등가물로 교체했다 — 전부 fail-closed에 실기기 검증까지.
->
-> 이 중 어느 것도 채팅 기록에 없었다. 저장소에 있었고, 나는 파일 경로를 대서 얻었다.
+[보안](SECURITY.md) ·
+[호환성](docs/COMPATIBILITY.md) ·
+[근거](docs/evidence.md)
 
-대안은 2주치 merge된 PR을 읽는 것이었다. 에이전트가 자발적으로 하는 일이 아니고, 사람이
-매 편집 전에 하는 일도 아니다. 같은 리포트의 도입 비용: 명령 하나, 그리고 커밋 768개
-인덱싱에 7.4초. 히스토리도 작업 트리도 건드리지 않는다. 콘솔 출력과 리포트 전문은
-[docs/evidence.md](docs/evidence.md)에 있다.
+<details>
+<summary><strong>보안과 신뢰 모델</strong></summary>
 
-그건 커밋 768개짜리 저장소였다. **커밋 10만 개에서 인덱스를 쓴 `context` 질의는 p50
-496 ms에 답한다.** 그 뒤에서 도는 훅은 `commit-msg`가 p50 185.85 ms, 주입 훅이 p50
-102.40 ms다. 큰 저장소에 이걸 계속 설치해 둘지 결정하는 건 이 숫자들이고, 주장이 아니라
-측정값이다. 같은 실행에는 보기 나쁜 숫자도 들어 있다. 인덱스 없이 같은 질의를 커밋 10만
-개에서 하면 86,673 ms가 걸린다. 인덱스는 잘 도는 질의 위에 얹은 최적화가 아니라 그
-규모에서 질의를 가능하게 만드는 것 자체이고, 그래서 `init`이 그것을 만들고 `doctor`가
-그것을 확인한다.
+record는 등급이 매겨질 때까지 신뢰할 수 없습니다. 기본 author matching은 인증이 아니라 policy
+metadata입니다. signed directive mode에는 Git 검증과 repository-local signer allowlist가 필요하며,
+allowlist가 없거나 읽을 수 없으면 아무도 권한을 얻지 못합니다. injection 모양 payload는
+model-readable route에서 보류됩니다.
 
-**호스팅형 채팅 기록 제품이 줄 수 없는 세 가지**, 그리고 권위를 서비스가 아니라 Git에 둔 이유:
+[전체 보안 모델 →](SECURITY.md)
 
-| 도구 | 기억하는 것 |
-|---|---|
-| `CLAUDE.md` / `AGENTS.md` | 에이전트가 어떻게 일해야 하는가 |
-| ADR | 큰 아키텍처 결정을 문서로 |
-| Chat memory / RAG | 과거의 관련 텍스트 |
-| [Lore](https://arxiv.org/abs/2603.15566) | 같은 발상, 먼저 발표됨 — git trailer에 담은 결정 레코드 |
-| **CommitLore** | **이 코드 경로에 지금도 유효한 결정** |
+</details>
 
-유사도 검색은 관련된 결정을 찾아줄 수 있다. CommitLore는 거기에 더해 그 결정이 아직
-유효한지, 대체됐는지, 만료됐는지를 알고 — 첫 번째 것만 보여준다.
+<details>
+<summary><strong>설치, 업그레이드, 이전 hook 세대</strong></summary>
 
-**세 번째 행에 대하여.** [Lore](https://arxiv.org/abs/2603.15566)(2026년 3월)는 이
-저장소가 생기기 넉 달 전에 native git trailer에 결정 레코드를 담는 방식을 제안했고, 그
-어휘는 이쪽과 거의 일대일로 대응한다. **프로토콜 발상은 여기서 새로운 것이 아니며**,
-아니라고 말해봐야 논문을 읽는 사람 앞에서 버티지 못한다. Lore에 대응물이 없는 것은
-lifecycle(`Supersedes:`와 `Expires:`, 그리고 위 표의 마지막 행을 참으로 만드는 필터링)과
-신뢰 등급이고, 논문 자신은 "empirical validation path를 *제시한다*"고 쓴다. 실행하지는
-않는다. 그 검증을 실패한 부분까지 포함해 가진 것이 이 프로젝트가 논문보다 가진 것이다
-([ADR-0029](docs/adr/ADR-0029-lore-is-prior-art-and-this-is-what-differs.md)).
+CLI installer는 자신이 모르는 저장소의 hook을 다시 쓸 수 없고, 실행 중인 host session은 처음
+불러온 runtime을 유지합니다. `commitlore doctor`는 두 상태와 수리 방법을 알려 주고,
+`commitlore upgrade`는 새 release가 있는지 보고합니다.
 
-## 무엇이 다른가
+[설치와 업그레이드 →](docs/install.md)
 
-- **CLAUDE.md는 에이전트에게 어떻게 일할지 알려준다. CommitLore는 이 코드가 왜 존재하는지 알려준다.**
-- **ADR은 아키텍처를 문서화한다. CommitLore는 diff 안에 숨은 결정을 문서화한다.**
-- **또 하나의 메모리 데이터베이스가 아니다. Git에 들어가는 결정 프로토콜이다.**
+</details>
 
-권위 있는 원본은 평범한 commit trailer와 `refs/notes/commitlore`다. 인덱스와 보고서는 이 Git 기록에서 파생되며 다시 만들 수 있다.
+<details>
+<summary><strong>프로토콜과 Git 저장소</strong></summary>
 
-## 어디서 값을 하나
+record는 평범한 Git trailer 또는 notes입니다. Protocol 2.0은 lifecycle, trust grade, validation,
+compatibility를 정의합니다.
 
-**모듈 경계를 지킨다.** *"`calculatePrice`는 최종 checkout 가격만 담당한다. 관리자 미리보기에 재사용하지 않는다."*
+[사람을 위한 안내 →](docs/protocol.md) ·
+[규범 명세 →](spec/SPEC.md)
 
-**기각된 우회책을 보존한다.** *"타임아웃을 올리면 커넥션 누수가 가려진다. cleanup 경로를 고쳐라."*
+</details>
 
-**임시 호환 코드를 표시한다.** *"이 caller는 임시이며 지원 계약의 일부가 아니다."*
+<details>
+<summary><strong>근거와 부정적 결과</strong></summary>
 
-**검증 공백을 전달한다.** *"단일 사용자 동작은 테스트했다. 동시 갱신은 미검증이다."*
+저장소는 방법, 제외 항목, 실패한 측정, 원래 benchmark 또는 진단이 틀렸던 경우를 공개합니다.
 
-전부 diff가 실어 나를 수 없고, 없으면 리뷰어가 두 번 말해야 하는 문장이다.
+[근거 →](docs/evidence.md) ·
+[자체 점검 →](docs/SELF-AUDIT.md)
 
-## record가 만들어지는 방법
+</details>
 
-모든 커밋에 trailer를 손으로 쓸 필요는 없다. 대부분의 커밋에는 record가 없어야 한다. 외부 제약, 제외한 대안, 경고, 검증 공백처럼 diff만으로 복구할 수 없는 결정에만 record를 추가한다.
+<hr>
 
-에이전트에게 평소대로 커밋하고 diff로 설명할 수 없는 결정 맥락만 보존하도록 요청한다.
+<p align="center">
+  <strong>이력이 있는 저장소에서 사용해 보세요.</strong><br>
+  <sub>path 범위, lifecycle, capture, 설치가 깨지는 곳을 알려 주세요.</sub>
+</p>
 
-> 이 변경을 커밋해. diff로 중요한 제약, 제외한 대안, 경고 또는 검증 공백을 복구할 수 없을 때만 CommitLore record를 추가해.
+<p align="center">
+  <a href="https://github.com/MongLong0214/commitlore/issues/new">실패 사례 보고</a>
+  ·
+  <a href="docs/SELF-AUDIT.md">자체 점검 읽기</a>
+</p>
 
-에이전트 지침은 `skills/commitlore-commits/`에 있고, commit-msg hook은 에이전트가 추가한 record를 검증할 뿐 record를 발명하거나 조용히 추가하지 않는다. `harvest` 경로, `capture` 트랜잭션, 그리고 사람이 trailer를 직접 쓰는 탈출구는 모두 [docs/capture.md](docs/capture.md)에 있다.
+<hr>
 
-## record 프로토콜
-
-record는 평범한 Git commit trailer 묶음이고, 대개는 작은 것으로 충분하다:
-
-```text
-Fix expired-token refresh
-
-Ruled-out: Extend token TTL to 24h | security policy violation
-Warn: Do not narrow the 4xx handler without verifying upstream behavior
-```
-
-어휘 전체를 쓰는 완전한 예제, 모든 trailer key 표, 그리고 CommitLore 없이 순수 Git으로 읽는 방법은 [docs/protocol.md](docs/protocol.md)에 있다. 규범적 정의는 [SPEC §3](spec/SPEC.md)이다.
-
-## 저장소가 증명하는 것
-
-- 테스트한 Git workflow에서 결정 이력은 rebase, remote transfer, 경로 rename을 거쳐도 유지된다. squash merge는 여느 trailer와 마찬가지로 trailer block을 버린다. `commitlore squash-preserve` 또는 그 GitHub Action이 기록을 옮긴다 — 테스트가 그 경로를 덮는다.
-- 모든 route는 같은 trust grading을 써서 신뢰하지 않는 텍스트를 지시가 아닌 정보로 전달한다.
-- 자유 형식 trailer의 injection 같은 텍스트는 model-readable route에서 보류된다.
-- 읽을 수 있는 저장소의 기록 없음은 불완전한 history나 fetch하지 않은 notes mirror와 구별된다.
-
-이것은 Git에 묶여 사람이 검증할 수 있는 결정 이력에 대한 제품 주장이다. CommitLore가 에이전트 성능을 높인다는 주장에 기대지 않는다.
-
-## 근거: 더 좁은 제품 주장
-
-112회 실험은 기록됐지만 M4에는 run별 `guard_exposure` 기록이 없다. treatment가 있었는지 검증할 수 없으므로 agent behavior 주장을 시험하거나 뒷받침하거나 반박하지 못한다. 위의 더 좁은 제품 주장은 독립적으로 검증 가능한 동작에 근거한다. 깨끗한 데이터셋과 철회 내용은 [M4 verdict](bench/VERDICT-M4.md)에서 읽을 수 있다.
-
-무엇이 측정됐고 무엇이 측정되지 않았는지는 [docs/evidence.md](docs/evidence.md)에 정리돼 있다. 측정된 쪽은 검색, 노출, 지연 시간과 확장, hook 오버헤드이고, 측정되지 않은 쪽은 손익분기와 에이전트 행동에 대한 효과다.
-
-
-## 제거
-
-```bash
-commitlore uninstall
-```
-
-`install.sh` 또는 `install.ps1`이 쓴 것을 제거한다 — wrapper, 고정된 checkout,
-각 agent config에 추가한 MCP 항목. 자신이 쓰지 않은 것은 제거하지 않는다.
-남기는 것을 명시한다: 저장소별 hook, agent hook, Claude Code plugin.
-`--dry-run`은 아무것도 바꾸지 않고 보고만 한다. 각각을 무엇이 제거하는지, 그리고
-소스 체크아웃에서 실행하는 방법은 [docs/install.md](docs/install.md)에 있다.
-
+<!-- README:DOCS -->
 ## 문서
 
-- [docs/install.md](docs/install.md) — 설치 경로, 각 경로가 쓰는 것, 되돌리는 방법
-- [docs/cli.md](docs/cli.md) — 모든 명령과 플래그
-- [docs/capture.md](docs/capture.md) — record가 쓰이는 과정
-- [docs/protocol.md](docs/protocol.md) — record 형식과 Git만으로 읽는 방법
-- [docs/evidence.md](docs/evidence.md) — 무엇이 측정됐고 무엇이 아닌지
-- [spec/SPEC.md](spec/SPEC.md) — 규범 프로토콜
+- [설치, 업그레이드, 제거](docs/install.md)
+- [CLI 참고서](docs/cli.md)
+- [Capture 워크플로](docs/capture.md)
+- [Record 프로토콜](docs/protocol.md)
+- [보안 모델](SECURITY.md)
+- [근거와 한계](docs/evidence.md)
+- [운영 계약](docs/PRODUCTION-READINESS-SSOT.md)
+- [문서 색인](docs/README.md)
 
 ## 기여하기
 
-[spec](spec/SPEC.md), [ADR](docs/adr/), [`CONTRIBUTING.md`](CONTRIBUTING.md)를 읽어보라. CommitLore는 [MIT License](LICENSE) 아래에서 영원히 무료인 오픈소스다.
+[CONTRIBUTING.md](CONTRIBUTING.md)에는 이 저장소가 스스로 지키는 record protocol, release gate,
+그리고 근거를 재현하는 방법이 있습니다.
+
+## 라이선스
+
+MIT — [LICENSE](LICENSE)를 보세요.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,107 +1,140 @@
+<!-- README:BRAND -->
 <p align="center">
-  <img src="./assets/readme/hero.svg" width="100%" alt="CommitLore 将仓库的决策权威带入下一次编辑：src/pricing.ts 中仍然有效的决策连同它已排除的替代方案一起交付，而被取代的、此前更宽泛的 limit 不会作为当前指引继续向前。">
+  <img src="./assets/readme/commitlore-logo.svg" width="440" alt="CommitLore">
+</p>
+
+<h1 align="center">CommitLore</h1>
+
+<h3 align="center">你的编程代理不断重新提议团队早已否决的方案。</h3>
+
+<p align="center">
+  <strong>由 Git 所有的编程代理决策权威。</strong><br>
+  把约束、已否决的替代方案和警告保存在 Git 中，只交付仍然有效的内容。
+  这样代理就不会把仓库早已推翻的决定当作当前指引。
 </p>
 
 <p align="center">
-  <a href="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="LICENSE"><img alt="许可证: MIT" src="https://img.shields.io/badge/license-MIT-3f6b52"></a>
-  <a href="package.json"><img alt="Node.js 22.23.2 或更高版本" src="https://img.shields.io/badge/Node.js-%3E%3D22.23.2-3f6b52"></a>
+  <strong>CommitLore 没有托管服务。record 归仓库所有。</strong>
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> · <a href="README.ko.md">한국어</a> · <a href="README.ja.md">日本語</a> · <strong>简体中文</strong>
+  <a href="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml">
+    <img alt="CI" src="https://github.com/MongLong0214/commitlore/actions/workflows/ci.yml/badge.svg">
+  </a>
+  <a href="https://github.com/MongLong0214/commitlore/releases">
+    <img alt="最新发布" src="https://img.shields.io/github/v/release/MongLong0214/commitlore?display_name=tag">
+  </a>
+  <a href="spec/SPEC.md">
+    <img alt="协议 2.0 稳定" src="https://img.shields.io/badge/protocol-2.0%20stable-3FB950">
+  </a>
+  <a href="package.json">
+    <img alt="Node.js 22.23.2 或更高版本" src="https://img.shields.io/badge/node-22.23.2%2B-3FB950">
+  </a>
+  <a href="LICENSE">
+    <img alt="MIT 许可证" src="https://img.shields.io/badge/license-MIT-3FB950">
+  </a>
 </p>
 
-# CommitLore
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <strong>简体中文</strong>
+</p>
 
-**你的编程代理不断重新提议团队早已否决的方案。**
-
-CommitLore 把这些决策保存在 Git 中，并在它编辑文件之前，把仍然有效的决策交给它。
-
-CommitLore 没有托管服务；它把 record 保存在 Git 中。其 MCP 服务器或 hook 返回
-上下文后，host 会按自己的政策处理这些上下文；CommitLore 无法控制那条数据流。
-
-**两半之中只有一半是自动的。** *delivery* —— 在代理编辑某个路径之前把仍然有效的
-决策交给它 —— 安装后即自动进行。*capture* —— 记录新的决策 —— 由代理在变更带有
-diff 无法展示的理由时执行。普通的 `git commit` 无法启动它：hook 拿到的是 diff，
-而 capture 需要会话。
-
-<details>
-<summary><strong>目录</strong></summary>
-
-- [安装](#安装)
-- [代理收到的内容](#看它实际运行)
-- [哪些是自动的，哪些不是](#哪些是自动的哪些不是)
-- [这在什么情况下帮不上忙](#这在什么情况下帮不上忙)
-- [一个例子中的问题](#代码留了下来决定没有)
-- [完整地说，它是什么](#完整地说它是什么)
-- [查看路径查询](#查看路径查询)
-- [这个仓库本身就是演示](#这个仓库本身就是演示)
-- [路径范围与检索](#检索能找到记录路径范围会排除已经推翻的决策)
-- [工作方式](#工作方式)
-- [来自另一仓库的现场报告](#在真实仓库中的样子)
-- [有何不同](#有何不同)
-- [在哪里见效](#在哪里见效)
-- [record 如何创建](#record-如何创建)
-- [完整 record](#完整-record)
-- [仓库能够证明什么](#仓库能够证明什么)
-- [证据](#evidence更窄的产品主张)
-- [卸载](#卸载) · [文档](#文档) · [贡献](#贡献)
-
-</details>
-
-## 安装
-
-安装一次。装好 host integration，并初始化要使用的仓库。
-
-**Claude Code** — 一个插件即可注册 MCP 服务器、编辑前上下文钩子与技能:
-
-```
-/plugin marketplace add MongLong0214/commitlore
-/plugin install commitlore@commitlore
-```
-
-插件所含仅此而已：MCP 服务器、编辑前钩子与技能。它不会把 `commitlore` 放到 `PATH` 上，因此下面的 `commitlore …` 命令来自 `install.sh` / `install.ps1`，还需要那一步安装。
-
-**Codex** — 原生插件只需一条命令即可安装:
-
-```bash
-commitlore plugin install-codex
-```
-
-它通过 Codex 自己的 CLI 注册 marketplace 与 plugin，绝不直接修改其配置或缓存。下面的标准安装脚本在检测到 Codex 时也会执行同一条命令。安装后请开启新的 Codex session —— plugin 的 skill 与 MCP server 在 session 启动时加载，而不是在安装时。下面的 CLI 提供 repository 命令。
-
-两条路径的前置条件都是 Node.js 22.23.2+ 与 Git。脚本在写入任何内容之前会检查这两项。
-
-**其他编程代理** — 安装 CLI:
+<p align="center">
+  <strong>安装一次。</strong> 然后初始化每个要使用它的仓库。
+</p>
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
 ```
 
-**Windows** — 在 PowerShell 中执行同样的安装：
+<details>
+<summary>想先阅读安装器吗？</summary>
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
+sh install.sh v1.2.0
+
+# 或者跳过脚本：它创建的检出，你自己也能创建。
+git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
+node commitlore/dist/commitlore.mjs --version
+```
+
+它安装固定版本的源码检出，以及一个运行 `node <checkout>/dist/commitlore.mjs` 的 wrapper。
+没有编译产物下载，也没有构建步骤。
+
+</details>
+
+<p align="center">
+  <img
+    src="./assets/readme/demo.gif"
+    width="900"
+    alt="commitlore 演示会打印为 src/pricing.ts 记录的两项决定，只交付带有 limit 与已排除替代方案的 active 决定，并说明 superseded 决定仍留在 Git 中但不会作为当前指引交付。"
+  >
+</p>
+
+---
+
+> **代码留得住，判断留不住。**
+
+代理提出一种做法。团队因一个不明显的约束而否决它。最终代码保留了结果，却通常不会保留
+为什么否决该替代方案。之后的代理只看到代码，又会提出同一个主意。
+
+CommitLore 把那份判断留在代码旁边。
+
+## CommitLore 做什么
+
+| | 行为 | 产品路径 |
+|---|---|---|
+| **Capture** | 保存 diff 无法展示的约束、已否决替代方案与警告。候选内容会与 session transcript 和 staged diff 核对。 | `commitlore capture` |
+| **Preserve** | 将已接受的 record 保存到 Git trailer 或 notes，而不是托管记忆数据库。 | commit hook · `refs/notes/commitlore` |
+| **跟踪生命周期** | 区分 active、superseded 与 expired 的决定。 | `commitlore stale` |
+| **限定范围** | 为代理将要编辑的 path 选择决定。 | `commitlore context` |
+| **信任分级** | 将 record 作为 directive、claim 或 withheld content 交付。 | 默认 / signed mode |
+| **Delivery** | 在编辑前向受支持的代理提供当前上下文。 | plugin hook · MCP |
+
+绝大多数 commit 都不应带 record。CommitLore 用于代码无法保留的判断，而不是叙述每一项更改。
+
+<!-- README:QUICKSTART -->
+## 60 秒让代理具备决策意识
+
+### 1. 安装 CLI
+
+macOS 和 Linux：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh | sh -s v1.2.0
+```
+
+Windows：
 
 ```powershell
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.ps1))) v1.2.0
 ```
 
-在 Windows 上配置 host 需要 **v1.1.1 或更高版本**。在此之前，检测看不到 `.cmd` shim，安装器也无法运行它，因此 Windows 安装只放下 CLI 而不配置任何 host —— 报告为 `ok: false`，而不是成功。已在 1.1.1 上于真实机器验证 Codex、Gemini CLI 与 Hermes。
+需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。
 
-**Hermes** — 安装 CLI 后，配置它的 host integration：
+### 2. 连接代理
 
-```bash
-commitlore hermes install
+Claude Code：
+
+```text
+/plugin marketplace add MongLong0214/commitlore
+/plugin install commitlore@commitlore
 ```
 
-支持哪些 host，以及各条安装路径需要什么：[docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)。
+Codex：
 
-**把上一个代理挣得的判断，交给下一个代理。**
+```bash
+commitlore plugin install-codex
+```
 
-### 然后，在每个仓库中
+plugin 不会把 `commitlore` 放到 `PATH` 上，因此下面的命令还需要 CLI 安装。
+安装器会在能安全处理的地方检测并配置受支持的 MCP host；准确矩阵见下文。
 
-然后在每个需要验证 hook、本地 index 与仓库自有 agent procedure 的仓库运行
-`commitlore init`。安装程序会检测受支持的编程代理，并在可以安全处理的地方注册
-本地 MCP server。
+### 3. 初始化仓库
 
 ```bash
 cd your-repository
@@ -109,344 +142,251 @@ commitlore init
 commitlore context .
 ```
 
-在那之后：
+安装或更新 plugin 后，请启动新的 agent session；正在运行的 session 会保留已加载的 runtime。
 
-- 照常提交。绝大多数提交没有 record。
-- 如果已有 record，commit-msg hook 会验证它；不会创建 record。
-- delivery 与 capture 是不同 layer。下一节会准确说明每个 host 具备的两层。
+接着照常工作和 commit。支持 skill integration 时，CommitLore 会在普通 commit 请求中被考虑；
+没有值得保存的内容时会保持安静。无需在每次 commit 时都点名 CommitLore。
 
-继续通过编程代理工作。若某项更改包含 diff 无法保存的决策上下文，请让代理在提交中加入 CommitLore record。
+若想让已接受的 record 不经逐条提示就 stage，仓库可以一次性选择
+`commitlore auto on`。这项政策由仓库所有并适用于团队，因此本页不会悄悄启用它。
 
-<details>
-<summary>想检查或固定安装版本？</summary>
+<!-- README:PAYLOAD -->
+## 代理收到的内容
 
-这一行命令是为了方便。若需要经过审阅或固定版本的安装，请先下载并检查 `install.sh`，或 clone 仓库。脚本只安装一个固定标签的源码检出，以及一个运行 `node <checkout>/dist/commitlore.mjs` 的薄 wrapper —— 它不下载任何编译产物，也没有构建步骤，因此放到机器上的就是你能阅读的源码。
+编辑 `src/pricing.ts` 之前：
 
-```bash
-# 固定版本并检查 installer 后再执行。
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.0/install.sh
-sh install.sh v1.2.0
-
-# 或者完全不用脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.0 https://github.com/MongLong0214/commitlore
-node commitlore/dist/commitlore.mjs --version
-```
-
-</details>
-
-### 升级
-
-重新运行安装脚本，并开启一个新的 agent 会话。
-
-钩子是安装时写下的文件，因此有三个世代。**v1.0.2 之前**安装的钩子直接指向某一个发布版本。**v1.0.2 到 v1.1.2** 之间安装的钩子会跟随 `current`，但当时的隔离 stub 认不出一次普通升级，在 git 交给钩子的 `PATH` 下会拒绝提交。**v1.1.3 及之后**安装的钩子会自动跟随普通升级。
-
-前两个世代需要在每个仓库里各执行一次：
-
-```bash
-commitlore hooks install
-commitlore doctor
-```
-
-安装程序无法代劳。它没有办法知道哪些仓库装了钩子，而不触碰仓库的 `.git` 是一项策略而非疏漏。正在运行的会话保留着启动时加载的运行时，因此还需要重启。哪些仓库需要，由 `commitlore doctor` 列出。
-
-## 看它实际运行
-
-在编辑 `src/pricing.ts` 前，代理会收到这份 payload——record 本身，而不是对它的描述：
-
-```
+```text
 commitlore: active records for src/pricing.ts
 
 Limit
-  [claim]      r-price01  87e36511  calculatePrice owns final checkout pricing only
+  [claim] r-price01  calculatePrice owns final checkout pricing only
 
 Ruled-out
-  [claim]      r-price01  87e36511  Reuse checkout pricing for admin quotes | eligibility
-                                    and rounding semantics differ between the two flows
+  [claim] r-price01  Reuse it for admin quotes |
+                     eligibility and rounding semantics differ
 ```
 
-`[claim]` 有实际含义：这条 record 的 author string 没有匹配仓库为 directive 配置的
-字符串，所以代理会被告知把它当作信息权衡，而不是当作命令服从。默认 author-string
-mode 的 `[directive]` 仅表示仓库决定将该字符串视为约束，并不证明身份；commit author
-自己选择该字符串，任何能写入 commit 的人都可以伪造它。设置
-`commitlore.requireSignedDirective=true` 后，还需要 Git 按验证者自己的 trust store
-验证 signature，并要求 Git 报告的 `%GF` fingerprint 在 repository-local
-`commitlore.trustedSigner` allowlist 中。allowlist 缺失、为空或不可读取时，任何人都不会被
-授权。该 signature 同样不证明签名者有权指挥仓库，也不证明 record 的真实性。delivery 给代理
-的是上下文，并不阻止编辑。
+`[claim]` 表示“把它作为信息权衡”。仓库可以选择更强的 signed-authority mode。
+delivery 只提供上下文，并不阻止编辑。
 
-## 哪些是自动的，哪些不是
+[安全模型 →](SECURITY.md)
 
-**Delivery** 表示 record 会在代理编辑 path 前到达。**Capture** 表示一项决定可以进入
-经过验证的 commit-time flow。二者是不同的 layer：
+## 为什么是 Git？
 
-| Host | Delivery | Capture |
-|---|---|---|
-| Claude Code | **有——通过 plugin 自动完成。** | **有——通过 plugin 提供。** |
-| Codex | **有——通过 plugin 自动完成。** | **有——通过 plugin 提供。** |
-| Hermes | **有——`commitlore hermes install`。** | **有——`commitlore hermes install`。** |
-| Gemini CLI、Cursor、Windsurf、opencode | **是 —— 两个安装器都会配置 MCP server。** 它们并非各自实现，而是走同一个共享步骤。 | **是 procedure，不自动。** server 在每次连接时说明 prepare → verify → stage 流程。host 可能遵循，也可能不遵循。 |
-| 其他遵循 `AGENTS.md` convention 的 host | **是 procedure，不自动。** `commitlore init --agents-md` 会写入 repository。 | **是 procedure，不自动。** 同一个文件，同样的前提。 |
+**仓库应当拥有其代码背后的判断。**
 
-“有”只表示该 layer 已安装，不表示每次 commit 都会得到 record。绝大多数 commit
-本就不应携带 record。只有前三行会自动运行 integration。在其他 `AGENTS.md` host 上，
-两步都是 instruction，而不是 hook。host 仍须启动 capture，candidate 也必须先通过
-验证，commit hook 才会附加它。commit-msg hook 会验证已有的 record；它从不凭空创建 record。
+CommitLore 将 record 存入普通 Git trailer 和 notes，因此它们会随所解释的代码一起 branch、
+merge、clone、review，并在 provider 变更后继续存在。
 
-## 这在什么情况下帮不上忙
+SQLite 只是可重建的 index。删掉它，record 仍在 Git 中。
 
-请在安装前阅读，而不是之后。
+## 仅找到一个旧决定还不够
 
-- **测量的是较弱的那一档。** 在 1,160 次研究中，所有记录都渲染为 `[claim]`，
-  它告诉代理把记录当作信息来权衡，而不是当作命令。`[directive]` 档位是在那之后
-  才可达的，这里并未测量它 —— 研究自己的判定写道，这个数字"不会转移到更强的那一
-  档"。directive 是更好、更差还是相同，**两个方向都没有测量**。
-- **一个模型、一套 harness、十个构造的 fixture。** oracle 读取的是最终实现状态，
-  因此它显示收到记录的代理更少重提被排除的方案，但并不显示其中任何一个读过什么。
-- 尚未实现 cryptographic author verification、repository-wide record coverage、symbol anchor 和 interactive record builder：[#28](https://github.com/MongLong0214/commitlore/issues/28)、[#32](https://github.com/MongLong0214/commitlore/issues/32)、[#33](https://github.com/MongLong0214/commitlore/issues/33)、[#34](https://github.com/MongLong0214/commitlore/issues/34)。
-- M4 没有检验 guard 效果：row 没有 `guard_exposure`，因而无法验证 treatment exposure（[#122](https://github.com/MongLong0214/commitlore/issues/122)）。
-- Guard（ruled-out alternative matching）是实验性参考信息：precision 44.8%（95% Wilson CI 32.7%–57.5%），recall 22.0%，基于 417-decision corpus（[ADR-0020](docs/adr/ADR-0020-guard-is-an-experimental-advisory.md)）。空的 guard 结果不保证提案避开了所有 ruled-out alternative——在 recall 22% 下，遗漏才是常态。
+一般的 memory 或 retrieval system 会问：
 
-完整方法、排除项与每个 arm 的 truncation split 见 [bench/VERDICT-M5.md](bench/VERDICT-M5.md)
-及[它没有显示什么](docs/evidence.md)。delivery 方法和 retrieval 证据见
-[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)。
+> 哪段旧 text 看起来相关？
 
-## 代码留了下来，决定没有。
+CommitLore 会问：
 
-*不再重复评审同一个坏主意。*
+> 已记录的决定中，哪些现在仍适用于这条 path？
 
-**没有 CommitLore。** 新会话看到两个输入相似的函数，复用了其中一个。
-
-```ts
-calculatePrice(input, { isAdminPreview: true, skipCoupon: true });
-```
-
-团队于是多了一个标志、一个包装器，以及一个守护该函数本不该承担的用例的兼容分支。评审者
-第二次写下“我们已经否决过这个了”。
-
-**有 CommitLore。** 编辑之前，代理收到的是上方展示的 active record，而不是从评审意见
-重新拼凑出的指令。
-
-模块边界在代理提出改动**之前**就摆在它面前，而不是事后出现在评审意见里。
-
-在 1,160 次已登记的运行中，重新提议已否决方案的比例从 **18.8%** 降至 **2.8%**。
-这个数字没有说明的内容，见上方的
-[这在什么情况下帮不上忙](#这在什么情况下帮不上忙)。
-
-## 完整地说，它是什么
-
-**面向编程代理的 Git 原生 decision layer。**
-
-每个新代理都继承了实现。但它不会继承约束、团队否决过的替代方案、警告，以及验证缺口 ——
-除非有什么东西把它们带上，否则这些并不随代码一起走。
-
-CommitLore 把这份工程判断保存在 Git 中，并在下一次编辑前只呈现**当下仍然有效的决定**。
-后来被取代或已过期的决定，不会以仍然成立的样子送到代理面前。
-
-**仓库拥有 · 感知生命周期 · 证据经过验证 · 不依赖特定代理**
-
-Claude Code · Codex · Cursor · Gemini CLI · OpenCode · Windsurf
-
-没有托管记忆服务，也没有特定供应商的聊天历史。只有由仓库拥有、可供审查的
-决策上下文。commit trailer 会随 commit 流转；notes-backed record 则需要在 clone
-之后配置 notes fetch。普通 clone 不会获取 `refs/notes/*`，因为 Git 默认不 fetch 它。
-
-## 查看路径查询
-
-
-
-**一个全新的代理，没有聊天历史。它仍被交到手上：为什么那个显而易见的修复被排除了。** 在改动前查询 path：
-
-```bash
-commitlore context install.sh
-```
-
-输出会包含一条 active record：它排除了把发布 `-musl` target 当作 installer 缺陷修复的做法，并说明原因。hook 提供上下文；它并不声称会阻止编辑。
-
-```console
-context for install.sh as of <timestamp> — 0 limits, 1 ruled-out, 1 warnings, 2 other in 1 record (no index, 1 commit record(s) scanned)
-
-ruled-out
-  r-instci99a  <commit>  [claim]  Publish a -musl release target | a release.yml/build-matrix change, not an install.sh or CI-verification fix
-
-warnings
-  r-instci99a  <commit>  [claim]  Revisit this wording if a musl target ships
-```
-
-如何原样复现这条 `PreToolUse` hook path，以及其余全部命令：[docs/cli.md](docs/cli.md)。
-
-## 这个仓库本身就是演示
-
-一个声称能阻止代理重新决定已尘埃落定的问题的工具，应当能够展示它在自身上捕获了什么。这个工具公开维护该清单，其中也包括本项目已经发布、后来被证明有误的内容。
-
-- **没有任何一种安装方式能产生 README 的主张所依赖的信任等级。** record 到达代理时会被评为 `directive` 或 `claim`。结果是，没有已安装的 surface 配置 directive author string，于是所有人的等级都 fail-closed 为 `claim`，而注入的图例却展示了没人能达到的 tier。此前两项 benchmark 测量的都是 `claim` 等级的送达（[#415](https://github.com/MongLong0214/commitlore/issues/415)）。
-- **已登记的 benchmark 分析本会同时读取四项不同的实验。** 由于它的停止规则是行数，这种污染会让研究*通过*它自己的完整性关卡（[#441](https://github.com/MongLong0214/commitlore/issues/441)）。
-- **没有任何东西运行 result-schema gate。** 因此 schema 比 runner 落后五个字段，两天都没人发现（[#392](https://github.com/MongLong0214/commitlore/issues/392)）。
-- **一个已发布的 pre-push hook 会挂起每一次 `git push`。** 40 秒内调用 hook 1,240 次，因为函数被测试了十一次，而 hook path 一次也没有测试（[#422](https://github.com/MongLong0214/commitlore/issues/422)）。
-
-每一项都是 commit trailer 中的一行 `Ruled-out:`、`Warn:` 或 `Limit:`，由本项目请你安装的 hook 验证，并且可以用你在其他地方运行的同一条 `commitlore context` 读取。
-
-**完整列表及每一项的代价：[docs/SELF-AUDIT.md](docs/SELF-AUDIT.md)。**
-
-## 检索能找到记录。路径范围会排除已经推翻的决策。
-
-在代理进行第一次编辑之前，仓库中仍然有效的决策，究竟有多少真正到达了它？在本仓库中，按钩子默认使用的 800 token 预算：
-
-| 路由 | 预算 | 送达的有效决策 | 送达的已推翻决策 | token |
-|---|---:|---:|---:|---:|
-| 仅代码 | — | 0.0% | 0 | 0 |
-| 该路径的 `git log` | 800 | 42.0% | 7 | 673,134 |
-| **CommitLore 路径范围** | **800** | **81.7%** | **0** | **511,412** |
-| CommitLore，取消上限 | 无 | 92.3% | 0 | 741,429 |
-
-取消上限后，路径范围回收的正是全仓库倾倒所回收的那一批 —— 2,217 组中的 2,047 组 —— 却只用掉其 92,175,612 token 中的一小部分，并且一条也不送出它随附的 7,322 条已推翻记录。**范围没有任何代价。** 上限消耗 10.6 个百分点。剩下的 170 组是信任分级器扣留的记录。
-
-**这测的是送达，不是效果。** 没有代理参与运行，所以它给出的是*可能*回收多少的上界，而不是实际回收了多少。而且检索指标完全可能在它本应预测的结果变差时继续上升。SWE-bench 测得随着上下文预算增加，BM25 的 recall 从 29.58 升至 51.06，却同时报告"即便增大 BM25 的最大上下文会提升相对 oracle 文件的 recall，性能仍会下降……因为模型根本不擅长定位有问题的代码"（[arXiv:2310.06770](https://arxiv.org/abs/2310.06770)）。一个语料库，一个仓库。被替代的记录有 7 条、已过期的有 0 条，所以"零条已推翻决策送达"对过期一事尚未给出任何结论。方法与完整表格：[bench/DECISION-DELIVERY.md](bench/DECISION-DELIVERY.md)。
-
-**`git log` 基线并非我们自己测自己得出的产物。** 把同一测量应用到本项目并未撰写的四个仓库 —— Django、SymPy、scikit-learn 与 Requests，均固定在指定提交 —— 一条路径的历史在 800 token 截断下存活的比例落在 **37.4% 到 55.6%** 之间。上面的 42.0% 就在这个区间内。固定预算砍掉一个文件近半历史，是 `git log` 在大型、长期存续的仓库上普遍会做的事，而不是本仓库特有的现象。**没有转移的是机制。** 我们的路径中位数是 1 次提交 687 token，Django 则是 8 次提交 213 token —— 较长的提交信息会在固定预算下让普通 Git 基线更差，这是本项目自身实践付出的代价。[bench/EXTERNAL-CORPUS.md](bench/EXTERNAL-CORPUS.md) 也报告了那些仓库上的送达数值，但请先读 §9.0 与 §9.5：其中的记录由程序从 revert 提交生成，标题数字是附着谓词强制的结果，并非检索成绩。
-
-漏掉一条记录，模型损失的是上下文；交给它一项已经推翻的决策，损失的是正确性。在这项[检索测量](bench/retrieval/result.md)中，从 0 到 10,000 条干扰记录的每个规模，BM25、embedding top-k、hybrid RRF 与带路径过滤的 embedding 都各返回了一条已被替代的记录。带生命周期的 CommitLore 路径范围返回零条过时记录，并返回两条当前记录 (2/2)。
-
-召回率是辅助结果：两种方式的检索大体找到相同的记录，但只有一条路由知道哪些仍然有效。决策被推翻时优势才会出现——而这正是本产品存在的情形。
-
-独立的 #167 暴露运行仍然重要：10,002 条记录中只有 2 条到达模型。
-
-| 路由 | 模型可见记录 | 相关记录 | 模型可见令牌 |
-|---|---:|---:|---:|
-| 注入全部内容 | 10,002 | 2/2 | 1,004,554 |
-| top-k 词法检索 | 2 | 1/2 | 190 |
-| CommitLore 路径范围 | 2 | 2/2 | 335 |
-
-这项测量是在固定的两条记录输出预算下进行的暴露与召回率测量，不测量令牌成本、计费成本、准确率或代理行为。它只涉及一个语料库、一个查询和一个固定的 embedding 模型。召回率打平的地方，以及此外还测量了什么、没测量什么：[docs/evidence.md](docs/evidence.md)。
+被 supersede 的决定可能非常相关，但作为当前指引仍然是错的。相关性与权威是不同的问题。
 
 ## 工作方式
 
-1. **Capture** — 代理只起草 diff 无法呈现的决策上下文。
-2. **Verify** — CommitLore 将草稿与会话和暂存 diff 进行核对。
-3. **Preserve** — 通过验证的记录带着身份与生命周期留在 Git 中。
-4. **Deliver** — 下一个代理在编辑路径前，只收到**当下仍然有效的决定**。
+<p align="center">
+  <img src="./assets/readme/hero.svg" width="720" alt="对于 src/pricing.ts，Git 历史中的 active 决定会进入下一次编辑前交付的上下文，并带着其 limit 和已排除的替代方案。此前也涉及管理员报价的决定已被 supersede，仍留在历史中，但不会作为当前指引向前交付。">
+</p>
 
-## 在真实仓库中的样子
+1. **Capture** — 代理只起草 diff 无法展示的决策上下文。
+2. **Verify** — CommitLore 将草稿与 session 和 staged diff 核对。
+3. **Preserve** — 已接受的 record 连同 identity 和 lifecycle 留在 Git 中。
+4. **Deliver** — 后续编辑前，只返回该 path 的 active record。
 
-来自一份约 768 次提交的 Swift MCP 服务器现场报告，安装后第二天。只给出一个文件路径，
-就浮出了一个工程师并不知道其存在的已合并 PR，而它改变了留存代码的含义。
+绝大多数 commit 没有 record。commit hook 会在 record 存在时验证它，不会凭空发明一个。
 
-> **我不知道那个提交存在。** 那是两周前合并的 PR，已经移除了其中八处，并把每一处都换成了
-> accessibility-native 的等价实现，全部 fail-closed 并经过真机验证。
->
-> 这些都不在任何聊天记录里。它们在仓库里，而我只是给出了一个文件路径。
+不会覆盖已有 hook。 `commitlore init` 会遵守 `core.hooksPath`，把已安装的 hook 移到
+`<hook>.commitlore-chained`，并先调用它； `commitlore hooks uninstall` 会将其还原。
 
-替代方案是通读两周的已合并 PR。这不是代理会主动做的事，也不是人在每次编辑前会做的事。
-同一份报告中的接入成本：一条命令，768 次提交索引耗时 7.4 秒。不触碰历史，也不触碰工作区。
-控制台输出与报告全文见 [docs/evidence.md](docs/evidence.md)。
+<!-- README:CAPABILITY -->
+## 哪些是自动的，哪些不是
 
-那是一个 768 次提交的仓库。**在 10 万次提交上，带索引的 `context` 查询 p50 为 496 ms。**
-其背后运行的钩子，`commit-msg` p50 为 185.85 ms，注入钩子 p50 为 102.40 ms。决定这东西
-是否会一直留在一个大仓库里的正是这些数字，而它们是测出来的，不是声称的。同一次运行里
-也有难看的数字：不用索引，同样的查询在 10 万次提交上要 86,673 ms。索引不是加在一个本
-就可用的查询之上的优化，而是让该规模下的查询成为可能的东西本身 —— 这也是 `init` 会
-建立它、`doctor` 会检查它的原因。
+| Host | 编辑前 delivery | 已验证的 capture 工作流 | 每个 commit 都确定执行 capture |
+|---|---|---|---|
+| Claude Code | 通过 plugin 自动完成 | 通过 plugin skill 可用 | **未认证** |
+| Codex | 通过 plugin 自动完成 | 通过 plugin skill 可用 | **未认证** |
+| Hermes | 执行 `commitlore hermes install` 后可用 | host 安装后可用 | **未认证** |
+| Gemini CLI、Cursor、Windsurf、opencode | host 使用注册时提供 MCP delivery | 通过 MCP 暴露的 procedure | 否 |
+| `AGENTS.md` host | 仅 procedure | 仅 procedure | 否 |
 
-**托管式聊天记录产品无法提供的三个性质**，也是把权威放在 Git 而非服务上的理由：
+“可用”表示 prepare → verify → stage workflow 存在，并不表示每个符合条件的 commit 都会自动评估。
 
-| 工具 | 它记住什么 |
-|---|---|
-| `CLAUDE.md` / `AGENTS.md` | 代理应该如何工作 |
-| ADR | 以文档形式记录大的架构决策 |
-| Chat memory / RAG | 过去的相关文本 |
-| [Lore](https://arxiv.org/abs/2603.15566) | 同样的想法，更早发表 —— 放在 git trailer 里的决策记录 |
-| **CommitLore** | **对这条代码路径当下仍然有效的决定** |
+受支持 skill host 的用户无需在每次 commit 时说“把这个记到 CommitLore”。剩下的限制是 host 是否
+发起流程，而不是每条 record 都要用户命令。
 
-相似度检索能找到相关的决定。CommitLore 还知道那个决定是否仍然有效、是否已被取代或过期 ——
-并且只呈现第一种。
+## 现场报告，不是测量
 
-**关于第三行。** [Lore](https://arxiv.org/abs/2603.15566)（2026 年 3 月）在本仓库存在的
-四个月前就提出了把决策记录放进 native git trailer 的做法，其词汇与这里几乎一一对应。
-**协议这个想法在这里并不新颖**，说它新颖也经不起任何读过那篇论文的人。Lore 没有对应物
-的是生命周期 —— `Supersedes:` 与 `Expires:`，以及让上表最后一行成立的那层过滤 —— 以及
-信任分级；论文本身写的是"*勾勒出*一条实证验证路径"，并未做实验。把那份验证做出来、连同
-失败的部分一起留下，才是本项目相对那篇论文所拥有的东西
-（[ADR-0029](docs/adr/ADR-0029-lore-is-prior-art-and-this-is-what-differs.md)）。
+这是某人在一个无关仓库首次安装 v1.2.0 时的一次运行。这里没有测量任何东西，也没有写进
+evidence log。之所以放在这里，是因为上段主张了一种本页表格未覆盖的 loop。
 
-## 有何不同
+那个人让 agent 修复一个舍入 bug，顺带提到 decimal library 已经考虑过又被否决，最后说“commit it”。
+从未提到 CommitLore。commit 携带的部分内容如下：
 
-- **CLAUDE.md 告诉代理如何工作。CommitLore 告诉它这段代码为何存在。**
-- **ADR 记录架构。CommitLore 记录藏在 diff 中的决策。**
-- **不是又一个 memory database，而是构建在 Git 中的 decision protocol。**
-
-权威来源是普通的 commit trailer 与 `refs/notes/commitlore`。index 和 report 都从这些 Git record 派生，且可以重建。
-
-## 在哪里见效
-
-**守住模块边界。** *"`calculatePrice` 只负责最终的 checkout 定价。不要复用于管理员预览。"*
-
-**保留被否决的权宜之计。** *"调高超时会掩盖连接泄漏。请修复 cleanup 路径。"*
-
-**标记临时兼容代码。** *"这个调用方是临时的，不属于受支持的契约。"*
-
-**传递验证缺口。** *"单用户行为已测试。并发刷新仍未验证。"*
-
-每一条都是 diff 无法承载的句子，否则评审者就得说第二遍。
-
-## record 如何创建
-
-不必为每次提交手写 trailer。绝大多数提交都不应带 record。只在 diff 无法还原的决策中添加 record：外部限制、排除的方案、warning 或 verification gap。
-
-让代理照常提交，只保留 diff 无法解释的决策上下文：
-
-> 提交这项更改。只有当 diff 无法还原重要限制、排除的方案、warning 或 verification gap 时，才添加 CommitLore record。
-
-代理说明位于 `skills/commitlore-commits/`，commit-msg hook 只验证代理添加的 record，不会凭空创建或静默添加。`harvest` 路径、`capture` 事务，以及手写 trailer 这条逃生出口，都在 [docs/capture.md](docs/capture.md)。
-
-## record 协议
-
-record 就是一组普通的 Git commit trailer，通常小的就够用:
-
-```text
-Fix expired-token refresh
-
-Ruled-out: Extend token TTL to 24h | security policy violation
-Warn: Do not narrow the 4xx handler without verifying upstream behavior
+```
+Ruled-out: adopting a decimal library such as Decimal.js | the backend is a
+  number contract, so it is meaningless
+Warn: do not revert the test file to console.assert: it exits 0 even on
+  failure, so CI passes silently
+Provenance: drafted
 ```
 
-使用全部语汇的完整示例、所有 trailer key 的表格，以及不用 CommitLore 直接用 Git 读取的方法，都在 [docs/protocol.md](docs/protocol.md)。规范性定义见 [SPEC §3](spec/SPEC.md)。
+`Warn` 并不是人逐字指示给 agent 的；它是在工作中撞上这个陷阱后留给下一位的。
+`Provenance: drafted` 记录的是没有人阅读该 record，因而将其评为 `claim`：作为需要权衡的报告，
+而不是命令来交付。
 
-## 仓库能够证明什么
+一个没有共享历史的后续 session 后来被要求最终采用 decimal library。它没有采用，并把 record
+作为理由；它还读了该等级。 `claim` 不是指令，所以它先把所述理由与代码核对，才表示赞同。
 
-- 在经过测试的 Git workflow 中，决策历史会跨越 rebase、remote transfer 与 path rename 保留下来。squash merge 会像丢弃任何普通 trailer 一样丢弃 trailer block；由 `commitlore squash-preserve` 或其 GitHub Action 承接这些记录 —— 测试覆盖了该路径。
-- 所有 route 使用相同的 trust grading，因此不受信任的 text 会作为 information 而不是 instruction 传递。
-- free-form trailer 中类似 injection 的 text 会从 model-readable route 中被保留。
-- 可读取的 repository 没有 record，与不完整的 history 或未 fetch 的 notes mirror 是不同状态。
+## 不同于记忆存储
 
-这是关于绑定到 Git、可由人验证的决策历史的产品主张。它不依赖“CommitLore 提升 agent performance”的主张。
+| | 一般 memory / RAG | **CommitLore** |
+|---|---|---|
+| 首要问题 | 哪段旧 text 相关？ | 哪些决定现在仍适用于这里？ |
+| 权威 | memory store 或 provider | Git |
+| 范围 | 语义相似性 | repository path |
+| lifecycle | 通常 append-first | active · superseded · expired |
+| 信任 | 检索到的 text | directive · claim · blocked |
+| capture | transcript 或 note 存储 | 已核对证据的决策 record |
+| 可移植性 | 依赖 backend | 普通 Git |
 
-## Evidence：更窄的产品主张
+CommitLore 有意更窄。它不是通用 user-memory system、对话 archive 或 vector database 的替代品。
 
-已记录 112 次实验，但 M4 没有逐次运行的 `guard_exposure` 记录。无法验证 treatment 是否存在，因此它没有检验、支持或反驳 agent behavior 的主张。上面更窄的产品主张基于可独立验证的行为。关于干净的数据集和撤回，请见 [M4 verdict](bench/VERDICT-M4.md)。
+<!-- README:EVIDENCE -->
+## 证据：检索能找到记录
 
-哪些已被测量——检索、暴露、延迟与扩展、hook overhead——以及哪些尚未被测量——盈亏平衡，以及对代理行为的任何影响——都写在 [docs/evidence.md](docs/evidence.md)。
+| 问题 | 测量结果 | 边界 |
+|---|---|---|
+| 在已登记研究中，claim 等级上下文是否改变了重新提议？ | 有 CommitLore 时 **2.8%** (16/580)，没有时 **18.8%** (109/579) | 一个模型、一套 harness、构造的 task |
+| lifecycle filtering 是否在测量的 active projection 中交付 retired record？ | **retired record 0 条** | 有 superseded record；没有 expiry |
+| 有 index 的 lookup 能扩展吗？ | **100k commit 下 p50 496 ms** | 无 index 的 fallback 慢得多 |
 
+index 的构建时间取决于 *record* 数量，而不是 commit 数量。高成本步骤每条 record 只运行一次，
+所以记录较少的长历史比 record 密集的短历史构建得更快。
 
-## 卸载
+path scope 阻止大型历史到达 model。在 #167 corpus 中，10,002 条 record 里只有 2 条到达。
 
-```bash
-commitlore uninstall
-```
+| route | 模型可见记录 | 相关记录 | 模型可见 token |
+|---|---:|---:|---:|
+| 注入全部内容 | 10,002 | 2/2 | 1,004,554 |
+| top-k lexical | 2 | 1/2 | 190 |
+| CommitLore path scope | 2 | 2/2 | 335 |
 
-移除 `install.sh` 或 `install.ps1` 写入的内容 — wrapper、固定的 checkout，以及它
-添加到各 agent config 的 MCP 条目。它不会移除自己没有写入的东西，并会明确说明留下
-了什么：各仓库的 hook、agent hook、Claude Code plugin。`--dry-run` 只报告，不做任何
-更改。它们各自由什么移除，以及如何改从 source 检出运行，见
-[docs/install.md](docs/install.md)。
+这在固定两条 record 预算下测量 exposure 和 recall，不测量 token cost、计费成本、准确率或
+agent 行为。它只涉及一个 corpus、一个 query 和一个固定的 embedding model。
 
+agent study 并不证明普遍的 model 效果。delivery 不是 model 阅读或遵循 record 的证据。
+
+[方法、完整表格、排除项与负面结果 →](docs/evidence.md)
+
+<!-- README:LIMITS -->
+## 这在什么情况下帮不上忙
+
+- **Capture 是辅助的，不是确定性的。** 支持的 skill 会考虑普通 commit 请求，但没有 host 被认证为会评估
+  每一项符合条件的 commit。
+- **默认 directive mode 不是认证。** 它匹配 commit author header，任何能写 commit 的人都能设置该 header。
+  因而默认 mode 的 `[directive]` 是 policy metadata，不是 identity 证明。signature mode 还要求 Git 自己的
+  verified status 与 repository-local `commitlore.trustedSigner` allowlist 相匹配；signer allowlist 缺失、
+  为空或不可读取时无人被授权，因此该 mode 会 fail-closed。
+- **Guard 是实验性参考信息**，不是安全网：precision 44.8% (95% Wilson CI 32.7%–57.5%)，
+  recall 22.0%，基于 417-decision corpus。空的 guard 结果不是安全判定。
+- **Delivery 在每次匹配的 tool call 中消耗 token。** 编辑前 hook 不仅在 `Read` 时运行，也在 `Edit`、
+  `Write`、`MultiEdit`、`NotebookEdit` 时运行，远多于 editing agent commit 的次数。每次最多使用默认
+  800 token 的 payload，可用 `--budget` 修改。没有 record 的仓库不消耗任何内容，所以这项成本随采纳而非安装出现。
+- **答案可能不完整。** coverage 会被披露；部分结果没有某条 record，并不证明它不存在。
+  repository-wide coverage、symbol anchor 与 interactive record builder 仍未完成：
+  [#32](https://github.com/MongLong0214/commitlore/issues/32)、
+  [#33](https://github.com/MongLong0214/commitlore/issues/33)。
+- **commit trailer 会随 clone 传递，notes 不会。** Git 默认不会 fetch `refs/notes/*`，
+  所以 `refs/notes/commitlore` 中的 record 在 `commitlore init` 配置该 mirror 前不会出现在普通 clone 中。
+- **没有托管 backend。** 但 server 或 hook 返回上下文后，host 会按自己的政策处理它；CommitLore 不控制那条数据流。
+
+[安全](SECURITY.md) ·
+[兼容性](docs/COMPATIBILITY.md) ·
+[证据](docs/evidence.md)
+
+<details>
+<summary><strong>安全与信任模型</strong></summary>
+
+record 在分级前不可信。默认 author matching 是 policy metadata，不是认证。signed directive mode 需要
+Git verification 与 repository-local signer allowlist；allowlist 缺失或不可读取时无人被授权。
+形似 injection 的 payload 会从 model-readable route 中被保留。
+
+[完整安全模型 →](SECURITY.md)
+
+</details>
+
+<details>
+<summary><strong>安装、升级与旧 hook 世代</strong></summary>
+
+CLI installer 无法重写它不知道的仓库里的 hook，正在运行的 host session 会保留加载的 runtime。
+`commitlore doctor` 会指出两种状态及其修复，`commitlore upgrade` 会报告是否有更新的 release。
+
+[安装与升级 →](docs/install.md)
+
+</details>
+
+<details>
+<summary><strong>协议与 Git 存储</strong></summary>
+
+record 是普通 Git trailer 或 notes。Protocol 2.0 定义 lifecycle、trust grade、validation 与 compatibility。
+
+[面向人的指南 →](docs/protocol.md) ·
+[规范说明 →](spec/SPEC.md)
+
+</details>
+
+<details>
+<summary><strong>证据与负面结果</strong></summary>
+
+仓库发布方法、排除项、失败的测量，以及原始 benchmark 或诊断出错的情况。
+
+[证据 →](docs/evidence.md) ·
+[自我审计 →](docs/SELF-AUDIT.md)
+
+</details>
+
+<hr>
+
+<p align="center">
+  <strong>请在有历史的仓库上试用。</strong><br>
+  <sub>告诉我们 path scope、lifecycle、capture 或安装在哪些地方出错。</sub>
+</p>
+
+<p align="center">
+  <a href="https://github.com/MongLong0214/commitlore/issues/new">报告失败案例</a>
+  ·
+  <a href="docs/SELF-AUDIT.md">阅读自我审计</a>
+</p>
+
+<hr>
+
+<!-- README:DOCS -->
 ## 文档
 
-- [docs/install.md](docs/install.md) — 各条安装路径、各自写入什么、如何撤销
-- [docs/cli.md](docs/cli.md) — 每条命令及其参数
-- [docs/capture.md](docs/capture.md) — record 是怎么写出来的
-- [docs/protocol.md](docs/protocol.md) — record 格式，以及只用 Git 读取的方法
-- [docs/evidence.md](docs/evidence.md) — 哪些已被测量，哪些没有
-- [spec/SPEC.md](spec/SPEC.md) — 规范协议
+- [安装、升级与卸载](docs/install.md)
+- [CLI 参考](docs/cli.md)
+- [Capture 工作流](docs/capture.md)
+- [Record 协议](docs/protocol.md)
+- [安全模型](SECURITY.md)
+- [证据与限制](docs/evidence.md)
+- [生产契约](docs/PRODUCTION-READINESS-SSOT.md)
+- [文档索引](docs/README.md)
 
 ## 贡献
 
-请阅读 [spec](spec/SPEC.md)、[ADR](docs/adr/) 和 [`CONTRIBUTING.md`](CONTRIBUTING.md)。CommitLore 是采用 [MIT License](LICENSE) 的永久免费开源软件。
+[CONTRIBUTING.md](CONTRIBUTING.md) 说明本仓库自身遵守的 record protocol、release gate，
+以及如何复现证据。
+
+## 许可证
+
+MIT — 见 [LICENSE](LICENSE)。


### PR DESCRIPTION
Closes #795.

The 2026-08-19 redesign rebuilt `README.md` and left the three translations on the structure that preceded it — **14 headings against 20**, no brand logo, a hero the redesign had already reformatted. A reader following the language links landed on a different document, not a translated one.

**The tests did not catch it, and that is the part worth stating.** Every suite asserts *per-file* contracts — install pin, guard figures, exposure table, `refs/notes/*`, section order — and each translation satisfied its own. Nothing asked whether the four files describe the same product in the same order, so the divergence was invisible to CI while every assertion passed.

All four now agree:

| | README.md | ko | ja | zh-CN |
|---|---|---|---|---|
| `## ` headings | 14 | 14 | 14 | 14 |
| logo ref | 1 | 1 | 1 | 1 |
| hero on one line | 1 | 1 | 1 | 1 |
| `](docs/COMPATIBILITY.md)` | 1 | 1 | 1 | 1 |

Plus the facts the English rewrite restored: the #167 exposure table, the trailers-versus-notes distinction, the host-policy sentence, and guard precision 44.8% / recall 22.0%.

**Limit, in the commit:** parity is shown here by four counts that happen to agree, not by a test. A parity assertion written in *this* change would pass by construction — it belongs in its own change where it can be made to fail first.

143 README assertions pass; full suite **3452 passed**.