### PR TITLE
fix: the shapes a record-preserving squash produces (#896, #897, #898)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,64 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.9
+
+Three reports from one repository in one morning, and they share a cause: a
+squash that preserves every record produces shapes the rest of the tool had not
+been taught to read.
+
+**`stale` called a `Follows:` dangling when its target was in the same commit
+(#898).** It reported `want an existing Record-Id in history` about a record
+present in that very commit. The rule was never wrong — `findDanglingRefs`
+builds its set from the whole stream with no ordering requirement. The stream
+was. The scan extracted a commit's trailers with git's view of a message, which
+is the last paragraph only, so a message carrying several record blocks arrived
+as a single record holding the final block and every id declared above it was
+invisible.
+
+`validate` and the index have always read every block, which is why
+`validate -c HEAD` said `references ok` about the commit `stale` called dangling
+— the same disagreement, on one commit, from two parsers. The scan now reads
+every block too. A commit still counts as one commit, so a multi-block history
+is not overstated and does not trip the truncation flag early.
+
+**`squash-conservation` reported records as lost when they were on the tracked
+upstream (#897).** The check reads local `HEAD`. The reporter's squash had
+landed on `origin/main` and their checkout had not caught up, so thirteen
+records were named as absent while `git log origin/main` found every one of
+them. They verified against the remote, the check reads HEAD, and both were
+right about different refs — which is also why an index rebuild changed nothing.
+
+A record the tracked upstream carries is no longer a loss; the row says it is on
+`origin/main` and that this checkout is behind. Scoped to the tracked upstream
+rather than every remote-tracking ref, because a feature branch pushed to
+`origin` and never merged carries its ids too, and counting those would excuse
+the loss this check exists to find.
+
+It also stops asserting more than it measured. `undetermined` findings rendered
+under the sentence *"do not appear in HEAD's history"*, a positive claim the
+check had not established; the row now says they could not be found there. This
+matters because the remedy it recommends writes a duplicate note, which is the
+withheld-record condition of #890 — the wrong warning could manufacture the
+corruption.
+
+**A staged capture expired silently (#896).** Five minutes after prepare, and
+when it lapsed the record was dropped with nothing said: the commit succeeded
+without it. Four records were lost this way in one working day, surfaced only
+afterwards by `doctor` as a count — by which time the transcript needed to
+re-capture may be gone. One of them carried a `Warn:` about what a green check
+does not prove and an `Unverified:` denying a coverage claim. Both had passed
+verification; neither reached history.
+
+Skipping an expired record is right: it binds to the tree it was prepared for.
+Saying nothing was not. The hook now names it on the commit that misses the
+window, and only for a record that was otherwise attachable — a record that
+fails another gate stays quiet, as before. It reports and does not block.
+
+Not changed, and left for its own decision: the five-minute window itself, and
+whether a record whose tree moved could be re-bound rather than expired. Both
+were suggested in #896; the second touches the binding every capture rests on.
+
 ## 1.2.8
 
 `upgrade` could not reach the release it was pointed at, and this one is 1.2.6's

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh
-sh install.sh v1.2.8
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh
+sh install.sh v1.2.9
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.8 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.9 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh
-sh install.sh v1.2.8
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh
+sh install.sh v1.2.9
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.8 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.9 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh
-sh install.sh v1.2.8
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh
+sh install.sh v1.2.9
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.8 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.9 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh
-sh install.sh v1.2.8
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh
+sh install.sh v1.2.9
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.8 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.9 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.ps1))) v1.2.8
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.8/install.sh | sh -s v1.2.8",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.8"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.9"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/doctor/checks/history-squash-conservation.ts
+++ b/src/commands/doctor/checks/history-squash-conservation.ts
@@ -98,6 +98,47 @@ const squashCandidates = (ctx: DoctorContext, head: string): SquashCandidateScan
 type BranchContentFate = 'present-in-head' | 'absent-from-head' | 'unknown';
 
 /**
+ * Record ids declared on the branch this checkout tracks (#897).
+ *
+ * `known` is HEAD's history, and a checkout that is merely behind its remote
+ * therefore reads as a repository that lost records. The reporter's case: the
+ * squash landed on `origin/main`, their local branch had not caught up, and the
+ * check named thirteen records as absent while `git log origin/main` found
+ * every one of them. They had verified against the remote; the check reads
+ * HEAD. Both were right about different refs, which is why an index rebuild
+ * changed nothing.
+ *
+ * Scoped to the tracked upstream rather than every remote-tracking ref. A
+ * feature branch pushed to `origin` but never merged carries its ids too, and
+ * counting those would excuse exactly the loss this check exists to find.
+ *
+ * A literal `^Record-Id:` scan rather than the parser, because the question is
+ * only whether the identity appears at all, and the reporter proposed the same:
+ * an id is a literal string. Anchoring to the declaration form matters —
+ * `Supersedes: r-x` names an id without declaring it, and must not count.
+ */
+const upstreamRecordIds = (ctx: DoctorContext): { ref: string; ids: Set<string> } | null => {
+  const { opts, git } = ctx;
+  const upstream = git(
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+    gitOptions(opts),
+  );
+  if (upstream.code !== 0) return null;
+  const ref = upstream.stdout.trim();
+  if (ref === '') return null;
+
+  const log = git(['log', ref, '--format=%B'], gitOptions(opts));
+  if (log.code !== 0) return null;
+
+  const ids = new Set<string>();
+  for (const match of log.stdout.matchAll(/^Record-Id:[ \t]*(\S+)[ \t]*$/gm)) {
+    const id = match[1];
+    if (id !== undefined) ids.add(id);
+  }
+  return { ref, ids };
+};
+
+/**
  * Compares blob ids per touched path rather than trees or patch ids.
  *
  * `git cherry` and `patch-id` cannot answer this: a squash collapses N commits
@@ -144,6 +185,23 @@ const branchContentFate = (
   if (matching === paths.length) return 'present-in-head';
   if (missingFromHead === paths.length) return 'absent-from-head';
   return 'unknown';
+};
+
+/**
+ * Names the records the tracked upstream already carries, so the row cannot be
+ * read as a loss when the only thing missing is a pull (#897).
+ */
+const upstreamNote = (
+  upstream: { ref: string; ids: Set<string> } | null,
+  onUpstreamOnly: readonly { branch: string; recordId: string }[],
+): string => {
+  if (upstream === null || onUpstreamOnly.length === 0) return '';
+  const named = [...new Set(onUpstreamOnly.map((entry) => entry.recordId))].slice(0, 5).join(', ');
+  const more = onUpstreamOnly.length > 5 ? `, and ${onUpstreamOnly.length - 5} more` : '';
+  return (
+    `. A further ${onUpstreamOnly.length} record(s) are already on ${upstream.ref} and are not lost` +
+    ` — this checkout is behind it: ${named}${more}`
+  );
 };
 
 const scanLimitDetail = (scan: SquashCandidateScan): string =>
@@ -235,7 +293,9 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
   }
 
   let known: Set<string> | null = null;
