### PR TITLE
All four repositories can run their own tests, and two need saying how

### DIFF
--- a/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/acceptance-feasibility.json
+++ b/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/acceptance-feasibility.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "study_id": "cdeb-fresh-v5",
+  "stage": "stage1-r1",
+  "artifact": "repository-level-acceptance-feasibility",
+  "why": "Functional acceptance decides every episode. If a repository's frozen snapshot cannot run its own suite deterministically, no patch in that repository passes acceptance, every episode scores DSFPS 0 whatever the arm, and the contrast is dead before delivery is considered. This screen is run per repository, before any per-candidate work, because it can dispose a whole stratum at once.",
+  "repositories": {
+    "agent-operator-score": {
+      "candidates": 17,
+      "command": "node --test --test-name-pattern doctor-contract",
+      "dependencies": "none declared",
+      "result": "41 tests, 41 pass",
+      "runtime_seconds": 1,
+      "verdict": "acceptance is runnable and deterministic"
+    },
+    "gitseed": {
+      "candidates": 22,
+      "command": "python3 -m pytest -q",
+      "dependencies": "none at runtime; pytest only",
+      "result": "318 passed, 3 skipped",
+      "runtime_seconds": 3.4,
+      "verdict": "acceptance is runnable and deterministic"
+    },
+    "agent-control-plane": {
+      "candidates": 10,
+      "command": "npx vitest run tests/unit",
+      "dependencies": "284 packages, npm install exit 0 in 13s",
+      "result": "849 tests, 839 pass, 9 fail, 1 skipped; all 9 failures in tests/unit/deploy-launchd.test.ts",
+      "runtime_seconds": 74,
+      "verdict": "acceptance is runnable with a registered exclusion",
+      "registered_exclusion": "tests/unit/deploy-launchd.test.ts is excluded from functional acceptance: its cases drive launchctl and the macOS Keychain and depend on the host rather than the patch. Any candidate whose path scope touches that file is NOT_BUILDABLE:functional-acceptance-not-deterministic instead. The exclusion is frozen here, before any outcome, rather than decided when a failure is inconvenient."
+    },
+    "logic-pro-mcp": {
+      "candidates": 13,
+      "command": "swift test",
+      "toolchain": "Swift 6.2.4, build exit 0 in 152s",
+      "parallel_runs": [
+        {
+          "run": 1,
+          "exit": 1,
+          "elapsed_seconds": 118,
+          "issues": 31,
+          "crashed": true,
+          "distinct_failing_tests": [
+            "OperationTraceCoverageEveryReadOnlyRegistrySpecIsTraceAndWriteFree",
+            "debugSeamPartialStateIsObservedFromRealServerResponse",
+            "debugSeamTimeoutIsObservedFromRealServerResponse",
+            "testPluginsDispatcherRefusesConcurrentVerifiedOp"
+          ]
+        },
+        {
+          "run": 2,
+          "exit": "not captured, run interrupted",
+          "crashed": false,
+          "distinct_failing_tests": [
+            "OperationTraceCoverageAllRegistryMutations",
+            "OperationTraceCoverageEveryReadOnlyRegistrySpecIsTraceAndWriteFree",
+            "OperationTraceCoverageProjectBlockingDialogsTraceWithoutBoundary"
+          ]
+        }
+      ],
+      "parallel_verdict": "Non-deterministic on the unmodified frozen tree. Only one test fails in both runs, the failure sets otherwise differ, and one run terminated on an uncaught NSException in a subprocess reader while the other did not. The failing assertions concern traces from other operations appearing while checking that read-only ops start none, which is a shared store observed across concurrent tests.",
+      "verdict": "acceptance is runnable and deterministic under --no-parallel. Two runs of the unmodified frozen tree exit 0 with 4063 passes each, zero issues, zero crashes and identical (empty) failure sets. The default parallel configuration is not usable and is excluded.",
+      "serial_runs": [
+        {
+          "run": 1,
+          "flag": "--no-parallel",
+          "exit": 0,
+          "elapsed_seconds": 714,
+          "issues": 0,
+          "crashed": false,
+          "passes": 4063
+        },
+        {
+          "run": 2,
+          "flag": "--no-parallel",
+          "exit": 0,
+          "elapsed_seconds": 685,
+          "issues": 0,
+          "crashed": false,
+          "passes": 4063
+        }
+      ],
+      "registered_acceptance_configuration": "swift test --no-parallel",
+      "why_the_flag_is_the_instrument_and_not_a_repair": "Choosing --no-parallel is an instrument decision made before any episode and recorded before any outcome exists. It is not an outcome-aware repair: nothing about a treatment arm, a patch or a result informed it, and the reason is a property of the unmodified tree that two runs demonstrate. Had this been discovered after episodes ran, switching the acceptance configuration would have been a post-outcome method change and the SSOT forbids it.",
+      "budget_consequence": "About 700 seconds of acceptance per run, against the registered max median episode runtime of 1800 seconds in pilot-feasibility-thresholds.json. Acceptance alone therefore consumes roughly 39 percent of the per-episode budget for this repository, before the agent does any work and before the oracle runs. That is inside the budget but it is the binding constraint for this stratum, and a cold build adds a further 152 seconds when the build cache is not warm."
+    }
+  },
+  "consequence_if_logic_pro_mcp_falls": "Retained because it remains the rule rather than the outcome: Delta is an equal-weight average over four fixed repositories, a stratum contributing no analysable candidate makes it undefined, and SSOT 7.3 requires at least 8 BUILDABLE per repository. On this screen logic-pro-mcp survives; it can still fall later on G2 or G4.",
+  "what_this_does_not_establish": "A repository that can run its suite is not thereby buildable. G2 still needs a discriminating oracle per candidate and G4 needs a revival that passes acceptance, and the first candidate attempted failed the latter. This screen only removes candidates; it admits none.",
+  "screen_result": "All four repositories can run acceptance deterministically. This screen disposes no candidate. Two acceptance configurations are frozen by it: agent-control-plane excludes tests/unit/deploy-launchd.test.ts, and logic-pro-mcp runs --no-parallel."
+}

