### PR TITLE
Cover the three exclusion identities a candidate can actually carry

### DIFF
--- a/bench/cdeb/guards/baseline.json
+++ b/bench/cdeb/guards/baseline.json
@@ -54,8 +54,7 @@
     },
     {
       "guard_id": "exclusion-index-blocks-candidate-id",
-      "outcome": "uncovered",
-      "reason": "The census can match this candidate identifier by value, but the registry has no mutation that proves the claim makes it ineligible."
+      "outcome": "bound"
     },
     {
       "guard_id": "exclusion-index-blocks-record-id",
@@ -83,13 +82,11 @@
     },
     {
       "guard_id": "exclusion-index-blocks-benchmark-authored-record",
-      "outcome": "uncovered",
-      "reason": "The census can match this source-record identity by value, but the registry has no mutation that proves the claim makes its candidate ineligible."
+      "outcome": "bound"
     },
     {
       "guard_id": "exclusion-index-blocks-publicly-answer-exposed-decision",
-      "outcome": "uncovered",
-      "reason": "The census can match this decision's source-record identity by value, but the registry has no mutation that proves the claim makes its candidate ineligible."
+      "outcome": "bound"
     },
     {
       "guard_id": "frozen-bundle-digest-is-verified",

--- a/bench/cdeb/guards/registry.json
+++ b/bench/cdeb/guards/registry.json
@@ -190,8 +190,17 @@
       "guard_id": "exclusion-index-blocks-candidate-id",
       "claim": "The candidate r-d0004gatecensus cannot reach the registry as anything but ineligible.",
       "test_file": "test/cdeb-v3-census.test.ts",
-      "test_name": "keeps a Record-Id named by the index as an ineligible visible row",
-      "mutations": []
+      "test_name": "keeps the index's ambiguous candidate identity ineligible",
+      "mutations": [
+        {
+          "mutation_id": "candidate-id-value-changed",
+          "file": "bench/cdeb/studies/cdeb-fresh-v3r1/corpus/legacy-exclusion-index.json",
+          "find": "\"kind\": \"candidate-id\",\n      \"value\": \"r-d0004gatecensus\"",
+          "replace": "\"kind\": \"candidate-id\",\n      \"value\": \"r-no-candidate-carries-this\"",
+          "must_fail_test": true,
+          "why": "The index stops naming this identity, so a candidate carrying it is no longer made ineligible and the census lets it through as an ordinary row."
+        }
+      ]
     },
     {
       "guard_id": "exclusion-index-blocks-record-id",
@@ -241,15 +250,33 @@
       "guard_id": "exclusion-index-blocks-benchmark-authored-record",
       "claim": "A candidate associated with the recorded benchmark-authored decision cannot reach the registry as anything but ineligible.",
       "test_file": "test/cdeb-v3-census.test.ts",
-      "test_name": "keeps a Record-Id named by the index as an ineligible visible row",
-      "mutations": []
+      "test_name": "keeps the benchmark-authored record ineligible",
+      "mutations": [
+        {
+          "mutation_id": "benchmark-authored-value-changed",
+          "file": "bench/cdeb/studies/cdeb-fresh-v3r1/corpus/legacy-exclusion-index.json",
+          "find": "\"kind\": \"benchmark-authored-record\",\n      \"value\": \"r-cdebp01\"",
+          "replace": "\"kind\": \"benchmark-authored-record\",\n      \"value\": \"r-no-candidate-carries-this\"",
+          "must_fail_test": true,
+          "why": "The index stops naming this identity, so a candidate carrying it is no longer made ineligible and the census lets it through as an ordinary row."
+        }
+      ]
     },
     {
       "guard_id": "exclusion-index-blocks-publicly-answer-exposed-decision",
       "claim": "A candidate associated with the publicly answer-exposed decision cannot reach the registry as anything but ineligible.",
       "test_file": "test/cdeb-v3-census.test.ts",
-      "test_name": "keeps a Record-Id named by the index as an ineligible visible row",
-      "mutations": []
+      "test_name": "keeps the publicly answer-exposed decision ineligible under its own reason",
+      "mutations": [
+        {
+          "mutation_id": "answer-exposed-value-changed",
+          "file": "bench/cdeb/studies/cdeb-fresh-v3r1/corpus/legacy-exclusion-index.json",
+          "find": "\"kind\": \"publicly-answer-exposed-decision\",\n      \"value\": \"r-gcunstageable\"",
+          "replace": "\"kind\": \"publicly-answer-exposed-decision\",\n      \"value\": \"r-no-candidate-carries-this\"",
+          "must_fail_test": true,
+          "why": "The index stops naming this identity, so a candidate carrying it is no longer made ineligible and the census lets it through as an ordinary row."
+        }
+      ]
     },
     {
       "guard_id": "frozen-bundle-digest-is-verified",

--- a/test/cdeb-v3-census.test.ts
+++ b/test/cdeb-v3-census.test.ts
@@ -203,6 +203,58 @@ describe("CDEB-Fresh v3 snapshot census", () => {
     expect(entry.ineligibility_codes).toContain(`legacy-exclusion:${record!.reason}`);
   });
 
+  // The three below are the rest of the index that a candidate can actually
+  // carry. `exclusionsFor` matches an entry against candidate_id, record_ids and
+  // decision_source_refs, so a study id, a task id, a prompt or fixture hash, a
+  // randomization block and a trajectory id have no field to arrive in and no
+  // candidate can be made ineligible by them.
+  //
+  // Each pins the value it expects instead of reading it back out of the index.
+  // A test that sources both the fixture and the expectation from the same entry
+  // passes whatever that entry happens to say, which leaves the identity itself
+  // unguarded.
+  it("keeps the index's ambiguous candidate identity ineligible", () => {
+    const index = readLegacyExclusionIndex(ACTIVE_INDEX);
+    const record = index.exclusions.find((e) => e.kind === "candidate-id" && e.value === "r-d0004gatecensus");
+    expect(record).toBeDefined();
+    const files = fixture([record!]);
+    const frozen = commitDecision(files.repositoryPath, record!.value);
+    writeCensusInputs(files, frozen);
+    runCensus(files.options);
+    const [entry] = readFileSync(files.registryPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    expect(entry).toMatchObject({ candidate_id: "r-d0004gatecensus", qualification_status: "ineligible" });
+    expect(entry.ineligibility_codes).toContain("legacy-exclusion:ambiguous-pending-adjudication");
+  });
+
+  it("keeps the benchmark-authored record ineligible", () => {
+    const index = readLegacyExclusionIndex(ACTIVE_INDEX);
+    const record = index.exclusions.find((e) => e.kind === "benchmark-authored-record" && e.value === "r-cdebp01");
+    expect(record).toBeDefined();
+    const files = fixture([record!]);
+    const frozen = commitDecision(files.repositoryPath, record!.value);
+    writeCensusInputs(files, frozen);
+    runCensus(files.options);
+    const [entry] = readFileSync(files.registryPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    expect(entry).toMatchObject({ candidate_id: "r-cdebp01", qualification_status: "ineligible" });
+    expect(entry.ineligibility_codes).toContain("legacy-exclusion:benchmark-authored");
+  });
+
+  it("keeps the publicly answer-exposed decision ineligible under its own reason", () => {
+    // This value is also the record-id entry's value, so a candidate carrying it
+    // collects both codes. The reason is what separates them, and the reason is
+    // what a reader of the census sees.
+    const index = readLegacyExclusionIndex(ACTIVE_INDEX);
+    const record = index.exclusions.find((e) => e.kind === "publicly-answer-exposed-decision" && e.value === "r-gcunstageable");
+    expect(record).toBeDefined();
+    const files = fixture([record!]);
+    const frozen = commitDecision(files.repositoryPath, record!.value);
+    writeCensusInputs(files, frozen);
+    runCensus(files.options);
+    const [entry] = readFileSync(files.registryPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    expect(entry).toMatchObject({ candidate_id: "r-gcunstageable", qualification_status: "ineligible" });
+    expect(entry.ineligibility_codes).toContain("legacy-exclusion:publicly-answer-exposed");
+  });
+
   it("refuses a declared dist digest that differs from the release-tagged dist", () => {
     const files = fixture();
     const frozen = commitDecision(files.repositoryPath);


### PR DESCRIPTION
The legacy exclusion index names fifteen identities that must make a candidate
ineligible. Fifteen guards claimed that, all fifteen pointed at the **same** test,
and that test finds `kind === "record-id"` and exercises only it. Thirteen were
recorded `uncovered`; the recorded reason was right about the mechanism and wrong
about how many were reachable.

## What splits them

`exclusionsFor` matches an index entry against a candidate's `candidate_id`,
`record_ids` and `decision_source_refs`:

| | value | reachable |
| --- | --- | --- |
| `candidate-id` | `r-d0004gatecensus` | yes |
| `record-id` | `r-gcunstageable` | yes — already tested |
| `publicly-answer-exposed-decision` | `r-gcunstageable` | yes |
| `benchmark-authored-record` | `r-cdebp01` | yes |
| study-id ×3, task-id ×2, three hashes, `block-000`, trajectory/result-row | — | **no** |

The bottom row has no field to arrive in — a study id or a prompt hash is not
something a candidate carries. `trajectory-id` and `result-row-id` share a value
outright (`pending-rm-force__on__r1`), so matching by value cannot separate them
even in principle. Those ten stay uncovered and their baseline reasons say why.

The other three were reachable all along and simply had no test.

```
before   64 bound,  1 inert, 1 unavailable, 13 uncovered, 66 mutations
after    67 bound,  1 inert, 1 unavailable, 10 uncovered, 69 mutations
         0 misfiled, 0 unresolved
```

## Why the new tests pin their value

The existing record-id test sources both the fixture and the expectation from the
same index entry. Change that entry's value and the test changes what it asks for
— and still passes. Its guard has to mutate `census.ts` instead.

Each new test pins the identity it expects, so it fails when the index stops
naming it. That is the property the claim actually states, and it makes a
per-identity mutation possible:

```
"kind": "candidate-id",              →   "kind": "candidate-id",
"value": "r-d0004gatecensus"             "value": "r-no-candidate-carries-this"
```

Every mutation was hand-applied and its test observed failing, then restored and
observed passing.

## Verification

```
guard-mutations   exit 0, no ratchet failures
                  67 bound, 0 misfiled, 0 unresolved, 1 inert, 1 unavailable, 10 uncovered
tsc --noEmit      clean on root and bench tsconfigs
vitest run        3747 passed, 13 skipped, 0 failed
```

This covers three identities and repairs none of the ten. The claims for those
ten are stronger than what the census can enforce, and nothing here changes that.