+  let upstreamKnown: { ref: string; ids: Set<string> } | null = null;
   const lost: { branch: string; recordId: string; fate: BranchContentFate }[] = [];
+  const onUpstreamOnly: { branch: string; recordId: string }[] = [];
   let uncheckable = 0;
   let checked = 0;
   const headSha = head.stdout.trim();
@@ -270,12 +330,22 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
           .filter((recordId): recordId is string => recordId !== undefined),
       );
     }
+    if (upstreamKnown === null) upstreamKnown = upstreamRecordIds(ctx);
 
     // Classified once per branch, and only when the branch has actually lost
     // something — an ok run pays nothing for it.
     let fate: BranchContentFate | null = null;
     for (const recordId of ids) {
       if (known.has(recordId)) continue;
+      // Present on the branch this checkout tracks: the record is not lost, the
+      // checkout is behind (#897). Reported separately so the operator learns
+      // to pull rather than to run squash-preserve -- which would write a
+      // duplicate note for a record the upstream already carries, producing the
+      // withheld-record condition of #890.
+      if (upstreamKnown !== null && upstreamKnown.ids.has(recordId)) {
+        onUpstreamOnly.push({ branch: candidate.branch, recordId });
+        continue;
+      }
       fate ??= branchContentFate(ctx, candidate, headSha);
       lost.push({ branch: candidate.branch, recordId, fate });
     }
@@ -340,7 +410,8 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
       category,
       title,
       'warn',
-      `${lost.length} record(s) declared on a branch not reachable from HEAD do not appear in HEAD's history: ${named}${more}${scanLimitDetail(scan)}`,
+      `${lost.length} record(s) declared on a branch not reachable from HEAD could not be found in ` +
+        `HEAD's history: ${named}${more}${upstreamNote(upstreamKnown, onUpstreamOnly)}${scanLimitDetail(scan)}`,
       fix,
       false,
       undefined,
