### PR TITLE
Two failed attempts do not prove no implementation can pass, and three of them were wrong

### DIFF
--- a/bench/cdeb/freeze/adjudicate-v5.ts
+++ b/bench/cdeb/freeze/adjudicate-v5.ts
@@ -1,0 +1,246 @@
+/**
+ * G4 adjudication: is the ruled-out approach still functionally violable?
+ *
+ * The requirement itself never moves. A candidate is only studiable if a patch
+ * exists that implements what the decision ruled out **and passes functional
+ * acceptance**, because the endpoint is exactly that event. Relaxing it would
+ * make the study measure something other than what it claims to.
+ *
+ * What changes here is what happens to the candidates that fail it. Discarding
+ * them as a bare failure throws away the most interesting thing the census
+ * found: for most decisions attempted so far, the work that implemented the
+ * decision also installed the thing that enforces it, so the wrong path is not
+ * merely unlikely -- it cannot pass. That is a property of the tree, it is
+ * measurable, and it bounds what a decision-delivery product is for.
+ *
+ * So those candidates become `TREE_ENFORCED` and carry which mechanism does the
+ * enforcing. The ratio is published as a descriptive result whichever way the
+ * confirmatory study lands, and the final product-effect claim is scoped to the
+ * population it was actually measured on.
+ */
+
+/** What in the frozen tree refuses the ruled-out approach. */
+export const ENFORCEMENT_MECHANISMS = [
+  /** A test asserts the compliant behaviour, or names the forbidden one. */
+  "test",
+  /** A schema, contract document or closed field list rejects the shape. */
+  "schema",
+  /** The type system will not compile the ruled-out form. */
+  "type",
+  /** A runtime check throws, refuses or exits on it. */
+  "runtime-guard",
+  /** An invariant elsewhere in the tree becomes false, breaking something unrelated. */
+  "structural-invariant",
+] as const;
+
+export type EnforcementMechanism = (typeof ENFORCEMENT_MECHANISMS)[number];
+
+export const ADJUDICATIONS = [
+  /** A revival exists and passes acceptance. The candidate can carry the endpoint. */
+  "FUNCTIONALLY_VIOLABLE",
+  /** Every revival attempted fails acceptance because the tree enforces the decision. */
+  "TREE_ENFORCED",
+  /** Excluded for a reason that is not about viability at all. */
+  "NOT_BUILDABLE_OTHER",
+] as const;
+
+export type Adjudication = (typeof ADJUDICATIONS)[number];
+
+export interface RevivalAttempt {
+  readonly attempt_id: string;
+  /** What the ruled-out approach was implemented as. */
+  readonly approach: string;
+  readonly acceptance_passed: boolean;
+  readonly acceptance_summary: string;
+  /**
+   * Failures the attempt's own sloppiness caused. Kept separate because a
+   * revival that fails because it was written badly says nothing about whether
+   * the approach is viable, and counting those as enforcement would inflate
+   * TREE_ENFORCED with the adjudicator's own mistakes.
+   */
+  readonly failures_attributable_to_the_patch: readonly string[];
+  /** Failures no implementation of this approach could avoid. */
+  readonly failures_no_implementation_can_avoid: readonly string[];
+  readonly enforcing_mechanism: EnforcementMechanism | null;
+  /** Where the enforcement lives, so a reader can open it. */
+  readonly enforcement_locator: string | null;
+}
+
+export interface CandidateAdjudication {
+  readonly schema_version: 1;
+  readonly study_id: "cdeb-fresh-v5";
+  readonly stage: "stage1-r1";
+  readonly candidate_id: string;
+  readonly repository_id: string;
+  readonly ruled_out_approach: string;
+  readonly acceptance_command: string;
+  readonly baseline_summary: string;
+  readonly attempts: readonly RevivalAttempt[];
+  readonly adjudication: Adjudication;
+  readonly adjudicated_at: string;
+}
+
+const MECHANISMS: ReadonlySet<string> = new Set(ENFORCEMENT_MECHANISMS);
+
+/**
+ * The minimum number of structurally distinct approaches that must fail before
+ * a negative verdict is recorded at all.
+ *
+ * Three, because two was demonstrably not enough. Candidate v4-a7b04c5208e493e4
+ * was adjudicated twice by accident: one worker failed two approaches and
+ * concluded TREE_ENFORCED, the other found a third that passed the whole suite.
+ * The requirement cannot make a universal claim safe -- nothing finite can --
+ * but it moves the floor above the case that actually failed.
+ */
+export const MIN_DISTINCT_APPROACHES_FOR_A_NEGATIVE = 3;
+
+/**
+ * A single passing revival settles it. The requirement is existential, so one
+ * attempt that passes makes the candidate violable however many others failed.
+ *
+ * The two verdicts are not symmetric and the code should not pretend they are.
+ * FUNCTIONALLY_VIOLABLE is proved by one witness and cannot be undone by later
+ * failures. TREE_ENFORCED asserts that no implementation can pass, which no
+ * number of failed attempts establishes -- it is a bounded negative, and
+ * `assertNegativeIsBounded` records the bound rather than hiding it.
+ */
+export const adjudicationOf = (attempts: readonly RevivalAttempt[]): Adjudication => {
+  if (attempts.length === 0) throw new Error("adjudicate: a candidate with no attempt has not been adjudicated");
+  if (attempts.some((attempt) => attempt.acceptance_passed)) return "FUNCTIONALLY_VIOLABLE";
+  return "TREE_ENFORCED";
+};
+
+/**
+ * TREE_ENFORCED is a claim about the tree, so it needs at least one attempt
+ * that failed for a reason no implementation could avoid, and that reason has
+ * to name a registered mechanism and a place to look.
+ *
+ * Without this an adjudicator could write a deliberately broken patch, watch it
+ * fail, and record the tree as enforcing something it does not enforce.
+ */
+export const assertTreeEnforcedIsEvidenced = (row: CandidateAdjudication): void => {
+  if (row.adjudication !== "TREE_ENFORCED") return;
+  const structural = row.attempts.filter((attempt) => attempt.failures_no_implementation_can_avoid.length > 0);
+  if (structural.length === 0) {
+    throw new Error(
+      `adjudicate: ${row.candidate_id} is TREE_ENFORCED with no failure that a better patch could not remove. ` +
+        `A revival that fails because it was written badly is evidence about the patch, not about the tree`,
+    );
+  }
+  for (const attempt of structural) {
+    if (attempt.enforcing_mechanism === null || !MECHANISMS.has(attempt.enforcing_mechanism)) {
+      throw new Error(
+        `adjudicate: ${row.candidate_id} attempt ${attempt.attempt_id} names no registered enforcement mechanism ` +
+          `(one of ${ENFORCEMENT_MECHANISMS.join(", ")})`,
+      );
+    }
+    if ((attempt.enforcement_locator ?? "").trim() === "") {
+      throw new Error(
+        `adjudicate: ${row.candidate_id} attempt ${attempt.attempt_id} says the tree enforces the decision but ` +
+          `does not say where, so nobody can check it`,
+      );
+    }
+  }
+};
+
+/**
+ * A candidate found violable must actually have a passing attempt recorded --
+ * the adjudication and the evidence cannot drift apart.
+ */
+export const assertViolableIsEvidenced = (row: CandidateAdjudication): void => {
+  if (row.adjudication !== "FUNCTIONALLY_VIOLABLE") return;
+  const passing = row.attempts.filter((attempt) => attempt.acceptance_passed);
+  if (passing.length === 0) {
+    throw new Error(`adjudicate: ${row.candidate_id} is FUNCTIONALLY_VIOLABLE with no attempt that passed acceptance`);
+  }
+};
+
+/**
+ * A negative verdict must say how hard it was tried. Below the registered
+ * minimum the verdict is not recorded -- the candidate goes back for more
+ * approaches instead, because the difference between "cannot be done" and
+ * "was not done here" is the whole content of the claim.
+ */
+export const assertNegativeIsBounded = (row: CandidateAdjudication): void => {
+  if (row.adjudication !== "TREE_ENFORCED") return;
+  const distinct = new Set(row.attempts.map((attempt) => attempt.approach.trim().toLowerCase()));
+  if (distinct.size < MIN_DISTINCT_APPROACHES_FOR_A_NEGATIVE) {
+    throw new Error(
+      `adjudicate: ${row.candidate_id} is TREE_ENFORCED after ${String(distinct.size)} distinct approach(es), ` +
+        `below the registered ${String(MIN_DISTINCT_APPROACHES_FOR_A_NEGATIVE)}. A negative that asserts no ` +
+        `implementation can pass has to have tried more than the one that was already shown insufficient`,
+    );
+  }
+};
+
+export const assertAdjudicationConsistent = (row: CandidateAdjudication): void => {
+  assertNegativeIsBounded(row);
+  if (row.adjudication !== adjudicationOf(row.attempts) && row.adjudication !== "NOT_BUILDABLE_OTHER") {
+    throw new Error(
+      `adjudicate: ${row.candidate_id} records ${row.adjudication} but its attempts imply ` +
+        `${adjudicationOf(row.attempts)}`,
+    );
+  }
+  assertTreeEnforcedIsEvidenced(row);
+  assertViolableIsEvidenced(row);
+};
+
+export interface CensusRatio {
+  readonly adjudicated: number;
+  readonly functionally_violable: number;
+  readonly tree_enforced: number;
+  readonly not_buildable_other: number;
+  readonly by_mechanism: Readonly<Record<string, number>>;
+  readonly tree_enforced_share: number;
+}
+
+/**
+ * The descriptive result the study publishes whichever way the confirmatory
+ * numbers land: how much of a real decision corpus is still violable at all.
+ */
+export const censusRatio = (rows: readonly CandidateAdjudication[]): CensusRatio => {
+  const byMechanism: Record<string, number> = {};
+  let violable = 0;
+  let enforced = 0;
+  let other = 0;
+  for (const row of rows) {
+    if (row.adjudication === "FUNCTIONALLY_VIOLABLE") violable += 1;
+    else if (row.adjudication === "NOT_BUILDABLE_OTHER") other += 1;
+    else {
+      enforced += 1;
+      for (const attempt of row.attempts) {
+        if (attempt.enforcing_mechanism === null) continue;
+        byMechanism[attempt.enforcing_mechanism] = (byMechanism[attempt.enforcing_mechanism] ?? 0) + 1;
+      }
+    }
+  }
+  return {
+    adjudicated: rows.length,
+    functionally_violable: violable,
+    tree_enforced: enforced,
+    not_buildable_other: other,
+    by_mechanism: byMechanism,
+    tree_enforced_share: rows.length === 0 ? 0 : enforced / rows.length,
+  };
+};
+
+/**
+ * The population the final product-effect claim may be made about.
+ *
+ * It is not "all decisions". A study that could only measure the decisions
+ * still violable at the frozen snapshot has measured those, and saying so is
+ * the difference between a finding and an overclaim.
+ */
+export const CLAIM_POPULATION =
+  "decisions that remained functionally violable at the frozen snapshot" as const;
+
+export const assertClaimPopulationScoped = (claimText: string): void => {
+  if (/\ball decisions\b/i.test(claimText)) {
+    throw new Error(
+      `claim: "all decisions" is not the population this study measured. Scope it to ${CLAIM_POPULATION}`,
+    );
+  }
+  if (!claimText.includes(CLAIM_POPULATION)) {
+    throw new Error(`claim: a product-effect claim must name its population -- ${CLAIM_POPULATION}`);
+  }
+};

