### PR TITLE
fix(backfill): reach the records a draft carries; state the Ruled-out rule where drafts are written

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.11
+
+A third backfill round in the same repository, and the two failures it found are
+both the tool answering a question nobody asked.
+
+**A wholly valid draft could attach zero records and call it convergence
+(#907).** `--draft` applies in batches over the target list and stops after two
+that produce nothing. An entry whose `records` is an empty array produces
+nothing — and that is the honest answer for a commit the session found no
+context in, so a well-formed draft is mostly made of them. A 40-commit draft
+whose records all sat at target #21 or beyond therefore converged on the twenty
+honest empties above them and attached nothing, reporting `stopped: converged`
+at exit 0. A reader who did not diff the note mirror would conclude the draft
+was rejected on content.
+
+Worse, the workaround it rewarded was padding: the reporter had to insert a
+real record among the early targets to keep the walk alive long enough to reach
+the later ones.
+
+Only entries that claim at least one record are worked now, so an empty batch
+means what convergence assumes it means — records that failed verification, not
+commits nobody drafted for. A malformed `records` is still worked, because it
+has to reach the parser and be reported rather than be dropped for looking
+empty.
+
+**Running outside a repository reported a zero-length history as a normal walk
+(#907).** Every sha came back `unknown-commit` under `history: 0 commits
+walked`, at exit 0 — visually identical to the stale-window failure fixed in
+1.2.10, so the natural response was to raise `--limit`, which cannot help when
+there is no repository to walk. The reporter hit it three times chaining `cd
+<scratchpad> && commitlore backfill`. It now refuses the way git does, at exit
+2.
+
+**The `Ruled-out` rejection described the wrong fix (#902, reopened by
+measurement).** The message said to quote where the alternative "was actually
+turned down", which reads as *quote more context*. Three drafting rounds
+answered it by selecting quotes that argued the alternative would be bad — a
+counterfactual consequence — and all seven of the third round's records failed.
+The checker scans for the act of evaluating and dropping: considered, rejected,
+ruled out, decided against, abandoned, superseded, `instead`, `rather than`. An
+argument against the alternative is not one of those.
+
+Both the rejection message and the recording contract now say that, and say
+which half is not enough. The contract matters more: it is read before a draft
+is written, and the rejection is read after the record is already discarded.
+
+The bar itself did not move. Widening the marker list was ruled out previously
+and stays ruled out — a rule that accepts reasoning about an alternative would
+accept most prose that merely mentions one.
+
 ## 1.2.10
 
 Two reports about `backfill`, and one habit under both: the command reasons in

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh
-sh install.sh v1.2.10
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh
+sh install.sh v1.2.11
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.10 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.11 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh
-sh install.sh v1.2.10
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh
+sh install.sh v1.2.11
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.10 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.11 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh
-sh install.sh v1.2.10
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh
+sh install.sh v1.2.11
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.10 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.11 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh
-sh install.sh v1.2.10
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh
+sh install.sh v1.2.11
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.10 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.11 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.ps1))) v1.2.10
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.10/install.sh | sh -s v1.2.10",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.10"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.11"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/core/backfill.ts
+++ b/src/core/backfill.ts
@@ -908,10 +908,24 @@ const applyMode = (
    * #901: raising --limit appeared to fix the window when it was also giving
    * the walk more chances to reach the commit before converging.
    *
-   * Convergence still applies to the drafted set, where an empty batch means
-   * records that failed verification rather than commits nobody drafted for.
+   * #907: an entry whose `records` is an empty array is the same no-op wearing
+   * the draft's clothes. It is the honest answer for a commit the session found
+   * nothing in, and a well-formed draft is mostly made of them -- so counting
+   * them towards convergence let a wholly valid draft attach nothing and call
+   * it success, and rewarded padding early entries to keep the walk alive. Only
+   * entries that claim at least one record are worked, which makes an empty
+   * batch mean what convergence assumes: records that failed verification.
+   *
+   * A malformed `records` is deliberately still worked -- it must reach the
+   * parser and be reported, not be dropped for looking empty.
    */
-  const worked = [...targets.filter((target) => entries.has(target.sha)), ...extra];
+  const claimsRecords = (entry: DraftCommitEntry): boolean =>
+    !(Array.isArray(entry.records) && entry.records.length === 0);
+  const drafted = (target: BackfillTarget): boolean => {
+    const entry = entries.get(target.sha);
+    return entry !== undefined && claimsRecords(entry);
+  };
+  const worked = [...targets.filter(drafted), ...extra.filter(drafted)];
   runBatches(state, worked, options.batchSize ?? DEFAULT_BATCH_SIZE, (batch) => {
     let produced = 0;
     for (const target of batch) {
@@ -1030,6 +1044,18 @@ export const backfill = (options: BackfillOptions = {}): BackfillResult => {
   const budget = options.budgetTokens;
   if (budget !== undefined && (!Number.isInteger(budget) || budget < 0)) {
     throw new Error(`--budget-tokens is not a non-negative integer: ${String(budget)}`);
+  }
+
+  /*
+   * #907: outside a repository every sha came back `unknown-commit` over a
+   * zero-length history, which reads exactly like the stale-window failure in
+   * #901 -- so the natural response was to raise `--limit`, which cannot help
+   * when there is no repository to walk. Refuse the way git does instead. The
+   * reporter hit this three times chaining `cd <scratchpad> && commitlore
+   * backfill`.
+   */
+  if (execGit(['rev-parse', '--git-dir'], gitOpts(options.cwd)).code !== 0) {
+    throw new Error('not a git repository — backfill reads history, so it must run inside one');
   }
 
   const mode = modeOf(options);

--- a/src/core/harvest-verify.ts
+++ b/src/core/harvest-verify.ts
@@ -509,8 +509,11 @@ export const REPAIR_GUIDANCE: Readonly<Record<RejectionReason, string>> = {
   'evidence-missing':
     'Add a citation for every decision-context key the record carries, or drop the record.',
   'ruled-out-no-rejection':
-    'Quote the place where the alternative was actually turned down, not where it was ' +
-    'first suggested. If the source only mentions the alternative, drop the Ruled-out trailer.',
+    'The quote must name the alternative being evaluated and dropped — considered, rejected, ' +
+    'ruled out, decided against, abandoned, superseded, or chosen against with "instead" or ' +
+    '"rather than". Describing why the alternative would be bad is not enough: a consequence ' +
+    'argues against it, it does not record that anyone turned it down. If the source only ' +
+    'reasons about the alternative and never says it was dropped, drop the Ruled-out trailer.',
   'verified-unsupported':
     'Remove Verified from the draft. Record it only from the command or test run that performed the check.',
   enum: 'Use one of the values listed for that key, exactly. A synonym is a violation, not a shortcut.',

--- a/src/core/harvest.ts
+++ b/src/core/harvest.ts
@@ -305,6 +305,13 @@ const RULES = [
   '   cannot check it.',
   '7. Do not emit Verified. Reading a transcript or diff cannot prove a check ran.',
   '   Record Verified only from the command or test run that performed the check.',
+  '8. A Ruled-out quote must show the alternative being evaluated and dropped —',
+  '   considered, rejected, ruled out, decided against, abandoned, superseded, or',
+  '   chosen against with "instead" or "rather than". Reasoning about why the',
+  '   alternative would be bad is not a rejection: a consequence argues against',
+  '   it, it does not record that anyone turned it down. If the source only',
+  '   argues and never drops, omit the Ruled-out trailer rather than quoting the',
+  '   argument.',
 ];
 
 /**

--- a/test/backfill.test.ts
+++ b/test/backfill.test.ts
@@ -432,6 +432,47 @@ describe('backfill convergence', () => {
     expect(result.report.attached).toBe(0);
     expect(noteShas(fixture.dir)).toEqual([]);
   });
+
+  /*
+   * #907: a well-formed draft is mostly `"records": []` -- the honest answer for
+   * a commit the session found nothing in. Counting those towards convergence
+   * let a wholly valid draft attach nothing and report success, and made padding
+   * an early entry the way to reach a later one.
+   */
+  it('reaches a record past two commits the draft answered with no records', () => {
+    const fixture = buildFixture('backfill-empty-entries');
+    const draft = draftFile(fixture, {
+      commits: [
+        { sha: fixture.tidy, records: [] },
+        { sha: fixture.parser, records: [] },
+        { sha: fixture.upload, records: [uploadRecord()] },
+      ],
+    });
+
+    // batchSize 1 puts the two empty entries in consecutive batches, which is
+    // exactly the shape that used to converge before reaching the third.
+    const result = run(fixture, { draft, batchSize: 1 });
+
+    expect(result.report.attached).toBe(1);
+    expect(result.report.stoppedBy).not.toBe('converged');
+    expect(noteShas(fixture.dir)).toEqual([fixture.upload]);
+  });
+});
+
+describe('backfill outside a repository', () => {
+  /*
+   * #907: every sha came back `unknown-commit` over a zero-length history, which
+   * is visually identical to the stale-window failure in #901 -- so the natural
+   * response was to raise `--limit`, which cannot help when there is no
+   * repository at all.
+   */
+  it('refuses instead of reporting a zero-length history as a normal walk', () => {
+    const outside = tempDir('backfill-no-repo');
+    const draft = join(outside, 'draft.json');
+    writeFileSync(draft, JSON.stringify({ commits: [{ sha: 'deadbeef1234567', records: [] }] }));
+
+    expect(() => backfill({ cwd: outside, draft })).toThrow(/not a git repository/);
+  });
 });
 
 describe('backfill budget caps', () => {

--- a/test/harvest-verify.test.ts
+++ b/test/harvest-verify.test.ts
@@ -386,7 +386,16 @@ describe('the bounded repair loop', () => {
     const prompt = buildRepairFeedback(rejectedFrom(draftOf('draft-ruled-out-mention.json')));
 
     expect(prompt).toContain('ruled-out-no-rejection');
-    expect(prompt).toContain('where the alternative was actually turned down');
+    expect(prompt).toContain('evaluated and dropped');
+    /*
+     * #902: three rounds were drafted against the old wording, which read as
+     * "quote more context". The drafter answered it by selecting quotes that
+     * argued the alternative was bad -- a counterfactual consequence -- and all
+     * seven failed, because the checker scans for the act of turning it down.
+     * The guidance has to separate those two things or it sends the next author
+     * the same way.
+     */
+    expect(prompt).toContain('not enough');
   });
 
   it('has nothing to say when nothing was rejected', () => {


### PR DESCRIPTION
#907's two mechanical findings, and the `Ruled-out` characterisation posted to
#902 after that issue's fix shipped.

### A wholly valid draft could attach zero records and report convergence

Apply mode stops after two batches that produce nothing. An entry whose
`records` is an empty array produces nothing — and that is the honest answer for
a commit the session found no context in, so a well-formed draft is mostly made
of them. A 40-commit draft whose records all sat at target #21 or beyond
converged on the twenty honest empties above them, attached nothing, and
reported `stopped: converged` at exit 0.

The workaround it rewarded is the part worth fixing: the reporter had to insert
a genuinely-cited record among the early targets to keep the walk alive long
enough to reach the later ones. Padding a draft to reach your own records is not
a workflow this should teach.

Only entries claiming at least one record are worked now, so an empty batch
means what convergence assumes — records that failed verification, not commits
nobody drafted for. A malformed `records` is still worked, so the parser can
report it rather than it being dropped for looking empty.

This is adjacent to the 1.2.10 fix, not covered by it. 1.2.10 made drafted
commits the unit of work; this is the second cause on the same path, and
1.2.10's changelog described the remaining behaviour as if it were correct.

### Running outside a repository read as the stale-window failure

Every sha came back `unknown-commit` under `history: 0 commits walked`, at exit
0 — visually identical to the window failure fixed in 1.2.10, so the natural
response was to raise `--limit`, which cannot help when there is no repository
to walk. The reporter hit it three times chaining `cd <scratchpad> && commitlore
backfill`. It refuses the way git does now, at exit 2, before any work begins.

### The `Ruled-out` rejection described the wrong fix

The reporter refuted their own earlier hypothesis with three rounds of data:
`Ruled-out` discards went 12 of 15 then **7 of 7**, while `Limit` and `Warn`
stayed at zero throughout. Round three was drafted *knowing* the guidance
shipped in 1.2.10, and the drafter answered it by selecting quotes carrying a
counterfactual consequence — "refusing with exit 1 retries every 30 seconds
forever". All seven failed, and they should have: the checker scans for the act
of evaluating and dropping (`rejected`, `ruled out`, `decided against`,
`instead`, `대신`, `접었`), and an argument against an alternative is not one.

The bar does not move here — widening the marker list was ruled out previously
and a rule accepting reasoning about an alternative would accept most prose that
mentions one. What was wrong is that nothing said it: "quote where the
alternative was actually turned down" reads as *quote more context*, which is
what two rounds did in opposite directions.

Both the rejection and the **recording contract** now name the distinction. The
contract matters more — it is read before a draft is written, while the
rejection is read after the record is already discarded, which is where most
authors meet the rule exactly once.

The seven records the reporter lost stay lost. No quote in those sources names
the evaluate-and-drop act, and they were right not to reshape text until a
checker accepted it.

### Verification

- Full suite: 3,228 passed, 4 skipped, 0 failed; `tsc` exit 0.
- Negative control for the convergence fix: the reporter's shape reproduces at
  `attached 0 / stoppedBy converged` before the change and `attached 20 /
  stoppedBy exhausted` after it; a non-repo cwd exits 2 where it exited 0.
- `guard` and `dogfood` run post-commit against this branch's own records: 82/82.
- `dist/` is deliberately not rebuilt here — `canonical-merge.yml` rebuilds it on
  linux/amd64.

Closes #907