@@ -353,16 +424,24 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
           squashed_count: String(lost.filter((entry) => entry.fate === 'present-in-head').length),
           unmerged_count: String(lost.filter((entry) => entry.fate === 'absent-from-head').length),
           undetermined_count: String(lost.filter((entry) => entry.fate === 'unknown').length),
+          on_upstream_count: String(onUpstreamOnly.length),
         }),
       },
     );
   }
 
+  // "Reachable from HEAD" would be false for a record this checkout has not
+  // pulled yet, so the ok row says where each one actually is (#897).
+  const reach =
+    upstreamKnown !== null && onUpstreamOnly.length > 0
+      ? `every declared Record-Id is accounted for — ${onUpstreamOnly.length} of them on ` +
+        `${upstreamKnown.ref} rather than in this checkout, which is behind it`
+      : 'every declared Record-Id is reachable from HEAD';
   const detail =
     uncheckable > 0
-      ? `${checked} squash-shaped branch(es) checked, every declared Record-Id is reachable from HEAD ` +
+      ? `${checked} squash-shaped branch(es) checked, ${reach} ` +
         `(${uncheckable} branch(es) recorded nothing with an id and could not be checked this way)${scanLimitDetail(scan)}`
-      : `${checked} squash-shaped branch(es) checked, every declared Record-Id is reachable from HEAD${scanLimitDetail(scan)}`;
+      : `${checked} squash-shaped branch(es) checked, ${reach}${scanLimitDetail(scan)}`;
   return check(
     id,
     category,
@@ -378,6 +457,12 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
         checked: String(checked),
         uncheckable: String(uncheckable),
         lost_count: '0',
+        // Only when it says something. `scanEvidence` sets the same precedent
+        // for the branch cap, and a key that is always "0" on a healthy
+        // repository is churn in every pinned report.
+        ...(onUpstreamOnly.length === 0
+          ? {}
+          : { on_upstream_count: String(onUpstreamOnly.length) }),
       }),
     },
   );

--- a/src/commands/stale.ts
+++ b/src/commands/stale.ts
@@ -27,8 +27,8 @@ import {
   type RecordState,
   type StaleRecord,
 } from '../core/stale.js';
