### PR TITLE
fix(upgrade): ask when asked, and stop confirming an upgrade that did not happen (#893)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.8
+
+`upgrade` could not reach the release it was pointed at, and this one is 1.2.6's
+fault.
+
+**It reported 1.2.6 as newest while 1.2.7 was the newest release, and `--force`
+installed 1.2.6 (#893).** Nothing was wrong with the lookup — `git ls-remote`
+sees every tag. The answer is cached for a day, and 1.2.6 taught the command to
+re-ask only when the cached tag was *strictly older* than the running version,
+on the reasoning that the equal case is every up-to-date machine and re-asking
+it would spawn `git ls-remote` on every invocation.
+
+The equal case is exactly the one that goes stale. A machine on 1.2.6 with
+`v1.2.6` cached keeps being told it is current for the rest of the day after
+1.2.7 ships, and there was no way through: `--force` acted on the same stale
+value and reported `upgraded to v1.2.6` on a machine already running 1.2.6.
+The previous direction of this bug was harmless — the newer version was already
+in place. This one is not, because the operator cannot get the new release
+through the tool's own path.
+
+**The cost was measured wrong rather than weighed wrong.** `buildReport` has one
+caller, the `upgrade` command itself. The day-long cache exists for the ambient
+callers — the update notice, and `doctor` and `init` through
+`latestReleaseSync` — and none of them come through it. So the command whose
+whole purpose is to ask now asks, every time, and the extra lookup falls only on
+someone who typed it. The cache is refreshed rather than bypassed, so the
+ambient callers get the fresh answer too.
+
+**`--force` no longer confirms an upgrade it did not perform.** It names the
+target before installing, and when the newest release is the version already
+installed it says so and changes nothing, rather than reinstalling the same
+bytes under a success message.
+
+**The answer says where it came from.** "This is the newest release" and "this
+is the newest release I was told about yesterday" were the same sentence; the
+output now carries the source it resolved against.
+
+```
+installed  1.2.8
+latest     v1.2.8
+source     https://github.com/MongLong0214/commitlore.git
+```
+
 ## 1.2.7
 
 Three diagnostics that named a cause they had not established. One prescribed a

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh
-sh install.sh v1.2.7
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh
+sh install.sh v1.2.8
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.7 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.8 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh
-sh install.sh v1.2.7
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh
+sh install.sh v1.2.8
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.7 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.8 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh
-sh install.sh v1.2.7
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh
+sh install.sh v1.2.8
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.7 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.8 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh
-sh install.sh v1.2.7
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh
+sh install.sh v1.2.8
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.7 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.8 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.ps1))) v1.2.7
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.7/install.sh | sh -s v1.2.7",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.7"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.8"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -92,25 +92,28 @@ export const buildReport = async (
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<UpgradeReport> => {
   const current = packageVersion();
-  let result = await latestRelease({ env });
-  // A "latest" older than the version already running cannot be the latest
-  // (#885). The answer is cached for a day and only `upgrade` acting clears it,
-  // so a release installed any other way -- install.sh, the plugin marketplace,
-  // a manual checkout -- leaves the previous answer standing, and `upgrade`
-  // then reports an older tag as `latest` and says "this is the newest
-  // release". Reported against 1.2.5 while the cache still held v1.2.3.
+
+  // Somebody typed `upgrade`. Asking is the whole command, so it asks (#893).
   //
-  // Only strictly-older re-asks. Equal is the ordinary up-to-date answer and
-  // must stay cached, or the cache would never serve the case it exists for.
-  if (
-    result.cached &&
-    result.outcome.kind === 'resolved' &&
-    isNewerRelease(`v${current}`, result.outcome.tag)
-  ) {
-    forgetCachedRelease(env['HOME']);
-    result = await latestRelease({ env });
-  }
-  const { outcome, checkedAt } = result;
+  // 1.2.6 re-asked only when the cached answer was strictly older than the
+  // running version, on the reasoning that the equal case is every up-to-date
+  // machine and re-asking it would spawn `git ls-remote` on every upgrade
+  // (r-runtimevis885). The equal case is exactly the one that goes stale: a
+  // machine on 1.2.6 with `v1.2.6` cached keeps being told it is current for
+  // the rest of the day after 1.2.7 ships, and `--force` then reinstalls the
+  // version it already has. Reported with 1.2.7 an hour old.
+  //
+  // The cost objection was measured wrong rather than weighed wrong. The
+  // day-long cache exists for the *ambient* callers -- `core/update-notice.ts`,
+  // and `latestReleaseSync` under `doctor` and `init` -- and none of them come
+  // through here. This function has exactly one caller, the `upgrade` command
+  // itself, so the extra lookup lands only on someone who asked for it.
+  //
+  // Dropping the cache rather than passing `fresh` is deliberate: `fresh` skips
+  // the write too, which would leave the stale entry in place for the ambient
+  // notice to keep serving.
+  forgetCachedRelease(env['HOME']);
+  const { outcome, checkedAt } = await latestRelease({ env });
   const latest = outcome.kind === 'resolved' ? outcome.tag : null;
   const unknown = describe(outcome);
   return {
@@ -134,6 +137,10 @@ const render = (report: UpgradeReport): string => {
     return `${lines.join('\n')}\n`;
   }
   lines.push(`latest     ${report.latest ?? 'unknown'}`);
+  // Where the answer came from (#893). "This is the newest release" was
+  // indistinguishable from "this is the newest release I was told about a day
+  // ago", and the reporter had no way to tell those apart from the output.
+  lines.push(`source     ${report.source}`);
   lines.push(
     report.updateAvailable
       ? `\na newer release is available. To upgrade:\n\n  ${report.command}`
@@ -170,6 +177,22 @@ export const register = (program: Command): void => {
 
       // A typo must not silently downgrade a machine.
       if (!report.updateAvailable && options.force !== true) return;
+
+      // `--force` is the escape hatch for "the version looks stuck", so it must
+      // not confirm an upgrade it did not perform (#893). It acted on whatever
+      // the resolver had decided and printed `upgraded to v1.2.6` on a machine
+      // already running 1.2.6 -- a success message for a reinstall of the same
+      // bytes, which is the reading that made the operator believe the tool had
+      // done something. Naming the target and refusing the no-op costs nothing
+      // and cannot be misread. Exit 0: being current is not an error.
+      if (report.latest === `v${report.current}`) {
+        process.stdout.write(
+          `\n${report.current} is already installed and ${report.latest} is the newest release, ` +
+            'so there is nothing to install. Nothing was changed.\n',
+        );
+        return;
+      }
+      process.stdout.write(`\ninstalling ${report.latest}\n`);
 
       const blocked = process.env['COMMITLORE_NO_AUTO_UPDATE'];
       if (blocked !== undefined && blocked !== '') {

--- a/test/update-command.test.ts
+++ b/test/update-command.test.ts
@@ -124,6 +124,42 @@ describe('T-1603 ADR-0037 is enforced, not described', () => {
     expect(report.latest).toBe('v98.0.0');
   });
 
+  /**
+   * #893: `--force` is documented as "act even when the newest release is not
+   * newer than this one", so it is what an operator reaches for when the
+   * version looks stuck. It acted on whatever the resolver had decided and
+   * printed `upgraded to v1.2.6` on a machine already running 1.2.6 — a
+   * success line for a reinstall of the same bytes, which is what made the
+   * operator believe an upgrade had happened.
+   */
+  it('--force names its target and refuses a no-op instead of reporting success', () => {
+    const current = `v${packageVersion()}`;
+    const out = execFileSync(process.execPath, [cli, 'upgrade', '--force'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        COMMITLORE_INSTALL_SOURCE: remoteWithTags([current]),
+        HOME: scratch('home-force-noop'),
+      },
+    });
+
+    expect(out).toContain('nothing to install');
+    expect(out).toContain('Nothing was changed');
+    expect(out, 'reported an upgrade it did not perform').not.toContain('upgraded to');
+  });
+
+  it('names the source the answer came from', () => {
+    const source = remoteWithTags(['v96.0.0']);
+    const out = execFileSync(process.execPath, [cli, 'upgrade', '--check'], {
+      encoding: 'utf8',
+      env: { ...process.env, COMMITLORE_INSTALL_SOURCE: source, HOME: scratch('home-src-cli') },
+    });
+
+    // "this is the newest release" and "the newest release I was told about
+    // yesterday" were the same sentence; the source is what separates them.
+    expect(out).toContain(`source     ${source}`);
+  });
+
   it('starts nothing but the check it owns', () => {
     // A comment saying the CLI does not replace itself is not a guard (#723).
     // `git` is replaced with a recorder for the length of the run; anything
@@ -160,11 +196,24 @@ describe('T-1603 ADR-0037 is enforced, not described', () => {
  * binary printing it. Nothing was wrong with the lookup; the cache had simply
  * outlived the fact.
  *
- * A `latest` older than the version already running cannot be the latest, and
- * that is the whole rule. Equality still serves from the cache, or the cache
- * would never serve the case it exists for.
+ * #893 finished it. 1.2.6 re-asked only when the cached tag was strictly older
+ * than the running version, reasoning that the equal case is every up-to-date
+ * machine and re-asking it would spawn `git ls-remote` on every upgrade. The
+ * equal case is precisely the one that goes stale: a machine on 1.2.6 with
+ * `v1.2.6` cached kept being told it was current for the rest of the day after
+ * 1.2.7 shipped, and `--force` reinstalled the version it already had.
+ *
+ * The cost was measured wrong rather than weighed wrong. `buildReport` has one
+ * caller — the `upgrade` command — and the day-long cache exists for the
+ * ambient callers (`core/update-notice.ts`, and `latestReleaseSync` under
+ * `doctor` and `init`), none of which come through here. So the command that
+ * exists to ask, asks.
+ *
+ * A test here previously asserted the opposite ("still serves the cache when it
+ * agrees with the running version"). It pinned the defect, and it is replaced
+ * rather than deleted so the reversal is visible.
  */
-describe('#885 a cached latest older than the running version is re-asked', () => {
+describe('#885/#893 upgrade does not serve a stale latest', () => {
   it('re-asks rather than reporting a tag older than the binary printing it', async () => {
     const home = scratch('home-stale');
 
@@ -185,7 +234,11 @@ describe('#885 a cached latest older than the running version is re-asked', () =
     expect(report.updateAvailable).toBe(true);
   });
 
-  it('still serves the cache when it agrees with the running version', async () => {
+  // The #893 case, and the one the replaced test asserted backwards. A machine
+  // that is up to date today is the machine that will be out of date tomorrow,
+  // so "the cached answer agrees with the running version" is not a reason to
+  // stop asking — it is the state every stale answer starts from.
+  it('asks again even when the cached answer agrees with the running version', async () => {
     const home = scratch('home-current');
     const current = `v${packageVersion()}`;
 
@@ -193,16 +246,26 @@ describe('#885 a cached latest older than the running version is re-asked', () =
       COMMITLORE_INSTALL_SOURCE: remoteWithTags([current]),
       HOME: home,
     });
-    expect(primed.latest).toBe(current);
+    expect(primed.latest, 'the cache was not primed').toBe(current);
 
-    // The remote has moved, but "up to date" is exactly the answer the cache
-    // exists to hold. Re-asking here would make the cache decorative.
     const report = await buildReport({
       COMMITLORE_INSTALL_SOURCE: remoteWithTags([current, 'v99.0.0']),
       HOME: home,
     });
 
-    expect(report.latest).toBe(current);
-    expect(report.updateAvailable).toBe(false);
+    expect(report.latest).toBe('v99.0.0');
+    expect(report.updateAvailable).toBe(true);
+  });
+
+  // The reporter could not tell "newest" from "newest as of yesterday" from the
+  // output, so the answer now says what it consulted.
+  it('names the source it resolved the answer from', async () => {
+    const source = remoteWithTags(['v99.0.0']);
+    const report = await buildReport({
+      COMMITLORE_INSTALL_SOURCE: source,
+      HOME: scratch('home-source'),
+    });
+
+    expect(report.source).toBe(source);
   });
 });


### PR DESCRIPTION
Closes #893

Source only — no `dist/`, no `installer/canonical-artifact.json`. Please run `canonical-merge.yml` against this number and merge the canonical PR with a merge commit.

**This one is 1.2.6's fault, and the reasoning is in that commit's own record.**

`upgrade` reported 1.2.6 as newest while 1.2.7 was the newest release, and `--force` installed 1.2.6. Nothing is wrong with the lookup — `git ls-remote` sees every tag. Verified on my own machine mid-investigation: the cache held `v1.2.6`, checked 171 minutes earlier, with a 1440-minute TTL.

1.2.6 taught the command to re-ask only when the cached tag was **strictly older** than the running version, recording this as `r-runtimevis885`:

> `Ruled-out: re-ask whenever the cached latest is not newer than the running version | that includes the equal case, which is every up-to-date machine, and would spawn git ls-remote on every upgrade`

The equal case is precisely the one that goes stale. A machine on 1.2.6 with `v1.2.6` cached keeps being told it is current for the rest of the day after 1.2.7 ships, and there was no way through — `--force` acted on the same stale value. The previous direction of this bug was harmless because the newer version was already installed. This one denies the operator the release.

## The cost was measured wrong, not weighed wrong

`buildReport` has exactly one caller: the `upgrade` command. The day-long cache exists for the **ambient** callers — `core/update-notice.ts`, and `latestReleaseSync` under `doctor` and `init` — and none of them come through it.

```
update-notice.ts ──> latestRelease      (cached, ambient)
doctor / init    ──> latestReleaseSync  (cached, ambient)
upgrade          ──> buildReport ──> latestRelease   <-- only this one
```

So the objection was about a cost this path never imposed on them. The command whose whole purpose is to ask now asks, and the extra lookup falls only on someone who typed `upgrade`. The cache is **dropped and refetched** rather than bypassed with `fresh`, because `fresh` skips the write too — bypassing would leave the stale entry for the ambient notice to keep serving.

## `--force` stops confirming an upgrade it did not perform

It printed `upgraded to v1.2.6` on a machine already running 1.2.6 — a success line for a reinstall of the same bytes, which is what made the operator believe something had happened. It now names its target before installing, and refuses the no-op:

```
1.2.7 is already installed and v1.2.7 is the newest release, so there is
nothing to install. Nothing was changed.
```

Exit stays 0 — being current is not an error, and SPEC §10 reserves non-zero for a check that could not run.

## The answer says where it came from

"This is the newest release" and "this is the newest release I was told about yesterday" were the same sentence.

```
installed  1.2.8
latest     v1.2.8
source     https://github.com/MongLong0214/commitlore.git
```

## A test that pinned the defect

`still serves the cache when it agrees with the running version` asserted the behaviour this fixes. It is **replaced rather than deleted**, with the reversal explained in the block, so the next reader sees that the rule changed and why.

## Evidence

Reproduced before fixing: with the newest tag equal to the installed version and a newer tag then added to the remote, `upgrade` reported the old one; after, it reports the new one.

| | before | after |
|---|---|---|
| cached latest **older** than installed | re-asks (1.2.6 fix, kept) | re-asks |
| cached latest **equal** to installed, newer release exists | reports the stale tag | reports the new release |
| `--force` when newest == installed | `upgraded to <same version>` | names the target, changes nothing |
| output | no source | names the source resolved against |

Three negative controls, each failing exactly one case: restoring the strictly-older rule, letting `--force` act on the no-op, and dropping the source line.

Full suite **3217 passed, 4 skipped, 0 failed**; `tsc --noEmit` exit 0; dogfood green.

## Limits recorded

Every `upgrade` invocation now spends one `git ls-remote`, including `--json` in a polling script; `COMMITLORE_NO_UPDATE_CHECK` still turns the lookup off entirely. And this fixes the resolution, not the class — another caller that gains a reason to ask fresh will need the same judgement, and nothing here notices.