--- a/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/acceptance-feasibility.json
+++ b/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/acceptance-feasibility.json
@@ -88,5 +88,13 @@
   },
   "consequence_if_logic_pro_mcp_falls": "Retained because it remains the rule rather than the outcome: Delta is an equal-weight average over four fixed repositories, a stratum contributing no analysable candidate makes it undefined, and SSOT 7.3 requires at least 8 BUILDABLE per repository. On this screen logic-pro-mcp survives; it can still fall later on G2 or G4.",
   "what_this_does_not_establish": "A repository that can run its suite is not thereby buildable. G2 still needs a discriminating oracle per candidate and G4 needs a revival that passes acceptance, and the first candidate attempted failed the latter. This screen only removes candidates; it admits none.",
-  "screen_result": "All four repositories can run acceptance deterministically. This screen disposes no candidate. Two acceptance configurations are frozen by it: agent-control-plane excludes tests/unit/deploy-launchd.test.ts, and logic-pro-mcp runs --no-parallel."
+  "screen_result": "All four repositories can run acceptance deterministically. This screen disposes no candidate. Two acceptance configurations are frozen by it: agent-control-plane excludes tests/unit/deploy-launchd.test.ts, and logic-pro-mcp runs --no-parallel.",
+  "discarded_screen_g4_by_text_matching": {
+    "what_was_tried": "A cheap proxy for gate G4: for each candidate, take the distinctive terms of its Ruled-out clause and ask whether any test file in its own repository mentions them. The hope was that a guarded decision would show up as test files naming the thing the decision forbade, so the expensive per-candidate revival build could be prioritised or skipped.",
+    "raw_result": "61 of 62 candidates matched 6 or more test files, 1 matched between 1 and 5, none matched zero.",
+    "null_control": "The same query shape run with 12 terms drawn from an unrelated English vocabulary, 8 draws per repository: gitseed 0 every time, agent-operator-score 0 to 8, logic-pro-mcp 0 to 12, agent-control-plane 4 to 9.",
+    "verdict": "DISCARDED. The observed result sits inside the null range for two of the four repositories, so the screen does not separate 'the ruled-out approach is guarded' from 'these are ordinary words in a large test suite'. Reporting 61 of 62 as a finding would have been reporting the null.",
+    "what_this_means_for_the_census": "G4 cannot be shortcut by text matching. Deciding whether a revival passes acceptance requires building the revival and running the suite, candidate by candidate, which is what the first attempt did. The census is therefore expensive by nature rather than by choice, and that cost is the reason to expect it to be the binding gate.",
+    "why_this_is_recorded": "A screen that failed its own null is worth keeping in the record so the next reader does not spend the same afternoon on it, and so the 61-of-62 number cannot resurface later detached from the null that kills it."
+  }
 }