-import { parseCommitMessage } from '../core/trailers.js';
-import type { Violation } from '../core/types.js';
+import { parseRecordBlocks } from '../core/trailers.js';
+import type { Trailer, Violation } from '../core/types.js';
 
 /**
  * How many commits a scan reads when `--all-history` is not given. A bounded
@@ -88,21 +88,36 @@ export interface Scan {
   notes: NotesAvailability;
 }
 
-const parseChunk = (chunk: string): CollectedRecord | null => {
+/**
+ * Every record block in the message, not just the last one (#898).
+ *
+ * This used `parseCommitMessage`, which is git's view: the last paragraph only.
+ * A squash that preserves each source record as its own block therefore reached
+ * the fold as a single record carrying the final block, and every id declared in
+ * an earlier block was invisible. A `Follows:` pointing at one of them was then
+ * reported as `dangling-ref` — "want an existing Record-Id in history" — about a
+ * record present in the very same commit.
+ *
+ * `validate` already reads every block through `parseRecordBlocks`, and so does
+ * the index, which is why the two disagreed on one commit: `validate -c HEAD`
+ * said references ok while `stale` called the same reference dangling.
+ *
+ * A commit with no blocks still yields one record with no trailers, so the
+ * commit count and the notes-mirror comparison below keep their shape.
+ */
+const parseChunk = (chunk: string): CollectedRecord[] => {
   const firstSep = chunk.indexOf(UNIT);
-  if (firstSep === -1) return null;
+  if (firstSep === -1) return [];
   const secondSep = chunk.indexOf(UNIT, firstSep + 1);
-  if (secondSep === -1) return null;
+  if (secondSep === -1) return [];
 
+  const sha = chunk.slice(0, firstSep);
+  const committedAt = canonicalCommittedAt(chunk.slice(firstSep + 1, secondSep));
   const message = chunk.slice(secondSep + 1);
-  const trailers = CANDIDATE_LINE_RE.test(message) ? parseCommitMessage(message) : [];
+  const blocks = CANDIDATE_LINE_RE.test(message) ? parseRecordBlocks(message) : [];
 
-  return {
-    sha: chunk.slice(0, firstSep),
-    committedAt: canonicalCommittedAt(chunk.slice(firstSep + 1, secondSep)),
-    trailers,
-    source: 'commit',
-  };
+  if (blocks.length === 0) return [{ sha, committedAt, trailers: [], source: 'commit' }];
+  return blocks.map((trailers) => ({ sha, committedAt, trailers, source: 'commit' }));
 };
 
 /**
@@ -126,11 +141,29 @@ export const collectRecords = (opts: CollectOptions = {}): Scan => {
   const commitRecords = result.stdout
     .split('\u0000')
     .filter((chunk) => chunk.length > 0)
-    .map(parseChunk)
-    .filter((record): record is CollectedRecord => record !== null);
-  const commitsBySha = new Map(commitRecords.map((record) => [record.sha, record]));
+    .flatMap(parseChunk);
+
+  // One commit may now contribute several records, so anything that counts
+  // commits counts distinct shas. Counting records here would report a
+  // multi-block repository as larger than it is, and would trip the truncation
+  // flag below on a history well short of the scan limit.
+  const shas = new Set(commitRecords.map((record) => record.sha));
+
+  // The mirror comparison is against everything the commit declares, across all
+  // of its blocks -- a note mirroring one block of a squash must still count as
+  // mirrored.
+  const trailersBySha = new Map<string, { committedAt: string; trailers: Trailer[] }>();
+  for (const record of commitRecords) {
+    const existing = trailersBySha.get(record.sha);
+    if (existing === undefined) {
+      trailersBySha.set(record.sha, { committedAt: record.committedAt, trailers: [...record.trailers] });
+    } else {
+      existing.trailers.push(...record.trailers);
+    }
+  }
+
   const noteRecords = listRecordShas({ cwd }).flatMap((sha): CollectedRecord[] => {
-    const commit = commitsBySha.get(sha);
+    const commit = trailersBySha.get(sha);
     if (commit === undefined) return [];
 
     const trailers = readRecord(sha, { cwd });
@@ -144,8 +177,8 @@ export const collectRecords = (opts: CollectOptions = {}): Scan => {
 
   return {
     records: [...commitRecords, ...noteRecords],
-    commits: commitRecords.length,
-    truncated: opts.allHistory !== true && commitRecords.length >= DEFAULT_SCAN_LIMIT,
+    commits: shas.size,
+    truncated: opts.allHistory !== true && shas.size >= DEFAULT_SCAN_LIMIT,
     notes,
   };
 };

--- a/src/hooks/prepare-commit-msg.ts
+++ b/src/hooks/prepare-commit-msg.ts
@@ -221,6 +221,36 @@ const usesTemporaryCommitIndex = (cwd: string): boolean => {
   return resolve(cwd, currentIndex) !== resolve(cwd, gitDir.stdout.trim(), 'index');
 };
 
+/**
+ * An expired staged capture is dropped, and the commit succeeds without it
+ * (#896). Nothing said so. The record binds to the tree it was prepared for and
+ * is correctly skipped once that binding lapses, but the author gets a clean
+ * commit with no trailer and no statement that one was discarded -- which is
+ * indistinguishable from "there was nothing to record".
+ *
+ * Measured by the reporter in one working day: four staged records dropped this
+ * way, surfaced only by `doctor` afterwards as a count. One of them carried a
+ * `Warn:` about what a green check does not prove and an `Unverified:` denying a
+ * coverage claim -- both verified, neither in history. By the time a count
+ * appears, the transcript that would allow a re-capture may be gone.
+ *
+ * Said at the moment it happens, on the commit that misses the window, because
+ * that is the first occurrence rather than the twenty-fourth. It reports and
+ * does not block: a hook that fails a commit because the recorder lapsed would
+ * be worse than the silence it replaces.
+ */
+const reportExpired = (pending: PendingRecord): void => {
+  const label = captureLabel(pending);
+  const expiredAt = pending.expires_at;
+  const agoMinutes =
+    expiredAt === null ? null : Math.max(0, Math.round((Date.now() - new Date(expiredAt).getTime()) / 60_000));
+  const when = agoMinutes === null ? '' : ` ${agoMinutes} minute(s) ago`;
+  process.stderr.write(
+    `commitlore: staged capture ${label} expired${when} and was not attached; ` +
+      'this commit carries no record. Re-run capture to record it, or see `commitlore pending show`.\n',
+  );
+};
+
 const reportDiffMismatch = (pending: PendingRecord, cwd: string): void => {
   const label = captureLabel(pending);
   const detail = usesTemporaryCommitIndex(cwd)
@@ -313,12 +343,20 @@ const applyCaptureRecord = (messageFile: string, cwd: string): void => {
       continue;
     }
 
-    // Gate 3: Unexpired (expires_at must be non-null and in the future)
-    if (!pending.expires_at) continue;
-    if (now >= new Date(pending.expires_at).getTime()) continue;
-
     // Gate 5: Policy identity unchanged
     if (pending.policy_identity_hash !== currentPolicyHash) continue;
+
+    // Gate 3: Unexpired (expires_at must be non-null and in the future).
+    //
+    // Checked last so that anything reaching it was attachable but for the
+    // deadline: the report below then names a record this commit could have
+    // carried, rather than every lapsed file in the directory (#896). A record
+    // that also fails another gate stays silent here, as it was before.
+    if (!pending.expires_at) continue;
+    if (now >= new Date(pending.expires_at).getTime()) {
+      reportExpired(pending);
+      continue;
+    }
 
     eligible.push(pending);
   }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1361,6 +1361,55 @@ describe('doctor: squash conservation (bug-issue-60 finding 1)', () => {
     expect(entry?.evidence['unmerged_count']).toBe('1');
   });
 
