### PR TITLE
chore(deps): js-yaml 5.4.1 and @modelcontextprotocol/sdk 1.30.0 in one canonical rebuild

### DIFF
--- a/dist/commitlore.mjs
+++ b/dist/commitlore.mjs
@@ -34485,16 +34485,7 @@ var Server = class extends Protocol {
     if (!methodSchema) {
       throw new Error("Schema is missing a method literal");
     }
-    let methodValue;
-    if (isZ4Schema(methodSchema)) {
-      const v4Schema = methodSchema;
-      const v4Def = v4Schema._zod?.def;
-      methodValue = v4Def?.value ?? v4Schema.value;
-    } else {
-      const v3Schema = methodSchema;
-      const legacyDef = v3Schema._def;
-      methodValue = legacyDef?.value ?? v3Schema.value;
-    }
+    const methodValue = getLiteralValue(methodSchema);
     if (typeof methodValue !== "string") {
       throw new Error("Schema method literal must be a string");
     }
@@ -34803,8 +34794,17 @@ var Server = class extends Protocol {
 import process4 from "node:process";
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
+var STDIO_DEFAULT_MAX_BUFFER_SIZE = 10 * 1024 * 1024;
 var ReadBuffer = class {
+  constructor(options) {
+    this._maxBufferSize = options?.maxBufferSize ?? STDIO_DEFAULT_MAX_BUFFER_SIZE;
+  }
   append(chunk) {
+    const newSize = (this._buffer?.length ?? 0) + chunk.length;
+    if (newSize > this._maxBufferSize) {
+      this.clear();
+      throw new Error(`ReadBuffer exceeded maximum size of ${this._maxBufferSize} bytes`);
+    }
     this._buffer = this._buffer ? Buffer.concat([this._buffer, chunk]) : chunk;
   }
   readMessage() {
@@ -34832,18 +34832,24 @@ function serializeMessage(message) {
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 var StdioServerTransport = class {
-  constructor(_stdin = process4.stdin, _stdout = process4.stdout) {
+  constructor(_stdin = process4.stdin, _stdout = process4.stdout, options) {
     this._stdin = _stdin;
     this._stdout = _stdout;
-    this._readBuffer = new ReadBuffer();
     this._started = false;
     this._ondata = (chunk) => {
-      this._readBuffer.append(chunk);
-      this.processReadBuffer();
+      try {
+        this._readBuffer.append(chunk);
+        this.processReadBuffer();
+      } catch (error2) {
+        this.onerror?.(error2);
+        this.close().catch(() => {
+        });
+      }
     };
     this._onerror = (error2) => {
       this.onerror?.(error2);
     };
+    this._readBuffer = new ReadBuffer({ maxBufferSize: options?.maxBufferSize });
   }
   /**
    * Starts listening for messages on stdin.

--- a/installer/canonical-artifact.json
+++ b/installer/canonical-artifact.json
@@ -15,10 +15,10 @@
       "tsconfig.json",
       "src"
     ],
-    "sha256": "c939c152715ab8f01eea0888e26f73435db53c82931c4741b28ad162ad73619c"
+    "sha256": "3ed9923564b0c4fab22a6499431443d543acd140e8317388cf050d8755d529ed"
   },
   "artifact": {
-    "sha256": "469d61aa6502ebdbdd9915e5b962144bb718b782a634cd43cf19a53f8fde5a5e",
+    "sha256": "8ca06b24a111ad6e28e6f6319af53cf4140d0f31fcb791879d8844d784b0dbe0",
     "files": [
       {
         "path": "dist/cli.d.ts",
@@ -622,7 +622,7 @@
       },
       {
         "path": "dist/commitlore.mjs",
-        "sha256": "24b845a7ee9b7a65f2b335f0a299a6d623a7131cdb54f8e664ec6a4b838cacde"
+        "sha256": "a24a4f9b6091365c0bcf5323c3f0425f5b7f4d3dd7a2f2066135144d0c0e3bd5"
       },
       {
         "path": "dist/core/agent-configs.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "commander": "^15.0.0"
@@ -18,7 +18,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.10.0",
         "esbuild": "^0.28.2",
-        "js-yaml": "^5.2.3",
+        "js-yaml": "^5.4.1",
         "typescript": "^5.7.0",
         "vitest": "^2.1.0"
       },
@@ -488,12 +488,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1780,9 +1780,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
-      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.10.0",
     "esbuild": "^0.28.2",
-    "js-yaml": "^5.2.3",
+    "js-yaml": "^5.4.1",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "commander": "^15.0.0"


### PR DESCRIPTION
Supersedes #862 and #863, which cannot be repaired independently.

Both failed `check` for the reason `r-cdebmanifest` describes: `package-lock.json` is in `SOURCE_INPUTS`, so any dependency bump moves the manifest's source checksum. And each repair regenerates `installer/canonical-artifact.json` — so whichever merged first would invalidate the other's manifest and force a second rebuild, a second review and a second CI run for a change already made. Separate branches produce a conflict by construction.

| bump | kind | reaches the bundle |
|---|---|---|
| `js-yaml` 5.2.3 → 5.4.1 | dev | no |
| `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0 | runtime | yes |

Artifact digest moves to `8ca06b24a111ad6e28e6f6319af53cf4140d0f31fcb791879d8844d784b0dbe0`.

## Verified locally

- `npm audit --omit=dev --audit-level=low` → 0 vulnerabilities
- pinned `linux/amd64` canonical build produced the committed `dist`; `artifact:verify` exits 0
- `tsc --noEmit` clean, `check-engines` clean
- **3157 tests passed, 4 skipped, 164 files**

## Independent pre-merge review

`gpt-5.6-sol` (read-only, adversarial framing — asked to *disprove* the three claims). No merge-blocking findings. It independently recomputed the source digest, all 310 `dist` entries and the aggregate from the commit's git blobs and got exact matches, and confirmed the lockfile keeps the same 94 non-dev packages with no additions or removals.

Its two honest limits, recorded rather than paraphrased away:

- it could not rerun the Docker build in a read-only workspace, so it verified the committed tree and not builder reproducibility — CI does that rebuild twice
- batching loses isolated CI/bisect attribution for the two bumps; it found no masked artifact or runtime effect