### PR TITLE
fix: establish the cause before naming it — squash vs abandoned, a timeout that never happened, and a mirror read as a rival (#888, #889, #890)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,106 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.7
+
+Three diagnostics that named a cause they had not established. One prescribed a
+remedy that would have done harm; another hid a record for being stored
+correctly.
+
+**`squash-conservation` could not tell an abandoned branch from a squashed one
+(#888).** It reported records "declared on a branch not reachable from HEAD" and
+concluded a squash had dropped them. A squash is one cause. The other is a
+branch closed without merging — an ordinary and correct outcome, where the
+records are absent because the work is absent.
+
+The two are identical in the commit graph, which is all the check looked at, so
+it prescribed the same remedy for both:
+
+```
+fix: commitlore squash-preserve <base>..<branch> --target <the commit that squashed it>
+```
+
+On an abandoned branch that is not merely unnecessary. `--target` mirrors the
+branch's records onto whatever commit it is handed, with no check that the
+commit contains the work, so following the advice writes decision records
+describing work that was deliberately discarded onto a commit that does not
+contain it. Reported against a pull request closed as superseded, where there
+was no "commit that squashed it" for `--target` to name at all.
+
+**The content separates them**, and the check now uses it: a squash carries the
+branch's tree into HEAD even though its commits are gone, while an abandoned
+branch's tree is nowhere. Each branch is classified by comparing the blob of
+every path it touched against HEAD's, and the row says which case it is and
+prescribes accordingly — `squash-preserve` for a branch whose changes reached
+HEAD, and nothing to do for one whose changes did not.
+
+**The finding set is unchanged.** Every record reported before is still
+reported; only the claim and the remedy vary. The classification is deliberately
+asymmetric for that reason — "never merged" requires that *no* touched path
+exist in HEAD, and a squash whose files `main` has since edited falls to
+"could not be determined", which still prescribes preserving. A vaguer message
+is a cheap mistake; a dropped finding is not.
+
+This is not identification by content, which this project has repeatedly found
+unsafe: records are still matched by `Record-Id` exactly as before. What the
+content decides is what happened to the *branch*.
+
+**A record stored in both supported places was withheld as declared twice
+(#890).** `context` hid a record whose declarations were a trailer block in a
+commit's message and the same records on the notes ref for that same commit —
+both CommitLore's own storage, and the second one produced by following the
+tool's own advice. The merge helper's output tells the operator to pass
+`--target` so the records are mirrored where git will not parse them as
+trailers; doing so is what created the second declaration.
+
+The rule was already right and the comparison was not. Exact commit and note
+mirrors are meant to be one logical record, with only divergent note payloads
+colliding — but the comparison weighed every trailer except `Record-Id`, while
+the mirroring stamps each block it writes with its own `Provenance: inherited
+<sha>`, by design. The two disagreed about what "same content" means, so a
+mirror written by the tool was never identical to the block it mirrored and the
+exact-mirror path could not fire for the case it exists for.
+
+A note is now recognised as its own commit's mirror when it sits on that
+commit's sha and matches the message block once the provenance stamp is set
+aside. **Only the stamp is forgiven, and only within one commit.** A note whose
+`Limit:` changed, one carrying a trailer the message does not, and one missing a
+trailer the message has all still collide and are still withheld — notes are
+remote-reachable, and divergent note content must not inherit an identity a
+human approved. Two different commits declaring one id and differing only in
+provenance still collide too, because there "which is current" is a real
+question.
+
+**The withholding message also stops making the operator guess.** It reported
+that a record was declared more than once without saying where either
+declaration was, and the reporter deleted a branch and rebuilt the index before
+finding the note. Each collision now names its own locations:
+
+```
+... r-branch890aa in 10a0f5d2's commit message and in its note on
+refs/notes/commitlore, which differ
+```
+
+**`before_change` reported a timeout that never happened (#889).** With
+unreadable Git history and a proposal supplied, the guard is skipped and never
+starts — and the response called that `guard_confidence: "timed-out"`. A
+completed Git failure presented as an expiry, with no guard execution and no
+elapsed time behind it. Measured against a directory that is not a repository:
+the whole call returned in about 37 ms claiming it had timed out.
+
+There is now a fourth value, `unavailable`, meaning a proposal was supplied and
+the guard could not run. `not-run` keeps its documented meaning — no proposal was
+supplied — so the two cases stay distinct, and `verification_gaps` still carries
+`history-unavailable` as the reason. The fail-closed behaviour is untouched:
+unreadable history is still reported as a gap and never as a verified empty
+answer.
+
+`timed-out` stays in the enum and is now emitted by nothing. F11 specifies a
+bounded guard leg that returns it on expiry; that bound was never implemented,
+and this branch was its only emitter. It is the specified name for a real
+expiry, and it stays unreachable until something actually bounds the guard and
+can say so from a measured elapsed time.
+
 ## 1.2.6
 
 A long session killed the process outright, and an upgrade nobody could see had

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh
-sh install.sh v1.2.6
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh
+sh install.sh v1.2.7
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.6 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.7 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.ps1))) v1.2.6
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh
-sh install.sh v1.2.6
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh
+sh install.sh v1.2.7
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.6 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.7 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.ps1))) v1.2.6
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh
-sh install.sh v1.2.6
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh
+sh install.sh v1.2.7
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.6 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.7 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.ps1))) v1.2.6
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh
-sh install.sh v1.2.6
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh
+sh install.sh v1.2.7
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.6 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.7 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.ps1))) v1.2.6
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.ps1))) v1.2.6
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -1653,9 +1653,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.6/install.sh | sh -s v1.2.6",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.6"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.7"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/doctor/checks/history-squash-conservation.ts
+++ b/src/commands/doctor/checks/history-squash-conservation.ts
@@ -72,6 +72,80 @@ const squashCandidates = (ctx: DoctorContext, head: string): SquashCandidateScan
   };
 };
 