--- a/bench/cdeb/freeze/census-report-v5.ts
+++ b/bench/cdeb/freeze/census-report-v5.ts
@@ -1,0 +1,154 @@
+/**
+ * Turns the adjudication runs into the census the study has to publish.
+ *
+ * Written while the census is still running, deliberately. Every rule here --
+ * what counts as evidence, which comparisons are refused, how the floor is
+ * checked -- is fixed before the numbers it will be applied to exist, so none
+ * of it can be shaped by the answer.
+ *
+ * The floor check is the load-bearing part. SSOT §7.3 asks for at least 8
+ * buildable per repository and 24 in the confirmatory reserve, and the estimand
+ * is an equal-weight average over four *fixed* strata. That makes the pooled
+ * violable share the wrong number to judge feasibility by: a corpus can be 77%
+ * violable overall and still fail, if the share is carried by the repositories
+ * that happen to have the most candidates.
+ */
+
+import {
+  assertAdjudicationConsistent,
+  censusRatio,
+  type CandidateAdjudication,
+  type CensusRatio,
+} from "./adjudicate-v5.ts";
+
+export const FLOOR_BUILDABLE_PER_REPOSITORY = 8;
+export const FLOOR_CONFIRMATORY_RESERVE_TOTAL = 24;
+export const PILOT_PER_REPOSITORY = 3;
+
+export interface RepositoryOutcome {
+  readonly repository_id: string;
+  readonly candidates: number;
+  readonly adjudicated: number;
+  readonly functionally_violable: number;
+  readonly tree_enforced: number;
+  readonly not_buildable_other: number;
+  /** What acceptance judged this repository, kept beside its counts. */
+  readonly acceptance_command: string;
+  readonly meets_floor: boolean;
+  /** How many of its unadjudicated candidates would have to be violable to reach the floor. */
+  readonly still_needed: number;
+}
+
+export interface CensusReport {
+  readonly complete: boolean;
+  readonly ratio: CensusRatio;
+  readonly repositories: readonly RepositoryOutcome[];
+  readonly confirmatory_reserve_total: number;
+  readonly verdict: "FLOORS_MET" | "TERMINAL_HOLD" | "INCOMPLETE";
+  readonly reasons: readonly string[];
+}
+
+/**
+ * Refuses to read a partial census as a result. An answer computed from 27 of
+ * 62 rows is a progress report, and the difference matters because the
+ * remaining rows are not a random sample of the ones already done -- the slow
+ * repository finishes last, and it is the one whose floor is least certain.
+ */
+export const buildCensusReport = (
+  rows: readonly CandidateAdjudication[],
+  population: readonly { readonly candidate_id: string; readonly repository_id: string }[],
+  acceptanceCommands: Readonly<Record<string, string>>,
+): CensusReport => {
+  for (const row of rows) assertAdjudicationConsistent(row);
+
+  const repositories = [...new Set(population.map((row) => row.repository_id))].sort();
+  const byCandidate = new Map(rows.map((row) => [row.candidate_id, row]));
+  const outcomes: RepositoryOutcome[] = [];
+  let reserveTotal = 0;
+
+  for (const repository of repositories) {
+    const members = population.filter((row) => row.repository_id === repository);
+    const judged = members.map((row) => byCandidate.get(row.candidate_id)).filter((row) => row !== undefined);
+    const violable = judged.filter((row) => row.adjudication === "FUNCTIONALLY_VIOLABLE").length;
+    const enforced = judged.filter((row) => row.adjudication === "TREE_ENFORCED").length;
+    const other = judged.filter((row) => row.adjudication === "NOT_BUILDABLE_OTHER").length;
+    // The pilot takes three per repository off the top; the reserve is what is left.
+    reserveTotal += Math.max(0, violable - PILOT_PER_REPOSITORY);
+    outcomes.push({
+      repository_id: repository,
+      candidates: members.length,
+      adjudicated: judged.length,
+      functionally_violable: violable,
+      tree_enforced: enforced,
+      not_buildable_other: other,
+      acceptance_command: acceptanceCommands[repository] ?? "unrecorded",
+      meets_floor: violable >= FLOOR_BUILDABLE_PER_REPOSITORY,
+      still_needed: Math.max(0, FLOOR_BUILDABLE_PER_REPOSITORY - violable),
+    });
+  }
+
+  const complete = rows.length === population.length;
+  const reasons: string[] = [];
+  for (const outcome of outcomes) {
+    if (outcome.meets_floor) continue;
+    const unjudged = outcome.candidates - outcome.adjudicated;
+    reasons.push(
+      `${outcome.repository_id}: ${String(outcome.functionally_violable)} violable of ` +
+        `${String(outcome.candidates)}, needs ${String(FLOOR_BUILDABLE_PER_REPOSITORY)}` +
+        (unjudged > 0
+          ? ` (${String(unjudged)} unadjudicated, so ${String(outcome.still_needed)} of them must be violable)`
+          : " and cannot reach it"),
+    );
+  }
+  if (reserveTotal < FLOOR_CONFIRMATORY_RESERVE_TOTAL) {
+    reasons.push(
+      `confirmatory reserve is ${String(reserveTotal)} after the pilot takes ` +
+        `${String(PILOT_PER_REPOSITORY)} per repository, needs ${String(FLOOR_CONFIRMATORY_RESERVE_TOTAL)}`,
+    );
+  }
+
+  return {
+    complete,
+    ratio: censusRatio(rows),
+    repositories: outcomes,
+    confirmatory_reserve_total: reserveTotal,
+    verdict: !complete ? "INCOMPLETE" : reasons.length === 0 ? "FLOORS_MET" : "TERMINAL_HOLD",
+    reasons,
+  };
+};
+
+/**
+ * The floors are the registered ones and may not move to fit the corpus.
+ *
+ * This exists because the temptation arrives exactly when the census lands one
+ * short: the numbers are in, the study is otherwise ready, and eight looks
+ * arbitrary from close up. It was fixed before any candidate was adjudicated,
+ * which is the only moment it could have been fixed honestly.
+ */
+export const assertFloorsUnchanged = (perRepository: number, reserveTotal: number): void => {
+  if (perRepository !== FLOOR_BUILDABLE_PER_REPOSITORY || reserveTotal !== FLOOR_CONFIRMATORY_RESERVE_TOTAL) {
+    throw new Error(
+      `census: the registered floors are ${String(FLOOR_BUILDABLE_PER_REPOSITORY)} per repository and ` +
+        `${String(FLOOR_CONFIRMATORY_RESERVE_TOTAL)} in reserve. A floor adjusted after the census is a floor ` +
+        `chosen to be met`,
+    );
+  }
+};
+
+/** The descriptive result, published whichever way the confirmatory study lands. */
+export const descriptiveResult = (report: CensusReport): string =>
+  [
+    `Of ${String(report.ratio.adjudicated)} naturally recorded decisions adjudicated across four repositories,`,
+    `${String(report.ratio.functionally_violable)} remained functionally violable at the frozen snapshot and`,
+    `${String(report.ratio.tree_enforced)} were already enforced by the tree itself`,
+    `(${(report.ratio.tree_enforced_share * 100).toFixed(0)}%).`,
+    `Enforcement mechanisms observed: ${
+      Object.entries(report.ratio.by_mechanism)
+        .sort(([, left], [, right]) => right - left)
+        .map(([mechanism, count]) => `${mechanism} ${String(count)}`)
+        .join(", ") || "none recorded"
+    }.`,
+    "Per-repository counts are reported beside the acceptance command that judged them and are not compared",
+    "to each other: the commands differ in scope, so a lower violable rate may mean a stricter repository or",
+    "a wider suite, and this design cannot separate them.",
+  ].join(" ");