+  /**
+   * #897: the check reads local HEAD, and a checkout that is merely behind its
+   * remote therefore reads as a repository that lost records. The reporter saw
+   * thirteen named as absent while `git log origin/main` found every one of
+   * them — they verified against the remote, the check reads HEAD, and both
+   * were right about different refs. An index rebuild changed nothing because a
+   * rebuild re-derives the same HEAD-scoped answer.
+   *
+   * It matters beyond a false warning: acting on it runs `squash-preserve
+   * --target` and writes a duplicate note for a record the upstream already
+   * carries, which is the withheld-record condition of #890.
+   */
+  const withUpstreamCarrying = (repo: string, recordId: string): void => {
+    const base = git(repo, ['rev-parse', 'HEAD']).trim();
+    git(repo, ['checkout', '--quiet', '-b', 'feature']);
+    writeFileSync(join(repo, 'feature.ts'), 'export const x = 1;\n');
+    git(repo, ['add', '--', 'feature.ts']);
+    git(repo, ['commit', '--quiet', '-m', `add the feature\n\nLimit: capped\nRecord-Id: ${recordId}\n`]);
+    git(repo, ['checkout', '--quiet', 'main']);
+    git(repo, ['merge', '--squash', 'feature']);
+    // The squash message carries the branch's record, the way a preserving
+    // merge helper writes it.
+    git(repo, ['commit', '--quiet', '-m', `Squash in the feature\n\nLimit: capped\nRecord-Id: ${recordId}\n`]);
+    const squash = git(repo, ['rev-parse', 'HEAD']).trim();
+
+    // The squash exists only on the tracked upstream; this checkout is behind.
+    git(repo, ['remote', 'add', 'origin', 'https://example.invalid/r.git']);
+    git(repo, ['update-ref', 'refs/remotes/origin/main', squash]);
+    git(repo, ['checkout', '--quiet', '-B', 'main', base]);
+    git(repo, ['config', 'branch.main.remote', 'origin']);
+    git(repo, ['config', 'branch.main.merge', 'refs/heads/main']);
+  };
+
+  it('does not call a record lost when the tracked upstream carries it', () => {
+    const repo = initRepo('squash-conservation-upstream');
+    git(repo, ['commit', '--quiet', '--allow-empty', '-m', 'seed']);
+    withUpstreamCarrying(repo, 'r-upstream8971');
+
+    const report = runDoctor({ cwd: repo });
+    const entry = report.checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('ok');
+    expect(entry?.detail).toContain('origin/main');
+    expect(entry?.detail, 'told the operator to preserve a record the remote already has').not.toContain(
+      'squash-preserve',
+    );
+    expect(entry?.evidence['on_upstream_count']).toBe('1');
+  });
+
   it('still prescribes squash-preserve for the squashed branch when both kinds are present', () => {
     const repo = initRepo('squash-conservation-mixed');
     git(repo, ['commit', '--quiet', '--allow-empty', '-m', 'seed']);

--- a/test/prepare-commit-msg-capture.test.ts
+++ b/test/prepare-commit-msg-capture.test.ts
@@ -270,6 +270,64 @@ describe('prepare-commit-msg capture guard', () => {
     expect(msg).not.toContain('Record-Id:');
   });
 
+  /**
+   * #896: skipping it is right; saying nothing about it is not. The record binds
+   * to the tree it was prepared for and is correctly dropped once the window
+   * lapses, but the author got a clean commit with no trailer and no statement
+   * that one was discarded — indistinguishable from "there was nothing to
+   * record". Four records were lost this way in one working day, surfaced only
+   * afterwards by `doctor` as a count, by which time the transcript needed to
+   * re-capture may be gone.
+   */
+  it('says so when an otherwise attachable record expired, and still does not block', async () => {
+    const past = new Date(Date.now() - 4 * 60_000).toISOString();
+    writePendingFile(repoDir, { expires_at: past });
+
+    const warnings: string[] = [];
+    const write = process.stderr.write.bind(process.stderr);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = (chunk: any, ...rest: any[]): boolean => {
+      warnings.push(String(chunk));
+      return write(chunk, ...(rest as []));
+    };
+    try {
+      await runHook(messageFile, repoDir);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process.stderr as any).write = write;
+    }
+
+    const said = warnings.join('');
+    expect(said, 'the drop was silent').toContain('expired');
+    expect(said).toContain('was not attached');
+    // Reporting, not blocking: the message is still written and unchanged.
+    const msg = readFileSync(messageFile, 'utf8');
+    expect(msg).toBe('test commit\n');
+  });
+
+  it('stays quiet about a lapsed record this commit could not have carried anyway', async () => {
+    // Wrong HEAD as well as expired: it was never attachable here, so naming it
+    // would be noise on every commit rather than a report about this one.
+    const past = new Date(Date.now() - 4 * 60_000).toISOString();
+    writePendingFile(repoDir, { expires_at: past, base_head: 'f'.repeat(40) });
+
+    const warnings: string[] = [];
+    const write = process.stderr.write.bind(process.stderr);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = (chunk: any, ...rest: any[]): boolean => {
+      warnings.push(String(chunk));
+      return write(chunk, ...(rest as []));
+    };
+    try {
+      await runHook(messageFile, repoDir);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process.stderr as any).write = write;
+    }
+
+    expect(warnings.join('')).not.toContain('expired');
+  });
+
   // -----------------------------------------------------------------------
   // Gate 4: Unconsumed
   // -----------------------------------------------------------------------

