### PR TITLE
Legacy decisions have no identity to bind them, so the benchmark computes one from the history it already has

### DIFF
--- a/bench/cdeb/freeze/decision-anchor.ts
+++ b/bench/cdeb/freeze/decision-anchor.ts
@@ -1,0 +1,141 @@
+import { createHash } from "node:crypto";
+
+/**
+ * A benchmark-internal identity for a historical repository decision.
+ *
+ * It exists because the v4 estimand is delivery of a prior decision rather than
+ * delivery of a product `Record-Id`, and legacy-era decisions predate that
+ * field entirely. Something still has to bind a source decision to its gold and
+ * to its delivery evidence, so the benchmark computes its own key from what the
+ * frozen history already contains.
+ *
+ * What it is not: it is not a product identifier, it is never written back to
+ * any repository, it never appears in a payload the coding agent can read, and
+ * it is not a backfill -- nothing here is added to history, only read from it.
+ */
+
+export const STORAGE_KINDS = ["commit-trailer", "git-note", "ordinary-source"] as const;
+export type StorageKind = (typeof STORAGE_KINDS)[number];
+
+export const DECISION_LIFECYCLES = ["active", "superseded", "withdrawn"] as const;
+export type DecisionLifecycle = (typeof DECISION_LIFECYCLES)[number];
+
+export interface DecisionAnchorInput {
+  readonly repository_id: string;
+  readonly snapshot_sha: string;
+  readonly source_commit_sha: string;
+  readonly storage_kind: StorageKind;
+  readonly storage_locator: string;
+  readonly decision_ordinal: number;
+  readonly normalized_decision_sha256: string;
+  readonly normalized_reason_sha256: string;
+  readonly path_scope: readonly string[];
+  readonly lifecycle: DecisionLifecycle;
+}
+
+/**
+ * Every field is load-bearing, so the order is fixed here rather than derived
+ * from whatever object a caller happens to pass. Adding a field to the type
+ * without adding it here would leave it out of the hash silently.
+ */
+export const DECISION_ANCHOR_FIELDS = [
+  "decision_ordinal",
+  "lifecycle",
+  "normalized_decision_sha256",
+  "normalized_reason_sha256",
+  "path_scope",
+  "repository_id",
+  "snapshot_sha",
+  "source_commit_sha",
+  "storage_kind",
+  "storage_locator",
+] as const;
+
+const GIT_OID = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const refuse = (message: string): never => {
+  throw new Error(`decision anchor: ${message}`);
+};
+
+/**
+ * Whitespace normalization, and nothing more. The same decision text reflowed
+ * by a different renderer must anchor identically; different words must not.
+ * Case, punctuation and word order all survive, because all three carry the
+ * judgment this benchmark is about.
+ */
+export const normalizeDecisionText = (text: string): string =>
+  text.normalize("NFC").replace(/\s+/gu, " ").trim();
+
+export const decisionTextSha256 = (text: string): string =>
+  createHash("sha256").update(normalizeDecisionText(text), "utf8").digest("hex");
+
+export const assertDecisionAnchorInput = (value: unknown): DecisionAnchorInput => {
+  if (!isRecord(value)) refuse("input must be an object");
+  const input = value as Record<string, unknown>;
+  const extra = Object.keys(input).filter((key) => !(DECISION_ANCHOR_FIELDS as readonly string[]).includes(key));
+  if (extra.length > 0) {
+    // An unknown key is either a field that should be in the hash or a field
+    // that should not exist. Both are the caller's mistake, and ignoring it
+    // would produce an anchor that omits something a reader assumes it covers.
+    refuse(`unknown field(s) ${extra.sort().join(", ")}`);
+  }
+  for (const field of DECISION_ANCHOR_FIELDS) {
+    if (!(field in input)) refuse(`missing field ${field}`);
+  }
+  if (typeof input.repository_id !== "string" || input.repository_id.trim() === "") refuse("repository_id must be a non-empty string");
+  if (typeof input.snapshot_sha !== "string" || !GIT_OID.test(input.snapshot_sha)) refuse("snapshot_sha must be a 40-character git object id");
+  if (typeof input.source_commit_sha !== "string" || !GIT_OID.test(input.source_commit_sha)) refuse("source_commit_sha must be a 40-character git object id");
+  if (typeof input.storage_kind !== "string" || !(STORAGE_KINDS as readonly string[]).includes(input.storage_kind)) refuse(`storage_kind must be one of ${STORAGE_KINDS.join(", ")}`);
+  if (typeof input.storage_locator !== "string" || input.storage_locator.trim() === "") refuse("storage_locator must be a non-empty string");
+  if (typeof input.decision_ordinal !== "number" || !Number.isInteger(input.decision_ordinal) || input.decision_ordinal < 0) refuse("decision_ordinal must be a non-negative integer");
+  if (typeof input.normalized_decision_sha256 !== "string" || !SHA256.test(input.normalized_decision_sha256)) refuse("normalized_decision_sha256 must be a sha256 hex digest");
+  if (typeof input.normalized_reason_sha256 !== "string" || !SHA256.test(input.normalized_reason_sha256)) refuse("normalized_reason_sha256 must be a sha256 hex digest");
+  if (!Array.isArray(input.path_scope) || input.path_scope.length === 0) refuse("path_scope must be a non-empty array");
+  const scope = input.path_scope as unknown[];
+  for (const entry of scope) {
+    if (typeof entry !== "string" || entry.trim() === "") refuse("path_scope entries must be non-empty strings");
+  }
+  if (new Set(scope as string[]).size !== scope.length) refuse("path_scope must not repeat a path");
+  if (typeof input.lifecycle !== "string" || !(DECISION_LIFECYCLES as readonly string[]).includes(input.lifecycle)) refuse(`lifecycle must be one of ${DECISION_LIFECYCLES.join(", ")}`);
+  return input as unknown as DecisionAnchorInput;
+};
+
+/**
+ * Deterministic serialization: fixed key order, sorted scope, no whitespace.
+ * `path_scope` is a set of paths -- listing the same two paths in the other
+ * order describes the same scope, so it must anchor the same. Adding or
+ * removing one does not.
+ */
+export const canonicalDecisionAnchorJson = (value: unknown): string => {
+  const input = assertDecisionAnchorInput(value);
+  const parts = DECISION_ANCHOR_FIELDS.map((field) => {
+    const raw = field === "path_scope" ? [...input.path_scope].sort() : input[field];
+    return `${JSON.stringify(field)}:${JSON.stringify(raw)}`;
+  });
+  return `{${parts.join(",")}}`;
+};
+
+export const computeDecisionAnchor = (value: unknown): string =>
+  createHash("sha256").update(canonicalDecisionAnchorJson(value), "utf8").digest("hex");
+
+/**
+ * The exposure check. The anchor is benchmark-side evidence; a payload the
+ * coding agent can read must not contain it, because an agent that can see the
+ * anchor can tell which decisions the benchmark is watching.
+ */
+export const assertNoDecisionAnchorExposure = (
+  payload: string,
+  anchors: readonly string[],
+  where: string,
+): void => {
+  for (const anchor of anchors) {
+    if (!SHA256.test(anchor)) refuse(`exposure check received a value that is not an anchor: ${anchor}`);
+    if (payload.includes(anchor)) {
+      throw new Error(`decision anchor exposure: anchor ${anchor.slice(0, 12)} appears in ${where}`);
+    }
+  }
+};