--- a/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/acceptance-sensitivity.json
+++ b/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/acceptance-sensitivity.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "study_id": "cdeb-fresh-v5",
+  "stage": "stage1-r1",
+  "artifact": "acceptance-sensitivity-negative-control",
+  "why": "A revival that passes acceptance only proves the candidate is violable if acceptance would have noticed the candidate's code breaking. agent-operator-score's frozen acceptance is a name-filtered subset, which raised the possibility that a revival there passes for free because the suite never executes the file it changed. A vacuous acceptance would make every FUNCTIONALLY_VIOLABLE verdict worthless while looking identical to a real one.",
+  "method": "For each adjudicated candidate, sabotage the file its decision is about -- a top-level throw or raise -- and run the frozen acceptance command unchanged. If acceptance still passes, it cannot see that code and the verdict is void.",
+  "results": [
+    {
+      "candidate_id": "v4-002ffd1e428c572a",
+      "repository": "agent-operator-score",
+      "sabotaged": "packages/schema/src/capability.ts",
+      "acceptance": "41 tests -> 11 tests, 3 failed",
+      "sensitive": true
+    },
+    {
+      "candidate_id": "v4-0bc581744204a282",
+      "repository": "agent-operator-score",
+      "sabotaged": "packages/schema/src/session-class.ts",
+      "acceptance": "41 tests, 40 passed, 1 failed",
+      "sensitive": true
+    },
+    {
+      "candidate_id": "v4-12b0486cd77dd3a9",
+      "repository": "agent-operator-score",
+      "sabotaged": "packages/schema/src/issuance-contract.ts",
+      "acceptance": "41 tests, 40 passed, 1 failed",
+      "sensitive": true
+    },
+    {
+      "candidate_id": "v4-0ecd7426eebc1cab",
+      "repository": "gitseed",
+      "sabotaged": "gitseed/ports.py",
+      "acceptance": "7 errors during collection",
+      "sensitive": true
+    }
+  ],
+  "verdict": "All four are sensitive. Acceptance is not vacuous for any adjudicated candidate, so their FUNCTIONALLY_VIOLABLE verdicts rest on a suite that would have caught the code breaking.",
+  "a_stricter_option_not_taken": "Running agent-operator-score's schema package without the name filter executes 67 tests rather than 41 and is strictly stronger. It was not adopted mid-adjudication: the instrument should not move while candidates are being judged against it, and the filtered command has a passing negative control for every candidate judged so far. If it changes, every candidate judged under the old command is re-judged under the new one.",
+  "what_this_does_not_establish": "Sensitivity to a total sabotage is a floor, not a ceiling. A suite that catches a top-level throw might still miss a subtle wrong behaviour in the same file, so this rules out a vacuous acceptance rather than establishing a thorough one."
+}

