### PR TITLE
feat(backfill): collect pull request bodies by default

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.14
+
+**`backfill` collects pull request bodies by default (#902).** `--with-prs` was
+opt-in, and three rounds of real reconstruction in one repository showed the cost:
+every trailer that survived rounds two and three rested on pull request body text
+rather than a commit message. With the flag off, the command whose whole job is
+recovering context that was never recorded mostly recovers nothing.
+
+The stronger reason is an asymmetry that lost work quietly. The same function
+builds the text for the prompt and for verification, so the flag had to be passed
+to the `--draft` call as well — and a run that collected bodies for the prompt but
+not for the draft discarded exactly the quotes the session had taken from them.
+That refusal was correct about a document nobody had assembled the same way twice.
+Defaulting both sides on removes the way to get it wrong.
+
+The degraded path is unchanged. An absent or unauthenticated `gh` is a normal
+state of the world: the probe runs once, the run continues from commit messages
+and diffs, and the summary says which. `--no-with-prs` turns collection off for a
+repository whose pull requests are irrelevant, or to avoid one `gh` call per
+target commit.
+
 ## 1.2.13
 
 Three reports about the same habit from three directions: answering more

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh
-sh install.sh v1.2.13
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh
+sh install.sh v1.2.14
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.13 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.14 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.ps1))) v1.2.14
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。
@@ -289,7 +289,7 @@ jobs:
       - run: git fetch --no-tags --force origin
           '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.13
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.14
 ```
 
 `pull_request_target` は書き込み可能なトークンで動くため、次にこれを編集する人への規則が

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh
-sh install.sh v1.2.13
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh
+sh install.sh v1.2.14
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.13 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.14 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.ps1))) v1.2.14
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.
@@ -287,7 +287,7 @@ jobs:
       - run: git fetch --no-tags --force origin
           '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.13
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.14
 ```
 
 `pull_request_target` 은 쓰기 가능한 토큰으로 실행되므로, 다음에 이 파일을 고치는 사람을

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh
-sh install.sh v1.2.13
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh
+sh install.sh v1.2.14
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.13 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.14 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.ps1))) v1.2.14
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.
@@ -299,7 +299,7 @@ jobs:
       - run: git fetch --no-tags --force origin
           '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.13
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.14
 ```
 
 Two rules for whoever edits this next, because `pull_request_target` runs with a

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh
-sh install.sh v1.2.13
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh
+sh install.sh v1.2.14
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.13 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.14 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.ps1))) v1.2.14
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。
@@ -281,7 +281,7 @@ jobs:
       - run: git fetch --no-tags --force origin
           '+refs/pull/${{ github.event.pull_request.number }}/head:refs/commitlore/pr-head'
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.13
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.14
 ```
 
 由于 `pull_request_target` 以可写令牌运行，给下一位编辑此文件的人两条规则：不要在这里

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.ps1))) v1.2.13
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.ps1))) v1.2.14
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.13",
+      "version": "1.2.14",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.13/install.sh | sh -s v1.2.13",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.13"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.14/install.sh | sh -s v1.2.14",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.14"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/backfill.ts
+++ b/src/commands/backfill.ts
@@ -18,7 +18,7 @@
  * different facts and the user acts differently on each.
  */
 
-import type { Command } from 'commander';
+import { Option, type Command } from 'commander';
 
 import { notesAvailability } from '../core/notes.js';
 
@@ -85,7 +85,11 @@ export const toBackfillOptions = (options: BackfillCommandOptions): BackfillOpti
     ...(budgetTokens === undefined ? {} : { budgetTokens }),
     ...(options.draft === undefined ? {} : { draft: options.draft }),
     ...(options.batchSize === undefined ? {} : { batchSize: options.batchSize }),
-    withPrs: options.withPrs === true,
+    // #902: the CLI default lives here, not only in the commander declaration,
+    // so a caller that reaches runBackfill directly gets the same behaviour the
+    // command line does. `--no-with-prs` is the only thing that turns it off.
+    // The core keeps its own opt-in default: a programmatic caller states intent.
+    withPrs: options.withPrs !== false,
     promptOnly: options.promptOnly === true,
     dryRun: options.dryRun === true,
   };
