### PR TITLE
fix: the shadow snapshot was measuring git's background work

### DIFF
--- a/test/capture-shadow.test.ts
+++ b/test/capture-shadow.test.ts
@@ -81,6 +81,17 @@ const makeRepository = (): { cwd: string; since: string; secret: string } => {
   git(cwd, ['init', '--quiet']);
   git(cwd, ['config', 'user.email', 'shadow@example.test']);
   git(cwd, ['config', 'user.name', 'Shadow Test']);
+  // `byteSnapshot` below is exhaustive on purpose -- it is the evidence that
+  // `capture --shadow` touched nothing. That makes it sensitive to files whose
+  // lifetime belongs to git rather than to the code under test: a run on CI
+  // (2026-09-07, run 34073112868) captured `.git/objects/maintenance.lock` in
+  // `before` and found it gone in `after`, and the empty-file digest
+  // e3b0c442...b7852b855 in the diff is what identified it. Filtering the
+  // snapshot would have been the wrong repair, because then the snapshot would
+  // stop being exhaustive and a real stray file could hide behind the filter.
+  // Deny git the background work instead, so there is nothing transient to see.
+  git(cwd, ['config', 'gc.auto', '0']);
+  git(cwd, ['config', 'maintenance.auto', 'false']);
   writeFileSync(join(cwd, 'README.md'), '# fixture\n');
   commit(cwd, 'initial fixture');
   const since = git(cwd, ['rev-parse', 'HEAD']).trim();


### PR DESCRIPTION
`check (24)` failed on #866 with

```
expected [ …(39) ] to deeply equal [ …(40) ]
```

in `capture --shadow > runs prepare and verify against history without changing the worktree or .git`. The array diff named exactly one entry:

```
- file .git/objects/maintenance.lock e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

`e3b0c442…b7852b855` is the SHA-256 of the empty string, so the missing entry is an **empty lock file created by git's auto-maintenance** between the two snapshots. Nothing `capture --shadow` did produced or consumed it — the test was measuring git's background work.

## Why not filter the snapshot

`byteSnapshot` is exhaustive on purpose: its exhaustiveness *is* the assertion that the command is read-only. A `*.lock` filter would make it non-exhaustive and give a real stray file somewhere to hide. So the fixture denies git the background work instead — `gc.auto 0` and `maintenance.auto false` on the temporary repository — and the snapshot stays total.

## Verified

- `test/capture-shadow.test.ts` 3/3 locally
- `test/dogfood.test.ts` 10/10 on this commit
- `test/` is not in `SOURCE_INPUTS`, so no canonical rebuild or manifest change is needed

## Note

`createTestRepo` in `test/git-fixtures.ts` does not disable maintenance either. No other suite compares `.git` byte for byte today, so nothing else is exposed — but that is why this is fixed in the fixture rather than in the walker.