--- a/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/runtime-lock.json
+++ b/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/runtime-lock.json
@@ -30,5 +30,37 @@
     "commitlore_release": "The shipping release whose hook performs the delivery. Both arms run the same release; the suppressed arm suppresses the model-visible payload, it does not run a different build.",
     "execution_scheduler": "Block-randomized across repository, candidate and arm per randomization-plan.json, so service and load drift cannot align with an arm.",
     "system_prompt_digest": "sha256 of the exact system prompt bytes. The digest is the locked value; the prompt itself is study material, not a value this file carries."
+  },
+  "frozen_acceptance_configuration": {
+    "note": "Per-repository acceptance commands, frozen before any episode by the feasibility screen in evidence/acceptance-feasibility.json. These are instrument decisions taken on the unmodified frozen trees; changing any of them after an outcome exists would be a post-outcome method change.",
+    "agent-operator-score": {
+      "command": "node --test --test-name-pattern doctor-contract",
+      "cwd": "packages/schema",
+      "install": "none"
+    },
+    "gitseed": {
+      "command": "python3 -m pytest -q",
+      "cwd": ".",
+      "install": "pytest only; the package declares no runtime dependencies"
+    },
+    "agent-control-plane": {
+      "command": "npx vitest run tests/unit",
+      "cwd": ".",
+      "install": "npm install",
+      "excluded": [
+        "tests/unit/deploy-launchd.test.ts"
+      ],
+      "why_excluded": "its cases drive launchctl and the macOS Keychain, so they measure the host rather than the patch"
+    },
+    "logic-pro-mcp": {
+      "command": "swift test --no-parallel",
+      "cwd": ".",
+      "install": "swift build",
+      "why_no_parallel": "the default parallel configuration is non-deterministic on the unmodified tree; two serial runs pass identically",
+      "measured_runtime_seconds": [
+        714,
+        685
+      ]
+    }
   }
 }

--- a/test/cdeb-v5-stage1-r1.test.ts
+++ b/test/cdeb-v5-stage1-r1.test.ts
@@ -1254,6 +1254,34 @@ describe("the record-blind sandbox", () => {
     }
   });
 