+/**
+ * What became of a candidate branch's content, which is a different question
+ * from what became of its commits (#888).
+ *
+ * `squashCandidates` asks only whether the branch's *commits* are reachable
+ * from HEAD. A squash makes them unreachable, and so does closing a pull
+ * request without merging — the two are identical in the commit graph, and the
+ * check concluded "squashed" for both. That is not merely imprecise: the remedy
+ * it prescribed, `squash-preserve --target`, writes the branch's records onto a
+ * commit chosen by the caller with no check that the commit contains the work.
+ * Run on an abandoned branch it manufactures provenance for something that was
+ * deliberately discarded, which is the failure this tool exists to prevent.
+ *
+ * The content separates them: a squash carries the branch's tree into HEAD even
+ * though its commits are gone, and an abandoned branch's tree is nowhere.
+ *
+ * This is not the content-guessing the module doc rules out. That warns against
+ * identifying *records* by content instead of by `Record-Id`, and nothing here
+ * does: the set of records reported is computed exactly as before and is
+ * unchanged by this classification. What varies is only what the row claims
+ * happened and what it prescribes — so a misclassification costs a vaguer
+ * message, never a dropped finding.
+ */
+type BranchContentFate = 'present-in-head' | 'absent-from-head' | 'unknown';
+
+/**
+ * Compares blob ids per touched path rather than trees or patch ids.
+ *
+ * `git cherry` and `patch-id` cannot answer this: a squash collapses N commits
+ * into one whose diff matches none of them individually, so a genuine squash
+ * reads as "not applied" to both. `merge-tree --write-tree` would answer it
+ * directly but needs Git 2.38, and this project declares no Git floor —
+ * `git rev-parse <rev>:<path>` works everywhere.
+ *
+ * Deliberately asymmetric. `present-in-head` demands that *every* touched path
+ * resolve to the same blob in HEAD, and `absent-from-head` that *no* touched
+ * path exists in HEAD at all. A squash whose files `main` has since edited
+ * satisfies neither and lands on `unknown`, which still prescribes preserving —
+ * the direction that cannot lose a record.
+ */
+const branchContentFate = (
+  ctx: DoctorContext,
+  candidate: SquashCandidate,
+  head: string,
+): BranchContentFate => {
+  const { opts, git } = ctx;
+  const changed = git(
+    ['diff', '--name-only', `${candidate.base}..${candidate.sha}`],
+    gitOptions(opts),
+  );
+  if (changed.code !== 0) return 'unknown';
+  const paths = changed.stdout.split('\n').filter((line) => line !== '');
+  if (paths.length === 0) return 'unknown';
+
+  let matching = 0;
+  let missingFromHead = 0;
+  for (const path of paths) {
+    const onBranch = git(['rev-parse', '--verify', '--quiet', `${candidate.sha}:${path}`], gitOptions(opts));
+    const onHead = git(['rev-parse', '--verify', '--quiet', `${head}:${path}`], gitOptions(opts));
+    // A path deleted by the branch has no blob on either side; it says nothing
+    // either way, so it is neither a match nor a miss.
+    if (onBranch.code !== 0) return 'unknown';
+    if (onHead.code !== 0) {
+      missingFromHead += 1;
+      continue;
+    }
+    if (onHead.stdout.trim() === onBranch.stdout.trim()) matching += 1;
+  }
+
+  if (matching === paths.length) return 'present-in-head';
+  if (missingFromHead === paths.length) return 'absent-from-head';
+  return 'unknown';
+};
+
 const scanLimitDetail = (scan: SquashCandidateScan): string =>
   scan.branchesSeen > MAX_SQUASH_CANDIDATE_BRANCHES
     ? `; only the first ${MAX_SQUASH_CANDIDATE_BRANCHES} of ${scan.branchesSeen} local branches were checked`
@@ -161,9 +235,10 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
   }
 
   let known: Set<string> | null = null;
-  const lost: { branch: string; recordId: string }[] = [];
+  const lost: { branch: string; recordId: string; fate: BranchContentFate }[] = [];
   let uncheckable = 0;
   let checked = 0;
+  const headSha = head.stdout.trim();
 
   for (const candidate of candidates) {
     let records;
@@ -196,8 +271,13 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
       );
     }
 
+    // Classified once per branch, and only when the branch has actually lost
+    // something — an ok run pays nothing for it.
+    let fate: BranchContentFate | null = null;
     for (const recordId of ids) {
-      if (!known.has(recordId)) lost.push({ branch: candidate.branch, recordId });
+      if (known.has(recordId)) continue;
+      fate ??= branchContentFate(ctx, candidate, headSha);
+      lost.push({ branch: candidate.branch, recordId, fate });
     }
   }
 