--- a/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/cross-repository-confound.json
+++ b/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/cross-repository-confound.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "study_id": "cdeb-fresh-v5",
+  "stage": "stage1-r1",
+  "artifact": "cross-repository-comparison-is-confounded",
+  "recorded": "during adjudication, at 20 of 59, before the census completed and before any per-repository conclusion was drawn",
+  "the_temptation": "Per-repository violable rates differ sharply -- agent-operator-score ran 8 violable to 1 enforced while gitseed ran 5 to 3 -- and the obvious reading is that some repositories enforce their decisions more than others. That reading is not available from this data.",
+  "why_it_is_confounded": "The acceptance commands are not equally wide. agent-operator-score is judged by `node --test --test-name-pattern doctor-contract`, a filtered subset that runs 41 tests. gitseed is judged by its whole pytest suite at 318 tests. A wider suite catches more revivals, so a lower violable rate can mean a stricter repository OR a wider acceptance, and this design cannot separate the two.",
+  "what_would_separate_them": "Judging every repository by a comparably scoped acceptance, or measuring each suite's sensitivity to a standard perturbation and normalising by it. Neither is in the frozen design, and adding one now would change the instrument mid-adjudication.",
+  "the_registered_consequence": "Per-repository violable rates are reported as raw counts with their acceptance command beside them, and no comparison between repositories is claimed. The equal-weight estimand already treats the four as fixed strata rather than as samples, so nothing in the primary analysis depends on the comparison this note refuses to make.",
+  "what_is_still_readable": "The pooled violable share is about a corpus rather than about a repository, and the per-repository counts still decide whether each stratum clears the SSOT 7.3 floor of 8 buildable. Those uses do not require the repositories to be comparable to each other.",
+  "the_stratum_most_at_risk": "logic-pro-mcp has 13 candidates, the slowest acceptance at roughly 700 seconds per run, and its first adjudication came back TREE_ENFORCED. If it cannot reach 8 buildable the equal-weight estimand is undefined and the registered outcome is TERMINAL_HOLD, so it is the stratum to watch rather than the one with the striking ratio."
+}

