### PR TITLE
fix(doctor): ask twice before calling a preserved hook broken

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.12
+
+**`doctor` called a deliberately fail-closed hook broken, and offered to break it
+(#910).** The preserved `commit-msg` hook is probed under a PATH carrying no
+interpreter, and any non-zero exit was a `fail` prescribing `fix or remove`. A
+hook written to refuse when it cannot run its own check therefore failed that
+row permanently — and the remedy on offer was to make it fail open, which
+reopens the class of defect the hook exists to close. The reporting repository
+had closed exactly that defect days earlier: a missing interpreter used to make
+their hook blame the message, announcing that the message wrote a record git
+would not store, about a check that had never run.
+
+The probe itself was measuring the right thing. `PATH=/usr/bin:/bin` is close to
+what a commit started from a GUI or a daemon actually gets, so a fail-closed hook
+does block those commits and that is worth a row. What the check could not do was
+tell a deliberate refusal from a broken script, because it read only the exit
+code.
+
+It now asks the same question twice. A hook that accepts the probe when an
+interpreter is on PATH and refuses when none is, is PATH-sensitive rather than
+broken: that is the repository's own decision, and it reports as a `warn` naming
+the consequence — commits started where git's PATH has no interpreter are blocked
+by it — with nothing prescribed and no effect on `doctor`'s exit code. A hook
+that fails under either PATH is broken whatever it intended, and still reports
+`fail`.
+
+CommitLore's own hook keeps the stricter contract: it must work with no node on
+PATH, because it records its interpreter.
+
+The `commit-msg hook` row inherits the runtime's outcome, and a finding that
+names nothing to repair used to acquire `commitlore hooks install` on the way
+out. That was the same misdirection removed in #876, in a milder form; a fix of
+nothing now passes through as nothing.
+
 ## 1.2.11
 
 A third backfill round in the same repository, and the two failures it found are

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh
-sh install.sh v1.2.11
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh
+sh install.sh v1.2.12
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.11 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.12 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh
-sh install.sh v1.2.11
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh
+sh install.sh v1.2.12
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.11 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.12 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh
-sh install.sh v1.2.11
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh
+sh install.sh v1.2.12
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.11 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.12 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh
-sh install.sh v1.2.11
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh
+sh install.sh v1.2.12
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.11 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.12 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.ps1))) v1.2.11
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.11",
+      "version": "1.2.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.11/install.sh | sh -s v1.2.11",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.11"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.12"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/doctor/checks/capture-commit-msg-hook.ts
+++ b/src/commands/doctor/checks/capture-commit-msg-hook.ts
@@ -119,7 +119,11 @@ export const checkHook = (ctx: DoctorContext, runtime?: DoctorCheck): DoctorChec
     // finding is the only fix that moves this one. Prescribing `hooks install`
     // here regardless is how a preserved hook's failure came to carry a remedy
     // that reinstalls the hook which worked (#876).
-    const inheritedFix = runtime.fix ?? install;
+    // #910: a runtime finding that names nothing to repair passes that through.
+    // A row blocked on "the preserved hook refuses deliberately, and nothing here
+    // needs repairing" must not acquire `hooks install` on the way out — the same
+    // mistake as #876, milder: a remedy that reinstalls the hook which worked.
+    const inheritedFix = runtime.fix === null ? null : (runtime.fix ?? install);
     // A skipped runtime would make this row a skip too, and a skip has to name
     // a reason. Inheriting the runtime's is the only answer that stays true —
     // this row did not look for the same reason that one did not. The branch is