--- a/bench/cdeb/studies/cdeb-fresh-v4/feasibility/decision-anchor.schema.json
+++ b/bench/cdeb/studies/cdeb-fresh-v4/feasibility/decision-anchor.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cdeb-v4-decision-anchor",
+  "title": "CDEB-Fresh v4 decision audit anchor input",
+  "description": "The canonical inputs hashed into a decision_audit_anchor. Benchmark-internal only: this is not a product Record-Id, it is never written to any repository, and it must not appear in a payload the coding agent can read.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "decision_ordinal",
+    "lifecycle",
+    "normalized_decision_sha256",
+    "normalized_reason_sha256",
+    "path_scope",
+    "repository_id",
+    "snapshot_sha",
+    "source_commit_sha",
+    "storage_kind",
+    "storage_locator"
+  ],
+  "properties": {
+    "repository_id": { "type": "string", "minLength": 1 },
+    "snapshot_sha": { "$ref": "#/$defs/gitOid" },
+    "source_commit_sha": { "$ref": "#/$defs/gitOid" },
+    "storage_kind": { "enum": ["commit-trailer", "git-note", "ordinary-source"] },
+    "storage_locator": { "type": "string", "minLength": 1 },
+    "decision_ordinal": { "type": "integer", "minimum": 0 },
+    "normalized_decision_sha256": { "$ref": "#/$defs/sha256" },
+    "normalized_reason_sha256": { "$ref": "#/$defs/sha256" },
+    "path_scope": {
+      "description": "A set of paths. Order does not change the anchor; membership does.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "lifecycle": { "enum": ["active", "superseded", "withdrawn"] }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "gitOid": { "type": "string", "pattern": "^[0-9a-f]{40}$" }
+  }
+}