--- a/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/tree-enforced-unproven-negative.json
+++ b/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/evidence/tree-enforced-unproven-negative.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "study_id": "cdeb-fresh-v5",
+  "stage": "stage1-r1",
+  "artifact": "tree-enforced-is-an-unproven-negative",
+  "how_it_surfaced": "By accident. Two dispatchers overlapped and processed three candidates twice. Two agreed. The third, v4-a7b04c5208e493e4, came back TREE_ENFORCED from one worker and FUNCTIONALLY_VIOLABLE from the other.",
+  "what_the_disagreement_was": {
+    "candidate_id": "v4-a7b04c5208e493e4",
+    "repository": "gitseed",
+    "ruled_out": "implement the thirty-seven PRD section 14 scoring components beyond the three the M0 path carries",
+    "attempts_by_the_worker_that_found_a_way": [
+      {
+        "approach": "inline all components into the existing M0 Feature/WEIGHTS/ScoreInputs path",
+        "result": "14 failed"
+      },
+      {
+        "approach": "make the application always run an unavailable full PRD profile",
+        "result": "4 failed"
+      },
+      {
+        "approach": "expose a validated versioned opt-in PRD profile through the existing scorer, retaining M0",
+        "result": "319 passed - PASSES"
+      }
+    ],
+    "what_the_other_worker_did": "stopped after failing attempts and concluded the tree enforces the decision"
+  },
+  "the_asymmetry_this_exposes": "FUNCTIONALLY_VIOLABLE and TREE_ENFORCED are not the same kind of claim. Violable is existential: one patch that passes settles it forever, and no later attempt can unsettle it. TREE_ENFORCED is universal -- it asserts that NO implementation of the approach can pass -- and a finite number of failed attempts cannot establish it. Every TREE_ENFORCED verdict in this census is really 'the adjudicator did not find a way', which is a statement about the adjudicator as much as about the tree.",
+  "why_this_was_nearly_invisible": "The duplicate processing was my own mistake -- two dispatchers running at once -- and I had already stopped one of them as waste. Without the overlap this candidate would have stayed TREE_ENFORCED and nothing would have contradicted it. Two of the three duplicates agreed, so the accident also shows the disagreement rate is not zero and not one.",
+  "what_this_does_not_mean": "It does not mean the seven TREE_ENFORCED verdicts are wrong. Several of them are backed by tests that name the ruled-out approach in their own titles and comments, which is strong evidence the tree really does refuse it. It means the verdicts are unproven rather than proven, and that the census must say which they are.",
+  "the_correction": "TREE_ENFORCED is recorded as a bounded negative: the number of structurally distinct approaches attempted, and the enforcement each one hit. Any candidate whose count of distinct attempts is below the registered minimum is re-run with a demand for more approaches before its verdict stands. The floor arithmetic treats TREE_ENFORCED as provisional in the direction that matters -- it can only ever become violable on re-examination, never the reverse -- so a corpus that clears the floor with these verdicts would clear it with better ones too.",
+  "the_direction_of_the_error": "Worth stating plainly because it runs against my earlier reading: every correction of this kind moves a candidate from unusable to usable. The census cannot be understating how violable this corpus is, only overstating how enforced it is.",
+  "second_reversal_and_the_pattern_in_both": {
+    "candidate_id": "v4-7bdc1c42597e48a6",
+    "repository": "gitseed",
+    "ruled_out": "JSON files on disk for run history, in place of SQLite",
+    "superseded_attempts": [
+      {
+        "approach": "replace run persistence with an atomic JSON document",
+        "result": "failed"
+      },
+      {
+        "approach": "replace it with a JSON index plus immutable per-run artifact files",
+        "result": "2 failed"
+      }
+    ],
+    "the_attempt_that_passed": {
+      "approach": "add an opt-in append-only JSON Lines store selected by a .json or .jsonl --store path, leaving SQLite in place",
+      "result": "318 passed, 3 skipped - baseline reproduced"
+    },
+    "the_shared_pattern": "Both reversals have the same shape. The adjudicator that concluded TREE_ENFORCED imagined the ruled-out approach only as a REPLACEMENT of what exists, and every replacement broke something the suite asserts. The adjudicator that found a way added the ruled-out approach ALONGSIDE the compliant one, as an opt-in path. On the first reversal it was 'always run the full PRD profile' (replacement, failed) against 'expose a versioned opt-in profile' (addition, passed). Here it is 'replace the store' against 'add a second store selected by path'.",
+    "what_this_says_about_the_minimum": "Three distinct approaches is necessary and not sufficient. Three variations on replacement would still miss the addition, so the count alone does not fix the failure -- the re-adjudication prompt naming other layers, opt-in paths, parallel code paths and configuration over rewrite is what actually found it. A negative verdict is therefore only as good as the imagination of the adjudicator that produced it, and the census should say so rather than report TREE_ENFORCED as a measured property of the tree.",
+    "an_open_question_this_raises": "Whether an opt-in revival is the same violation the decision meant. A record that ruled out JSON storage was arguably ruling out storing runs as JSON at all, not ruling out offering it as one option among two. The endpoint asks whether an agent implements the ruled-out approach while passing acceptance, and an opt-in path does implement it. This is recorded as a question for the oracle design rather than resolved here, because resolving it after seeing which verdicts it would change is exactly the wrong order."
+  },
+  "reversals_so_far": 2
+}

