### PR TITLE
fix: a truncated window cannot assert about history; make the squash protection discoverable

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,82 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.13
+
+Three reports about the same habit from three directions: answering more
+confidently than the evidence allows, and staying quiet where the evidence is
+missing.
+
+**`stale` reported a truncated window's absence as a definite dangling reference
+(#914).** The default scan reads the most recent 1000 commits and says
+`truncated: true`. Inside that same report it emitted a `dangling-ref` wanting
+"an existing Record-Id in history" — an assertion about history made from a
+window the report itself declares incomplete. In the reporting repository three
+`Follows:` references sat inside the window while the `Record-Id` defining them
+sat at commit 1397 of 1554, so the finding was produced entirely by the
+truncation and cleared under `--all-history`.
+
+It is the inference this project refuses everywhere else and tells its own
+callers not to make: a partial scan means absence of a record is not evidence the
+record does not exist. A candidate is now resolved against the whole history
+before it is asserted, through the same reader that produced the window, so a
+default run still answers definitely and a CI job reading `danglingRefs` keeps
+working. Only a caller holding no repository gets `unresolvedRefs`, which is the
+honest answer where none can be computed.
+
+**`prepare_capture` succeeded over an empty staged diff and said so nowhere a
+caller reads (#911).** It returned a nonce, a prompt and `policy_error: null` for
+a repository with nothing staged; the prompt said `(no diff)` in prose and
+`staged_diff_hash` held the SHA-256 of the empty string. The contract's first
+rule is cite or omit, and with no diff half the citable surface is gone while
+every rule after it still reads as though it were there.
+
+It is not refused, and the reason is measured: the transaction binds to the
+staged diff, so a record prepared this way cannot reach a commit that has one —
+the commit is refused with "the staged diff differs from the verified capture".
+Refusing would also remove recording a decision that has no code change, and
+contradict the earlier decision not to withhold the contract when nothing is
+staged, which is exactly when someone is learning the format. So the absence is
+stated where it is read: `staged_diff_empty` as a field, and a contract rule
+naming what it costs. `repository` now travels with the response too — the report
+came from an MCP server owned by another process, answering about a tree that was
+not the caller's, with every other field internally consistent.
+
+**A squash-merge repository lost every record by default, and nothing said so
+(#915).** Two paths cover a squash. A local `git merge --squash` is carried by
+the installed `prepare-commit-msg` hook. The merge GitHub performs on its own
+servers runs no local hook at all and is carried by the `action/preserve` GitHub
+Action, which was built, which this repository has run on its own merges since,
+and which **no README mentioned**. The reporter made one record in twelve
+commits, the squash dropped it, and they found out only by going looking.
+
+Every README now documents the workflow, with the two rules that keep
+`pull_request_target` safe beside it. And `doctor` gains a `squash inheritance`
+row that reports whether the protection is switched on — before a record is lost,
+where `squash conservation` reports records already gone. It warns rather than
+fails: a repository merging with merge commits or rebase keeps its records
+either way, and nothing local can read the remote's merge setting.
+
+No hook was added. A `post-merge` hook is told by git that the merge was not a
+squash and given no way to name which branch was collapsed, so it could only
+re-run the conservation scan — measured here at 11.2s, with nine undetermined
+prescriptions and zero confirmed squashes, on every pull.
+
+**`doctor` prescribed fabricating provenance for a branch whose fate it could not
+determine (#915).** 1.2.7 stopped prescribing `squash-preserve` for a branch
+proven unmerged and deliberately left the undetermined case prescribing it, on
+the argument that an unnecessary preservation costs only a discarded plan. That
+weighed the wrong cost — `--target` mirrors records onto whatever commit it is
+handed without checking the commit contains the work, so on an abandoned branch
+it writes provenance for changes HEAD never took.
+
+And undetermined is not the rare case that grouping assumed. The fate is decided
+by comparing blobs, so an abandoned branch that edited a file HEAD still has
+satisfies neither arm and lands there — the ordinary shape of an abandoned
+branch. The command is still named, because it is still the right one once the
+squash commit is known, but the condition now comes first and the hazard is
+stated.
+
 ## 1.2.12
 
 **`doctor` called a deliberately fail-closed hook broken, and offered to break it

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh
-sh install.sh v1.2.12
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh
+sh install.sh v1.2.13
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.12 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.13 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。
@@ -289,7 +289,7 @@ jobs:
       - run: git fetch --no-tags --force origin
           '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.12
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.13
 ```
 
 `pull_request_target` は書き込み可能なトークンで動くため、次にこれを編集する人への規則が

--- a/README.ja.md
+++ b/README.ja.md
@@ -230,6 +230,80 @@ superseded な決定は大いに関係があり得ても、現在の指針とし
 対応 skill host の利用者は、毎回「これを CommitLore に記録して」と言う必要はありません。
 残る制約は record ごとのユーザー命令ではなく、host が開始するかどうかです。
 
+## squash マージを使うリポジトリ
+
+squash マージはブランチのコミット群を 1 つの新しいコミットに置き換えますが、その
+コミットはブランチのトレーラーを持ちません。squash ボタンでマージするリポジトリでは、
+ブランチで作ったレコードは、それを squash したコミットへ運ぶ仕組みがない限り、マージ時に
+失われます。
+
+これを埋める経路は 2 つあり、片方は一度だけ設定が必要です。
+
+| squash の発生場所 | レコードを運ぶもの | 設定 |
+|---|---|---|
+| ローカルの `git merge --squash` | インストール済みの `prepare-commit-msg` フックが `SQUASH_MSG` から処理 | 不要 — `commitlore init` が済ませている |
+| GitHub の **Squash and merge** ボタン | `action/preserve` GitHub Action | 下のワークフロー |
+
+GitHub はそのマージを自社サーバー上で行い、そこではローカルの git フックは一切実行され
+ません。したがってローカルフックはこれを見られません。その瞬間に必要なもの — プル
+リクエスト、そのコミット、そしてそれらが squash された先のコミット — を持つのは Action
+だけです。
+
+`.github/workflows/commitlore-preserve.yml` を追加します。
+
+```yaml
+name: CommitLore squash inheritance
+
+# pull_request_target, not pull_request: a pull request from a fork gets a
+# read-only token on pull_request, so the job would build the record and then
+# fail to publish it.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write   # the one push to refs/notes/commitlore
+
+concurrency:
+  group: commitlore-notes
+  cancel-in-progress: false
+
+jobs:
+  preserve:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the merge commit is on the base branch, and a closed pull request
+          # has no merge ref left to check out
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      # the mirror this action writes; publishing from a checkout that never
+      # read it would fork the notes history
+      - run: git fetch --no-tags origin '+refs/notes/commitlore:refs/notes/commitlore'
+
+      # a squash merge usually deletes the branch, and then the pull request's
+      # own ref is the only one still reaching the commits that carry records
+      - run: git fetch --no-tags --force origin
+          '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
+
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.12
+```
+
+`pull_request_target` は書き込み可能なトークンで動くため、次にこれを編集する人への規則が
+2 つあります。ここでプルリクエストの head を**チェックアウトしないこと**、そして
+`refs/commitlore/pr-head` から到達できるものを**実行しないこと**。フォークのコミットは
+トレーラーを読むためのデータとして届くもので、実行するコードではありません。
+
+`commitlore doctor` はこれが有効かを `squash inheritance` の行で報告します。レコードを
+**失う前に**知らせます。`squash conservation` の行は、すでに失われたレコードを報告する側
+です。
+
+マージコミットやリベースでマージしているなら、レコードはそのまま残り、この設定は不要です。
+
+
 ## 現場報告であって測定ではない
 
 無関係な一つのリポジトリで、初めて v1.2.1 を入れた人の一回の実行です。ここでは何も測定されず、

--- a/README.ko.md
+++ b/README.ko.md
@@ -230,6 +230,77 @@ CommitLore는 이렇게 묻습니다.
 지원되는 skill host 사용자는 매 commit마다 "이것을 CommitLore에 기록해"라고 말할 필요가 없습니다.
 남는 한계는 record마다 필요한 사용자 명령이 아니라 host가 시작하는가입니다.
 
+## squash 머지를 쓰는 레포지토리
+
+squash 머지는 브랜치의 커밋들을 새 커밋 하나로 대체하고, 그 커밋은 브랜치의 트레일러를
+갖고 있지 않습니다. squash 버튼으로 머지하는 레포라면, 브랜치에서 만든 레코드는 그것을
+squash한 커밋으로 옮겨주는 무언가가 없으면 머지 때 사라집니다.
+
+이를 덮는 경로가 두 개이고, 그중 하나는 한 번의 설정이 필요합니다.
+
+| squash가 일어나는 방식 | 레코드를 옮기는 주체 | 설정 |
+|---|---|---|
+| 로컬 `git merge --squash` | 설치된 `prepare-commit-msg` 훅이 `SQUASH_MSG`에서 읽어 처리 | 없음 — `commitlore init`이 이미 해둠 |
+| GitHub의 **Squash and merge** 버튼 | `action/preserve` GitHub Action | 아래 워크플로 |
+
+GitHub은 그 머지를 자기 서버에서 수행하고, 거기서는 로컬 git 훅이 하나도 실행되지
+않습니다. 그래서 로컬 훅은 이것을 볼 수 없습니다. 그 시점에 필요한 것 — 풀 리퀘스트,
+그 커밋들, 그리고 그것들이 합쳐진 커밋 — 을 가진 곳은 Action뿐입니다.
+
+`.github/workflows/commitlore-preserve.yml` 을 추가합니다.
+
+```yaml
+name: CommitLore squash inheritance
+
+# pull_request_target, not pull_request: a pull request from a fork gets a
+# read-only token on pull_request, so the job would build the record and then
+# fail to publish it.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write   # the one push to refs/notes/commitlore
+
+concurrency:
+  group: commitlore-notes
+  cancel-in-progress: false
+
+jobs:
+  preserve:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the merge commit is on the base branch, and a closed pull request
+          # has no merge ref left to check out
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      # the mirror this action writes; publishing from a checkout that never
+      # read it would fork the notes history
+      - run: git fetch --no-tags origin '+refs/notes/commitlore:refs/notes/commitlore'
+
+      # a squash merge usually deletes the branch, and then the pull request's
+      # own ref is the only one still reaching the commits that carry records
+      - run: git fetch --no-tags --force origin
+          '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
+
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.12
+```
+
+`pull_request_target` 은 쓰기 가능한 토큰으로 실행되므로, 다음에 이 파일을 고치는 사람을
+위한 두 가지 규칙이 있습니다. 여기서 **풀 리퀘스트의 head를 체크아웃하지 말 것**, 그리고
+`refs/commitlore/pr-head` 에서 도달 가능한 것을 **실행하지 말 것**. 포크의 커밋은
+트레일러를 읽을 데이터로 도착하는 것이며, 실행할 코드가 아닙니다.
+
+`commitlore doctor` 가 이것이 켜져 있는지 `squash inheritance` 행으로 보고합니다. 레코드를
+**잃기 전에** 알려줍니다. `squash conservation` 행은 이미 사라진 레코드를 보고하는 쪽입니다.
+
+머지 커밋이나 리베이스로 머지한다면 레코드는 그대로 살아남고 이 설정은 필요 없습니다.
+
+
 ## 현장 보고이지 측정은 아닙니다
 
 관련 없는 한 저장소에서 v1.2.1을 처음 설치한 사람이 한 번 실행한 사례입니다. 여기서는 아무것도

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh
-sh install.sh v1.2.12
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh
+sh install.sh v1.2.13
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.12 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.13 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.
@@ -287,7 +287,7 @@ jobs:
       - run: git fetch --no-tags --force origin
           '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.12
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.13
 ```
 
 `pull_request_target` 은 쓰기 가능한 토큰으로 실행되므로, 다음에 이 파일을 고치는 사람을

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh
-sh install.sh v1.2.12
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh
+sh install.sh v1.2.13
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.12 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.13 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.
@@ -299,7 +299,7 @@ jobs:
       - run: git fetch --no-tags --force origin
           '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.12
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.13
 ```
 
 Two rules for whoever edits this next, because `pull_request_target` runs with a

--- a/README.md
+++ b/README.md
@@ -240,6 +240,81 @@ every commit. The remaining limitation is host initiation, not a required
 per-record user command.
 
 
+## Squash-merge repositories
+
+A squash merge replaces a branch's commits with one new commit, and that commit
+does not carry the branch's trailers. If your repository merges with the squash
+button, a record made on a branch is dropped by the merge unless something
+carries it onto the commit that squashed it.
+
+Two paths cover that, and one of them needs a one-time setup:
+
+| How the squash happens | What carries the record | Setup |
+|---|---|---|
+| `git merge --squash` locally | The installed `prepare-commit-msg` hook, from `SQUASH_MSG` | None — `commitlore init` already did it |
+| GitHub's **Squash and merge** button | The `action/preserve` GitHub Action | The workflow below |
+
+GitHub performs that merge on its own servers, where no local git hook runs at
+all, so the local hook cannot see it. The Action is the only place that has what
+it needs at that moment: the pull request, its commits, and the commit they were
+squashed into.
+
+Add `.github/workflows/commitlore-preserve.yml`:
+
+```yaml
+name: CommitLore squash inheritance
+
+# pull_request_target, not pull_request: a pull request from a fork gets a
+# read-only token on pull_request, so the job would build the record and then
+# fail to publish it.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write   # the one push to refs/notes/commitlore
+
+concurrency:
+  group: commitlore-notes
+  cancel-in-progress: false
+
+jobs:
+  preserve:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the merge commit is on the base branch, and a closed pull request
+          # has no merge ref left to check out
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      # the mirror this action writes; publishing from a checkout that never
+      # read it would fork the notes history
+      - run: git fetch --no-tags origin '+refs/notes/commitlore:refs/notes/commitlore'
+
+      # a squash merge usually deletes the branch, and then the pull request's
+      # own ref is the only one still reaching the commits that carry records
+      - run: git fetch --no-tags --force origin
+          '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
+
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.12
+```
+
+Two rules for whoever edits this next, because `pull_request_target` runs with a
+writable token: never check out the pull request's head here, and never execute
+anything reachable from `refs/commitlore/pr-head`. The fork's commits arrive as
+data to read trailers from, not as code to run.
+
+`commitlore doctor` reports whether this is switched on, under
+`squash inheritance`. It says so **before** a record is lost;
+`squash conservation` is the row that reports records already gone.
+
+If you merge with merge commits or rebase, records survive on their own and this
+setup is unnecessary.
+
+
 ## A field report, not a measurement
 
 One run, on an unrelated repository, by someone installing v1.2.1 for the first

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -224,6 +224,76 @@ CommitLore 会问：
 受支持 skill host 的用户无需在每次 commit 时说“把这个记到 CommitLore”。剩下的限制是 host 是否
 发起流程，而不是每条 record 都要用户命令。
 
+## 使用 squash 合并的仓库
+
+squash 合并会把分支的多个提交替换为一个新提交，而该提交不携带分支的 trailer。如果你的
+仓库用 squash 按钮合并，那么在分支上创建的记录会在合并时丢失，除非有东西把它转移到执行
+squash 的那个提交上。
+
+有两条路径覆盖这一点，其中一条需要一次性设置。
+
+| squash 发生的位置 | 由什么转移记录 | 设置 |
+|---|---|---|
+| 本地 `git merge --squash` | 已安装的 `prepare-commit-msg` 钩子，从 `SQUASH_MSG` 读取 | 无需 — `commitlore init` 已完成 |
+| GitHub 的 **Squash and merge** 按钮 | `action/preserve` GitHub Action | 下面的工作流 |
+
+GitHub 在它自己的服务器上执行该合并，那里不会运行任何本地 git 钩子，因此本地钩子看不到
+它。在那一刻拥有所需信息的只有 Action：拉取请求、它的提交，以及它们被 squash 进入的那个
+提交。
+
+添加 `.github/workflows/commitlore-preserve.yml`：
+
+```yaml
+name: CommitLore squash inheritance
+
+# pull_request_target, not pull_request: a pull request from a fork gets a
+# read-only token on pull_request, so the job would build the record and then
+# fail to publish it.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write   # the one push to refs/notes/commitlore
+
+concurrency:
+  group: commitlore-notes
+  cancel-in-progress: false
+
+jobs:
+  preserve:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the merge commit is on the base branch, and a closed pull request
+          # has no merge ref left to check out
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      # the mirror this action writes; publishing from a checkout that never
+      # read it would fork the notes history
+      - run: git fetch --no-tags origin '+refs/notes/commitlore:refs/notes/commitlore'
+
+      # a squash merge usually deletes the branch, and then the pull request's
+      # own ref is the only one still reaching the commits that carry records
+      - run: git fetch --no-tags --force origin
+          '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
+
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.12
+```
+
+由于 `pull_request_target` 以可写令牌运行，给下一位编辑此文件的人两条规则：不要在这里
+**检出拉取请求的 head**，也不要**执行**任何从 `refs/commitlore/pr-head` 可达的东西。派生
+仓库的提交是作为读取 trailer 的数据到达的，不是要运行的代码。
+
+`commitlore doctor` 会在 `squash inheritance` 一行报告它是否已启用。它在记录**丢失之前**
+告知；`squash conservation` 那一行报告的是已经丢失的记录。
+
+如果你用合并提交或 rebase 合并，记录会自行保留，无需此设置。
+
+
 ## 现场报告，不是测量
 
 这是某人在一个无关仓库首次安装 v1.2.1 时的一次运行。这里没有测量任何东西，也没有写进

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh
-sh install.sh v1.2.12
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh
+sh install.sh v1.2.13
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.12 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.13 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。
@@ -281,7 +281,7 @@ jobs:
       - run: git fetch --no-tags --force origin
           '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.12
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.13
 ```
 
 由于 `pull_request_target` 以可写令牌运行，给下一位编辑此文件的人两条规则：不要在这里

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.ps1))) v1.2.12
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.12",
+      "version": "1.2.13",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.12/install.sh | sh -s v1.2.12",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.12"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.13"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/doctor/checks/history-squash-conservation.ts
+++ b/src/commands/doctor/checks/history-squash-conservation.ts
@@ -385,10 +385,27 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
       .join(', ');
     const more = lost.length > 5 ? `, and ${lost.length - 5} more` : '';
 
-    // Only branches whose work actually landed are worth preserving records
-    // for. `unknown` is grouped with them deliberately: prescribing a
-    // preservation that turns out to be unnecessary costs a discarded plan,
-    // while withholding it from a real squash loses the record for good.
+    /*
+     * #915: `unknown` used to be grouped with the squashed ones, on the argument
+     * that prescribing an unnecessary preservation costs only a discarded plan
+     * while withholding it from a real squash loses a record for good. That
+     * weighed the wrong cost. `squash-preserve --target` mirrors records onto
+     * whatever commit it is handed without checking the commit contains the work,
+     * so running it on a branch that was abandoned writes provenance for work
+     * nobody merged — fabricating history rather than preserving it, which is the
+     * failure this project exists to prevent.
+     *
+     * And `unknown` is not the rare case the grouping assumed. The fate is decided
+     * by comparing blobs, so an abandoned branch that edited a file HEAD still has
+     * satisfies neither arm — the path is present, the content differs — and lands
+     * here. That is the ordinary shape of an abandoned branch, not an edge.
+     *
+     * So a definite squash is prescribed for directly, and an undetermined one is
+     * told what to establish first. The command is still named, because it is
+     * still the right command once the squash commit is known.
+     */
+    const squashed = lost.filter((entry) => entry.fate === 'present-in-head');
+    const undetermined = lost.filter((entry) => entry.fate === 'unknown');
     const preservable = lost.filter((entry) => entry.fate !== 'absent-from-head');
     const abandonedOnly = preservable.length === 0;
     const fix = abandonedOnly
@@ -399,11 +416,23 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
         // deliberately discarded.
         'nothing to preserve — these branches were closed without merging, and their records ' +
         'describe work HEAD does not contain; delete the branches, or leave them'
-      : `commitlore squash-preserve <base>..<branch> --target <the commit that squashed it>, ` +
-        `then commit or attach the result` +
-        (preservable.length === lost.length
-          ? ''
-          : ` (only the ${preservable.length} on a branch whose changes reached HEAD)`);
+      : squashed.length === 0
+        ? // Nothing is known to have landed, so the only honest instruction is to
+          // establish that first. Naming the command without that condition is
+          // what let it be run on an abandoned branch (#915).
+          `identify the squash commit for each branch first — \`git log --oneline\` on HEAD for the ` +
+          `work, or the merged pull request — then commitlore squash-preserve <base>..<branch> ` +
+          `--target <that commit>. \`--target\` does not check that the commit contains the work, ` +
+          `so on a branch that was abandoned rather than squashed it writes provenance for changes ` +
+          `HEAD never took; for those, there is nothing to preserve`
+        : `commitlore squash-preserve <base>..<branch> --target <the commit that squashed it>, ` +
+          `then commit or attach the result` +
+          (squashed.length === lost.length
+            ? ''
+            : ` (the ${squashed.length} whose changes are in HEAD). For the ${undetermined.length} ` +
+              `undetermined, identify the squash commit before running it — \`--target\` does not ` +
+              `check that the commit contains the work, and on an abandoned branch it writes ` +
+              `provenance for changes HEAD never took`);
 
     return check(
       id,

--- a/src/commands/doctor/checks/history-squash-inheritance.ts
+++ b/src/commands/doctor/checks/history-squash-inheritance.ts
@@ -1,0 +1,149 @@
+/**
+ * The `squash-inheritance` doctor check (#915).
+ *
+ * A squash merge drops the branch commits' trailers, so the record is lost unless
+ * something carries it onto the commit that squashed it. Two paths already do:
+ *
+ *   - a **local** `git merge --squash` is handled by the installed
+ *     `prepare-commit-msg` hook, which reads `SQUASH_MSG` and appends every
+ *     squashed record block to the draft (`src/hooks/prepare-commit-msg.ts`);
+ *   - a **server-side** squash — the GitHub merge button — runs no local hook at
+ *     all, and is handled by the `action/preserve` GitHub Action (ADR-0004).
+ *
+ * The second is the one nobody has running. It was built, this repository runs it
+ * on itself, and it appeared in no README until #915: the reporter made one
+ * record in twelve commits, the squash dropped it, and they found out only
+ * because they went looking. Nothing was broken — the protection simply was not
+ * installed, and no surface said so.
+ *
+ * `squash-conservation` is the other half of this and reports after the fact, on
+ * records that are already gone. This one reports before: a repository with a
+ * GitHub remote and no inheritance workflow will lose the next record it makes on
+ * a branch, and that is knowable now.
+ *
+ * Deliberately a `warn` and not a `fail`. A repository may merge with merge
+ * commits or rebase, where records survive on their own, and this check cannot
+ * read the remote's merge settings — so it reports an exposure, not a defect.
+ * Scoped to a GitHub remote because the Action is GitHub's mechanism; a GitLab or
+ * Gitea host squashes too and has no answer here yet, which the detail says
+ * rather than implying the check covered it.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { execGit } from '../../../core/git.js';
+import { check, type DoctorCheck, type DoctorContext } from '../model.js';
+
+const WORKFLOW_DIR = join('.github', 'workflows');
+
+/**
+ * How a caller references the action. Both forms are real and this must match
+ * either: `uses: OWNER/commitlore/action/preserve@vX` from another repository,
+ * and `uses: ./action/preserve` from a checkout of this one — which is the form
+ * this repository's own workflow uses, and the form the first draft of this
+ * pattern missed because it required `commitlore` to appear in the path.
+ */
+const REFERENCES_ACTION = /uses:\s*\S*action[/\\]preserve/i;
+
+const SETUP = 'see README "Squash-merge repositories" for the workflow to add';
+
+/**
+ * Whether any workflow file mentions the inheritance action. Read as text rather
+ * than parsed as YAML: the question is whether the action is referenced at all,
+ * and a `uses:` line is the same bytes however the surrounding job is shaped.
+ */
+const workflowReferencesAction = (root: string): { found: boolean; scanned: number } => {
+  const dir = join(root, WORKFLOW_DIR);
+  if (!existsSync(dir)) return { found: false, scanned: 0 };
+  let scanned = 0;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return { found: false, scanned: 0 };
+  }
+  for (const entry of entries) {
+    if (!/\.ya?ml$/i.test(entry)) continue;
+    scanned += 1;
+    let text: string;
+    try {
+      text = readFileSync(join(dir, entry), 'utf8');
+    } catch {
+      continue;
+    }
+    if (REFERENCES_ACTION.test(text)) return { found: true, scanned };
+  }
+  return { found: false, scanned };
+};
+
+const githubRemote = (cwd: string): string | null => {
+  const result = execGit(['remote', '-v'], { cwd });
+  if (result.code !== 0) return null;
+  for (const line of result.stdout.split('\n')) {
+    if (/github\.com/i.test(line)) return line.split(/\s+/)[1] ?? 'origin';
+  }
+  return null;
+};
+
+export const checkSquashInheritance = (ctx: DoctorContext): DoctorCheck => {
+  const id = 'squash-inheritance';
+  const title = 'squash inheritance';
+  const cwd = ctx.opts.cwd ?? process.cwd();
+
+  const remote = githubRemote(cwd);
+  if (remote === null) {
+    return check(
+      id,
+      'history',
+      title,
+      'ok',
+      'no GitHub remote — the server-side squash path this protects against does not apply. ' +
+        'A local `git merge --squash` is carried by the installed prepare-commit-msg hook either way',
+      null,
+      false,
+      undefined,
+      { evidence: { github_remote: 'none' } },
+    );
+  }
+
+  const { found, scanned } = workflowReferencesAction(cwd);
+  if (found) {
+    return check(
+      id,
+      'history',
+      title,
+      'ok',
+      'a workflow runs the squash inheritance action, so a record squashed by the GitHub merge ' +
+        'button is carried onto the commit that squashed it',
+      null,
+      false,
+      undefined,
+      { evidence: { github_remote: remote, workflows_scanned: String(scanned), references_action: 'true' } },
+    );
+  }
+
+  return check(
+    id,
+    'history',
+    title,
+    'warn',
+    'no workflow runs the squash inheritance action. A squash merge drops the branch commits’ ' +
+      'trailers, and GitHub performs that merge on its servers where no local hook runs — so if ' +
+      'this repository is merged with the squash button, the next record made on a branch is lost ' +
+      'silently and the author sees a green merge. `squash-conservation` reports that afterwards, ' +
+      'once the record is already gone. A local `git merge --squash` is unaffected: the installed ' +
+      'prepare-commit-msg hook carries those records itself. Nothing is broken here — this is ' +
+      'protection that is not switched on',
+    SETUP,
+    false,
+    undefined,
+    {
+      evidence: {
+        github_remote: remote,
+        workflows_scanned: String(scanned),
+        references_action: 'false',
+      },
+    },
+  );
+};

--- a/src/commands/doctor/registry.ts
+++ b/src/commands/doctor/registry.ts
@@ -18,6 +18,7 @@ import { checkMcpLifecycle } from './checks/delivery-mcp-lifecycle.js';
 import { checkMcpRuntimeIdentity } from './checks/delivery-mcp-runtime-identity.js';
 import { checkHistoryDepth } from './checks/history-history-depth.js';
 import { checkSquashConservation } from './checks/history-squash-conservation.js';
+import { checkSquashInheritance } from './checks/history-squash-inheritance.js';
 import { checkIndex } from './checks/index-index-health.js';
 import { checkRuntime } from './checks/runtime-cli-runtime.js';
 import { checkRuntimeIdentity } from './checks/runtime-runtime-identity.js';
@@ -95,6 +96,7 @@ export const CHECK_REGISTRY: readonly CheckDefinition[] = [
   { id: 'history-depth', title: 'history depth', category: 'history', dependencies: [], optional: false, run: (ctx) => checkHistoryDepth(ctx) },
   { id: 'index-health', title: 'index health', category: 'index', dependencies: [], optional: false, run: (ctx) => checkIndex(ctx) },
   { id: 'squash-conservation', title: 'squash conservation', category: 'history', dependencies: [], optional: false, run: (ctx) => checkSquashConservation(ctx) },
+  { id: 'squash-inheritance', title: 'squash inheritance', category: 'history', dependencies: [], optional: false, run: (ctx) => checkSquashInheritance(ctx) },
 ] as const;
 
 /** An invalid selection is a usage error, never an empty health report. */

--- a/src/commands/stale.ts
+++ b/src/commands/stale.ts
@@ -67,6 +67,16 @@ const EMPTY_REPO_RE = /does not have any commits yet|bad default revision|ambigu
  * is impossible.
  */
 const CANDIDATE_LINE_RE = /^[A-Za-z][A-Za-z0-9-]*:/m;
+const RECORD_ID_KEY = 'Record-Id';
+/**
+ * #914: what an unresolved reference is owed instead of `dangling-ref`'s "an
+ * existing Record-Id in history". The window did not carry the declaration and
+ * the message search did not find one; neither of those is history denying it.
+ */
+const UNRESOLVED_WANT =
+  'undetermined — the scanned window does not carry this Record-Id and no commit message ' +
+  'declares it; a declaration in the notes mirror outside the window would not be found ' +
+  'here, so run with --all-history to decide';
 
 export interface CollectOptions {
   cwd?: string;
@@ -196,6 +206,13 @@ export interface StaleReport {
   /** The stale ones: superseded, expired, or flagged for review. */
   records: StaleReportRecord[];
   danglingRefs: Violation[];
+  /**
+   * #914: references whose target was not in the scanned window and could not be
+   * shown absent from history either. Separate from `danglingRefs` because that
+   * field is what a CI job fails on, and a truncated window cannot support the
+   * assertion `dangling-ref` makes. Always empty for `--all-history`.
+   */
+  unresolvedRefs: Violation[];
   idCollisions: Violation[];
 }
 
@@ -266,7 +283,64 @@ const withheldIfInjection = (record: StaleReportRecord): StaleReportRecord => {
   };
 };
 
-export const buildReport = (scan: Scan, at: Date): StaleReport => {
+/**
+ * Ids this repository declares anywhere reachable from HEAD, for a handful of
+ * ids the scanned window did not cover (#914).
+ *
+ * `stale`'s default window is the most recent 1000 commits, and a `Follows:`
+ * inside it may point at a `Record-Id` declared below it — in the reporter's
+ * repository, a reference at the surface pointing at a definition at commit 1397
+ * of 1554. The window is the caller's, and `findDanglingRefs` says so in as many
+ * words: it answers about the stream it is handed. Presenting that answer as
+ * `dangling-ref` — "want an existing Record-Id in history" — turned a fact about
+ * a window into an assertion about history, which is the inference this project
+ * refuses everywhere else and tells its own callers not to make.
+ *
+ * Targeted rather than a second full scan: only ids already suspected are looked
+ * up, so a clean repository pays nothing and a suspicious one pays one `git log`
+ * per id instead of re-reading every commit the window skipped.
+ */
+const declaredAnywhere = (
+  cwd: string | undefined,
+  ids: readonly string[],
+): ReadonlySet<string> => {
+  /*
+   * Resolved by re-collecting the whole history through the same reader, rather
+   * than by asking git to search commit text for the id.
+   *
+   * Message-pattern search is banned under `src/` and `test/source-guards.test.ts`
+   * enforces the ban by scanning for the option's name: such a search matches
+   * commit *text*, so a `Record-Id:` line written inside a prose paragraph would
+   * answer "declared" for something that is not a trailer at all. Trailer
+   * boundaries are git's to decide (SPEC §2.1 B3), and the first draft of this
+   * function got that wrong — the guard caught it. Going through `collectRecords`
+   * means the answer comes from the same parser, over the same two sources
+   * (commit messages and the notes mirror) as the windowed scan it corrects, so
+   * the two cannot disagree about what counts as a declaration.
+   */
+  const full = collectRecords({
+    ...(cwd === undefined ? {} : { cwd }),
+    allHistory: true,
+  });
+  const declared = new Set<string>();
+  for (const record of full.records) {
+    for (const trailer of record.trailers) {
+      if (trailer.key === RECORD_ID_KEY) declared.add(trailer.value);
+    }
+  }
+  return new Set(ids.filter((id) => declared.has(id)));
+};
+
+export const buildReport = (
+  scan: Scan,
+  at: Date,
+  /**
+   * Where to resolve a reference the window did not cover. Omitted by callers
+   * that hold no repository — they get `unresolvedRefs` rather than an assertion
+   * neither of us can support.
+   */
+  resolveIn?: { cwd?: string },
+): StaleReport => {
   const ordered = oldestFirst(scan.records);
   const states = foldLifecycle(ordered, { at });
   const stale = states.filter(isStale).map((state): StaleReportRecord => {
@@ -290,8 +364,46 @@ export const buildReport = (scan: Scan, at: Date): StaleReport => {
     // Both read the stream in order too — `findIdCollisions` asks whether a
     // *later* commit declared the succession, which is the same question the
     // fold asks and must get the same order to answer it with.
-    danglingRefs: findDanglingRefs(ordered),
+    ...partitionRefs(findDanglingRefs(ordered), scan, resolveIn),
     idCollisions: findIdCollisions(ordered),
+  };
+};
+
+/**
+ * Splits the window's candidates into what history denies and what it cannot
+ * answer (#914).
+ *
+ * A complete scan asserts freely: nothing was skipped, so absence is absence.
+ * A truncated one resolves each candidate against history by id and keeps only
+ * those history really has no declaration for; anything still unaccounted for
+ * moves to `unresolvedRefs`, because a declaration living only in a note outside
+ * the window would not be found by a message search and must not be reported as
+ * proven missing.
+ */
+const partitionRefs = (
+  candidates: Violation[],
+  scan: Scan,
+  resolveIn?: { cwd?: string },
+): { danglingRefs: Violation[]; unresolvedRefs: Violation[] } => {
+  if (!scan.truncated || candidates.length === 0) {
+    return { danglingRefs: candidates, unresolvedRefs: [] };
+  }
+  if (resolveIn === undefined) {
+    return {
+      danglingRefs: [],
+      unresolvedRefs: candidates.map((violation) => ({ ...violation, want: UNRESOLVED_WANT })),
+    };
+  }
+  const ids = [...new Set(candidates.map((violation) => violation.got))];
+  const declared = declaredAnywhere(resolveIn.cwd, ids);
+  // Both places a declaration can live have now been searched over the whole
+  // history — commit messages by id, and the notes mirror — so an id still
+  // missing is missing, and the assertion `dangling-ref` makes is supported. A
+  // default run therefore stays useful to a CI job instead of deferring every
+  // answer to `--all-history`.
+  return {
+    danglingRefs: candidates.filter((violation) => !declared.has(violation.got)),
+    unresolvedRefs: [],
   };
 };
 
@@ -328,6 +440,10 @@ export const formatReport = (report: StaleReport): string => {
     ...section(
       'dangling refs',
       report.danglingRefs.map((violation) => `${violation.key}: ${violation.got}  want ${violation.want}`),
+    ),
+    ...section(
+      'unresolved refs',
+      report.unresolvedRefs.map((violation) => `${violation.key}: ${violation.got}  ${violation.want}`),
     ),
     ...section(
       'id collisions',
@@ -395,7 +511,9 @@ export const register = (program: Command): void => {
         const scan = collectRecords(
           options.allHistory === true ? { allHistory: true } : { allHistory: false },
         );
-        const report = buildReport(scan, at);
+        // #914: resolve in this repository, so a truncated window reports what
+        // history denies rather than what the window happened not to reach.
+        const report = buildReport(scan, at, {});
         process.stdout.write(
           options.json === true ? `${JSON.stringify(report, null, 2)}\n` : formatReport(report),
         );

--- a/src/core/harvest.ts
+++ b/src/core/harvest.ts
@@ -305,7 +305,10 @@ const RULES = [
   '   cannot check it.',
   '7. Do not emit Verified. Reading a transcript or diff cannot prove a check ran.',
   '   Record Verified only from the command or test run that performed the check.',
-  '8. A Ruled-out quote must show the alternative being evaluated and dropped —',
+  '8. If the DIFF section reads `(no diff — nothing is staged)`, the diff is not',
+  '   part of the evidence for this capture and rule 1 has only the transcript to',
+  '   draw on. Do not record a claim that needs the change itself to support it.',
+  '9. A Ruled-out quote must show the alternative being evaluated and dropped —',
   '   considered, rejected, ruled out, decided against, abandoned, superseded, or',
   '   chosen against with "instead" or "rather than". Reasoning about why the',
   '   alternative would be bad is not a rejection: a consequence argues against',
@@ -581,7 +584,20 @@ export const buildHarvestPromptWithWindow = (
   precomputed?: { text: string; window: TranscriptWindow },
 ): { prompt: string; window: TranscriptWindow } => {
   const entries = loadVocabulary().filter((entry) => entry.key !== 'Verified');
-  const diff = input.diff.trim() === '' ? '(no diff)' : input.diff.replace(/\n+$/, '');
+  /*
+   * #911: `(no diff)` alone was too quiet — rule 1 is "cite or omit", and with
+   * nothing staged half the citable surface is gone while every rule still reads
+   * as though it were there.
+   *
+   * The explanation lives in the rules rather than here, and the reason is a
+   * pricing invariant: the token ledger prices a capture against a scaffold built
+   * with an empty diff, and asserts no real prompt is cheaper than that scaffold.
+   * Text that appears *only* in the no-diff branch inflates the scaffold above a
+   * prompt that carries a real diff, and `test/token-ledger.test.ts` caught
+   * exactly that. A rule is present in every prompt, so it prices identically and
+   * is read whether or not anything is staged.
+   */
+  const diff = input.diff.trim() === '' ? '(no diff — nothing is staged)' : input.diff.replace(/\n+$/, '');
   const { text, window } = precomputed ?? windowTranscript(input.transcript);
 
   const prompt = [

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -93,6 +93,13 @@ export const SERVER_NAME = 'commitlore';
 const FALLBACK_VERSION = '0.0.0';
 
 const JSON_MIME = 'application/json';
+/**
+ * SHA-256 of the empty string, which is what `staged_diff_hash` holds when
+ * nothing is staged (#911). Named rather than inlined: the literal is
+ * recognisable only to a reader who already knows what it is, which is the whole
+ * reason the condition needed a field of its own.
+ */
+const EMPTY_SHA256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
 
 
 /** The four consumer routes of SPEC §5, under the names the CLI uses. */
@@ -659,6 +666,25 @@ export const createServer = (opts: McpServerOptions = {}): Server => {
         // fallback PRD-F13 requirement 10 rules out.
         guard_advisory: result.guard_advisory,
         policy_error: result.policy_error,
+        /*
+         * #911: two facts a caller had no way to read.
+         *
+         * `staged_diff_empty` because nothing said so in a field. The prompt said
+         * `(no diff)` in prose and `staged_diff_hash` was the SHA-256 of the empty
+         * string, which is only legible to someone who already suspected it. The
+         * transaction is real and still binds — a record prepared here cannot
+         * attach to a commit with a different diff, the staged-diff binding
+         * refuses that — but half the citable surface is absent, and the caller
+         * should decide that rather than discover it at commit time.
+         *
+         * `repository` because the reporter reached this through a stale MCP
+         * server owned by another process, answering for a tree that was not
+         * theirs. Every other field was internally consistent; nothing named the
+         * repository the answer was about. A caller in a worktree can now compare
+         * it against the tree they meant in one glance.
+         */
+        staged_diff_empty: result.staged_diff_hash === EMPTY_SHA256,
+        repository: root,
       });
     },
     [VERIFY_CAPTURE_TOOL]: (args) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -94,6 +94,7 @@ const FALLBACK_VERSION = '0.0.0';
 
 const JSON_MIME = 'application/json';
 
+
 /** The four consumer routes of SPEC §5, under the names the CLI uses. */
 export const QUERY_KINDS = ['context', 'limits', 'ruled-out', 'warnings'] as const;
 
@@ -576,7 +577,10 @@ export const createServer = (opts: McpServerOptions = {}): Server => {
       const kind = kindArg(args);
       return asText(contextJson(root, kind, pathArg(root, args)));
     },
-    [STALE_TOOL]: () => asText(buildReport(collectRecords({ cwd: root }), new Date())),
+    // #914: the third argument resolves a reference the window did not cover, so
+    // an agent is never handed "no such Record-Id in history" about a record the
+    // scan simply stopped short of.
+    [STALE_TOOL]: () => asText(buildReport(collectRecords({ cwd: root }), new Date(), { cwd: root })),
     [GUARD_TOOL]: (args) => {
       const proposal = requiredString(args, 'proposal');
       const path = pathArg(root, args);

--- a/test/__snapshots__/doctor-snapshot.test.ts.snap
+++ b/test/__snapshots__/doctor-snapshot.test.ts.snap
@@ -22,6 +22,7 @@ exports[`#462 doctor text report, pinned > pins the check set and its order inde
   "history-depth",
   "index-health",
   "squash-conservation",
+  "squash-inheritance",
 ]
 `;
 
@@ -53,7 +54,8 @@ ok      pending captures — no captures are waiting
 ok      git interpret-trailers — git version <git>
 ok      history depth — full history is available
 ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS5 (value search falls back to LIKE)
-skipped squash conservation — no local branch looks like the source of a squash — nothing to check"
+skipped squash conservation — no local branch looks like the source of a squash — nothing to check
+ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way"
 `;
 
 exports[`#462 doctor text report, pinned > renders a stable report on a repository whose hook target resolves 1`] = `
@@ -84,7 +86,8 @@ ok      pending captures — no captures are waiting
 ok      git interpret-trailers — git version <git>
 ok      history depth — full history is available
 ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS5 (value search falls back to LIKE)
-skipped squash conservation — no local branch looks like the source of a squash — nothing to check"
+skipped squash conservation — no local branch looks like the source of a squash — nothing to check
+ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way"
 `;
 
 exports[`#470 doctor text report header > keeps the per-check tail byte-identical to the pre-ticket rows 1`] = `
@@ -111,7 +114,8 @@ ok      pending captures — no captures are waiting
 ok      git interpret-trailers — git version <git>
 ok      history depth — full history is available
 ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS5 (value search falls back to LIKE)
-skipped squash conservation — no local branch looks like the source of a squash — nothing to check",
+skipped squash conservation — no local branch looks like the source of a squash — nothing to check
+ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way",
   "working": "ok      cli runtime — <root><path> runs (<version>)
 ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v4
 ok      installation integrity — 3 shipped files are present and readable
@@ -134,6 +138,7 @@ ok      pending captures — no captures are waiting
 ok      git interpret-trailers — git version <git>
 ok      history depth — full history is available
 ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS5 (value search falls back to LIKE)
-skipped squash conservation — no local branch looks like the source of a squash — nothing to check",
+skipped squash conservation — no local branch looks like the source of a squash — nothing to check
+ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way",
 }
 `;

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -551,7 +551,7 @@ describe('doctor: the pinned CLI is a different version than the running one (#3
     // 17 since runtime-identity joined the registry. The count is asserted so
     // a check cannot be dropped without someone noticing; when it moves, it
     // should move because a check was deliberately added or removed.
-    expect(report.checks).toHaveLength(20);
+    expect(report.checks).toHaveLength(21);
   });
 });
 
@@ -1214,6 +1214,7 @@ describe('doctor: report', () => {
       'history-depth',
       'index-health',
       'squash-conservation',
+      'squash-inheritance',
     ]);
     for (const entry of report.checks) {
       expect(['ok', 'warn', 'fail', 'skipped']).toContain(entry.status);
@@ -1258,7 +1259,7 @@ describe('doctor: report', () => {
     const parsed = JSON.parse(JSON.stringify(report, null, 2)) as DoctorReport;
 
     expect(parsed).toEqual(report);
-    expect(parsed.checks).toHaveLength(20);
+    expect(parsed.checks).toHaveLength(21);
     for (const entry of parsed.checks) {
       expect(entry.status).toBeTypeOf('string');
       expect(entry.id).toBeTypeOf('string');
@@ -1859,5 +1860,145 @@ setInterval(() => {}, 1_000);
     expect(check?.status).toBe('ok');
     expect(check?.evidence).toMatchObject({ initiator: 'capture-tools-advertised', registration: 'custom-preserved' });
     expect(readFileSync(config, 'utf8')).toBe(before);
+  });
+});
+
+/**
+ * #915: a squash merge drops the branch commits' trailers. Two paths cover that
+ * — the installed prepare-commit-msg hook for a local `git merge --squash`, and
+ * the `action/preserve` GitHub Action for the merge GitHub performs on its own
+ * servers, where no local hook runs at all.
+ *
+ * The Action was built, this repository runs it on itself, and no README
+ * mentioned it: the reporter made one record in twelve commits, the squash
+ * dropped it, and they found out only by going looking. Nothing was broken. The
+ * protection was simply not switched on, and no surface said so.
+ *
+ * `squash-conservation` is the after-the-fact half and reports records already
+ * gone. This row reports the exposure before the first loss.
+ */
+describe('#915 squash inheritance is reported before a record is lost', () => {
+  const inheritanceRow = (repo: string) =>
+    runDoctor({ cwd: repo }).checks.find((entry) => entry.id === 'squash-inheritance');
+
+  it('does not apply without a GitHub remote', () => {
+    const repo = initRepo('squash-inheritance-no-remote');
+    const row = inheritanceRow(repo);
+
+    expect(row?.status).toBe('ok');
+    expect(row?.detail).toContain('no GitHub remote');
+    expect(row?.evidence['github_remote']).toBe('none');
+  });
+
+  it('warns when a GitHub remote has no workflow running the action', () => {
+    const repo = initRepo('squash-inheritance-unprotected');
+    git(repo, ['remote', 'add', 'origin', 'https://github.com/example/example.git']);
+
+    const row = inheritanceRow(repo);
+    expect(row?.status).toBe('warn');
+    // The consequence, not just the absence: the author sees a green merge.
+    expect(row?.detail).toContain('lost');
+    expect(row?.detail).toContain('squash-conservation');
+    // A local squash is a different path and must not be implied to be at risk.
+    expect(row?.detail).toContain('prepare-commit-msg');
+    expect(row?.evidence['references_action']).toBe('false');
+  });
+
+  it('is satisfied by the marketplace reference form', () => {
+    const repo = initRepo('squash-inheritance-marketplace');
+    git(repo, ['remote', 'add', 'origin', 'git@github.com:example/example.git']);
+    writeScript(
+      join(repo, '.github', 'workflows', 'preserve.yml'),
+      'name: p\non:\n  pull_request_target:\n    types: [closed]\njobs:\n  p:\n    steps:\n' +
+        '      - uses: MongLong0214/commitlore/action/preserve@v1.0.0\n',
+    );
+
+    expect(inheritanceRow(repo)?.status).toBe('ok');
+  });
+
+  /*
+   * The form this repository's own workflow uses. The first draft of the detector
+   * required `commitlore` to appear in the path and reported this repository as
+   * unprotected while it was running the action on every merge — which is why the
+   * pattern is asserted against both shapes rather than the one that was written
+   * first.
+   */
+  it('is satisfied by the local checkout reference form', () => {
+    const repo = initRepo('squash-inheritance-local-form');
+    git(repo, ['remote', 'add', 'origin', 'https://github.com/example/example.git']);
+    writeScript(
+      join(repo, '.github', 'workflows', 'preserve.yml'),
+      'name: p\non: pull_request_target\njobs:\n  p:\n    steps:\n      - uses: ./action/preserve\n',
+    );
+
+    expect(inheritanceRow(repo)?.status).toBe('ok');
+  });
+
+  it('does not mistake an unrelated workflow for the action', () => {
+    const repo = initRepo('squash-inheritance-other-workflow');
+    git(repo, ['remote', 'add', 'origin', 'https://github.com/example/example.git']);
+    writeScript(
+      join(repo, '.github', 'workflows', 'ci.yml'),
+      'name: ci\non: push\njobs:\n  a:\n    steps:\n      - uses: actions/checkout@v4\n',
+    );
+
+    const row = inheritanceRow(repo);
+    expect(row?.status).toBe('warn');
+    expect(row?.evidence['workflows_scanned']).toBe('1');
+  });
+});
+
+/**
+ * #915, second half: #888 stopped prescribing `squash-preserve` for a branch
+ * proven unmerged, and deliberately left `unknown` prescribing it — on the
+ * argument that an unnecessary preservation costs a discarded plan while
+ * withholding one from a real squash loses a record for good.
+ *
+ * That weighed the wrong cost, and `unknown` is not the rare case the grouping
+ * assumed. The fate is decided by comparing blobs, so an abandoned branch that
+ * edited a file HEAD still has satisfies neither arm — the path is present, the
+ * content differs — and lands on `unknown`. That is the ordinary shape of an
+ * abandoned branch. Following the printed fix there writes provenance for work
+ * HEAD never took, which is fabricating history rather than preserving it.
+ */
+describe('#915 an undetermined branch is not told to run --target blindly', () => {
+  /** Edits a file HEAD already has, so neither fate arm is satisfied. */
+  const undeterminedBranch = (repo: string, recordId: string): void => {
+    writeFileSync(join(repo, 'shared.ts'), 'export const v = 1;\n');
+    git(repo, ['add', '--', 'shared.ts']);
+    git(repo, ['commit', '--quiet', '-m', 'add shared']);
+    git(repo, ['checkout', '--quiet', '-b', 'undetermined']);
+    writeFileSync(join(repo, 'shared.ts'), 'export const v = 2;\n');
+    git(repo, ['add', '--', 'shared.ts']);
+    git(repo, [
+      'commit',
+      '--quiet',
+      '-m',
+      `change shared\n\nLimit: a constraint\nRecord-Id: ${recordId}\n`,
+    ]);
+    git(repo, ['checkout', '--quiet', 'main']);
+    // main moves on, so the branch's blob is neither absent nor matching.
+    writeFileSync(join(repo, 'shared.ts'), 'export const v = 3;\n');
+    git(repo, ['add', '--', 'shared.ts']);
+    git(repo, ['commit', '--quiet', '-m', 'main moves on']);
+  };
+
+  it('names the condition instead of prescribing --target for an undetermined fate', () => {
+    const repo = initRepo('squash-conservation-undetermined');
+    undeterminedBranch(repo, 'r-undetermined01');
+
+    const row = runDoctor({ cwd: repo }).checks.find(
+      (entry) => entry.id === 'squash-conservation',
+    );
+
+    expect(row?.status).toBe('warn');
+    expect(row?.evidence['undetermined_count']).toBe('1');
+    expect(row?.evidence['squashed_count']).toBe('0');
+    // The record is still reported: silence would be the worse failure.
+    expect(row?.detail).toContain('r-undetermined01');
+    // The command is still named — it is the right one once the squash commit is
+    // known — but the condition comes first, and the hazard is stated.
+    expect(row?.fix).toContain('identify the squash commit');
+    expect(row?.fix).toContain('does not check that the commit contains the work');
   });
 });

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -320,3 +320,44 @@ describe('the animated brand logo', () => {
     }
   });
 });
+
+/**
+ * #915: every README now documents the squash-inheritance Action, because the
+ * mechanism existed and no README mentioned it — the reporter's records were lost
+ * to a protection that was built, shipped, and undiscoverable.
+ *
+ * The `uses:` line carries a version pin, so it can drift from the release the
+ * rest of the page pins. A reader who copies a stale pin gets an old action
+ * against a new CLI, and nothing else in this file would notice: the assertions
+ * above match on `sh install.sh v`, `git clone --branch v` and the `fsSLO` URL,
+ * none of which is this line.
+ */
+describe('#915 the squash inheritance Action is documented and pinned', () => {
+  for (const file of README_FILES) {
+    describe(file, () => {
+      const content = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+      const lines = content.split('\n');
+
+      it('documents the Action', () => {
+        expect(content).toContain('action/preserve');
+      });
+
+      it('pins the Action to this package version', () => {
+        const usesLine = lines.find((l) => /uses:\s*\S*\/action\/preserve@/.test(l));
+        expect(usesLine).toBeDefined();
+        const match = usesLine!.match(/@v(\d+\.\d+\.\d+)/);
+        expect(match).not.toBeNull();
+        expect(match![1]).toBe(PACKAGE_VERSION);
+      });
+
+      it('keeps the two pull_request_target rules beside the workflow', () => {
+        // The event runs with a writable token against a fork's content. The
+        // workflow is safe only because it checks out the base branch and reads
+        // the fork's commits as data; a reader who drops either rule turns this
+        // into the vulnerability pull_request_target is known for.
+        expect(content).toContain('pull_request_target');
+        expect(content).toContain('refs/commitlore/pr-head');
+      });
+    });
+  }
+});

--- a/test/stale.test.ts
+++ b/test/stale.test.ts
@@ -1249,3 +1249,104 @@ describe('a stale record that matches an injection pattern', () => {
     rmSync(repo, { recursive: true, force: true });
   });
 });
+
+/**
+ * #914: `stale`'s default window is the most recent 1000 commits, and it reported
+ * a reference whose target sat below that window as `dangling-ref` — "want an
+ * existing Record-Id in history". That is an assertion about history made from a
+ * window the same report declares incomplete, and it is the inference this
+ * project refuses everywhere else: `coverage: "partial"` means absence of a
+ * record is not evidence the record does not exist.
+ *
+ * Driven through `buildReport` with a synthetic truncated scan rather than by
+ * building 1001 commits: the window is the input under test, and the resolution
+ * it now performs reads the repository by id, so a two-commit repository
+ * exercises both halves.
+ */
+describe('#914 a truncated window does not assert about history', () => {
+  const repos: string[] = [];
+  afterAll(() => {
+    for (const dir of repos) rmSync(dir, { recursive: true, force: true });
+  });
+
+  const repoDeclaring = (id: string | null): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'commitlore-stale-914-'));
+    repos.push(dir);
+    createTestRepo({ path: dir });
+    if (id !== null) {
+      spawnSync('git', ['commit', '--allow-empty', '--quiet', '-m', `declare\n\nLimit: a limit\nRecord-Id: ${id}\n`], {
+        cwd: dir,
+        env: { ...process.env, GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z', GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z' },
+      });
+    }
+    return dir;
+  };
+
+  /** A window that saw the reference and not the declaration, and says so. */
+  const truncatedScanReferencing = (id: string) => ({
+    records: [
+      {
+        sha: 'a'.repeat(40),
+        committedAt: '2026-02-01T00:00:00Z',
+        trailers: [
+          { key: 'Limit', value: 'a limit' },
+          { key: 'Record-Id', value: 'r-referrer00001' },
+          { key: 'Follows', value: id },
+        ],
+        source: 'commit' as const,
+      },
+    ],
+    commits: 1000,
+    truncated: true,
+    notes: 'available' as const,
+  });
+
+  it('clears a reference whose target history has, below the window', () => {
+    const repo = repoDeclaring('r-completioneffect');
+    const report = buildReport(
+      truncatedScanReferencing('r-completioneffect'),
+      new Date('2026-03-01T00:00:00Z'),
+      { cwd: repo },
+    );
+
+    expect(report.truncated).toBe(true);
+    expect(report.danglingRefs).toEqual([]);
+    expect(report.unresolvedRefs).toEqual([]);
+  });
+
+  it('still asserts a reference history really has no declaration for', () => {
+    const repo = repoDeclaring(null);
+    const report = buildReport(
+      truncatedScanReferencing('r-neverdeclared1'),
+      new Date('2026-03-01T00:00:00Z'),
+      { cwd: repo },
+    );
+
+    // Both places a declaration can live were searched over the whole history, so
+    // a default run stays useful to a CI job reading danglingRefs.
+    expect(report.danglingRefs).toHaveLength(1);
+    expect(report.danglingRefs[0]?.got).toBe('r-neverdeclared1');
+    expect(report.unresolvedRefs).toEqual([]);
+  });
+
+  it('reports undetermined rather than dangling when it cannot reach a repository', () => {
+    const report = buildReport(
+      truncatedScanReferencing('r-completioneffect'),
+      new Date('2026-03-01T00:00:00Z'),
+    );
+
+    expect(report.danglingRefs).toEqual([]);
+    expect(report.unresolvedRefs).toHaveLength(1);
+    expect(report.unresolvedRefs[0]?.want).toContain('undetermined');
+    expect(formatReport(report)).toContain('unresolved refs');
+  });
+
+  it('leaves a complete scan asserting exactly as before', () => {
+    const scan = { ...truncatedScanReferencing('r-neverdeclared1'), truncated: false };
+    const report = buildReport(scan, new Date('2026-03-01T00:00:00Z'), {});
+
+    expect(report.danglingRefs).toHaveLength(1);
+    expect(report.danglingRefs[0]?.want).toBe('an existing Record-Id in history');
+    expect(report.unresolvedRefs).toEqual([]);
+  });
+});


### PR DESCRIPTION
Three reports about one habit: answering more confidently than the evidence
allows, and staying quiet where the evidence is missing.

### `stale` asserted about history from a window it declared incomplete (#914)

The default scan reads 1000 commits and reports `truncated: true`. Inside that
same report it emitted a `dangling-ref` wanting "an existing Record-Id in
history". In the reporting repository three `Follows:` references sat inside the
window while the `Record-Id` defining them sat at commit **1397 of 1554**, so the
finding was produced entirely by the truncation and cleared under
`--all-history`.

`findDanglingRefs` never claimed otherwise — its contract is the stream it is
handed, and the caller owns the window. This is the caller's half. A candidate is
now resolved against the whole history before it is asserted, so a default run
still answers definitely and a CI job reading `danglingRefs` keeps working;
`unresolvedRefs` carries only the case where no repository is reachable.

**Resolution goes through `collectRecords`, not a message-pattern search.** The
first draft used the latter and `test/source-guards.test.ts` refused it: such a
search matches commit *text*, so a `Record-Id:` line written inside prose would
answer "declared" for something that is not a trailer. Trailer boundaries are
git's to decide (SPEC §2.1 B3).

### `prepare_capture` succeeded over an empty staged diff (#911)

A nonce, a prompt, `policy_error: null`, for a repository with nothing staged —
with `(no diff)` in prose and `staged_diff_hash` holding the SHA-256 of the empty
string, legible only to someone who already suspected it.

**Not refused, and the reason is measured.** Prepared with nothing staged, then
staged a real change and committed: the record did not attach —
`the staged diff differs from the verified capture; the record remains pending`.
The binding already closes the dangerous case. Refusing would also remove
recording a decision with no code change, and contradict #310's reason for still
emitting the contract when nothing is staged.

So: `staged_diff_empty` as a field, a contract rule naming what it costs, and
`repository` in the response — the report came from an MCP server owned by
another process answering about a different tree, with every other field
internally consistent.

The rule sits in the rules rather than the DIFF section because the token ledger
prices a capture against a scaffold built with an empty diff. Text appearing only
in the no-diff branch inflates that scaffold above a real prompt, and
`test/token-ledger.test.ts` caught exactly that.

### A squash-merge repository lost every record by default (#915)

A local `git merge --squash` is already carried by the installed
`prepare-commit-msg` hook. The merge GitHub performs **on its own servers** runs
no local hook at all, and is carried by the `action/preserve` Action — built,
run by this repository on its own merges, and mentioned in **no README**. The
reporter made one record in twelve commits and lost it silently.

Every README now documents the workflow, with the two rules that keep
`pull_request_target` safe beside it. `doctor` gains a `squash inheritance` row
reporting whether the protection is on — *before* a loss, where
`squash conservation` reports records already gone.

**No hook was added.** Git tells a `post-merge` hook the merge was *not* a squash
and gives it no way to name the collapsed branch, so it could only re-run the
conservation scan: measured here at **11.2s, nine undetermined prescriptions,
zero confirmed squashes** — on every pull.

### `doctor` prescribed fabricating provenance (#915, second half)

1.2.7 stopped prescribing `squash-preserve` for a branch proven unmerged and
deliberately left the undetermined case prescribing it, arguing an unnecessary
preservation costs only a discarded plan. That weighed the wrong cost:
`--target` mirrors records onto whatever commit it is handed without checking the
commit contains the work.

And undetermined is not rare. The fate compares blobs, so an abandoned branch
that edited a file HEAD still has satisfies neither arm — the ordinary shape of
an abandoned branch. The condition now comes first and the hazard is stated.

### Verification

- Full suite: **3,251 passed, 4 skipped, 0 failed**; `tsc` exit 0.
- #914: a 1007-commit repository whose declaration sits outside the window
  reported a dangling ref before and none after; a reference nothing declares
  still reports one on a default run.
- #911: binding measured end to end (above).
- #915: five new doctor cases — no remote, unprotected, both reference forms, an
  unrelated workflow. The first detector draft reported **this repository** as
  unprotected while it was running the action, because the pattern required
  `commitlore` in the path; both forms are now pinned.
- #915 second half: negative control — reverting gives the bare
  `squash-preserve ... --target` line the reporter saw.
- The doctor snapshot and two check-count pins moved by exactly one row, which is
  what they exist to surface when a check is added deliberately.
- `dist/` is deliberately not rebuilt here; `canonical-merge.yml` does it.

Closes #911
Closes #914
Closes #915