--- a/test/cdeb-v4-decision-anchor.test.ts
+++ b/test/cdeb-v4-decision-anchor.test.ts
@@ -1,0 +1,144 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DECISION_ANCHOR_FIELDS,
+  assertNoDecisionAnchorExposure,
+  canonicalDecisionAnchorJson,
+  computeDecisionAnchor,
+  decisionTextSha256,
+  normalizeDecisionText,
+  type DecisionAnchorInput,
+} from '../bench/cdeb/freeze/decision-anchor.js';
+
+const HERE = resolve(fileURLToPath(new URL('.', import.meta.url)));
+const SCHEMA_PATH = resolve(
+  HERE,
+  '..',
+  'bench/cdeb/studies/cdeb-fresh-v4/feasibility/decision-anchor.schema.json',
+);
+
+const base = (): DecisionAnchorInput => ({
+  repository_id: 'gitseed',
+  snapshot_sha: '222378defcb5d2d519184b6f23146abac631faba',
+  source_commit_sha: 'b909d2c4023d4c1ca9ebe142f61a3d19c666ccaa',
+  storage_kind: 'commit-trailer',
+  storage_locator: 'refs/heads/cdeb-snapshot',
+  decision_ordinal: 0,
+  normalized_decision_sha256: decisionTextSha256('the seeder must not write outside the target directory'),
+  normalized_reason_sha256: decisionTextSha256('a relative path from user input escaped the root in testing'),
+  path_scope: ['src/seed.ts', 'src/paths.ts'],
+  lifecycle: 'active',
+});
+
+const anchorWith = (overrides: Partial<Record<keyof DecisionAnchorInput, unknown>>): string =>
+  computeDecisionAnchor({ ...base(), ...overrides });
+
+describe('CDEB v4 decision audit anchor', () => {
+  it('is deterministic for the same source and stable across key order', () => {
+    const input = base();
+    const first = computeDecisionAnchor(input);
+    expect(computeDecisionAnchor({ ...input })).toBe(first);
+    // A different insertion order is the same decision.
+    const reordered = Object.fromEntries(
+      Object.entries(input).reverse(),
+    ) as unknown as DecisionAnchorInput;
+    expect(computeDecisionAnchor(reordered)).toBe(first);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('changes when any load-bearing field changes, and for every field', () => {
+    const original = computeDecisionAnchor(base());
+    const mutations: Record<keyof DecisionAnchorInput, unknown> = {
+      repository_id: 'agent-operator-score',
+      snapshot_sha: 'a'.repeat(40),
+      source_commit_sha: 'b'.repeat(40),
+      storage_kind: 'git-note',
+      storage_locator: 'refs/notes/commitlore',
+      decision_ordinal: 1,
+      normalized_decision_sha256: decisionTextSha256('the seeder may write outside the target directory'),
+      normalized_reason_sha256: decisionTextSha256('a different reason entirely'),
+      path_scope: ['src/seed.ts'],
+      lifecycle: 'superseded',
+    };
+    // Every declared field is exercised: a field added to the type without a
+    // mutation here fails this test rather than going unchecked.
+    expect(Object.keys(mutations).sort()).toEqual([...DECISION_ANCHOR_FIELDS].sort());
+    for (const [field, value] of Object.entries(mutations)) {
+      expect(anchorWith({ [field]: value })).not.toBe(original);
+    }
+  });
+
+  it('treats path scope as a set: reordering is the same scope, membership is not', () => {
+    const original = computeDecisionAnchor(base());
+    expect(anchorWith({ path_scope: ['src/paths.ts', 'src/seed.ts'] })).toBe(original);
+    expect(anchorWith({ path_scope: ['src/paths.ts', 'src/seed.ts', 'src/cli.ts'] })).not.toBe(original);
+    expect(anchorWith({ path_scope: ['src/paths.ts'] })).not.toBe(original);
+  });
+
+  it('normalizes whitespace in decision text but nothing else', () => {
+    expect(normalizeDecisionText('  a  decision\n\tstated  ')).toBe('a decision stated');
+    expect(decisionTextSha256('a decision\nstated')).toBe(decisionTextSha256('a decision stated'));
+    expect(decisionTextSha256('A decision stated')).not.toBe(decisionTextSha256('a decision stated'));
+    expect(decisionTextSha256('a decision stated.')).not.toBe(decisionTextSha256('a decision stated'));
+    expect(decisionTextSha256('stated a decision')).not.toBe(decisionTextSha256('a decision stated'));
+  });
+
+  it('refuses malformed, incomplete and over-complete input rather than hashing it', () => {
+    expect(() => computeDecisionAnchor({ ...base(), record_id: 'r-something' })).toThrow(/unknown field\(s\) record_id/);
+    const { lifecycle: _lifecycle, ...withoutLifecycle } = base();
+    expect(() => computeDecisionAnchor(withoutLifecycle)).toThrow(/missing field lifecycle/);
+    expect(() => computeDecisionAnchor({ ...base(), snapshot_sha: 'not-an-oid' })).toThrow(/snapshot_sha must be a 40-character git object id/);
+    expect(() => computeDecisionAnchor({ ...base(), decision_ordinal: -1 })).toThrow(/non-negative integer/);
+    expect(() => computeDecisionAnchor({ ...base(), decision_ordinal: 1.5 })).toThrow(/non-negative integer/);
+    expect(() => computeDecisionAnchor({ ...base(), path_scope: [] })).toThrow(/non-empty array/);
+    expect(() => computeDecisionAnchor({ ...base(), path_scope: ['a', 'a'] })).toThrow(/must not repeat a path/);
+    expect(() => computeDecisionAnchor({ ...base(), lifecycle: 'retired' })).toThrow(/lifecycle must be one of/);
+    expect(() => computeDecisionAnchor({ ...base(), storage_kind: 'database' })).toThrow(/storage_kind must be one of/);
+    expect(() => computeDecisionAnchor('a string')).toThrow(/input must be an object/);
+  });
+
+  it('carries no product identity: a Record-Id is not an input and cannot become one', () => {
+    expect([...DECISION_ANCHOR_FIELDS]).not.toContain('record_id');
+    expect(canonicalDecisionAnchorJson(base())).not.toMatch(/record[_-]?id/i);
+  });
+
+  it('keeps the published schema and the validator describing the same fields', () => {
+    const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8')) as {
+      required: string[];
+      properties: Record<string, unknown>;
+      additionalProperties: boolean;
+    };
+    expect(schema.additionalProperties).toBe(false);
+    expect([...schema.required].sort()).toEqual([...DECISION_ANCHOR_FIELDS].sort());
+    expect(Object.keys(schema.properties).sort()).toEqual([...DECISION_ANCHOR_FIELDS].sort());
+    const ajv = new Ajv2020({ allErrors: true, strict: true });
+    const validate = ajv.compile(schema);
+    expect(validate(base())).toBe(true);
+    expect(validate({ ...base(), record_id: 'r-x' })).toBe(false);
+  });
+
+  it('refuses an anchor that reached an agent-facing payload', () => {
+    const anchor = computeDecisionAnchor(base());
+    const clean = 'Refactor the seeder so relative paths resolve under the target directory.';
+    expect(() => assertNoDecisionAnchorExposure(clean, [anchor], 'task prompt')).not.toThrow();
+    expect(() => assertNoDecisionAnchorExposure(`${clean}\n<!-- ${anchor} -->`, [anchor], 'task prompt'))
+      .toThrow(/decision anchor exposure: anchor [0-9a-f]{12} appears in task prompt/);
+    // A caller that passes something other than an anchor gets a refusal, not a
+    // scan that quietly finds nothing.
+    expect(() => assertNoDecisionAnchorExposure(clean, ['r-seedpath'], 'task prompt'))
+      .toThrow(/not an anchor/);
+  });
+
+  it('binds the whole canonical form: the hash is over the serialization it publishes', () => {
+    const json = canonicalDecisionAnchorJson(base());
+    expect(createHash('sha256').update(json, 'utf8').digest('hex')).toBe(computeDecisionAnchor(base()));
+    expect(json.startsWith('{"decision_ordinal":')).toBe(true);
+    expect(json).not.toContain(' ');
+  });
+});


### PR DESCRIPTION
Stacked on #824.

The v4 estimand is delivery of a prior decision, not delivery of a `Record-Id`, and the oldest decisions in the corpus predate that field entirely — `logic-pro-mcp` has none at all. Something still has to bind a source decision to its gold and to its delivery evidence. This computes that binding from what the frozen snapshot already contains rather than adding anything to it.

`decision_audit_anchor = SHA256(canonical_json(inputs))` over ten fields. It is not a product identifier, it is never written back to any repository, and nothing about it reaches a payload the coding agent can read.

## Three choices worth stating

- The field order is fixed in `DECISION_ANCHOR_FIELDS` rather than taken from the object a caller passes. A field added to the type but not to that list fails a test instead of dropping out of the hash silently.
- An unknown key is refused rather than ignored. It is either a field that belongs in the hash or one that should not exist, and both are worth stopping for.
- `path_scope` is a set. The same two paths in the other order anchor identically; adding or removing one does not.

Decision text is normalized for whitespace only. The same ruling reflowed by a different renderer must anchor the same; different words, different case and different word order must not, because all three carry the judgment being measured.

## Verification

Both typechecks clean, 9 tests pass.

Negative control: removing `lifecycle` from the canonical field list fails 8 of the 9, leaving only the text-normalization case green.