--- a/test/stale-multiblock.test.ts
+++ b/test/stale-multiblock.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #898: `stale` reported a `Follows:` as dangling when its target was declared
+ * in the same squashed commit.
+ *
+ * The rule was fine. The stream was not. `collectRecords` extracted a commit's
+ * trailers with `parseCommitMessage` — git's view, the last paragraph only — so
+ * a message carrying several record blocks reached the fold as one record
+ * holding the final block, and every id above it was invisible. `validate` and
+ * the index have always read every block through `parseRecordBlocks`, which is
+ * why `validate -c HEAD` reported "references ok" about the very commit `stale`
+ * called dangling.
+ *
+ * This is the collector half. The fold's rule is asserted in test/stale.test.ts.
+ *
+ * The repository that hit it merges through a helper that deliberately
+ * preserves each source record as its own block, so any branch where one record
+ * follows another and is then squashed produces a same-commit `Follows:`.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { buildReport, collectRecords } from '../src/commands/stale.js';
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const git = (cwd: string, args: readonly string[]): string =>
+  execFileSync('git', args, { cwd, encoding: 'utf8' });
+
+/** A repo whose second commit carries two record blocks, the squash shape. */
+const squashedChain = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'stale-multiblock-'));
+  scratch.push(dir);
+  git(dir, ['init', '--quiet', '--initial-branch=main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+
+  writeFileSync(join(dir, 'f.txt'), 'a\n');
+  git(dir, ['add', 'f.txt']);
+  git(dir, ['commit', '--quiet', '-m', 'seed\n\nRecord-Id: r-seed898000\nBlast: local\n']);
+
+  writeFileSync(join(dir, 'f.txt'), 'a\nb\n');
+  git(dir, ['add', 'f.txt']);
+  git(dir, [
+    'commit',
+    '--quiet',
+    '-m',
+    [
+      'feat: a squash of two commits',
+      '',
+      'Limit: the earlier decision',
+      'Record-Id: r-earlier89801',
+      'Blast: module',
+      '',
+      'Limit: the later refinement',
+      'Record-Id: r-later8980001',
+      'Follows: r-earlier89801',
+      'Blast: module',
+      '',
+    ].join('\n'),
+  ]);
+  return dir;
+};
+
+describe('#898 the stale scan reads every record block in a message', () => {
+  it('collects one record per block, not one per commit', () => {
+    const scan = collectRecords({ cwd: squashedChain(), allHistory: true });
+    const ids = scan.records
+      .map((record) => record.trailers.find((trailer) => trailer.key === 'Record-Id')?.value)
+      .filter((id): id is string => id !== undefined)
+      .sort();
+
+    // Reading only the last paragraph would find r-later8980001 and r-seed898000
+    // and miss the block above it entirely.
+    expect(ids).toEqual(['r-earlier89801', 'r-later8980001', 'r-seed898000']);
+  });
+
+  it('counts commits, not records, so a multi-block message is one commit', () => {
+    const scan = collectRecords({ cwd: squashedChain(), allHistory: true });
+
+    // Counting records here would overstate the history and, on a real
+    // repository, trip the truncation flag well short of the scan limit.
+    expect(scan.records.length).toBe(3);
+    expect(scan.commits).toBe(2);
+    expect(scan.truncated).toBe(false);
+  });
+
+  it('does not report a same-commit Follows: as dangling', () => {
+    const dir = squashedChain();
+    const report = buildReport(collectRecords({ cwd: dir, allHistory: true }), new Date());
+
+    expect(report.danglingRefs).toEqual([]);
+  });
+
+  it('still reports a Follows: that no block declares', () => {
+    const dir = squashedChain();
+    writeFileSync(join(dir, 'f.txt'), 'a\nb\nc\n');
+    git(dir, ['add', 'f.txt']);
+    git(dir, [
+      'commit',
+      '--quiet',
+      '-m',
+      'later\n\nLimit: points at nothing\nRecord-Id: r-real8980002\nFollows: r-doesnotexist9\nBlast: local\n',
+    ]);
+
+    const report = buildReport(collectRecords({ cwd: dir, allHistory: true }), new Date());
+
+    expect(report.danglingRefs).toHaveLength(1);
+    expect(report.danglingRefs[0]?.value).toBe('r-doesnotexist9');
+  });
+});

--- a/test/stale.test.ts
+++ b/test/stale.test.ts
@@ -518,6 +518,55 @@ describe('findIdCollisions', () => {
     ).toHaveLength(1);
   });
 