@@ -224,19 +304,44 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
   }
 
   if (lost.length > 0) {
+    const FATE_NOTE: Record<BranchContentFate, string> = {
+      'present-in-head': 'its changes are in HEAD, so it was squashed',
+      'absent-from-head': 'none of its changes are in HEAD, so it was never merged',
+      unknown: 'whether its changes reached HEAD could not be determined',
+    };
     const named = lost
       .slice(0, 5)
-      .map((entry) => `${entry.recordId} (${entry.branch})`)
+      .map((entry) => `${entry.recordId} (${entry.branch} — ${FATE_NOTE[entry.fate]})`)
       .join(', ');
     const more = lost.length > 5 ? `, and ${lost.length - 5} more` : '';
+
+    // Only branches whose work actually landed are worth preserving records
+    // for. `unknown` is grouped with them deliberately: prescribing a
+    // preservation that turns out to be unnecessary costs a discarded plan,
+    // while withholding it from a real squash loses the record for good.
+    const preservable = lost.filter((entry) => entry.fate !== 'absent-from-head');
+    const abandonedOnly = preservable.length === 0;
+    const fix = abandonedOnly
+      ? // #888: this used to prescribe squash-preserve here too. `--target`
+        // mirrors the records onto whatever commit it is handed without
+        // checking that the commit contains the work, so running it on a
+        // branch that was closed unmerged writes provenance for work that was
+        // deliberately discarded.
+        'nothing to preserve — these branches were closed without merging, and their records ' +
+        'describe work HEAD does not contain; delete the branches, or leave them'
+      : `commitlore squash-preserve <base>..<branch> --target <the commit that squashed it>, ` +
+        `then commit or attach the result` +
+        (preservable.length === lost.length
+          ? ''
+          : ` (only the ${preservable.length} on a branch whose changes reached HEAD)`);
+
     return check(
       id,
       category,
       title,
       'warn',
       `${lost.length} record(s) declared on a branch not reachable from HEAD do not appear in HEAD's history: ${named}${more}${scanLimitDetail(scan)}`,
-      'commitlore squash-preserve <base>..<branch> --target <the commit that squashed it>, ' +
-        'then commit or attach the result',
+      fix,
       false,
       undefined,
       {
@@ -245,6 +350,9 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
           checked: String(checked),
           uncheckable: String(uncheckable),
           lost_count: String(lost.length),
+          squashed_count: String(lost.filter((entry) => entry.fate === 'present-in-head').length),
+          unmerged_count: String(lost.filter((entry) => entry.fate === 'absent-from-head').length),
+          undetermined_count: String(lost.filter((entry) => entry.fate === 'unknown').length),
         }),
       },
     );

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -21,6 +21,7 @@ import { buildId, runtimeIdentity } from '../core/runtime-identity.js';
 import type { Command } from 'commander';
 
 import { BLOCKED_RECORD_WITHHELD } from '../core/grade.js';
+import { NOTES_REF } from '../core/notes.js';
 import {
   CONSUMER_SCAN_BUDGET_MS,
   LIMIT_KEY,
@@ -63,6 +64,34 @@ const SECTIONS: readonly Section[] = [
 ];
 
 const SECTION_KEYS: readonly string[] = SECTIONS.map((section) => section.key);
+
+/**
+ * Where one collided `Record-Id`'s declarations actually are (#890).
+ *
+ * The three causes leave different traces, and the record already carries
+ * enough to tell them apart: more than one sha is two commits declaring the
+ * same identity, and a single sha contributing both sources is a note that
+ * diverged from the message it mirrors. Saying which costs a clause and saves
+ * the hunt — the operator who reported this deleted a branch and rebuilt the
+ * index before finding the note.
+ */
+const collisionSite = (record: GradedRecord): string => {
+  const id = record.recordId ?? 'a record with no id';
+  const shas = record.shas.map((sha) => sha.slice(0, 8));
+  if (shas.length > 1) return `${id} in commits ${shas.join(' and ')}`;
+  const at = shas[0] ?? record.sha.slice(0, 8);
+  if (record.sources.includes('commit') && record.sources.includes('notes')) {
+    return `${id} in ${at}'s commit message and in its note on ${NOTES_REF}, which differ`;
+  }
+  if (record.sources.includes('notes')) return `${id} in notes on ${NOTES_REF} at ${at}`;
+  return `${id} more than once in ${at}'s commit message`;
+};
+
+/** The first few sites, so one pathological repository cannot flood the line. */
+const collisionSites = (collisions: readonly GradedRecord[]): string => {
+  const named = collisions.slice(0, 3).map(collisionSite).join('; ');
+  return collisions.length > 3 ? `${named}; and ${collisions.length - 3} more` : named;
+};
 
 export const withholdBlocked = (result: QueryResult): QueryResult => {
   const blocked = result.records.filter(
@@ -133,8 +162,15 @@ export const withholdBlocked = (result: QueryResult): QueryResult => {
             // made in the same second declare it with different values
             // (issue #350). Naming only the first cause sends a reader
             // hunting for a note that is not there.
+            //
+            // Naming *none* of them sends them hunting too (#890). The
+            // reporter deleted a branch and rebuilt the index chasing the
+            // cause this sentence did not state. Each collision now says where
+            // its declarations are, which is the one thing the record already
+            // knows and this line was throwing away.
             `withheld the content of ${collisions.length} record(s) whose Record-Id is declared ` +
-              'more than once with no way to tell which declaration is current',
+              'more than once with no way to tell which declaration is current: ' +
+              collisionSites(collisions),
           ]),
     ],
   };