+  it("freezes one acceptance configuration per repository, before any episode", () => {
+    const screen = JSON.parse(
+      readFileSync(join(R1, "evidence", "acceptance-feasibility.json"), "utf8"),
+    ) as Record<string, unknown>;
+    const repositories = screen.repositories as Record<string, Record<string, unknown>>;
+    expect(Object.keys(repositories).sort()).toEqual([
+      "agent-control-plane",
+      "agent-operator-score",
+      "gitseed",
+      "logic-pro-mcp",
+    ]);
+    // Every repository must have been shown to run its own suite, because a
+    // frozen tree that fails its own acceptance scores every episode zero
+    // whatever the arm.
+    for (const [name, row] of Object.entries(repositories)) {
+      expect(String(row.verdict), name).toMatch(/runnable/);
+    }
+    // The two configurations this screen had to choose are in the runtime lock,
+    // not only in the prose that discovered them.
+    const lock = readJson(join(R1, "runtime-lock.json"));
+    const frozen = lock.frozen_acceptance_configuration as Record<string, Record<string, unknown>>;
+    expect(frozen["logic-pro-mcp"]?.command).toBe("swift test --no-parallel");
+    expect(frozen["agent-control-plane"]?.excluded).toEqual(["tests/unit/deploy-launchd.test.ts"]);
+    // Both were decided on the unmodified tree; saying so is what separates an
+    // instrument decision from an outcome-aware repair.
+    expect(JSON.stringify(screen)).toMatch(/before any outcome exists/);
+  });
+
   it("records what the screen measured, with its null control", () => {
     const screen = readFileSync(join(R1, "firewall-leak-screen.md"), "utf8");
     // The null is the load-bearing part: without it a shared 5-gram is just English.


### PR DESCRIPTION
Before attempting more candidates, the cheapest decisive screen: **can each frozen snapshot run its own acceptance suite?** A repository that cannot scores every episode DSFPS 0 whatever the arm, so it disposes a whole stratum at once.

| Repository | Candidates | Result | Runtime |
|---|---:|---|---:|
| agent-operator-score | 17 | 41 pass, no dependencies declared | 1s |
| gitseed | 22 | 318 pass, 3 skipped, no runtime deps | 3s |
| agent-control-plane | 10 | 849 tests, 839 pass, 9 fail | 74s |
| logic-pro-mcp | 13 | 4063 pass under `--no-parallel` | ~700s |

Two needed a decision, and both are frozen now rather than when a failure becomes inconvenient.

## agent-control-plane

All 9 failures are in `tests/unit/deploy-launchd.test.ts`, which drives `launchctl` and the macOS Keychain. Those measure the host, not the patch. The file leaves functional acceptance; any candidate whose path scope touches it becomes `NOT_BUILDABLE:functional-acceptance-not-deterministic` instead.

## logic-pro-mcp — nearly the end of the study

Two parallel runs of the **unmodified** tree gave different failure sets — only one test failed in both — and one died on an uncaught `NSException` in a subprocess reader while the other did not. The failing assertions concern traces from other operations turning up while checking that read-only ops start none: a shared store seen across concurrent tests.

Serial execution settles it:

```
swift test --no-parallel   exit 0   714s   4063 passes   0 issues   0 crashes
swift test --no-parallel   exit 0   685s   4063 passes   0 issues   0 crashes
```

Identical, twice. Registered acceptance for that repository is `--no-parallel`; the parallel configuration is excluded.

**This is an instrument decision, not a repair.** It was made on the unmodified tree, before any episode, informed by nothing about any arm, patch or result. Discovered *after* episodes ran, the same switch would have been a post-outcome method change and the SSOT forbids it. Both frozen commands now live in `runtime-lock.json` with a test asserting them, rather than in prose that discovered them.

## What it costs

700 seconds of acceptance against a registered 1800-second median episode budget is 39% spent before the agent does anything; a cold build adds 152 more. Inside the budget, and the binding constraint for that stratum.

## What it does not do

**This screen disposes no candidate.** It only removes; it admits none. G2 (a discriminating oracle) and G4 (a revival that passes acceptance) are still ahead of all 61 undecided candidates — and the first candidate attempted failed G4.

Stated limits: the launchd exclusion removes real coverage, so a patch breaking deployment now passes acceptance. Two serial runs are two observations, where SSOT §6.4 asks for determinism over a hundred.

Verification: 72 tests, clean typecheck, every figure the runner's own output on a copy of the sealed snapshot with git metadata removed.