### PR TITLE
fix(backfill): work the commits a draft names; stop the test suite leaking shims

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,70 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.10
+
+Two reports about `backfill`, and one habit under both: the command reasons in
+commits, while its input, its verification and its failures are all about
+records. A third is about the test suite, which had been quietly filling the
+temp directory with executables.
+
+**`--draft` skipped commits it had been told to work (#901).** Target selection
+is bounded by `--limit`, which defaults to 50, and a draft's shas were checked
+for membership in that window — a sha outside it was refused as `not-a-target`
+even though the draft named it explicitly. Raising `--limit` looked like the fix
+and was not, because a second stop sat behind the first: apply mode walked the
+whole window in batches and converged after two that produced nothing, and every
+commit without a draft entry produces nothing. A drafted commit far enough down
+the walk was never reached at any limit; raising the limit only moved where the
+empty batches fell, which is why the same command succeeded and failed on the
+same repository.
+
+A draft now names its own targets. A sha outside the window is worked because
+the draft named it, and apply mode works only the commits the draft covers — so
+convergence counts batches of drafted work rather than batches of empty walking,
+and still stops on drafted commits that yield nothing.
+
+**One rejected trailer took the rest of its record with it, silently (#901,
+#902).** Verification is per record, so a `Ruled-out:` whose quote shows the
+alternative being mentioned rather than turned down fails the whole record. The
+trailers beside it disappeared without a word — and because the grounding check
+runs only after the quote check has passed, those siblings had provably survived
+the re-read. The rejection line now names them and distinguishes the two cases:
+trailers that passed the re-read and were not stored, from trailers dropped
+along with a record that failed earlier.
+
+**A rejection said what was wrong and not what would pass (#902).** `harvest`
+prints repair guidance in its repair round; `backfill` has no repair round, so
+its authors got the diagnosis without the remedy and had to guess at the shape.
+The same guidance catalogue is now printed on backfill's rejections.
+
+**The summary counted commits and labelled them records (#902).** `attached`
+incremented once per commit while a commit's records are assembled together, so
+a commit carrying two records reported one attached and the arithmetic in the
+summary did not add up. It counts records now.
+
+**The test suite left a new pair of executables in the temp directory on every
+run, and removed none of them (#903).** Two test files shadow `git` and `sh` on
+`PATH` to record what a run starts. Both wrote a fresh shim pair per test case
+and neither cleaned up, so a full suite left about sixty directories behind;
+this machine had accumulated 1,433. macOS evaluates an executable's provenance
+on its first exec and caches the verdict against file identity, so a new file
+every time is an evaluation every time — a cache that cannot hit, and against a
+saturated `syspolicyd` the exec does not return at all. Both files now write the
+shim pair once and delete every scratch directory they make; the log they read
+back moves to its own path and reaches the shims through the environment.
+
+This is a defect in the test suite and not in the installed tool, which the
+report's framing ("on every invocation") suggests. The shipped hook writer
+touches only `.git/hooks/`, once per install, through a temporary file it
+renames into place. The two stuck processes in the report are still real, both
+were ours, and both came from a killed test run.
+
+Not changed: `--with-prs` remains opt-in. #902 suggests making it the default,
+which would spawn `gh` on every run of a command that otherwise touches only the
+local repository; that is a product decision rather than a defect, and it is
+open.
+
 ## 1.2.9
 
 Three reports from one repository in one morning, and they share a cause: a

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh
-sh install.sh v1.2.9
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh
+sh install.sh v1.2.10
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.9 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.10 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh
-sh install.sh v1.2.9
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh
+sh install.sh v1.2.10
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.9 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.10 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh
-sh install.sh v1.2.9
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh
+sh install.sh v1.2.10
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.9 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.10 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh
-sh install.sh v1.2.9
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh
+sh install.sh v1.2.10
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.9 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.10 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.ps1))) v1.2.9
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.9/install.sh | sh -s v1.2.9",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.9"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.10"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/core/backfill.ts
+++ b/src/core/backfill.ts
@@ -59,7 +59,13 @@ import {
   type DraftRecord,
   type DraftRejection,
 } from './harvest.js';
-import { verifyDraft, type RejectionReason, type Sources } from './harvest-verify.js';
+import {
+  REPAIR_GUIDANCE,
+  verifyDraft,
+  type RejectedRecord,
+  type RejectionReason,
+  type Sources,
+} from './harvest-verify.js';
 import { closeIndex, openIndex, scanTrailers, updateIndex } from './index-db.js';
 import { writeRecord } from './notes.js';
 import { validateRecord } from './schema.js';
@@ -714,12 +720,81 @@ const promptMode = (
  * Every trailer that survives to the mirror came out of a record the verifier
  * accepted, and the only trailer this module adds is the one it is required to.
  */
+/**
+ * What else went with a rejected record (#901).
+ *
+ * `verifyDraft` grades a whole record, so a draft carrying two grounded
+ * `Limit:` trailers and one `Ruled-out:` that fails is discarded entire. That
+ * is defensible for a record's identity and is unchanged here. What was missing
+ * is the report: the rejection named the failing trailer and said nothing about
+ * the others, so an author who did not re-read the whole record lost evidence
+ * they had and had to resubmit it alone.
+ *
+ * The claim about the re-read is only made where it is true. `verifyDraft`
+ * chains its rules and stops at the first failure, so a rejection for
+ * `ruled-out-no-rejection` or `invalid` is reached only after `unfoundEvidence`
+ * has confirmed every citation in the record — including the surviving ones.
+ * A rejection for a quote that was not found proves nothing about its siblings,
+ * and there the line says only what was dropped.
+ */
+const QUOTES_ALREADY_CHECKED: ReadonlySet<string> = new Set([
+  'ruled-out-no-rejection',
+  'enum',
+  'format',
+  'unknown-key',
+]);
+
+const collateral = (rejected: RejectedRecord): string => {
+  const failing = rejected.reason === 'ruled-out-no-rejection' ? 'Ruled-out' : null;
+  // Identity and provenance are this command's own, not the author's: backfill
+  // stamps `Provenance: reconstructed` on every draft record, so counting it
+  // would tell the author they lost a trailer they never wrote.
+  const machinery = new Set(['Record-Id', 'Provenance']);
+  const others = rejected.record.trailers.filter(
+    (trailer) => !machinery.has(trailer.key) && trailer.key !== failing,
+  );
+  if (others.length === 0) return '';
+  const keys = [...new Set(others.map((trailer) => trailer.key))].join(', ');
+  return QUOTES_ALREADY_CHECKED.has(rejected.reason)
+    ? ` — ${others.length} other trailer(s) in this record passed the re-read and were not stored (${keys})`
+    : ` — ${others.length} other trailer(s) in this record were dropped with it (${keys})`;
+};
+
+/**
+ * The repair guidance, which backfill never showed (#902).
+ *
+ * `harvest` prints it in its repair round. Backfill has no repair round by
+ * design, so the author saw the reason and the detail and nothing about what
+ * shape would have passed — and two independent drafting sessions read
+ * `ruled-out-no-rejection` as "quote more context" and over-read design prose
+ * again. There is no repair round to add; there is a sentence to print.
+ */
+const repairHint = (reason: RejectionReason): string => {
+  const guidance = REPAIR_GUIDANCE[reason];
+  return guidance === undefined ? '' : `. Fix: ${guidance}`;
+};
+
+/**
+ * The assembled trailer block, and how many of the draft's records survived to
+ * make it (#902).
+ *
+ * A commit's records are merged into one block, so the caller used to count one
+ * per commit and print that as a record total: a round that stored 25 records
+ * across 13 commits reported `attached 13 records`, and a reader who trusts the
+ * line under-counts what was written by half.
+ */
+interface AssembledRecord {
+  trailers: Trailer[];
+  /** Draft records that survived verification for this commit. */
+  records: number;
+}
+
 const assembleRecord = (
   state: RunState,
   sha: string,
   entry: DraftCommitEntry,
   sources: Sources,
-): Trailer[] | null => {
+): AssembledRecord | null => {
   let review;
   try {
     review = parseDraft(JSON.stringify({ records: entry.records }));
@@ -739,7 +814,11 @@ const assembleRecord = (
 
   const verified = verifyDraft(forced, sources);
   for (const rejected of verified.rejected) {
-    state.report.discarded.push({ sha, reason: rejected.reason, detail: rejected.detail });
+    state.report.discarded.push({
+      sha,
+      reason: rejected.reason,
+      detail: `${rejected.detail}${collateral(rejected)}${repairHint(rejected.reason)}`,
+    });
   }
   if (verified.accepted.length === 0) return null;
 
@@ -766,7 +845,7 @@ const assembleRecord = (
     return null;
   }
 
-  return trailers;
+  return { trailers, records: verified.accepted.length };
 };
 
 const applyMode = (
@@ -779,6 +858,24 @@ const applyMode = (
 ): void => {
   const entries = new Map<string, DraftCommitEntry>();
   const targetShas = new Set(targets.map((target) => target.sha));
+
+  /**
+   * A draft names the commits it means (#901). `--limit` bounds how many
+   * recordless commits to *offer*, and by the time a draft exists that choice
+   * has been made — so a commit the draft names is worked whether or not this
+   * run's window happens to reach it.
+   *
+   * Before, `--prompt-only --limit 20` could offer a commit that a later plain
+   * `--draft` refused as outside its own default-50 window, and the same file
+   * attached unchanged under `--limit 5000`. The window is the run's, not the
+   * draft's, and nothing about a draft entry depends on where a fresh walk
+   * would have stopped.
+   *
+   * The other gates are untouched: a sha git cannot resolve is still unknown,
+   * a commit that already carries a record is still refused, and a duplicate is
+   * still refused. Only "outside this run's window" stops being a reason.
+   */
+  const extra: BackfillTarget[] = [];
 
   for (const entry of parseDraftDocument(raw)) {
     const sha = resolveCommit(options.cwd, entry.sha);
@@ -795,13 +892,27 @@ const applyMode = (
       continue;
     }
     if (!targetShas.has(sha)) {
-      skip(state, sha, 'not-a-target', 'the commit is outside the selected targets — raise --limit to include it');
-      continue;
+      extra.push({ sha, subject: subjectOf(options.cwd, sha) });
+      targetShas.add(sha);
     }
     entries.set(sha, entry);
   }
 
-  runBatches(state, targets, options.batchSize ?? DEFAULT_BATCH_SIZE, (batch) => {
+  /*
+   * Apply mode works exactly the commits the draft names, in target order.
+   *
+   * Every other target is a no-op here -- the loop below skips a target with no
+   * entry -- but `runBatches` stops after EMPTY_BATCH_LIMIT consecutive batches
+   * that produced nothing, so those no-ops could converge the run before it
+   * reached a drafted commit further down the list. That is the other half of
+   * #901: raising --limit appeared to fix the window when it was also giving
+   * the walk more chances to reach the commit before converging.
+   *
+   * Convergence still applies to the drafted set, where an empty batch means
+   * records that failed verification rather than commits nobody drafted for.
+   */
+  const worked = [...targets.filter((target) => entries.has(target.sha)), ...extra];
+  runBatches(state, worked, options.batchSize ?? DEFAULT_BATCH_SIZE, (batch) => {
     let produced = 0;
     for (const target of batch) {
       const entry = entries.get(target.sha);
@@ -813,8 +924,9 @@ const applyMode = (
       state.report.pullRequests.collected += found.length;
       const sources = collectSources(options.cwd, target.sha, found);
 
-      const trailers = assembleRecord(state, target.sha, entry, sources);
-      if (trailers === null) continue;
+      const assembled = assembleRecord(state, target.sha, entry, sources);
+      if (assembled === null) continue;
+      const { trailers } = assembled;
 
       state.report.estimatedTokens += estimateTokens(sources.transcript) + estimateTokens(sources.diff);
 
@@ -826,7 +938,10 @@ const applyMode = (
           continue;
         }
       }
-      state.report.attached += 1;
+      // Records, not commits (#902). A commit's records are merged into one
+      // block and written once, so counting the write counted commits and
+      // printed the total as records.
+      state.report.attached += assembled.records;
       produced += 1;
     }
     return produced;

--- a/src/core/harvest-verify.ts
+++ b/src/core/harvest-verify.ts
@@ -497,7 +497,12 @@ export const formatResult = (result: VerifyResult): string => {
  * the session is being asked to act, and "drop the record" is on every one of
  * them because dropping is always a correct answer here.
  */
-const REPAIR_GUIDANCE: Readonly<Record<RejectionReason, string>> = {
+/**
+ * Exported so `backfill` can print it too (#902). `harvest` shows it in its
+ * repair round; backfill has no repair round by design, which left its authors
+ * with a reason and no statement of what shape would pass.
+ */
+export const REPAIR_GUIDANCE: Readonly<Record<RejectionReason, string>> = {
   'evidence-not-found':
     'Copy the quote out of the transcript or the diff character for character. ' +
     'Only whitespace may differ. If you cannot find the sentence, drop the record.',

--- a/test/backfill.test.ts
+++ b/test/backfill.test.ts
@@ -375,28 +375,60 @@ describe('backfill forcing provenance', () => {
   });
 });
 
+/**
+ * Convergence used to reach into the draft (#901).
+ *
+ * `runBatches` stops after two consecutive batches that produced nothing, and
+ * apply mode walked every target — so a commit the draft named could sit past
+ * the stop condition and never be worked. The previous test here pinned exactly
+ * that: "the draft covers only the oldest target, which sits in the third batch
+ * — reachable only if the run ignores its own stop condition", asserting
+ * `attached: 0` and no notes. That is the behaviour the reporter hit; raising
+ * `--limit` appeared to fix a window when it was also giving the walk more
+ * chances to arrive before converging.
+ *
+ * A draft names the commits it means, so apply mode now works exactly those.
+ * Convergence still applies to them — an empty batch there means records that
+ * failed verification, which is a real reason to stop — and the cost it was
+ * built for lives in prompt mode, where each target spends a prompt rather than
+ * a map lookup.
+ */
 describe('backfill convergence', () => {
-  let fixture: Fixture;
-  let result: BackfillResult;
-
-  beforeAll(() => {
-    fixture = buildFixture('backfill-converge');
-    /* The draft covers only the oldest target, which sits in the third batch —
-       reachable only if the run ignores its own stop condition. */
+  it('works a drafted commit that sits past where the walk used to converge', () => {
+    const fixture = buildFixture('backfill-converge');
     const draft = draftFile(fixture, {
       commits: [{ sha: fixture.upload, records: [uploadRecord()] }],
     });
-    result = run(fixture, { draft, batchSize: 1 });
+
+    const result = run(fixture, { draft, batchSize: 1 });
+
+    expect(result.report.attached).toBe(1);
+    expect(noteShas(fixture.dir)).toEqual([fixture.upload]);
   });
 
-  it('stops after two consecutive batches that produced nothing', () => {
+  it('still converges on consecutive drafted commits that produce nothing', () => {
+    const fixture = buildFixture('backfill-converge-fail');
+    // Three drafted commits whose quotes are not in their sources, so every
+    // batch produces nothing and the stop condition is the one under test.
+    const absent = (sha: string) => ({
+      sha,
+      records: [
+        {
+          trailers: [{ key: 'Limit', value: 'a limit nobody wrote' }],
+          evidence: [
+            { key: 'Limit', source: 'transcript', quote: 'no such sentence anywhere', locator: 'L1-L1' },
+          ],
+        },
+      ],
+    });
+    const draft = draftFile(fixture, {
+      commits: [absent(fixture.tidy), absent(fixture.parser), absent(fixture.upload)],
+    });
+
+    const result = run(fixture, { draft, batchSize: 1 });
+
     expect(result.report.stoppedBy).toBe('converged');
     expect(result.report.batches).toBe(2);
-  });
-
-  it('does not walk the whole target list once it has converged', () => {
-    expect(result.report.targets).toBe(3);
-    expect(result.report.batches).toBeLessThan(result.report.targets);
     expect(result.report.attached).toBe(0);
     expect(noteShas(fixture.dir)).toEqual([]);
   });

--- a/test/init-upgrade.test.ts
+++ b/test/init-upgrade.test.ts
@@ -11,16 +11,48 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const CLI = join(PACKAGE_ROOT, 'dist', 'commitlore.mjs');
-const scratch = (label: string): string => mkdtempSync(join(tmpdir(), `cl-initup-${label}-`));
+
+const temporaries: string[] = [];
+const scratch = (label: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), `cl-initup-${label}-`));
+  temporaries.push(dir);
+  return dir;
+};
+
+afterAll(() => {
+  for (const dir of temporaries) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * #903: the shim pair is written once for the whole file, not once per run.
+ * macOS evaluates an executable's provenance on its first exec and caches the
+ * verdict against file identity, so a fresh pair per test is a fresh evaluation
+ * per test — a cache that can never hit, and on a saturated `syspolicyd` the
+ * exec does not return. The log has to stay per-run, so it moves out of the
+ * shim directory and reaches the shims through the environment instead.
+ */
+const CALL_LOG_VAR = 'COMMITLORE_TEST_CALL_LOG';
+let shimDir: string | undefined;
+const shims = (): string => {
+  if (shimDir !== undefined) return shimDir;
+  const dir = scratch('bin');
+  const realGit = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+  const line = (name: string) => `echo "${name} $*" >> "\${${CALL_LOG_VAR}:-/dev/null}"`;
+  writeFileSync(join(dir, 'git'), `#!/bin/sh\n${line('git')}\nexec ${realGit} "$@"\n`);
+  writeFileSync(join(dir, 'sh'), `#!/bin/sh\n${line('sh')}\nexec /bin/sh "$@"\n`);
+  execFileSync('chmod', ['+x', join(dir, 'git'), join(dir, 'sh')]);
+  shimDir = dir;
+  return dir;
+};
 
 const remoteWithTags = (tags: readonly string[]): string => {
   const dir = join(scratch('remote'), 'origin');
@@ -46,12 +78,8 @@ const runRecorded = (
   args: readonly string[],
   extra: NodeJS.ProcessEnv,
 ): { calls: string[]; out: string; code: number } => {
-  const bin = scratch('bin');
-  const log = join(bin, 'calls.log');
-  const realGit = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
-  writeFileSync(join(bin, 'git'), `#!/bin/sh\necho "git $*" >> ${log}\nexec ${realGit} "$@"\n`);
-  writeFileSync(join(bin, 'sh'), `#!/bin/sh\necho "sh $*" >> ${log}\nexec /bin/sh "$@"\n`);
-  execFileSync('chmod', ['+x', join(bin, 'git'), join(bin, 'sh')]);
+  const bin = shims();
+  const log = join(scratch('log'), 'calls.log');
 
   const repo = join(scratch('repo'), 'repo');
   execFileSync('git', ['init', '--quiet', '--initial-branch=main', repo]);
@@ -65,7 +93,13 @@ const runRecorded = (
     out = execFileSync(process.execPath, [CLI, 'init', ...args], {
       encoding: 'utf8',
       cwd: repo,
-      env: { ...process.env, PATH: `${bin}:${process.env['PATH'] ?? ''}`, HOME: scratch('home'), ...extra },
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env['PATH'] ?? ''}`,
+        HOME: scratch('home'),
+        [CALL_LOG_VAR]: log,
+        ...extra,
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (error) {
@@ -136,12 +170,8 @@ describe('T-1607 the three ways --upgrade can fail are three facts', () => {
 
 describe('T-1607 only two commands may spawn an installer', () => {
   it.each([['status'], ['doctor'], ['query']])('%s spawns none', (name) => {
-    const bin = scratch('bin');
-    const log = join(bin, 'calls.log');
-    const realGit = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
-    writeFileSync(join(bin, 'git'), `#!/bin/sh\necho "git $*" >> ${log}\nexec ${realGit} "$@"\n`);
-    writeFileSync(join(bin, 'sh'), `#!/bin/sh\necho "sh $*" >> ${log}\nexec /bin/sh "$@"\n`);
-    execFileSync('chmod', ['+x', join(bin, 'git'), join(bin, 'sh')]);
+    const bin = shims();
+    const log = join(scratch('log'), 'calls.log');
 
     const repo = join(scratch('repo'), 'repo');
     execFileSync('git', ['init', '--quiet', '--initial-branch=main', repo]);
@@ -153,6 +183,7 @@ describe('T-1607 only two commands may spawn an installer', () => {
           ...process.env,
           PATH: `${bin}:${process.env['PATH'] ?? ''}`,
           HOME: scratch('home'),
+          [CALL_LOG_VAR]: log,
           COMMITLORE_INSTALL_SOURCE: remoteWithTags(['v99.0.0']),
         },
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/update-apply.test.ts
+++ b/test/update-apply.test.ts
@@ -16,15 +16,44 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from 'node:fs';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 import { dataRoot, performUpgrade, pointsAtTarget, resolvedCurrent } from '../src/commands/update.js';
 
-const scratch = (label: string): string => mkdtempSync(join(tmpdir(), `cl-upg-${label}-`));
+const temporaries: string[] = [];
+const scratch = (label: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), `cl-upg-${label}-`));
+  temporaries.push(dir);
+  return dir;
+};
+
+afterAll(() => {
+  for (const dir of temporaries) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * #903: written once for the whole file. A fresh executable per run is a fresh
+ * macOS provenance evaluation per run, keyed on file identity, so the verdict
+ * cache can never hit; the log stays per-run by arriving through the
+ * environment rather than by living beside the shims.
+ */
+const CALL_LOG_VAR = 'COMMITLORE_TEST_CALL_LOG';
+let shimDir: string | undefined;
+const shims = (): string => {
+  if (shimDir !== undefined) return shimDir;
+  const dir = scratch('bin');
+  const realGit = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+  const line = (name: string) => `echo "${name} $*" >> "\${${CALL_LOG_VAR}:-/dev/null}"`;
+  writeFileSync(join(dir, 'git'), `#!/bin/sh\n${line('git')}\nexec ${realGit} "$@"\n`);
+  writeFileSync(join(dir, 'sh'), `#!/bin/sh\n${line('sh')}\nexec /bin/sh "$@"\n`);
+  execFileSync('chmod', ['+x', join(dir, 'git'), join(dir, 'sh')]);
+  shimDir = dir;
+  return dir;
+};
 
 /** A data root with `old` installed and `current` pointing at it. */
 const machineOn = (old: string): { home: string; root: string } => {
@@ -213,17 +242,19 @@ describe('T-1606 the read-only form stays read-only', () => {
 
   /** Records everything the run starts, by shadowing the binaries on PATH. */
   const runRecorded = (args: readonly string[], extra: NodeJS.ProcessEnv): string[] => {
-    const bin = scratch('bin');
-    const log = join(bin, 'calls.log');
-    const realGit = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
-    writeFileSync(join(bin, 'git'), `#!/bin/sh\necho "git $@" >> ${log}\nexec ${realGit} "$@"\n`);
-    writeFileSync(join(bin, 'sh'), `#!/bin/sh\necho "sh $@" >> ${log}\nexec /bin/sh "$@"\n`);
-    execFileSync('chmod', ['+x', join(bin, 'git'), join(bin, 'sh')]);
+    const bin = shims();
+    const log = join(scratch('log'), 'calls.log');
 
     try {
       execFileSync(process.execPath, [CLI, 'upgrade', ...args], {
         encoding: 'utf8',
-        env: { ...process.env, PATH: `${bin}:${process.env['PATH'] ?? ''}`, HOME: scratch('home'), ...extra },
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env['PATH'] ?? ''}`,
+          HOME: scratch('home'),
+          [CALL_LOG_VAR]: log,
+          ...extra,
+        },
         stdio: ['ignore', 'pipe', 'pipe'],
       });
     } catch {


### PR DESCRIPTION
Two reports about `backfill`, and one about the test suite filling the temp
directory with executables.

### `backfill --draft` skipped commits it was told to work

Target selection is bounded by `--limit` (default 50), and a draft's shas were
checked for membership in that window — a sha outside it was refused as
`not-a-target` even though the draft named it. Raising `--limit` looked like the
fix and was not: apply mode walked the whole window in batches and converged
after two that produced nothing, and every commit without a draft entry produces
nothing. A drafted commit far enough down was unreachable at any limit; raising
it only moved where the empty batches fell, which is why the same command
succeeded and failed on the same repository.

A draft now names its own targets, and apply mode works only the commits the
draft covers, so convergence counts drafted work rather than empty walking.

### A rejected trailer took its grounded siblings with it, silently

Verification is per record, so a `Ruled-out:` whose quote shows the alternative
being mentioned rather than turned down fails the whole record. The trailers
beside it vanished unmentioned — and since the grounding check runs only after
the quote check passes, those siblings had provably survived the re-read. The
rejection now names them and distinguishes trailers that passed the re-read and
were not stored from trailers dropped with a record that failed earlier.

`REPAIR_GUIDANCE` moves out of `harvest` so backfill prints the remedy too.
Backfill has no repair round by design, which left its authors with a diagnosis
and no statement of what shape would pass.

### The summary counted commits and labelled them records

`report.attached` incremented once per commit while a commit's records are
assembled together, so two records on one commit reported one attached.

### The test suite leaked a pair of executables per test

Two test files shadow `git` and `sh` on `PATH` to record what a run starts. Both
wrote a fresh shim pair per test case and neither cleaned up: a full suite left
~60 directories behind, and the reporting machine had accumulated 1,433. macOS
evaluates an executable's provenance on first exec and caches against file
identity, so a new file every time is an evaluation that can never hit the
cache. Both files now write the shim pair once and delete every scratch
directory in `afterAll`, as the other 24 shim-writing test files already do.

Worth stating plainly: the report frames this as happening on every invocation
of the installed tool. It does not. The shipped hook writer touches only
`.git/hooks/`, once per install, via a temp file it renames into place. The
defect is the test suite's — but the two stuck processes in the report were both
ours, from a killed run.

### Not done

`--with-prs` stays opt-in. Making it the default would spawn `gh` on every run of
a command that otherwise touches only the local repository — a product decision
rather than a defect, and left open.

### Verification

- Full suite: 3,226 passed, 4 skipped, 0 failed; `tsc` exit 0.
- Each of the four backfill defects reproduced against the shipped 1.2.9 build
  before the fix.
- Shim leak measured directly: reverting the two test files and running only
  them adds 42 and 22 directories; with the fix the count does not move.
- `dist/` is deliberately not rebuilt here — `canonical-merge.yml` rebuilds it
  on linux/amd64.

Closes #901
Closes #902
Closes #903