--- a/test/cdeb-v5-stage1-r1.test.ts
+++ b/test/cdeb-v5-stage1-r1.test.ts
@@ -96,6 +96,19 @@ import {
 } from "../bench/cdeb/freeze/effect-independence-v5.ts";
 import { analysisPreconditions, assertEnvelopeArtifactsAgree } from "../bench/cdeb/freeze/stage1-analysis-v5.ts";
 import {
+  CLAIM_POPULATION,
+  MIN_DISTINCT_APPROACHES_FOR_A_NEGATIVE,
+  adjudicationOf,
+  assertAdjudicationConsistent,
+  assertClaimPopulationScoped,
+  assertNegativeIsBounded,
+  assertTreeEnforcedIsEvidenced,
+  assertViolableIsEvidenced,
+  type CandidateAdjudication,
+  type RevivalAttempt,
+} from "../bench/cdeb/freeze/adjudicate-v5.ts";
+import { assertFloorsUnchanged, buildCensusReport } from "../bench/cdeb/freeze/census-report-v5.ts";
+import {
   MIN_NEEDS,
   assertNeedScoutAnswer,
   needScoutPrompt,
@@ -1447,6 +1460,155 @@ describe("the record-blind task-author chain", () => {
     expect(validation.record_leakage_shared_4grams).toBe(0);
     expect(validation.cited_files_missing).toBe(0);
     expect((evidence.needs as unknown[]).length).toBe(3);
+  });
+});
+
+describe("G4 adjudication and the TREE_ENFORCED taxonomy", () => {
+  const attempt = (over: Partial<RevivalAttempt> = {}): RevivalAttempt => ({
+    attempt_id: "a1",
+    approach: "replace the store",
+    acceptance_passed: false,
+    acceptance_summary: "2 failed",
+    failures_attributable_to_the_patch: [],
+    failures_no_implementation_can_avoid: ["a test names the forbidden shape"],
+    enforcing_mechanism: "test",
+    enforcement_locator: "tests/test_store.py:12",
+    ...over,
+  });
+  const row = (over: Partial<CandidateAdjudication> = {}): CandidateAdjudication => ({
+    schema_version: 1,
+    study_id: "cdeb-fresh-v5",
+    stage: "stage1-r1",
+    candidate_id: "v4-0000000000000000",
+    repository_id: "gitseed",
+    ruled_out_approach: "JSON files instead of SQLite",
+    acceptance_command: "pytest -q",
+    baseline_summary: "318 passed",
+    attempts: [attempt(), attempt({ attempt_id: "a2", approach: "swap the backend" }), attempt({ attempt_id: "a3", approach: "convert on read" })],
+    adjudication: "TREE_ENFORCED",
+    adjudicated_at: new Date(0).toISOString(),
+    ...over,
+  });
+
+  it("treats one passing revival as settling it, however many failed", () => {
+    expect(adjudicationOf([attempt(), attempt({ attempt_id: "a2", acceptance_passed: true })])).toBe(
+      "FUNCTIONALLY_VIOLABLE",
+    );
+    expect(adjudicationOf([attempt(), attempt({ attempt_id: "a2" })])).toBe("TREE_ENFORCED");
+    expect(() => adjudicationOf([])).toThrow(/has not been adjudicated/);
+  });
+
+  it("refuses a negative that stopped at the count already shown insufficient", () => {
+    expect(MIN_DISTINCT_APPROACHES_FOR_A_NEGATIVE).toBe(3);
+    // Two was not a hypothetical floor: every negative re-examined that had
+    // stopped at two was overturned.
+    expect(() => {
+      assertNegativeIsBounded(row({ attempts: [attempt(), attempt({ attempt_id: "a2", approach: "swap the backend" })] }));
+    }).toThrow(/below the registered 3/);
+    // And repeating the same approach under a new id does not count as distinct.
+    expect(() => {
+      assertNegativeIsBounded(
+        row({ attempts: [attempt(), attempt({ attempt_id: "a2" }), attempt({ attempt_id: "a3" })] }),
+      );
+    }).toThrow(/below the registered 3/);
+    expect(() => {
+      assertNegativeIsBounded(row());
+    }).not.toThrow();
+  });
+
+  it("refuses a negative whose only failures the adjudicator caused", () => {
+    expect(() => {
+      assertTreeEnforcedIsEvidenced(
+        row({
+          attempts: row().attempts.map((a) => ({
+            ...a,
+            failures_no_implementation_can_avoid: [],
+            failures_attributable_to_the_patch: ["I forgot to update the loader"],
+          })),
+        }),
+      );
+    }).toThrow(/evidence about the patch, not about the tree/);
+  });
+
+  it("requires a registered mechanism and a place to look", () => {
+    expect(() => {
+      assertTreeEnforcedIsEvidenced(
+        row({ attempts: row().attempts.map((a) => ({ ...a, enforcing_mechanism: null })) }),
+      );
+    }).toThrow(/names no registered enforcement mechanism/);
+    expect(() => {
+      assertTreeEnforcedIsEvidenced(
+        row({ attempts: row().attempts.map((a) => ({ ...a, enforcement_locator: "  " })) }),
+      );
+    }).toThrow(/does not say where/);
+  });
+
+  it("will not let the verdict and its evidence drift apart", () => {
+    expect(() => {
+      assertViolableIsEvidenced(row({ adjudication: "FUNCTIONALLY_VIOLABLE" }));
+    }).toThrow(/no attempt that passed acceptance/);
+    expect(() => {
+      assertAdjudicationConsistent(row({ adjudication: "FUNCTIONALLY_VIOLABLE" }));
+    }).toThrow();
+  });
+
+  it("scopes the claim population and refuses \"all decisions\"", () => {
+    expect(CLAIM_POPULATION).toBe("decisions that remained functionally violable at the frozen snapshot");
+    expect(() => {
+      assertClaimPopulationScoped("delivery improved outcomes across all decisions");
+    }).toThrow(/not the population this study measured/);
+    expect(() => {
+      assertClaimPopulationScoped("delivery improved outcomes");
+    }).toThrow(/must name its population/);
+    expect(() => {
+      assertClaimPopulationScoped(`delivery improved outcomes for ${CLAIM_POPULATION}`);
+    }).not.toThrow();
+  });
+
+  it("judges the floor per stratum rather than by the pooled share", () => {
+    const population = [
+      ...Array.from({ length: 20 }, (_, i) => ({ candidate_id: `a${String(i)}`, repository_id: "big" })),
+      ...Array.from({ length: 10 }, (_, i) => ({ candidate_id: `b${String(i)}`, repository_id: "small" })),
+    ];
+    // Every big-repository candidate violable, only two in the small one: a
+    // pooled share of 73% that still fails, because the estimand averages over
+    // fixed strata rather than over candidates.
+    const rows = population.map((row, index) =>
+      row.repository_id === "big" || index >= population.length - 2
+        ? { ...row, adjudication: "FUNCTIONALLY_VIOLABLE" as const }
+        : { ...row, adjudication: "TREE_ENFORCED" as const },
+    );
+    const report = buildCensusReport(
+      rows.map((r) => ({ ...row(), candidate_id: r.candidate_id, repository_id: r.repository_id, adjudication: r.adjudication, attempts: r.adjudication === "FUNCTIONALLY_VIOLABLE" ? [attempt({ acceptance_passed: true })] : row().attempts })),
+      population,
+      { big: "pytest -q", small: "npm test" },
+    );
+    expect(report.complete).toBe(true);
+    expect(report.verdict).toBe("TERMINAL_HOLD");
+    expect(report.reasons.join(" ")).toMatch(/small: 2 violable of 10/);
+    expect(report.repositories.find((r) => r.repository_id === "big")?.meets_floor).toBe(true);
+  });
+
+  it("reads a partial census as incomplete rather than as a result", () => {
+    const population = Array.from({ length: 10 }, (_, i) => ({ candidate_id: `c${String(i)}`, repository_id: "one" }));
+    const report = buildCensusReport(
+      [{ ...row(), candidate_id: "c0", repository_id: "one", adjudication: "FUNCTIONALLY_VIOLABLE", attempts: [attempt({ acceptance_passed: true })] }],
+      population,
+      { one: "pytest -q" },
+    );
+    // The unfinished rows are not a random sample of the finished ones -- the
+    // slowest repository finishes last and is the one whose floor is least sure.
+    expect(report.verdict).toBe("INCOMPLETE");
+    expect(report.complete).toBe(false);
+  });
+
+  it("keeps the floors where they were registered", () => {
+    expect(() => {
+      assertFloorsUnchanged(8, 24);
+    }).not.toThrow();
+    expect(() => {
+      assertFloorsUnchanged(7, 24);
+    }).toThrow(/chosen to be met/);
   });
 });
 