@@ -262,7 +266,25 @@ export const register = (program: Command): void => {
     .command('backfill')
     .description('reconstruct records for past commits that have none (all Provenance: reconstructed)')
     .option('--limit <n>', `consider at most n commits with no record (default: ${DEFAULT_LIMIT})`)
-    .option('--with-prs', 'collect linked pull request bodies through the gh CLI')
+    /*
+     * #902: on by default. Across three real rounds in one repository every
+     * surviving trailer rested on pull request body text, so with this off the
+     * command mostly reconstructs nothing — and the flag had to be repeated on the
+     * `--draft` call or quotes taken from those bodies were silently discarded,
+     * which is a footgun the default removes. An absent or unauthenticated `gh`
+     * still degrades to commit messages alone and reports why.
+     *
+     * Only the negation is declared, because that is what gives commander the
+     * `true` default: declaring `--with-prs` as a plain option alongside it makes
+     * the default `undefined` again (measured). `--with-prs` survives as a hidden
+     * option defaulting to true so a script that already passes it keeps working.
+     */
+    .option('--no-with-prs', 'reconstruct from commit messages and diffs only, without running gh')
+    .addOption(
+      new Option('--with-prs', 'collect linked pull request bodies through gh (now the default)')
+        .default(true)
+        .hideHelp(),
+    )
     .option('--budget-tokens <n>', 'stop emitting prompts past this estimated token count')
     .option('--prompt-only', 'print the reconstruction contract for the session and exit')
     .option('--draft <file>', 'verify a draft the session produced and attach what survives')

--- a/src/core/backfill.ts
+++ b/src/core/backfill.ts
@@ -500,11 +500,16 @@ export const buildEnvelope = (count: number, withPrs: boolean): string =>
     ...(withPrs
       ? [
           '',
-          'Pass --with-prs on that command too. The verifier rebuilds these sources',
-          'from the repository, and rebuilding them without the pull request bodies',
-          'means your quotes from those bodies will not be found.',
+          'Pull request bodies are part of the text above, and the verifier rebuilds',
+          'these sources from the repository. They are collected by default, so the',
+          '--draft call needs no flag — but if you pass --no-with-prs to it, quotes',
+          'taken from those bodies will not be found and those records are discarded.',
         ]
-      : []),
+      : [
+          '',
+          'Pull request bodies were not collected for this prompt (--no-with-prs, or',
+          'gh is unavailable), so the text above is commit messages and diffs only.',
+        ]),
     '',
     'Reconstruction is checked, not trusted: every record is re-read against the',
     'same text you were given, and anything whose quote is not there is discarded',

--- a/test/backfill.test.ts
+++ b/test/backfill.test.ts
@@ -908,3 +908,89 @@ describe('#403 backfill fails closed on a mirror it could not read', () => {
     expect(runBackfill({ cwd, draft, dryRun: true }).exitCode).toBe(0);
   });
 });
