### PR TITLE
The largest source of interference was the study measuring itself

### DIFF
--- a/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/HOST-ISOLATION.md
+++ b/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/HOST-ISOLATION.md
@@ -1,0 +1,104 @@
+---
+document_id: cdeb-fresh-v5-stage1-r1-host-isolation
+study_id: cdeb-fresh-v5
+stage: stage1-r1
+status: method-registered-before-use
+measured_run_allowed: false
+---
+
+# There is no isolated host, so isolation has to be a measured precondition
+
+The acceptance-determinism protocol asks for a hundred runs on a host where
+nothing else is happening. This study does not have such a host, and saying so
+plainly is the first half of the method.
+
+## What the host actually is
+
+Twelve logical cores, eight performance and four efficiency. It runs the
+orchestrating session, whatever else its owner is doing, and a set of containers
+that belong to other work — six of them Buzz infrastructure that this study is
+not permitted to stop, since it is the only channel the study reports through.
+
+Load average over one working session moved between **4.3 and 161**. The high
+end was not ambient: five containers at roughly one core each, plus this study's
+own six concurrent adjudication agents. That last part matters more than it
+looks, and it is the first lever.
+
+## The three levers, in the order they were worth pulling
+
+### 1. Stop being the load
+
+The single largest contributor to the interference was the study itself. Six
+adjudication workers, each driving an agent and then a full test suite, on a
+twelve-core machine. Reducing concurrency to one during a measurement took the
+load from 141 to 6 without anyone else changing what they were doing.
+
+An acceptance measurement now runs alone: no adjudication agent, no second
+repository, no other acceptance run. This costs wall-clock and buys the only
+part of the environment the study controls outright.
+
+### 2. Gate on measured ambient load rather than assuming it
+
+A sampler records the one-minute load average every ten seconds to
+`iso/load.tsv`. It does one `sysctl` and one append per sample, deliberately
+small enough not to become part of what it measures.
+
+Before a measurement starts, the gate requires every sample in the preceding two
+minutes to sit below a registered ceiling, with at least eight samples present.
+Three properties are load-bearing:
+
+- **It is a precondition, not a monitor.** Once acceptance starts, the load it
+  generates is its own and says nothing about interference.
+- **It uses the peak, not the mean.** A two-minute window whose mean is quiet and
+  whose peak is 23 contains a spike, and a spike is what starves a test that
+  measures its own CPU time.
+- **Insufficient samples is BUSY, not quiet.** Absence of evidence is not the
+  evidence of absence, and a fresh log would otherwise read as an idle machine.
+
+The ceiling is registered in `acceptance-load-sensitivity-design.json` before any
+run, and the load at each run is recorded beside its result. A reader can see
+what "quiet" meant on the day instead of trusting the word.
+
+### 3. Make load an independent variable
+
+Gating alone cannot answer the question that matters. agent-control-plane's suite
+produced 9, 9, **11**, 9 failures on the unmodified tree, and until load is
+controlled there is no way to tell whether that is the machine or the suite. More
+uncontrolled runs produce more uninterpretable runs.
+
+So a load generator applies a known synthetic load — one busy process per logical
+core — and the same command runs in both conditions. That turns the thing that
+was contaminating the measurement into the thing being measured.
+
+The arms alternate rather than running in blocks, because the QUIET arm waits by
+construction and would otherwise all land later in the day than the LOADED arm.
+
+## What each outcome means
+
+| result | reading |
+| --- | --- |
+| identical failure sets in both arms | the suite is stable; the earlier disagreement needs another explanation |
+| differs only under load | load-induced; gate and proceed, and the two negative verdicts taken under uncontrolled load are void |
+| differs under quiet too | intrinsic; section 8 applies and the repository's stratum empties |
+
+## What this is not
+
+It is not the determinism protocol. Ten runs per arm is a diagnostic that decides
+whether the protocol can be run here at all; the protocol asks for a hundred and
+has not been run for any repository.
+
+It is also not isolation in the sense the protocol means. A gated quiet window on
+a shared machine is weaker than a dedicated host, and the honest name for what
+this achieves is *a measured and recorded precondition* rather than *an isolated
+environment*.
+
+## The asymmetry that makes the residual risk one-directional
+
+Across the four uncontrolled runs the anomaly only ever **added** failures — no
+run produced fewer than the baseline nine. Interference of that shape can turn a
+passing revival into a failing one and cannot do the reverse.
+
+So whatever this method fails to exclude, it cannot have manufactured a passing
+revival. The direction of any error left behind is toward understating how
+violable the corpus is, which is the same direction every other correction in
+this census has run.