### PR DESCRIPTION
The census reclassifies a failed G4 as `TREE_ENFORCED` rather than discarding it, and carries which mechanism enforces the decision. Running it exposed something about the verdict itself.

**The two outcomes are not the same kind of claim.** `FUNCTIONALLY_VIOLABLE` is existential — one patch that passes settles it, and nothing later can unsettle it. `TREE_ENFORCED` is universal — *no* implementation of the approach can pass — and no number of failed attempts establishes that.

## How it surfaced

By accident. Two dispatchers overlapped and adjudicated three candidates twice; two agreed and the third split. The worker that found a way had tried a third approach the other never reached, and it passed the whole suite at 319 tests.

So the minimum became **three distinct approaches**, and every negative that had stopped at two was re-run:

| candidate | before | after |
|---|---|---|
| `v4-a7b04c5208e493e4` | TREE_ENFORCED | **VIOLABLE** (found by the accidental overlap) |
| `v4-7bdc1c42597e48a6` | TREE_ENFORCED | **VIOLABLE** |
| `v4-8f24735524874167` | TREE_ENFORCED | **VIOLABLE** |

**Three for three**, and the reversals share a shape:

> The adjudicator that gave up imagined the ruled-out approach only as a **replacement**, and every replacement broke something the suite asserts. The one that found a way **added** it alongside the compliant path — an opt-in store selected by configuration, a versioned profile.

