### PR TITLE
A guard that blocks on any record at all would have emptied two strata over a template

### DIFF
--- a/bench/cdeb/freeze/need-scout-v5.ts
+++ b/bench/cdeb/freeze/need-scout-v5.ts
@@ -143,10 +143,102 @@ export const materializeRecordBlindTree = (input: {
   }
 };
 
+/** What a sandbox discloses about one specific candidate. */
+export interface CandidateDisclosure {
+  readonly candidate_id: string;
+  /** The candidate's own Record-Id, found verbatim in a working file. */
+  readonly own_record_id_present: boolean;
+  /** Shared 5-word runs between the candidate's ruling and the tree. */
+  readonly ruling_overlap: number;
+  readonly disclosing_paths: readonly string[];
+  /** Record lines belonging to other candidates. Reported, not blocking. */
+  readonly other_record_lines: number;
+}
+
+const shingle = (text: string, size = 5): Set<string> => {
+  const words = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter((word) => word !== "");
+  const out = new Set<string>();
+  for (let index = 0; index + size <= words.length; index += 1) out.add(words.slice(index, index + size).join(" "));
+  return out;
+};
+
+/**
+ * What the firewall is actually for: the author must not see **the decision the
+ * task is being built around**. A record belonging to a different candidate is
+ * a different question -- it matters when that candidate is built, and its own
+ * sandbox check is where it matters.
+ *
+ * `assertSandboxIsRecordBlind` blocks on any record line anywhere, which is the
+ * conservative reading and over-fires badly: two of the four corpus
+ * repositories carry a record line in an unrelated document, so the coarse rule
+ * disposes all 22 gitseed and all 10 agent-control-plane candidates and empties
+ * two fixed strata over documents that disclose nothing about the candidate in
+ * hand. This is the precise reading, and it is stricter where it counts -- it
+ * also catches a tree that discloses the ruling in prose without naming its id.
+ */
+export const disclosureForCandidate = (
+  sandbox: RecordBlindSandbox,
+  candidate: { readonly candidate_id: string; readonly record_id: string | null; readonly ruling_text: string },
+  files: readonly string[],
+): CandidateDisclosure => {
+  const ruling = shingle(candidate.ruling_text);
+  const disclosing: string[] = [];
+  let overlap = 0;
+  let ownId = false;
+  for (const file of files) {
+    if (!LIKELY_TEXT.test(file)) continue;
+    const full = join(sandbox.dir, file);
+    if (!existsSync(full) || statSync(full).size > 2 * 1024 * 1024) continue;
+    const text = readFileSync(full, "utf8");
+    const idHit =
+      candidate.record_id !== null && new RegExp(`Record-Id:\\s*${candidate.record_id}\\b`).test(text);
+    const treeShingles = shingle(text);
+    const shared = [...ruling].filter((run) => treeShingles.has(run)).length;
+    if (idHit || shared > 0) disclosing.push(file);
+    if (idHit) ownId = true;
+    overlap += shared;
+  }
+  return {
+    candidate_id: candidate.candidate_id,
+    own_record_id_present: ownId,
+    ruling_overlap: overlap,
+    disclosing_paths: disclosing,
+    other_record_lines: sandbox.leaks.length,
+  };
+};
+
+/** The per-candidate gate. Blocks on disclosure of *this* candidate's decision. */
+export const assertSandboxBlindForCandidate = (
+  sandbox: RecordBlindSandbox,
+  disclosure: CandidateDisclosure,
+): void => {
+  if (existsSync(join(sandbox.dir, ".git"))) {
+    throw new Error(`need-scout: ${sandbox.repository_id}'s sandbox still has a .git directory`);
+  }
+  if (disclosure.own_record_id_present) {
+    throw new Error(
+      `firewall: ${disclosure.candidate_id}'s own Record-Id appears in ${disclosure.disclosing_paths.join(", ")}, ` +
+        `so the author would read the decision the task is being built around`,
+    );
+  }
+  if (disclosure.ruling_overlap > 0) {
+    throw new Error(
+      `firewall: ${disclosure.candidate_id}'s ruling shares ${String(disclosure.ruling_overlap)} five-word run(s) ` +
+        `with ${disclosure.disclosing_paths.join(", ")}. The id is absent but the decision is legible`,
+    );
+  }
+};
+
 /**
  * A sandbox that still contains record content is not record-blind, whatever
- * was done to the history. This is the check that decides whether the chain may
- * run at all for a repository.
+ * was done to the history. Kept as the repository-level scan: it reports every
+ * record line in the tree, which is worth knowing even when none of them
+ * belongs to the candidate in hand.
  */
 export const assertSandboxIsRecordBlind = (sandbox: RecordBlindSandbox): void => {
   if (existsSync(join(sandbox.dir, ".git"))) {

--- a/test/cdeb-v5-stage1-r1.test.ts
+++ b/test/cdeb-v5-stage1-r1.test.ts
@@ -102,7 +102,9 @@ import {
   selectNeed,
 } from "../bench/cdeb/freeze/task-chain-v5.ts";
 import {
+  assertSandboxBlindForCandidate,
   assertSandboxIsRecordBlind,
+  disclosureForCandidate,
   materializeRecordBlindTree,
   scanForRecordLeaks,
 } from "../bench/cdeb/freeze/need-scout-v5.ts";
@@ -1245,6 +1247,60 @@ describe("the record-blind sandbox", () => {
       ).toThrow(/not the frozen/);
     } finally {
       rmSync(source.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("separates a record that belongs to this candidate from one that does not", () => {
+    const sandbox = {
+      dir: mkdtempSync(join(tmpdir(), "cdeb-disc-")),
+      repository_id: "gitseed",
+      snapshot_commit: "0".repeat(40),
+      tree_digest: "0".repeat(64),
+      file_count: 2,
+      leaks: [{ path: "docs/adr/ADR-0008.md", marker: "Record-Id", line: "Record-Id: r-gsf501" }],
+    };
+    try {
+      // A document carrying somebody else's decision. It is reported, and it is
+      // not this candidate's; blocking on it would empty two fixed strata over
+      // documents that disclose nothing about the candidate in hand.
+      writeFileSync(join(sandbox.dir, "ADR-0008.md"), "Record-Id: r-gsf501\nthe python floor moves to 3.9\n", "utf8");
+      const clean = disclosureForCandidate(
+        sandbox,
+        { candidate_id: "v4-mine", record_id: "r-gsb108", ruling_text: "adding coverage gates or a badge" },
+        ["ADR-0008.md"],
+      );
+      expect(clean.own_record_id_present).toBe(false);
+      expect(clean.ruling_overlap).toBe(0);
+      expect(clean.other_record_lines).toBe(1);
+      expect(() => {
+        assertSandboxBlindForCandidate(sandbox, clean);
+      }).not.toThrow();
+
+      // The candidate's own id in the tree is a block.
+      writeFileSync(join(sandbox.dir, "mine.md"), "Record-Id: r-gsb108\n", "utf8");
+      const owned = disclosureForCandidate(
+        sandbox,
+        { candidate_id: "v4-mine", record_id: "r-gsb108", ruling_text: "adding coverage gates or a badge" },
+        ["ADR-0008.md", "mine.md"],
+      );
+      expect(() => {
+        assertSandboxBlindForCandidate(sandbox, owned);
+      }).toThrow(/own Record-Id appears/);
+
+      // And so is the ruling in prose without its id, which the coarse scan
+      // cannot see at all.
+      writeFileSync(join(sandbox.dir, "prose.md"), "we considered adding coverage gates or a badge and declined\n", "utf8");
+      const legible = disclosureForCandidate(
+        sandbox,
+        { candidate_id: "v4-mine", record_id: null, ruling_text: "adding coverage gates or a badge" },
+        ["prose.md"],
+      );
+      expect(legible.ruling_overlap).toBeGreaterThan(0);
+      expect(() => {
+        assertSandboxBlindForCandidate(sandbox, legible);
+      }).toThrow(/the decision is legible/);
+    } finally {
+      rmSync(sandbox.dir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
The firewall gate I wrote blocks a sandbox containing **any** CommitLore record line. Running it for the first real candidate showed what that costs.

Two of the four corpus repositories carry a record line in an unrelated document, so the rule disposes **all 22 gitseed and all 10 agent-control-plane candidates**, empties two of four fixed strata, and makes `Delta` undefined — over documents that disclose nothing about the candidate in hand.

## What the leaks actually are

For candidate `v4-377f04276465b59d`:

| File | Record ids | |
|---|---|---|
| `AGENTS.md` | `r-<6+` | a format placeholder |
| `docs/adr/ADR-0008-…md` | `r-enadr17`, `r-gsf501` | two *other* candidates |

Its own record is `r-gsb108`, which appears nowhere, and neither file mentions coverage or a badge — what it ruled out. **The sandbox is blind with respect to this candidate, and the coarse rule cannot tell.**

## The change

The gate now says what the firewall is for: the author must not see **the decision the task is being built around**. Another candidate's record is a different question, and its own sandbox check is where that question gets asked.

**The precise gate is stricter where it counts.** It blocks on the candidate's own `Record-Id`, *and* it blocks when the ruling is legible in prose without its id — which the coarse scan cannot see at all, because it looks for trailer keys rather than for the decision.

The repository-wide scan stays, demoted to a reported observation. Two record lines in gitseed's tree is worth knowing even when neither belongs to the candidate being built.

## Limits

- The precise gate reads working files. A ruling paraphrased with no shared five-word run is invisible to it, exactly as the earlier leak screen was.
- This narrows what *blocks*. The wider question — whether seeing any record primes an author about how this repository records decisions — is real, unmeasured, and not addressed here.

Verification: 73 tests, clean typecheck. The gate is tested on three fixtures — another candidate's record which must not block, this candidate's own id which must, and the ruling in prose without an id which must. Candidate 4's disclosure was computed against the real sandbox and is zero on both blocking measures.