--- a/src/commands/doctor/checks/capture-hook-runtime.ts
+++ b/src/commands/doctor/checks/capture-hook-runtime.ts
@@ -137,6 +137,55 @@ export const checkHookRuntime = (ctx: DoctorContext): DoctorCheck => {
         const spoke = `${preserved.stderr ?? ''}`.trim();
         const said = preserved.error?.message ?? (spoke.split('\n')[0] ?? '');
         const shape = preserved.error === undefined ? classifyFailure(exit, said) : 'unclear';
+
+        /*
+         * #910: a preserved hook that refuses when it cannot run its own check is
+         * behaving correctly, and this row called it a broken installation and
+         * prescribed "fix or remove" -- which for a fail-closed hook means making
+         * it fail open, reopening the defect it was written to close.
+         *
+         * CommitLore cannot read intent, and parsing the hook's prose for it was
+         * ruled out: the wording is the repository's and this check is not the
+         * place to standardise it. What it can do is ask the same question twice.
+         * Under an inherited PATH the interpreter is present, so a hook that
+         * passes there and refuses here is PATH-sensitive rather than broken --
+         * the operator's own decision, reported as a fact with its consequence.
+         * A hook that fails under any PATH is broken whatever it intended, and
+         * that is still this check's finding to make.
+         *
+         * CommitLore's own hook keeps the stricter contract: it is required to
+         * work with no node on PATH, because it records its interpreter.
+         */
+        writeFileSync(probe, PROBE_MESSAGE);
+        const withPath = spawn('/bin/sh', ['-c', '"$0" "$1"', chained, probe], {
+          shell: false,
+          encoding: 'utf8',
+          cwd,
+          env: { ...hookEnv, PATH: env['PATH'] ?? hookEnv.PATH },
+        });
+        const pathSensitive = withPath.error === undefined && withPath.status === 0;
+        if (pathSensitive) {
+          return check(
+            id,
+            category,
+            title,
+            'warn',
+            `commitlore's hook runs. The hook it preserved -- ${chained} -- accepts this message when an interpreter is on PATH and refuses when none is: ${(said || `exit ${String(exit ?? 'unavailable')}`).replace(/[.\s]+$/, '')}. A hook written to refuse rather than pass a check it could not run is doing that deliberately, and nothing here needs repairing; the consequence is that commits started where git's PATH carries no interpreter (a GUI or a daemon, not a shell) are blocked by it, with that message`,
+            null,
+            false,
+            undefined,
+            {
+              evidence: {
+                hook_path: hook,
+                chained_hook_path: chained,
+                exit_code: String(exit ?? 'unavailable'),
+                exit_code_with_path: '0',
+                ...streamEvidence('stderr', preserved.stderr ?? ''),
+              },
+            },
+          );
+        }
+
         const because =
           shape === 'node-missing'
             ? `it calls node by name and git's PATH has none: ${said}`

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -697,6 +697,51 @@ describe('doctor: hook runtime', () => {
     expect(runtime?.evidence['exit_code']).toBe('127');
   });
 
+  /*
+   * #910: the reporter's hook refuses when it cannot run its own check, and says
+   * which of the two things happened. `doctor` read only the exit code, called a
+   * healthy installation broken, and prescribed "fix or remove" -- which for a
+   * fail-closed hook means making it fail open, reopening the defect it closes.
+   *
+   * The discriminator is behavioural rather than a reading of the hook's prose:
+   * a hook that accepts the probe when an interpreter is on PATH and refuses when
+   * none is, is PATH-sensitive; one that fails under either is broken whatever it
+   * intended, and the two tests around this one still say `fail`.
+   */
+  it('warns rather than fails when the preserved hook refuses only for want of an interpreter', () => {
+    const repo = initRepo('doctor-runtime-chained-fail-closed');
+    installedHook(repo);
+    // Refuses when it cannot find node, accepts the message when it can. The
+    // shape agent-control-plane adopted to stop a missing interpreter being
+    // reported as a bad message.
+    writeScript(
+      chainedPath(repo),
+      [
+        '#!/bin/sh',
+        'if command -v node >/dev/null 2>&1; then exit 0; fi',
+        'echo "commit-msg: could not run the trailer check — no \\`node\\` on the PATH git gave this hook." >&2',
+        'exit 1',
+      ].join('\n') + '\n',
+    );
+    chmodSync(chainedPath(repo), 0o755);
+
+    const report = runDoctor({ cwd: repo });
+    const runtime = report.checks.find((entry) => entry.id === 'hook-runtime');
+    expect(runtime?.status).toBe('warn');
+    expect(runtime?.detail).toContain(chainedPath(repo));
+    expect(runtime?.detail).toMatch(/accepts this message when an interpreter is on PATH/);
+    // The prescription that would reopen the defect must be gone from both rows.
+    expect(runtime?.fix).toBeNull();
+    expect(runtime?.evidence['exit_code_with_path']).toBe('0');
+
+    const installation = report.checks.find((entry) => entry.id === 'commit-msg-hook');
+    expect(installation?.status).toBe('warn');
+    expect(installation?.fix).toBeNull();
+
+    // A deliberate refusal is not a broken installation, so doctor must not exit 1.
+    expect(report.exitCode).toBe(0);
+  });
+
   it('names the preserved hook when it exits non-zero for a reason unrelated to node', () => {
     const repo = initRepo('doctor-runtime-chained-broken');
     installedHook(repo);


### PR DESCRIPTION
`doctor` probes the preserved `commit-msg` hook under a PATH with no interpreter,
and treated any non-zero exit as a broken installation, prescribing `fix or
remove`. A hook written to refuse when it cannot run its own check therefore
failed that row permanently — and the remedy on offer was to make it fail open,
reopening the class of defect the hook exists to close. The reporting repository
had closed exactly that defect days earlier.

**The probe is not wrong.** `PATH=/usr/bin:/bin` is close to what a commit
started from a GUI or a daemon really gets, so a fail-closed hook does block
those commits, and saying so is worth a row. What the check could not do is tell
a deliberate refusal from a broken script, because it read only the exit code.

**So it asks the same question twice.** Under the inherited PATH an interpreter
is present:

- accepts the probe with an interpreter, refuses without → **`warn`**, naming the
  consequence, no prescription, no effect on `doctor`'s exit code
- fails under either PATH → still **`fail`**

The discriminator is behavioural rather than a reading of the hook's prose. That
matters: the repo already ruled out parsing the preserved hook's stderr, its
wording belongs to the repository rather than to this checker, and a hook that
fails silently leaves nothing to read.

CommitLore's own hook keeps the stricter contract — it must work with no node on
PATH, because it records its interpreter.

One thing moved with it: the `commit-msg hook` row inherits the runtime's outcome
through `runtime.fix ?? install`, so a finding naming nothing to repair acquired
`commitlore hooks install` on the way out. Same misdirection as #876, milder. A
null fix now passes through.

### Not taken

The reporter's third option — a marker or agreed exit code letting a hook declare
itself fail-closed — is the cleanest in principle, but it only helps hooks edited
to adopt it, and the repositories that need this row read correctly are the ones
nobody will revisit.

### Verification

- Full suite: 3,229 passed, 4 skipped, 0 failed; `tsc` exit 0.
- Negative control: reverting both checks reports `fail` where the new test
  expects `warn`; the two neighbouring tests that must stay `fail` (a bare `node`
  against a missing script, and an unconditional `exit 3`) pass unchanged either
  way, because both fail under any PATH.
- Live repository wired with the reporter's hook shape: two `warn` rows, no fix
  line, `doctor` exits 0 — where it emitted two `fail` rows and exit 1.
- `dist/` is deliberately not rebuilt here; `canonical-merge.yml` does it.

Closes #910