--- a/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/acceptance-load-sensitivity-design.json
+++ b/bench/cdeb/studies/cdeb-fresh-v5/stage1-r1/acceptance-load-sensitivity-design.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "study_id": "cdeb-fresh-v5",
+  "stage": "stage1-r1",
+  "status": "FROZEN-BEFORE-EXECUTION",
+  "measured_run_allowed": false,
+
+  "what_this_is_not": "This is not the acceptance-determinism protocol. That protocol asks whether the registered command gives the same answer 100 times on an isolated host, and it has not been run. This is a diagnostic that asks a narrower question first, because the answer decides whether the protocol can be run here at all.",
+
+  "the_question": "agent-control-plane's suite produced 9, 9, 11, 9 failures across four runs on the unmodified tree. Is that difference caused by machine load, or is it intrinsic to the suite? The two have opposite consequences: load-induced nondeterminism can be gated around, and intrinsic nondeterminism disposes the whole repository under section 8.",
+
+  "why_a_contrast_rather_than_more_runs": "The earlier four runs are uninterpretable because load was not controlled and not recorded -- ambient load moved between 6 and 141 during the session, driven by processes belonging to other work. Running more of the same produces more uninterpretable runs. Making load an independent variable is what turns this into a measurement.",
+
+  "design": {
+    "arms": [
+      {
+        "arm": "QUIET",
+        "precondition": "ambient one-minute load average below the registered threshold across every sample in the 120 seconds before the run starts, with at least 8 samples",
+        "concurrent_study_work": "none -- no adjudication agent, no other acceptance run, no second repository"
+      },
+      {
+        "arm": "LOADED",
+        "precondition": "a synthetic CPU load is applied for the duration of the run",
+        "load_generator": "N busy processes, N registered below, started before the run and stopped after it"
+      }
+    ],
+    "runs_per_arm": 10,
+    "tree": "the unmodified frozen snapshot, identical in both arms",
+    "command": "the registered acceptance command, unchanged and unnarrowed",
+    "recorded_per_run": [
+      "structured result: total, passed, failed, skipped",
+      "the exact set of failing test ids",
+      "one-minute load average before the run",
+      "one-minute load average after the run",
+      "wall-clock duration"
+    ]
+  },
+
+  "registered_thresholds": {
+    "quiet_ceiling_loadavg_1min": 6.0,
+    "why_this_number": "The host has 12 logical cores. Ambient load with the orchestrating session running and nothing else measured 5.9 to 9.2 while still settling, and 4.3 to 5.8 once settled. Six sits above the settled floor and well below the 100-plus seen when other work is running, so it separates the two states the census actually encountered. It is registered here before any run of this diagnostic.",
+    "synthetic_load_processes": 12,
+    "why_twelve": "One busy process per logical core, which is the condition where a test that measures its own CPU time or waits on a scheduler will be starved. It reproduces the shape of the interference rather than its exact magnitude."
+  },
+
+  "how_the_result_is_read": {
+    "identical_failure_sets_in_both_arms": "The suite is stable under both conditions. The four earlier runs' disagreement then needs another explanation, and this diagnostic has not found it.",
+    "differs_only_in_LOADED": "The nondeterminism is load-induced. The determinism protocol can be run here, gated on the quiet precondition, and the two agent-control-plane negative verdicts are void because they were produced under uncontrolled load.",
+    "differs_in_QUIET_as_well": "The nondeterminism is intrinsic to the suite. Section 8 applies: agent-control-plane is FUNCTIONAL_ACCEPTANCE_NONDETERMINISTIC, its stratum empties, and the estimand is undefined."
+  },
+
+  "what_this_may_not_do": [
+    "change the quiet ceiling after seeing which runs fell on which side of it",
+    "change the number of runs per arm after seeing the first results",
+    "discard a run as anomalous. Every run started is recorded and counted, including one interrupted by something outside the study",
+    "treat the QUIET arm as satisfying the determinism protocol. Ten runs is a diagnostic; the protocol asks for a hundred"
+  ],
+
+  "the_asymmetry_that_makes_this_safe": "Across the four uncontrolled runs the anomaly only ever added failures -- no run produced fewer than the baseline nine. Interference of this shape can turn a passing revival into a failing one and cannot do the reverse. So whichever way this diagnostic lands, it cannot have manufactured a passing revival, and the direction of any error it leaves is toward understating how violable the corpus is."
+}


### PR DESCRIPTION
The determinism protocol asks for a host where nothing else is happening. This
study does not have one: twelve cores shared with the orchestrating session, its
owner's work, and containers belonging to other things — six of them the Buzz
infrastructure this study reports through and is not permitted to stop.

Load moved between 4.3 and 161 in a single session, and the honest reading of
the high end took a while to arrive. It was not ambient. Five foreign containers
accounted for part of it and **six concurrent adjudication workers of my own**
accounted for more. Stopping my own batches took the load from 141 to 6 without
anyone else changing anything.

That reorders the whole problem. The first lever was not finding a quieter
machine, it was not being the noise.

What is registered here is a method with three parts:

  1. A measurement runs alone. No adjudication agent, no second repository, no
     other acceptance run. This is the part the study controls outright.

  2. A sampler records the one-minute load average every ten seconds, and a gate
     requires every sample in the preceding two minutes to sit below a
     registered ceiling. It uses the peak rather than the mean, because a window
     whose mean is quiet and whose peak is 23 contains a spike, and a spike is
     what starves a test that measures its own CPU time. Too few samples reads
     as BUSY, not as quiet.

  3. Load becomes an independent variable. agent-control-plane produced 9, 9,
     11, 9 failures on the unmodified tree, and more uncontrolled runs would
     only have produced more uninterpretable runs. A generator applies a known
     synthetic load, the same command runs in both conditions, and the thing
     that was contaminating the measurement becomes the thing measured.

The arms alternate rather than running in blocks, because the quiet arm waits by
construction and would otherwise land later in the day than the loaded one.