--- a/src/core/before-change.ts
+++ b/src/core/before-change.ts
@@ -45,8 +45,24 @@ export type VerificationGap =
   | 'notes-unfetched'
   | 'unread-commits';
 
-/** Guard confidence enum — qualifies `possible_revival_matches` only. */
-export type GuardConfidence = 'not-run' | 'experimental' | 'timed-out';
+/**
+ * Guard confidence enum — qualifies `possible_revival_matches` only.
+ *
+ * - `not-run`      no `proposal` was supplied, so nothing was asked.
+ * - `experimental` the guard ran; the matches carry ADR-0020's grade.
+ * - `unavailable`  a proposal was supplied and the guard could not run. Today
+ *                  the only cause is unreadable history, which
+ *                  `verification_gaps` names (#889).
+ * - `timed-out`    the guard leg was cut short by its own bound.
+ *
+ * **Nothing emits `timed-out`.** F11 specifies a bounded guard leg that returns
+ * it on expiry, and that bound was never implemented — the value's only emitter
+ * was the unreadable-history branch below, which is not a timeout and never
+ * measured one. It stays in the enum because it is the specified name for a
+ * real expiry, and it stays unreachable until something actually bounds the
+ * guard and can say so from a measured elapsed time.
+ */
+export type GuardConfidence = 'not-run' | 'experimental' | 'unavailable' | 'timed-out';
 
 /** One active decision record, as surfaced to the caller. */
 export interface ActiveDecision {
@@ -236,8 +252,17 @@ export const beforeChange = (opts: BeforeChangeOptions): BeforeChangeResult => {
       matches = guardResult.matches.map(renderGuardMatch);
       confidence = 'experimental';
     } else {
-      // History unavailable but proposal given — guard cannot run meaningfully
-      confidence = 'timed-out';
+      // History unavailable but a proposal was given, so the guard is skipped
+      // here and never starts. This reported `timed-out` (#889): a completed
+      // git failure presented as an expiry, with no guard execution and no
+      // elapsed time behind it. Measured against a directory that is not a
+      // repository — `git rev-parse --git-dir` exits 128 — the whole call
+      // returned in ~37 ms claiming it had timed out.
+      //
+      // The gap already says why in `verification_gaps`; this says only that
+      // the guard did not produce an answer, which is the honest reading of an
+      // empty `possible_revival_matches` here.
+      confidence = 'unavailable';
     }
   }
 

--- a/src/core/stale.ts
+++ b/src/core/stale.ts
@@ -26,6 +26,8 @@ import {
 } from './types.js';
 
 const RECORD_ID_KEY = 'Record-Id';
+/** Rewritten per block by the notes mirroring, so it is not payload content. */
+const PROVENANCE_KEY = 'Provenance';
 const SUPERSEDES_KEY = 'Supersedes';
 const FOLLOWS_KEY = 'Follows';
 const EXPIRES_KEY = 'Expires';
@@ -422,11 +424,59 @@ const undecidableExpiry = (ordered: TimedRecord[]): Set<string> => {
   return found;
 };
 
+/** `payloadSignature` without the provenance stamp the mirroring rewrites. */
+const payloadSignatureWithoutProvenance = (record: StaleRecord): string =>
+  record.trailers
+    .filter((trailer) => trailer.key !== RECORD_ID_KEY && trailer.key !== PROVENANCE_KEY)
+    .map((trailer) => `${trailer.key} ${trailer.value}`)
+    .sort()
+    .join('');
+
+/**
+ * Whether a note is its own commit's mirror rather than a rival declaration.
+ *
+ * `squash-preserve --target` writes the branch's records onto the notes ref and
+ * stamps each block with its own `Provenance: inherited <sha>` — never
+ * inherited, rewritten per block, by design (core/squash.ts). When the same
+ * records are also composed into that commit's message, the note and the
+ * message differ by exactly that stamp and by nothing else, and the group was
+ * called ambiguous and withheld (#890).
+ *
+ * The workflow that produces it is the one the tool recommends: the merge
+ * helper's own output tells the operator to pass `--target` so the records are
+ * mirrored where git will not parse them as trailers. A record hidden because
+ * it was stored successfully in both supported places is a bad trade, and the
+ * operator who hit it had no way to see where either declaration was.
+ *
+ * Only the stamp is forgiven. Any other difference — a changed `Limit:`, an
+ * added or dropped trailer — still diverges and still withholds, which is
+ * r-refint74's rule and the reason it exists: notes are remote-reachable, so
+ * divergent note content must not inherit an identity a human approved.
+ */
+const isOwnCommitMirror = (record: StaleRecord, group: StaleRecord[]): boolean => {
+  if (record.source !== 'notes' || record.sha === undefined) return false;
+  const signature = payloadSignatureWithoutProvenance(record);
+  return group.some(
+    (sibling) =>
+      sibling.source === 'commit' &&
+      sibling.sha === record.sha &&
+      payloadSignatureWithoutProvenance(sibling) === signature,
+  );
+};
+
+/**
+ * A notes mirror diverging from the commit block it mirrors. Each note that is
+ * its own commit's mirror is dropped before the comparison, so the message
+ * block speaks for the pair; everything else is compared in full as before.
+ */
+const notesPayloadDiverges = (group: StaleRecord[]): boolean => {
+  if (!group.some((record) => record.source === 'notes')) return false;
+  const rivals = group.filter((record) => !isOwnCommitMirror(record, group));
+  return new Set(rivals.map(payloadSignature)).size > 1;
+};
+
 const hasAmbiguousGroup = (group: StaleRecord[]): boolean =>