+
+/**
+ * #902: pull request collection is on by default now.
+ *
+ * Across three real rounds in one repository every surviving trailer rested on
+ * pull request body text, so with it off the command mostly reconstructs nothing.
+ * And it had to be passed to the `--draft` call as well as the prompt call:
+ * `collectSources` rebuilds the same text for verification, so a run that
+ * collected bodies for the prompt and not for the draft discarded exactly the
+ * quotes the session took from them. The default removes that asymmetry.
+ *
+ * Driven through `runBackfill`, because the CLI layer owns the default — the core
+ * is called programmatically by callers that state their own intent, and its own
+ * default stays opt-in.
+ */
+describe('#902 pull request bodies are collected by default', () => {
+  const ghShim = (script: string): string => {
+    const dir = tempDir('backfill-gh-default');
+    const path = join(dir, 'gh');
+    writeFileSync(path, script);
+    chmodSync(path, 0o755);
+    return dir;
+  };
+
+  const withPath = <T>(dir: string, body: () => T): T => {
+    const original = process.env['PATH'] ?? '';
+    process.env['PATH'] = `${dir}:${original}`;
+    try {
+      return body();
+    } finally {
+      process.env['PATH'] = original;
+    }
+  };
+
+  /** Authenticated, and answers the per-commit lookup with an empty list. */
+  const WORKING_GH = ['#!/bin/sh', 'case "$1" in', '  auth) exit 0 ;;', '  *) echo "[]" ;;', 'esac', ''].join('\n');
+  const BROKEN_GH = ['#!/bin/sh', 'echo "not logged in" >&2', 'exit 1', ''].join('\n');
+
+  /** `runBackfill` returns rendered streams, so the report comes out of --json. */
+  const pullRequestsFrom = (stdout: string): Record<string, unknown> =>
+    (JSON.parse(stdout) as { report: { pullRequests: Record<string, unknown> } }).report
+      .pullRequests;
+
+  it('requests them with no flag at all', () => {
+    const fixture = buildFixture('backfill-prs-default-on');
+    const dir = ghShim(WORKING_GH);
+
+    const outcome = withPath(dir, () =>
+      runBackfill({ cwd: fixture.dir, promptOnly: true, json: true }),
+    );
+    const prs = pullRequestsFrom(outcome.stdout);
+
+    expect(outcome.exitCode).toBe(0);
+    expect(prs['requested']).toBe(true);
+    expect(prs['available']).toBe(true);
+  });
+
+  it('stops requesting them under --no-with-prs', () => {
+    const fixture = buildFixture('backfill-prs-opt-out');
+    const dir = ghShim(WORKING_GH);
+
+    const outcome = withPath(dir, () =>
+      runBackfill({ cwd: fixture.dir, promptOnly: true, json: true, withPrs: false }),
+    );
+    const prs = pullRequestsFrom(outcome.stdout);
+
+    expect(prs['requested']).toBe(false);
+    expect(prs['available']).toBe(false);
+  });
+
+  it('still degrades to commit messages when gh cannot be used', () => {
+    const fixture = buildFixture('backfill-prs-default-no-gh');
+    const dir = ghShim(BROKEN_GH);
+
+    const outcome = withPath(dir, () =>
+      runBackfill({ cwd: fixture.dir, promptOnly: true, json: true }),
+    );
+    const prs = pullRequestsFrom(outcome.stdout);
+
+    // The default must not turn a missing gh into a failure: requiring a GitHub
+    // login to backfill a local repository would be a strange thing to demand.
+    expect(outcome.exitCode).toBe(0);
+    expect(prs['available']).toBe(false);
+    expect(String(prs['reason'])).toContain('not authenticated');
+  });
+});


### PR DESCRIPTION
`--with-prs` was opt-in. Three rounds of real reconstruction in one repository
showed what that costs: **every trailer that survived rounds two and three rested
on pull request body text**, not a commit message. With the flag off, the command
whose whole job is recovering context that was never recorded mostly recovers
nothing.

### The stronger reason

`collectSources` builds the same text for the prompt and for verification, so the
flag had to be passed to the `--draft` call as well. A run that collected bodies
for the prompt and not for the draft **discarded exactly the quotes the session
had taken from them** — a correct refusal about a document nobody had assembled
the same way twice. Defaulting both sides on removes the way to get that wrong.

### What does not change

An absent or unauthenticated `gh` is still a normal state of the world: the probe
runs once, the run continues from commit messages and diffs, and the summary says
which. Requiring a GitHub login to backfill a local repository would be a strange
thing to demand, and it still is not demanded. `--no-with-prs` opts out.

### Two things that had to be measured

- **Commander gives a boolean its `true` default only when the negation is the
  declared option.** Declaring `--with-prs` as a plain option beside
  `--no-with-prs` puts the default back to `undefined` — which is how the first
  attempt shipped a default that was not actually on. `--with-prs` survives as a
  hidden option defaulting to true, so a script already passing it keeps working.
- **The default belongs in `toBackfillOptions`, not in the commander declaration
  alone.** `runBackfill` is reachable directly and was getting the old behaviour
  while the command line got the new one. The core keeps its own opt-in default: a
  programmatic caller of `backfill()` states its own intent.

### Verification

- Full suite: **3,254 passed, 4 skipped, 0 failed**; `tsc` exit 0.
- All three states measured against a `gh` shim: no flag requests and collects,
  `--no-with-prs` requests nothing, `--with-prs` still works, and an
  unauthenticated `gh` exits 0 reporting `not authenticated`.
- `dist/` is deliberately not rebuilt here; `canonical-merge.yml` does it.

Refs #902