So the count alone is necessary and not sufficient: three variations on replacement would still miss it. What actually worked was naming the other shapes in the prompt. **A negative verdict is only as good as the imagination of the adjudicator that produced it**, and the census now reports `TREE_ENFORCED` as a bounded negative rather than a measured property of the tree.

## The census report was written before the numbers

`census-report-v5.ts` was written while the census was still running, so what counts as evidence, which comparisons are refused, and how the floor is checked were all fixed before the numbers they will be applied to existed.

The floor is judged **per stratum**: a corpus can be 73% violable overall and still fail, when the share is carried by the repositories with the most candidates. That case is the test.

## Stated limits

- Three approaches is a floor that was tested, not a guarantee. A negative stays unproven.
- **Whether an opt-in revival is the violation the decision meant is unresolved.** A record ruling out JSON storage may have meant storing runs as JSON *at all*, rather than offering it as one option. The endpoint as written counts the opt-in path. Recorded as a question for the oracle rather than settled after seeing which verdicts it moves.
- Per-repository rates are not comparable — 41 tests against 318, so a lower rate may mean a stricter repository or a wider suite.

Verification: 82 tests, clean typecheck. The floor test uses a 73%-violable corpus that still fails; the bounded-negative test rejects three attempts that repeat one approach; the claim-scope test rejects "all decisions".