-  sharesACommit(group) ||
-  instantConflicts(group).size > 0 ||
-  (group.some((record) => record.source === 'notes') &&
-    new Set(group.map(payloadSignature)).size > 1);
+  sharesACommit(group) || instantConflicts(group).size > 0 || notesPayloadDiverges(group);
 
 /** Whether a record cannot be safely merged because its identity is ambiguous. */
 export const hasAmbiguousIdCollision = (records: StaleRecord[]): boolean =>

--- a/test/before-change.test.ts
+++ b/test/before-change.test.ts
@@ -140,6 +140,61 @@ describe('commitlore_before_change', () => {
     expect(result.active_decisions).toEqual([]);
   });
 
+  /**
+   * #889: with a proposal supplied and history unreadable, the guard is skipped
+   * and never starts — but the response called that `timed-out`. A completed
+   * git failure presented as an expiry, with no guard execution and no elapsed
+   * time behind it. Measured against a directory that is not a repository
+   * (`git rev-parse --git-dir` exits 128), the whole call returned in ~37 ms
+   * claiming it had timed out.
+   *
+   * The two cases below are the pair: the existing unavailable-history tests
+   * all pass no proposal, so none of them reaches this branch.
+   */
+  describe('#889 unreadable history is not reported as a guard timeout', () => {
+    const nonRepo = (): string => mkdtempSync(join(tmpdir(), 'no-git-889-'));
+
+    it('does not call a skipped guard timed-out', () => {
+      const dir = nonRepo();
+      try {
+        const result = beforeChange({ path: 'src/example.ts', cwd: dir, proposal: 'update example implementation' });
+
+        // The gap is the fail-closed half and must survive untouched.
+        expect(result.verification_gaps).toContain('history-unavailable');
+        expect(result.guard_confidence).not.toBe('timed-out');
+        expect(result.guard_confidence).toBe('unavailable');
+        expect(result.possible_revival_matches).toEqual([]);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    // Not an elapsed-time threshold: the reporter asked for the guard's absence
+    // to be proven rather than timed, and a duration assertion would be the
+    // fragile oracle they warned against. `unavailable` is only reachable from
+    // the branch that skips guard(), so the value is the proof.
+    it('keeps the no-proposal answer distinct from the skipped-guard answer', () => {
+      const dir = nonRepo();
+      try {
+        const withProposal = beforeChange({ path: 'src/example.ts', cwd: dir, proposal: 'a proposal' });
+        const without = beforeChange({ path: 'src/example.ts', cwd: dir });
+
+        expect(without.guard_confidence).toBe('not-run');
+        expect(withProposal.guard_confidence).toBe('unavailable');
+        // Both still report the gap; only the guard field separates them.
+        expect(without.verification_gaps).toContain('history-unavailable');
+        expect(withProposal.verification_gaps).toContain('history-unavailable');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('leaves the healthy-history proposal answer experimental', () => {
+      const result = beforeChange({ path: 'src/auth.ts', cwd: repoDir, proposal: 'switch to a shared cache' });
+      expect(result.guard_confidence).toBe('experimental');
+    });
+  });
+
   // Fail-closed: unreadable repo reports gap
   it('unreadable repository reports verification gap rather than empty context', async () => {
     const emptyTmp = mkdtempSync(join(tmpdir(), 'no-git-'));

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1303,12 +1303,84 @@ describe('doctor: squash conservation (bug-issue-60 finding 1)', () => {
     rebuildIndex(openIndex({ cwd: repo }));
   };
 
+  /**
+   * A branch closed without merging (#888): its commits are unreachable from
+   * HEAD exactly as a squashed branch's are, and its content never lands. It
+   * touches a path of its own so the two cases stay distinguishable by content.
+   */
+  const abandonBranch = (repo: string, recordId: string): void => {
+    git(repo, ['checkout', '--quiet', '-b', 'abandoned']);
+    writeFileSync(join(repo, 'abandoned.ts'), 'export const y = 2;\n');
+    git(repo, ['add', '--', 'abandoned.ts']);
+    git(repo, [
+      'commit',
+      '--quiet',
+      '-m',
+      `add the abandoned work\n\nLimit: superseded before review\nRecord-Id: ${recordId}\n`,
+    ]);
+    git(repo, ['checkout', '--quiet', 'main']);
+  };
+
   it('skips when no local branch looks like a squash source', () => {
     const repo = initRepo('squash-conservation-none');
     git(repo, ['commit', '--quiet', '--allow-empty', '-m', 'first']);
 
     const report = runDoctor({ cwd: repo });
     expect(statusOf(report, 'squash-conservation')).toBe('skipped');
+  });
+
+  /**
+   * #888: a branch closed without merging is unreachable from HEAD in exactly
+   * the same way a squashed one is, so the check called both squashes and
+   * prescribed `squash-preserve` for both. That prescription is not merely
+   * unnecessary on an abandoned branch — `--target` mirrors records onto
+   * whatever commit it is handed without checking the commit contains the
+   * work, so following it writes provenance for work that was deliberately
+   * discarded.
+   *
+   * Reported against a real pull request closed as superseded: every file it
+   * touched already existed on `main` in an equal or newer version, and there
+   * was no "commit that squashed it" for `--target` to name.
+   */
+  it('does not prescribe squash-preserve for a branch that was never merged', () => {
+    const repo = initRepo('squash-conservation-abandoned');
+    git(repo, ['commit', '--quiet', '--allow-empty', '-m', 'seed']);
+    abandonBranch(repo, 'r-abandoned01');
+
+    const report = runDoctor({ cwd: repo });
+    const entry = report.checks.find((check) => check.id === 'squash-conservation');
+
+    // The record is still reported — the finding set does not change, only the
+    // claim and the remedy. Silence here would be the worse failure.
+    expect(entry?.status).toBe('warn');
+    expect(entry?.detail).toContain('r-abandoned01');
+    expect(entry?.detail).toContain('never merged');
+    expect(entry?.fix, 'prescribed a remedy that would manufacture provenance').not.toContain(
+      'squash-preserve',
+    );
+    expect(entry?.evidence['unmerged_count']).toBe('1');
+  });
+
+  it('still prescribes squash-preserve for the squashed branch when both kinds are present', () => {
+    const repo = initRepo('squash-conservation-mixed');
+    git(repo, ['commit', '--quiet', '--allow-empty', '-m', 'seed']);
+    abandonBranch(repo, 'r-mixedaband1');
+    growFeatureBranch(repo, 'r-mixedsquash');
+    squashWithoutPreserving(repo);
+
+    const report = runDoctor({ cwd: repo });
+    const entry = report.checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('warn');
+    // Both are reported, and each is described by what actually happened to it.
+    expect(entry?.detail).toContain('r-mixedsquash');
+    expect(entry?.detail).toContain('r-mixedaband1');
+    expect(entry?.detail).toContain('so it was squashed');
+    expect(entry?.detail).toContain('never merged');
+    // The remedy survives for the branch that earns it.
+    expect(entry?.fix).toContain('squash-preserve');
+    expect(entry?.evidence['squashed_count']).toBe('1');
+    expect(entry?.evidence['unmerged_count']).toBe('1');
   });
 
   it('warns when a squashed branch left a Record-Id behind that HEAD cannot find', () => {

--- a/test/stale.test.ts
+++ b/test/stale.test.ts
@@ -563,6 +563,114 @@ describe('findIdCollisions', () => {
     expect(violations[0]?.value).toBe('r-collide');
   });
 
+  /**
+   * #890: `squash-preserve --target` mirrors a branch's records onto the notes
+   * ref and stamps each block with its own `Provenance: inherited <sha>` --
+   * never inherited, rewritten per block, by design (core/squash.ts). When the
+   * merge helper also composes those records into the merge commit's message,
+   * the note and the message differ by exactly that stamp, and the record was
+   * withheld as declared twice with no way to tell which was current.
+   *
+   * The workflow that produces it is the one the tool recommends: the merge
+   * helper's own output tells the operator to pass `--target`. A record hidden
+   * because it was stored successfully in both supported places is a bad trade.
+   */
+  it('does not flag a note that mirrors its own commit and differs only in Provenance', () => {
+    const violations = findIdCollisions([
+      {
+        sha: 'c1',
+        source: 'commit',
+        trailers: [trailer('Limit', 'assert cleanup before endpointFor()'), trailer('Record-Id', 'r-mirror')],
+      },
+      {
+        sha: 'c1',
+        source: 'notes',
+        trailers: [
+          trailer('Limit', 'assert cleanup before endpointFor()'),
+          trailer('Record-Id', 'r-mirror'),
+          trailer('Provenance', 'inherited 0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f'),
+        ],
+      },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  /**
+   * Only the stamp is forgiven. This is r-refint74's rule and the reason it
+   * exists: notes are remote-reachable, so a note whose content diverged must
+   * not inherit an identity a human approved.
+   */
+  it('still flags a mirror that also changed a payload trailer', () => {
+    const violations = findIdCollisions([
+      {
+        sha: 'c1',
+        source: 'commit',
+        trailers: [trailer('Limit', 'approved content'), trailer('Record-Id', 'r-tampered')],
+      },
+      {
+        sha: 'c1',
+        source: 'notes',
+        trailers: [
+          trailer('Limit', 'attacker content'),
+          trailer('Record-Id', 'r-tampered'),
+          trailer('Provenance', 'inherited 0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f'),
+        ],
+      },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.value).toBe('r-tampered');
+  });
+
+  it('still flags a mirror that added a trailer beyond the stamp', () => {
+    const violations = findIdCollisions([
+      {
+        sha: 'c1',
+        source: 'commit',
+        trailers: [trailer('Limit', 'approved content'), trailer('Record-Id', 'r-extra')],
+      },
+      {
+        sha: 'c1',
+        source: 'notes',
+        trailers: [
+          trailer('Limit', 'approved content'),
+          trailer('Record-Id', 'r-extra'),
+          trailer('Provenance', 'inherited 0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f'),
+          trailer('Certainty', 'firm'),
+        ],
+      },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.value).toBe('r-extra');
+  });
+
+  /**
+   * The forgiveness is scoped to one commit's own mirror. Two different commits
+   * declaring one id, differing only in Provenance, are still two declarations
+   * and nothing here says which is current.
+   */
+  it('still flags a Provenance-only difference between two different commits', () => {
+    const violations = findIdCollisions([
+      {
+        sha: 'c1',
+        source: 'commit',
+        committedAt: '2026-03-01T12:00:00Z',
+        trailers: [trailer('Limit', 'same content'), trailer('Record-Id', 'r-twoshas')],
+      },
+      {
+        sha: 'c2',
+        source: 'notes',
+        committedAt: '2026-03-01T12:00:01Z',
+        trailers: [
+          trailer('Limit', 'same content'),
+          trailer('Record-Id', 'r-twoshas'),
+          trailer('Provenance', 'inherited 0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f'),
+        ],
+      },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.value).toBe('r-twoshas');
+  });
+
   it('flags a same-second conflict that a declared succession cannot order (issue #350)', () => {
     // `Supersedes:` names the intent but not the order. Both commits landed in
     // the same committer second, so nothing in history says which declaration


### PR DESCRIPTION
Closes #888
Closes #889
Closes #890

Source only — no `dist/`, no `installer/canonical-artifact.json`. Please run `canonical-merge.yml` against this number and merge the canonical PR with a merge commit.

All three are the same shape: a diagnostic naming a cause it had not established. One prescribed a remedy that would have done harm; one hid a record for being stored correctly.

## #888 — an abandoned branch and a squashed one looked identical

The check reported records "declared on a branch not reachable from HEAD" and concluded a squash dropped them. A squash is one cause; a branch closed without merging is the other, and there the records are absent because the work is absent — which is correct.

The two are indistinguishable in the commit graph, and `merge-base --is-ancestor` was all the check looked at, so it prescribed the same fixed literal for both:

```
fix: commitlore squash-preserve <base>..<branch> --target <the commit that squashed it>
```

**On an abandoned branch that does harm.** `squash-preserve --target` mirrors the branch's records onto whatever commit it is handed and never verifies the commit contains the work, so following the advice writes records describing deliberately discarded work onto a commit that does not contain it. The reporter's case had no "commit that squashed it" for `--target` to name at all — the PR was closed as superseded.

### What changes

The content separates them: a squash carries the branch's tree into HEAD even though its commits are gone; an abandoned branch's tree is nowhere. Each branch that lost a record is classified by comparing the blob of every path it touched against HEAD's.

**Blob ids per path, not patch ids or trees.** `git cherry` and `patch-id` cannot answer this — a squash collapses N commits into one whose diff matches none individually, so a genuine squash reads as "not applied" to both. `merge-tree --write-tree` answers it directly but needs Git 2.38, and this project declares no Git floor; `git rev-parse <rev>:<path>` works everywhere.

**Deliberately asymmetric.** "Never merged" requires that *no* touched path exist in HEAD; "squashed" requires *every* touched path to match. A squash whose files `main` has since edited satisfies neither and falls to "could not be determined" — which still prescribes preserving, the direction that cannot lose a record.

**The finding set does not change.** Every record reported before is still reported; only the claim and the remedy vary, so a misclassification costs a worse sentence and never a lost finding. This is also why it is not the content-guessing the module doc rules out: records are still matched by `Record-Id` exactly as before, and what the content decides is what happened to the *branch*.

### Measured on a fixture holding both cases at once

```
before:
  r-abandoned01 (docs/abandoned), r-squashed001 (feature/squashed)
  fix: commitlore squash-preserve ... --target <the commit that squashed it>
       ^ prescribed for a branch whose file provably is not on HEAD

after:
  r-abandoned01 (docs/abandoned — none of its changes are in HEAD, so it was never merged),
  r-squashed001 (feature/squashed — its changes are in HEAD, so it was squashed)
  fix: commitlore squash-preserve ... (only the 1 on a branch whose changes reached HEAD)
  evidence: squashed_count=1 unmerged_count=1 undetermined_count=0
```

A repository holding only an abandoned branch is now told `nothing to preserve — these branches were closed without merging`.

## #889 — a timeout that never happened

With history unreadable and a proposal supplied, the guard is skipped and never starts — and the response called that `guard_confidence: "timed-out"`. The branch checked neither elapsed time nor timeout provenance, and reaching it needs nothing slow: a directory that is not a repository suffices. Measured against one, the call returned in **~37 ms** claiming it had timed out.

### What changes

A fourth value, `unavailable`: a proposal was supplied and the guard could not run. `not-run` keeps the meaning F11 gives it — *no proposal was supplied* — so the two cases stay distinct rather than collapsing into one word, and `verification_gaps` still carries `history-unavailable` as the reason.

Fail-closed behaviour is untouched and was never in question: unreadable history is still a reported gap, never a verified empty answer.

**`timed-out` stays in the enum and is now emitted by nothing.** `docs/tickets/F11-guard-classification.md:337` specifies a bounded guard leg returning it on expiry; that bound was never implemented, and this branch was its only emitter — so the value has never once been truthful. It is the specified name for a real expiry and stays reserved for one. The gap between a name in a document and the site that emits it is the shape worth noticing.

Nothing pins this enum outside the module — no JSON schema, no MCP output schema, no consumer beyond the file and its tests — so widening it is contained. The response still carries exactly five fields, as ADR-0020's confidence separation requires.

## #890 — a record stored in both supported places, withheld as declared twice

`context` hid a record whose two declarations were a trailer block in a commit's message and the same records on the notes ref **for that same commit**. Both are CommitLore's own storage, and the second was produced by following the tool's own advice — the merge helper tells the operator to pass `--target` so records are mirrored where git will not parse them as trailers.

**The rule was already right; the comparison was not.** `r-refint74` holds that exact commit and note mirrors are one logical record and only divergent note payloads collide, and `hasAmbiguousGroup` implements exactly that. But its `payloadSignature` weighs every trailer except `Record-Id`, while `planSquash` stamps each mirrored block with its own `Provenance: inherited <sha>` — never inherited, rewritten per block, by design. The two modules disagreed about what "same content" means, so a mirror written by the tool was *never* identical to the block it mirrored and the exact-mirror path could not fire for the case it exists for.

**This is the second surfacing.** `a73a1bc0` (#625) stopped squash preservation re-attaching a record the merge already carries, recording `Ruled-out: comparing record body text | provenance is rewritten during inheritance, but Record-Id is the protocol identity`. That fix went into the GitHub Action wrapper; the comparison in `core/stale.ts` was never told, so a direct `squash-preserve --target` still collided.

### Measured across the divergence matrix

| note vs the commit's message block | before | after |
|---|---|---|
| byte-identical mirror | rendered | rendered |
| same keys, reordered | rendered | rendered |
| **differs only by `Provenance: inherited <sha>`** | **WITHHELD** | **rendered** |
| mirror plus one extra trailer | WITHHELD | WITHHELD |
| subset of the message block | WITHHELD | WITHHELD |

Only the stamp is forgiven, and only within one commit — two different commits declaring one id and differing only in provenance still collide, because there "which is current" is a real question.

### The message stops making the operator guess

It said a record was declared more than once without saying where either declaration was; the reporter deleted a branch and rebuilt the index chasing it. Each collision now names its own locations, which the record already knew:

```
... r-branch890aa in 10a0f5d2's commit message and in its note on
refs/notes/commitlore, which differ
```

## Also on this branch: a dependency advisory that blocked the release

`audit` is one of the eleven contexts a release must pass at its exact commit, and it went red here for a reason unrelated to these three fixes: **three Hono advisories were published after the last release ran the same job green.** `hono` reaches this project through `@modelcontextprotocol/sdk` and `--omit=dev` still reports it, so it is a production dependency.

The SDK is already newest and asks for `^4.11.4`, so the fixed 4.13.7 is inside the range it already declares — nothing about the dependency contract changes, only the resolution.

**The lockfile edit is three lines, not thirty-six.** `npm audit fix` reaches the same resolution *and* strips all ten `libc` hints from the optional platform packages, because the npm on this machine (10.9.8) writes them differently from the canonical build's. Those hints are how npm chooses between glibc and musl binaries, and this project runs `install-alpine` on musl for both amd64 and arm64 — accepting that churn would have quietly changed how those installs resolve in order to fix an unrelated advisory. The surgical edit keeps all ten, and each of the three replacements refuses unless its string matches exactly once.

Worth stating though it did not decide anything: the three advisories are in `toSSG()`, `parseBody()` and the query parser — Hono's HTTP surface — and this MCP server speaks over stdio. The gate does not weigh reachability and neither did the fix.

## Evidence

| | before | after |
|---|---|---|
| #888 abandoned branch | `squash-preserve` prescribed | `nothing to preserve — closed without merging` |
| #888 squashed branch | `squash-preserve` prescribed | unchanged, and now says *why* |
| #888 both present | one undifferentiated warning | each named by its fate; remedy scoped to the one that earns it |
| #889 no proposal, no git | `not-run` | `not-run` (unchanged) |
| #889 proposal, no git | `timed-out` after 37 ms | `unavailable` |
| #889 proposal, healthy git | `experimental` | `experimental` (unchanged) |

Negative controls: restoring the unconditional prescription fails the abandoned-branch case while the squashed cases still pass; restoring `timed-out` fails both #889 cases. The #889 tests prove the guard's absence by the value rather than by an elapsed-time threshold, which is the fragile oracle the reporter asked me to avoid.

Full suite **3214 passed, 4 skipped, 0 failed**; `tsc --noEmit` exit 0; dogfood green against these five commits.

## Left as written

`docs/tickets/F11-guard-classification.md` still describes a three-value enum and a bounded guard leg that does not exist. It is a record of what was decided rather than a description of what runs, so I did not rewrite it; the discrepancy is documented at the type instead, and recorded as a `Limit:` on the commit.

## Release

`release: 1.2.7` is the third commit — 36 pins across 11 files, bumped by parsing the JSON manifests. This release is the clearest case yet for that rule: **`rolldown` is itself at 1.2.6** and its fifteen platform bindings each pin it, so text-replacing "1.2.6" would have rewritten 50+ lockfile lines unrelated to this project's version. The parse touched exactly two. The dependency that would have been corrupted has been a different one every release — `rolldown` at 1.2.4, `get-intrinsic` at 1.2.5, `rolldown` again now.