+  /**
+   * #898: a `Follows:` whose target is declared in the SAME commit was reported
+   * `dangling-ref` — "want an existing Record-Id in history" — about a record
+   * present in that very commit.
+   *
+   * `findDanglingRefs` was never the problem: it builds `declared` from the
+   * whole stream with no ordering rule. The stream was. `collectRecords`
+   * extracted trailers with `parseCommitMessage`, which is git's view of a
+   * message: the last paragraph only. A squash that preserves each source
+   * record as its own block therefore arrived as one record carrying the final
+   * block, and every id declared above it was invisible.
+   *
+   * `validate` and the index already read every block, which is why
+   * `validate -c HEAD` said "references ok" about the same commit `stale`
+   * called dangling. This asserts the rule the fold applies; the collector's
+   * half is covered in test/stale-multiblock.test.ts.
+   */
+  it('accepts a reference whose target is declared by another block of the same commit', () => {
+    const violations = findDanglingRefs([
+      {
+        sha: 'c1',
+        source: 'commit',
+        trailers: [trailer('Limit', 'the earlier decision'), trailer('Record-Id', 'r-earlier898')],
+      },
+      {
+        sha: 'c1',
+        source: 'commit',
+        trailers: [
+          trailer('Limit', 'the later refinement'),
+          trailer('Record-Id', 'r-later898'),
+          trailer('Follows', 'r-earlier898'),
+        ],
+      },
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  it('still flags a reference to an id no block declares', () => {
+    const violations = findDanglingRefs([
+      {
+        sha: 'c1',
+        source: 'commit',
+        trailers: [trailer('Record-Id', 'r-only898'), trailer('Follows', 'r-doesnotexist9')],
+      },
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.value).toBe('r-doesnotexist9');
+  });
+
   it('flags two commit-sourced blocks under the same sha sharing a Record-Id (bug-issue-92)', () => {
     // The shape `parseRecordBlocks` recovers from one message that carries
     // two blocks (SPEC §2.4): both blocks are `source: 'commit'` at the same


### PR DESCRIPTION
Closes #896
Closes #897
Closes #898

Source only — no `dist/`, no `installer/canonical-artifact.json`. Please run `canonical-merge.yml` against this number and merge the canonical PR with a merge commit.

Three reports from one repository in one morning. They share a cause: **a squash that preserves every record produces shapes the rest of the tool had not been taught to read.**

## #898 — `stale` called a `Follows:` dangling when its target was in the same commit

`findDanglingRefs` was never the problem — it builds `declared` from the whole stream and imposes no ordering. **The stream was.** `collectRecords` extracted trailers with `parseCommitMessage`, which is *git's* view of a message: the last paragraph only. A message carrying several record blocks arrived as one record holding the final block, and every id declared above it was invisible.

`validate` and the index have always read every block via `parseRecordBlocks`. That is why the two disagreed on one commit:

```
$ commitlore validate -c HEAD      shape ok · references ok
$ commitlore stale                 dangling refs
                                     Follows: r-238475016983
```

One message, two parsers, two answers.

**Counting had to move with the parse.** A commit may now contribute several records, so anything counting commits counts distinct shas — reporting record totals as commit totals would overstate the history and trip the truncation flag well inside the scan limit. The notes-mirror comparison likewise compares against everything a commit declares across all its blocks.

## #897 — records reported lost while they were on the tracked upstream

The check reads local `HEAD`; the reporter verified against `origin/main`. **Both were right about different refs.** Their squash had landed upstream and the checkout had not caught up, so an ordinary state — behind your remote — read as a repository that had lost records. An index rebuild changed nothing because a rebuild re-derives the same HEAD-scoped answer.

The cost is not a spurious line: the remedy this row prescribes writes the branch's records with `squash-preserve --target`, and doing that for a record the upstream already carries produces the same id in a message and in its note — **the withheld-record condition of #890.** The wrong warning could manufacture the corruption, and the reporter had to check each id by hand to separate twelve real losses from these thirteen.

Scoped to the **tracked upstream**, not every remote-tracking ref: a feature branch pushed to `origin` and never merged carries its ids too, and counting those would excuse the loss the check exists to find.

It also stops claiming more than it measured — `undetermined` findings rendered under *"do not appear in HEAD's history"*, a positive statement the check had not established.

| | before | after |
|---|---|---|
| squash landed upstream, checkout behind | `warn`, record named lost, `squash-preserve` prescribed | `ok`, names `origin/main`, prescribes nothing |
| branch squashed into HEAD | unchanged | unchanged |
| branch never merged | unchanged | unchanged |

## #896 — a staged capture expired in silence

Five minutes after prepare, and when it lapsed the record was dropped with nothing said. Four lost in one working day; the only trace was a `doctor` count afterwards, by which time the transcript needed to re-capture may be gone. One carried a `Warn:` about what a green check does not prove and an `Unverified:` denying a coverage claim — both verified, neither in history.

**Skipping it is right and is unchanged.** It binds to the tree it was prepared for. What was wrong is that silence here is indistinguishable from "there was nothing to record" — the failure this project exists to prevent, in its own pipeline.

The hook now names it on the commit that misses the window, and **only for a record that was otherwise attachable**: the expiry gate moved after the others, so a record failing another gate stays as quiet as before. It reports and does not block.

### Not changed, deliberately

The five-minute window itself, and whether a record whose tree moved could be re-bound rather than expired. Both were suggested in #896; the second touches the binding contract every capture rests on and wants its own evidence.

## Evidence

Each issue reproduced before fixing, and three negative controls each failing exactly its own case: restoring the last-paragraph view fails all four collector cases; ignoring the upstream set fails the new doctor case while the squashed and abandoned cases still pass; removing the expiry report fails the case asserting it while the case asserting quiet still passes.

Full suite **3226 passed, 4 skipped, 0 failed**; `tsc --noEmit` exit 0; dogfood green. `test/doctor.test.ts`'s byte-for-byte report-shape assertion still passes — the new evidence key is emitted only when it says something, following `scanEvidence`'s precedent for the branch cap.

## Noted, not fixed

The reporter's observation that `branches_seen: 308, branches_checked: 200` means the finding set changes as branches are cleaned up. That cap is untouched here.
