### PR TITLE
1.2.16 — say what could not be seen, and stop reading it twice

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.16
+
+A release about what a tool says when it cannot see something, and about how
+much work it does to find out. Most of it came from one report — an MCP server
+answering "no records" from a checkout that was behind — and from following that
+question into the places where the same bytes were being read over and over.
+
+**An answer now says where it was read from (#930).** `coverage: "complete"`
+means the scan was not truncated. It reads as "this answer is whole", and every
+other field described a source or the scan too, so all of them stayed healthy
+while the walk started from the wrong commit. A checkout five commits behind its
+own already-fetched upstream returned zero records with `coverage: "complete"`,
+`history: "ready"` and `notes: "present"` — byte-identical to the answer from a
+repository where nobody ever wrote one, with the record one `git merge --ff-only`
+away. Every answer now carries `vantage`: the commit walked from, the branch or
+null for a detached head, the upstream, and how far behind it is. Behind fires;
+the tip, an unmerged branch and a review worktree stay quiet, because a signal
+that fires on healthy repositories is the one people learn to skip. `doctor`'s
+`history-depth` row reports the same fact beside the shallow-history one it
+already owned.
+
+**A branch touching a non-ASCII filename was never classified.**
+`squash-conservation` compared blobs path by path, and the paths came from `git
+diff --name-only`, which prints anything outside ASCII C-quoted. No tree resolves
+that spelling, so the lookup failed and the whole branch returned `unknown` — a
+squashed branch reported as undetermined, an abandoned one never told there was
+nothing to preserve. Silent, because `unknown` is the safe verdict and looks like
+caution. One `git diff-tree -r -z` now answers for every path at once.
+
+**`stale` read only the last block of a note.** Every other reader of the same
+bytes recovers all of them, so `stale` alone answered differently about the same
+repository: a two-block note yielded one record, and a `Follows:` whose target
+sat in an earlier block of the same note was reported dangling. The shape is what
+`squash-preserve --target` writes, so this was the path a preserved squash's own
+records travel.
+
+**Reading the same message once instead of once per walk.** `validate --range`
+collects the whole reachable history once per commit in the range and re-read
+everything each time. On this project's own CI that step took 47 and 60 minutes
+per matrix leg, on every release. The walks stay — each one's reachable set is
+the question being asked — but a message is parsed once, the notes mirror is read
+once, and the last trailer block now comes from git's own trailer atom in the
+`git log` the walk already runs, rather than from a separate `interpret-trailers`
+process per message. Measured on this repository, counting every git invocation:
+a 164-commit range went from more than 147,000 spawns, still running when it was
+stopped at 42 minutes, to 1,193. The answers are byte-identical.
+
+That last change replaces one parser with another, so it is carried by a
+differential test rather than by a benchmark: every commit in this repository's
+history plus 23 constructed hazards, both readers compared. It found one real
+failure — a value containing the atom's own separator bytes cannot be framed —
+and those messages are routed to the process reader.
+
 ## 1.2.15
 
 Six reports about `doctor`, and what they have in common is worse than any one of

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh
-sh install.sh v1.2.15
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh
+sh install.sh v1.2.16
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.15 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.16 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.ps1))) v1.2.15
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.ps1))) v1.2.16
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。
@@ -295,11 +295,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.15
+          ref: v1.2.16
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.15
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.16
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh
-sh install.sh v1.2.15
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh
+sh install.sh v1.2.16
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.15 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.16 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.ps1))) v1.2.15
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.ps1))) v1.2.16
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.
@@ -293,11 +293,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.15
+          ref: v1.2.16
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.15
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.16
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh
-sh install.sh v1.2.15
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh
+sh install.sh v1.2.16
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.15 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.16 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.ps1))) v1.2.15
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.ps1))) v1.2.16
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.
@@ -305,11 +305,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.15
+          ref: v1.2.16
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.15
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.16
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh
-sh install.sh v1.2.15
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh
+sh install.sh v1.2.16
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.15 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.16 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.ps1))) v1.2.15
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.ps1))) v1.2.16
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。
@@ -287,11 +287,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.15
+          ref: v1.2.16
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.15
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.16
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.ps1))) v1.2.15
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.ps1))) v1.2.16
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.15",
+      "version": "1.2.16",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.15/install.sh | sh -s v1.2.15",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.15"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.16/install.sh | sh -s v1.2.16",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.16"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/doctor/checks/history-history-depth.ts
+++ b/src/commands/doctor/checks/history-history-depth.ts
@@ -3,31 +3,94 @@
  *
  * It owns the shallow-history observation because history completeness is an
  * independent limitation on every query, not a dependency on another check.
+ *
+ * #930 gave it a second instance of the same idea. A shallow clone cannot see
+ * records that were never fetched; a checkout behind its upstream cannot see
+ * records it *has* already fetched. Both make every query answer less than the
+ * truth while nothing in the answer used to say so, and both are one command
+ * away from fixed -- which is what keeps this a row rather than a fact. A row
+ * that cannot be cleared by fixing the thing it names teaches people to skip
+ * the section.
+ *
+ * Detached HEAD is stated, never warned about. `git worktree add <path> <ref>`
+ * is how a review is set up, the narrower scope is the point of being there,
+ * and a warning would fire on every one of them.
  */
 
-import { hasShallowHistory } from '../../../core/git.js';
+import { hasShallowHistory, readVantage, type Vantage } from '../../../core/git.js';
 import { check, type DoctorCheck, type DoctorContext } from '../model.js';
 
-export const checkHistoryDepth = (ctx: DoctorContext): DoctorCheck =>
-  hasShallowHistory(ctx.opts.cwd ?? process.cwd())
-    ? check(
-        'history-depth', 'history',
-        'history depth',
-        'warn',
-        'this clone has shallow history, so queries may be missing records that exist upstream',
-        'git fetch --unshallow',
-        false,
-        undefined,
-        { evidence: { shallow: 'true' } },
-      )
-    : check(
-        'history-depth',
-        'history',
-        'history depth',
-        'ok',
-        'full history is available',
-        null,
-        false,
-        undefined,
-        { evidence: { shallow: 'false' } },
-      );
+/** How the vantage reads in a detail line, once. */
+const describe = (vantage: Vantage): string =>
+  vantage.ref === null
+    ? `HEAD is detached at ${(vantage.head ?? 'an unknown commit').slice(0, 12)}, so queries answer for that commit`
+    : `HEAD is on ${vantage.ref}${vantage.upstream === null ? ' and tracks nothing' : ''}`;
+
+export const checkHistoryDepth = (ctx: DoctorContext): DoctorCheck => {
+  const cwd = ctx.opts.cwd ?? process.cwd();
+  const shallow = hasShallowHistory(cwd);
+  const vantage = readVantage(cwd);
+  const behind = vantage.behind ?? 0;
+
+  const evidence = {
+    shallow: shallow ? 'true' : 'false',
+    head: vantage.head ?? '',
+    ref: vantage.ref ?? '',
+    upstream: vantage.upstream ?? '',
+    behind: vantage.behind === null ? '' : String(vantage.behind),
+  };
+
+  if (shallow && behind > 0) {
+    return check(
+      'history-depth', 'history',
+      'history depth',
+      'warn',
+      `this clone has shallow history and is ${String(behind)} commit(s) behind ${vantage.upstream ?? 'its upstream'}, ` +
+        'so queries are missing records on both counts — an empty answer here is not evidence that nothing was recorded',
+      `git fetch --unshallow && git merge --ff-only`,
+      false,
+      undefined,
+      { evidence },
+    );
+  }
+
+  if (shallow) {
+    return check(
+      'history-depth', 'history',
+      'history depth',
+      'warn',
+      'this clone has shallow history, so queries may be missing records that exist upstream',
+      'git fetch --unshallow',
+      false,
+      undefined,
+      { evidence },
+    );
+  }
+
+  if (behind > 0) {
+    return check(
+      'history-depth', 'history',
+      'history depth',
+      'warn',
+      `this checkout is ${String(behind)} commit(s) behind ${vantage.upstream ?? 'its upstream'}. Those commits are ` +
+        'already in this object store, and the records they carry are absent from every query answered here — ' +
+        'which reports coverage "complete", because the scan was not truncated, only pointed at an older commit',
+      'git merge --ff-only',
+      false,
+      undefined,
+      { evidence },
+    );
+  }
+
+  return check(
+    'history-depth',
+    'history',
+    'history depth',
+    'ok',
+    `full history is available, and ${describe(vantage)}`,
+    null,
+    false,
+    undefined,
+    { evidence },
+  );
+};

--- a/src/commands/doctor/checks/history-squash-conservation.ts
+++ b/src/commands/doctor/checks/history-squash-conservation.ts
@@ -6,7 +6,7 @@
  */
 
 import { runQuery } from '../../../core/query.js';
-import { collectRange } from '../../../core/squash.js';
+import { collectRange, newRangeCache } from '../../../core/squash.js';
 import { check, gitOptions, type Category, type DoctorCheck, type DoctorContext } from '../model.js';
 
 /** Local branches this check will look at, past which a repository is skipped rather than walked exhaustively. */
@@ -145,7 +145,8 @@ const upstreamRecordIds = (ctx: DoctorContext): { ref: string; ids: Set<string> 
  * into one whose diff matches none of them individually, so a genuine squash
  * reads as "not applied" to both. `merge-tree --write-tree` would answer it
  * directly but needs Git 2.38, and this project declares no Git floor —
- * `git rev-parse <rev>:<path>` works everywhere.
+ * `git diff-tree` is plumbing whose raw format predates every Git this could
+ * meet.
  *
  * Deliberately asymmetric. `present-in-head` demands that *every* touched path
  * resolve to the same blob in HEAD, and `absent-from-head` that *no* touched
@@ -159,27 +160,77 @@ const branchContentFate = (
   head: string,
 ): BranchContentFate => {
   const { opts, git } = ctx;
+  // `-z`, because under the default `core.quotePath` a name outside ASCII (or
+  // holding a tab, a quote or a backslash) comes back C-quoted, and no tree
+  // lookup resolves the quoted spelling — every branch touching such a file
+  // read as `unknown`. `diff.relative` is pinned off because the paths are
+  // matched against a root-relative tree diff below, and a cwd-relative name
+  // would silently miss it and count as present. `--name-status` rather than
+  // `--name-only` only to learn which paths the branch deleted; the paths
+  // listed are the same, a rename or copy contributing its destination.
   const changed = git(
-    ['diff', '--name-only', `${candidate.base}..${candidate.sha}`],
+    ['-c', 'diff.relative=false', 'diff', '--name-status', '-z', `${candidate.base}..${candidate.sha}`],
     gitOptions(opts),
   );
   if (changed.code !== 0) return 'unknown';
-  const paths = changed.stdout.split('\n').filter((line) => line !== '');
+
+  const paths: string[] = [];
+  const tokens = changed.stdout.split('\0');
+  for (let i = 0; i < tokens.length; ) {
+    const status = tokens[i] ?? '';
+    if (status === '') break;
+    const width = status.startsWith('R') || status.startsWith('C') ? 3 : 2;
+    const path = tokens[i + width - 1];
+    i += width;
+    if (path === undefined) break;
+    // A path deleted by the branch has no blob on either side; it says nothing
+    // either way, so it is neither a match nor a miss.
+    if (status === 'D') return 'unknown';
+    paths.push(path);
+  }
   if (paths.length === 0) return 'unknown';
+
+  // One tree diff says what HEAD holds at every path, in place of two lookups
+  // per path. Not narrowed by pathspec on purpose: a pathspec is cwd-relative
+  // where `<rev>:<path>` is root-relative, `*` and a leading `:` are magic
+  // unless escaped, and each path would be an argv entry against the 32 KiB
+  // command line on Windows. The unnarrowed diff is bounded by the repository
+  // and costs bytes, not processes.
+  const diff = git(
+    ['diff-tree', '-r', '-z', '--no-renames', candidate.sha, head],
+    gitOptions(opts),
+  );
+  if (diff.code !== 0) return 'unknown';
+
+  const differs = new Map<string, { srcOid: string; dstOid: string; dstMode: string }>();
+  const raw = diff.stdout.split('\0');
+  for (let i = 0; i + 1 < raw.length; i += 2) {
+    const [, dstMode, srcOid, dstOid] = (raw[i] ?? '').split(' ');
+    const path = raw[i + 1];
+    if (dstMode === undefined || srcOid === undefined || dstOid === undefined || path === undefined) {
+      return 'unknown';
+    }
+    differs.set(path, { srcOid, dstOid, dstMode });
+  }
 
   let matching = 0;
   let missingFromHead = 0;
   for (const path of paths) {
-    const onBranch = git(['rev-parse', '--verify', '--quiet', `${candidate.sha}:${path}`], gitOptions(opts));
-    const onHead = git(['rev-parse', '--verify', '--quiet', `${head}:${path}`], gitOptions(opts));
-    // A path deleted by the branch has no blob on either side; it says nothing
-    // either way, so it is neither a match nor a miss.
-    if (onBranch.code !== 0) return 'unknown';
-    if (onHead.code !== 0) {
-      missingFromHead += 1;
+    const entry = differs.get(path);
+    // Not in the diff: the trees agree here, and the branch has the path, so
+    // HEAD holds the same blob.
+    if (entry === undefined) {
+      matching += 1;
       continue;
     }
-    if (onHead.stdout.trim() === onBranch.stdout.trim()) matching += 1;
+    if (entry.dstMode === '000000') {
+      // Gone from HEAD — unless HEAD grew a directory of that name, which a
+      // tree lookup resolves to a tree no blob equals: neither match nor miss.
+      const headHasTreeHere = [...differs.keys()].some((other) => other.startsWith(`${path}/`));
+      if (!headHasTreeHere) missingFromHead += 1;
+      continue;
+    }
+    if (entry.srcOid === entry.dstOid) matching += 1;
   }
 
   if (matching === paths.length) return 'present-in-head';
@@ -255,6 +306,10 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
   const category: Category = 'history';
   const cwd = opts.cwd ?? process.cwd();
 
+  // One cache for every candidate this row walks: the mirror is listed once
+  // instead of once per candidate, and a commit two ranges share is parsed once.
+  const cache = newRangeCache();
+
   const head = git(['rev-parse', '--verify', '--quiet', 'HEAD'], gitOptions(opts));
   if (head.code !== 0) {
     return check(
@@ -303,7 +358,7 @@ export const checkSquashConservation = (ctx: DoctorContext): DoctorCheck => {
   for (const candidate of candidates) {
     let records;
     try {
-      records = collectRange(`${candidate.base}..${candidate.sha}`, { cwd });
+      records = collectRange(`${candidate.base}..${candidate.sha}`, { cwd, cache });
     } catch {
       continue;
     }

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -289,6 +289,21 @@ export interface JsonOutput {
   runtime: { version: string; build_id: string };
   /** Whether this answer read everything it was asked about (#631, #669). */
   coverage: 'complete' | 'partial';
+  /**
+   * Where the answer was read from (#930).
+   *
+   * `coverage` answers "was the scan truncated". It cannot answer "was the walk
+   * started from a commit that can reach the records", and a checkout behind its
+   * own fetched upstream returns zero records with every other field green. A
+   * client deciding whether an empty answer means "nothing was recorded" has to
+   * read `vantage.behind` as well.
+   */
+  vantage: {
+    head: string | null;
+    ref: string | null;
+    upstream: string | null;
+    behind: number | null;
+  };
   at: string;
   paths: string[];
   aliases: string[];
@@ -372,6 +387,10 @@ export const toJson = (command: string, result: QueryResult): JsonOutput => {
     // #669 put this on the query result; it never reached the answer a client
     // reads, which is the only place it does any work.
     coverage: presented.coverage,
+    // Serialized here and not only on the query result: the comment above is
+    // about #669 computing a field that never reached a client, and a vantage
+    // nobody can read is that defect with a different name.
+    vantage: presented.vantage,
     at: presented.at.toISOString(),
     paths: presented.paths,
     aliases: presented.aliases,

--- a/src/commands/stale.ts
+++ b/src/commands/stale.ts
@@ -16,7 +16,7 @@ import { execGit, canonicalCommittedAt } from '../core/git.js';
 import {
   listRecordShas,
   notesAvailability,
-  readRecord,
+  readRecordBlocks,
   type NotesAvailability,
 } from '../core/notes.js';
 import {
@@ -27,7 +27,7 @@ import {
   type RecordState,
   type StaleRecord,
 } from '../core/stale.js';
-import { parseRecordBlocks } from '../core/trailers.js';
+import { parseRecordBlocksWithAtom, readTrailersAtom } from '../core/trailers.js';
 import type { Trailer, Violation } from '../core/types.js';
 
 /**
@@ -83,7 +83,43 @@ export interface CollectOptions {
   /** Read the whole reachable history instead of the most recent commits. */
   allHistory?: boolean;
   revision?: string;
+  /**
+   * What one invocation has already read, reused across its own walks.
+   *
+   * `validate --range` collects the whole reachable history once per commit in
+   * the range (`commands/validate.ts` `recordsFor`), so this repository's own
+   * CI step walked ~1500 commits 1486 times and re-read everything on every
+   * walk. Measured on run 34576438460: 2833s and 3578s for that one step, on
+   * each matrix leg, of every release.
+   *
+   * Both halves are cached because both were repeated. Commit messages are
+   * keyed by sha; the notes mirror is keyed by nothing at all, because its
+   * content is a function of the repository rather than of the revision being
+   * walked -- listing it and reading each note once per walk was 1980 of the
+   * 7887 spawns a 164-commit range still cost after only the commit half was
+   * cached.
+   *
+   * Safe because every cached value is a pure function of bytes that cannot
+   * change underneath one invocation: a sha's message, and a ref read once.
+   * The caller owns the cache and it dies with the invocation -- module-level
+   * state would outlive a `git replace` or a fetch in a long-lived MCP server,
+   * which is the one way these answers do change.
+   *
+   * Absent means no reuse, which is the right default for a single walk.
+   */
+  cache?: CollectCache;
 }
+
+/** Per-invocation scratch for `collectRecords`. Never share one across calls. */
+export interface CollectCache {
+  readonly commits: Map<string, CollectedRecord[]>;
+  /** Every record block of the note on a sha, as `readRecordBlocks` returns them. */
+  readonly notes: Map<string, Trailer[][]>;
+  /** The mirror, read once: its shas and whether it could be read at all. */
+  repository?: { shas: string[]; availability: NotesAvailability };
+}
+
+export const newCollectCache = (): CollectCache => ({ commits: new Map(), notes: new Map() });
 
 type RecordSource = NonNullable<StaleRecord['source']>;
 
@@ -115,19 +151,34 @@ export interface Scan {
  * A commit with no blocks still yields one record with no trailers, so the
  * commit count and the notes-mirror comparison below keep their shape.
  */
-const parseChunk = (chunk: string): CollectedRecord[] => {
+const parseChunk = (
+  chunk: string,
+  cache?: Map<string, CollectedRecord[]>,
+  atoms?: ReadonlyMap<string, string>,
+): CollectedRecord[] => {
   const firstSep = chunk.indexOf(UNIT);
   if (firstSep === -1) return [];
   const secondSep = chunk.indexOf(UNIT, firstSep + 1);
   if (secondSep === -1) return [];
 
   const sha = chunk.slice(0, firstSep);
+  const cached = cache?.get(sha);
+  // Keyed on the sha alone because the rest of the chunk is a function of it:
+  // `%cI` and `%B` of one commit are the same bytes on every walk.
+  if (cached !== undefined) return cached;
+
   const committedAt = canonicalCommittedAt(chunk.slice(firstSep + 1, secondSep));
   const message = chunk.slice(secondSep + 1);
-  const blocks = CANDIDATE_LINE_RE.test(message) ? parseRecordBlocks(message) : [];
+  const blocks = CANDIDATE_LINE_RE.test(message)
+    ? parseRecordBlocksWithAtom(message, atoms?.get(sha))
+    : [];
 
-  if (blocks.length === 0) return [{ sha, committedAt, trailers: [], source: 'commit' }];
-  return blocks.map((trailers) => ({ sha, committedAt, trailers, source: 'commit' }));
+  const records =
+    blocks.length === 0
+      ? [{ sha, committedAt, trailers: [], source: 'commit' as RecordSource }]
+      : blocks.map((trailers) => ({ sha, committedAt, trailers, source: 'commit' as RecordSource }));
+  cache?.set(sha, records);
+  return records;
 };
 
 /**
@@ -135,12 +186,18 @@ const parseChunk = (chunk: string): CollectedRecord[] => {
  */
 export const collectRecords = (opts: CollectOptions = {}): Scan => {
   const cwd = opts.cwd ?? process.cwd();
-  const notes = notesAvailability({ cwd });
-  const args = ['log', '-z', `--format=${LOG_FORMAT}`];
-  if (opts.allHistory !== true) args.push(`--max-count=${DEFAULT_SCAN_LIMIT}`);
-  args.push('--end-of-options', opts.revision ?? 'HEAD');
+  // The mirror is a property of the repository, not of the revision walked, so
+  // one invocation reads it once however many walks it makes.
+  const mirror =
+    opts.cache?.repository ??
+    { shas: listRecordShas({ cwd }), availability: notesAvailability({ cwd }) };
+  if (opts.cache !== undefined) opts.cache.repository = mirror;
+  const notes = mirror.availability;
+  const selection: string[] = [];
+  if (opts.allHistory !== true) selection.push(`--max-count=${DEFAULT_SCAN_LIMIT}`);
+  selection.push('--end-of-options', opts.revision ?? 'HEAD');
 
-  const result = execGit(args, { cwd });
+  const result = execGit(['log', '-z', `--format=${LOG_FORMAT}`, ...selection], { cwd });
   if (result.code !== 0) {
     if (EMPTY_REPO_RE.test(result.stderr)) {
       return { records: [], commits: 0, truncated: false, notes };
@@ -148,10 +205,27 @@ export const collectRecords = (opts: CollectOptions = {}): Scan => {
     throw new Error(`git log failed (exit ${result.code}): ${result.stderr.trim()}`);
   }
 
-  const commitRecords = result.stdout
+  const chunks = result.stdout
     .split('\u0000')
-    .filter((chunk) => chunk.length > 0)
-    .flatMap(parseChunk);
+    .filter((chunk) => chunk.length > 0);
+
+  // One more process for the walk buys the last block of every commit in it
+  // (`TRAILERS_ATOM`, git's parser through `git log`), so a message pays a
+  // process only for the earlier blocks of SPEC §2.4, or when it carries a
+  // byte the atom cannot frame. On this repository that was 1285 processes
+  // per full walk, now under a hundred. Run only when at least two uncached
+  // messages would read it: for one, the walk costs the process it saves, and
+  // for none nothing would read the answer.
+  const commitCache = opts.cache?.commits;
+  const wouldUseAtom = chunks.filter((chunk) => {
+    const at = chunk.indexOf(UNIT);
+    if (at === -1 || commitCache?.has(chunk.slice(0, at)) === true) return false;
+    const second = chunk.indexOf(UNIT, at + 1);
+    return second !== -1 && CANDIDATE_LINE_RE.test(chunk.slice(second + 1));
+  }).length;
+  const atoms = wouldUseAtom >= 2 ? readTrailersAtom(selection, { cwd }) : undefined;
+
+  const commitRecords = chunks.flatMap((chunk) => parseChunk(chunk, commitCache, atoms));
 
   // One commit may now contribute several records, so anything that counts
   // commits counts distinct shas. Counting records here would report a
@@ -172,17 +246,31 @@ export const collectRecords = (opts: CollectOptions = {}): Scan => {
     }
   }
 
-  const noteRecords = listRecordShas({ cwd }).flatMap((sha): CollectedRecord[] => {
+  const noteRecords = mirror.shas.flatMap((sha): CollectedRecord[] => {
     const commit = trailersBySha.get(sha);
     if (commit === undefined) return [];
 
-    const trailers = readRecord(sha, { cwd });
-    const mirrored = trailers.every((note) =>
-      commit.trailers.some((trailer) => trailer.key === note.key && trailer.value === note.value),
-    );
-    return trailers.length === 0 || mirrored
-      ? []
-      : [{ sha, committedAt: commit.committedAt, trailers, source: 'notes' }];
+    // Every block of the note, not git's last paragraph. A note written by
+    // `squash-preserve --target` carries one block per inherited record (SPEC
+    // §1, §2.4; `core/notes.ts` `writeRecordBlocks`), and the index reads all
+    // of them back. Reading the note through `readRecord` -- `parseCommitMessage`,
+    // the last paragraph -- left every earlier block invisible here and only
+    // here: the #898 shape, on the mirror instead of the message.
+    const cachedNote = opts.cache?.notes.get(sha);
+    const blocks = cachedNote ?? readRecordBlocks(sha, { cwd });
+    if (cachedNote === undefined) opts.cache?.notes.set(sha, blocks);
+    // Each block is its own record, and each is judged a mirror on its own
+    // against everything the commit declares -- so a block that mirrors one
+    // block of a squash is dropped while a block the message never carried
+    // stays, whichever order they appear in.
+    return blocks.flatMap((trailers): CollectedRecord[] => {
+      const mirrored = trailers.every((note) =>
+        commit.trailers.some((trailer) => trailer.key === note.key && trailer.value === note.value),
+      );
+      return trailers.length === 0 || mirrored
+        ? []
+        : [{ sha, committedAt: commit.committedAt, trailers, source: 'notes' }];
+    });
   });
 
   return {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -24,7 +24,7 @@ import { resolve } from 'node:path';
 
 import type { Command } from 'commander';
 
-import { collectRecords } from './stale.js';
+import { collectRecords, newCollectCache, type CollectCache } from './stale.js';
 import { execGit, hasShallowHistory } from '../core/git.js';
 import { closeIndex, ensureIndex, indexUnread, queryTrailers } from '../core/index-db.js';
 import { notesAvailability } from '../core/notes.js';
@@ -641,13 +641,31 @@ const recordsFor = (
   source: MessageSource,
   cwd: string,
   input: Pick<ValidateInput, 'scanBudgetMs' | 'scanNow'> = {},
+  /**
+   * One map for the whole range, because this function is the N+1.
+   *
+   * A range validation collects the full reachable history once per commit in
+   * the range, and parsed every message on every walk: this repository's own CI
+   * step spent 2833s and 3578s there per matrix leg, on every release. The
+   * walks stay -- each one's *reachable set* is what the check is about -- but
+   * a message is parsed once.
+   */
+  cache?: CollectCache,
 ): {
   records: StaleRecord[];
   notes: ReturnType<typeof notesAvailability>;
   unreadCommits: number;
 } => {
   if (source.sha !== undefined) {
-    return { ...collectRecords({ cwd, allHistory: true, revision: source.sha }), unreadCommits: 0 };
+    return {
+      ...collectRecords({
+        cwd,
+        allHistory: true,
+        revision: source.sha,
+        ...(cache === undefined ? {} : { cache }),
+      }),
+      unreadCommits: 0,
+    };
   }
   try {
     const indexed = indexedHeadRecords(cwd, input);
@@ -729,8 +747,10 @@ const checkReferences = (
         : undefined;
     let tipAllRecords: StaleRecord[] | undefined;
     let unreadCommits = 0;
+    // Shared by the tip scan and by every per-source scan below.
+    const cache = newCollectCache();
     if (tipSha !== undefined) {
-      const tipScan = recordsFor({ sha: tipSha, message: '' }, cwd, input);
+      const tipScan = recordsFor({ sha: tipSha, message: '' }, cwd, input, cache);
       if (tipScan.notes === 'unfetched') {
         return {
           check: {
@@ -763,7 +783,7 @@ const checkReferences = (
       // for the commit's own record and wrong for the block beside it
       // (bug-issue-352).
       const blocks = parseRecordBlocks(source.message);
-      const scan = recordsFor(source, cwd, input);
+      const scan = recordsFor(source, cwd, input, cache);
       if (scan.unreadCommits > unreadCommits) unreadCommits = scan.unreadCommits;
       if (scan.notes === 'unfetched') {
         return {

--- a/src/core/before-change.ts
+++ b/src/core/before-change.ts
@@ -24,7 +24,7 @@ import { createHash } from 'node:crypto';
 
 import { execGit, hasShallowHistory, historyAvailability } from './git.js';
 import { guard, renderGuardMatch, type RenderedGuardMatch } from './guard.js';
-import { notesAvailability } from './notes.js';
+import { notesAvailability, type NotesAvailability } from './notes.js';
 import { withholdBlocked } from '../commands/query.js';
 import {
   CONSUMER_SCAN_BUDGET_MS,
@@ -105,27 +105,31 @@ export interface BeforeChangeOptions {
  * already performs. The canonical order is fixed: `history-unavailable`,
  * `shallow-history`, `notes-unfetched`. `unread-commits` is appended after
  * the query, because only the query knows whether a budget left history unread.
+ *
+ * The two source gaps are taken from the query rather than re-measured, because
+ * `runQuery` computes and returns both. Measured on the injection path -- the
+ * one that runs on every file edit -- this route spawned 18 git processes, four
+ * of them byte-identical repeats issued by this function and by the query it
+ * then called. The same question asked twice in one invocation is the cost, and
+ * the answer was already in hand.
+ *
+ * `history` stays measured here because it is what decides whether the query
+ * runs at all; there is no result to read it from yet. When it says the history
+ * is unavailable the query is skipped, and `sourceGapsFromRepository` measures
+ * the other two directly -- the only branch that still pays for them.
  */
-const deriveVerificationGaps = (cwd: string): VerificationGap[] => {
-  const gaps: VerificationGap[] = [];
+const historyGap = (cwd: string): VerificationGap[] =>
+  historyAvailability(cwd) === 'unavailable' ? ['history-unavailable'] : [];
 
-  const history = historyAvailability(cwd);
-  if (history === 'unavailable') {
-    gaps.push('history-unavailable');
-  }
+/** The two source gaps, in canonical order, from values a query already reports. */
+const sourceGaps = (shallow: boolean, notes: NotesAvailability): VerificationGap[] => [
+  ...(shallow ? (['shallow-history'] as const) : []),
+  ...(notes === 'unfetched' ? (['notes-unfetched'] as const) : []),
+];
 
-  const shallow = hasShallowHistory(cwd);
-  if (shallow) {
-    gaps.push('shallow-history');
-  }
-
-  const notes = notesAvailability({ cwd });
-  if (notes === 'unfetched') {
-    gaps.push('notes-unfetched');
-  }
-
-  return gaps;
-};
+/** The same two, measured, for the branch where no query runs to report them. */
+const sourceGapsFromRepository = (cwd: string): VerificationGap[] =>
+  sourceGaps(hasShallowHistory(cwd), notesAvailability({ cwd }));
 
 /** Extracts the active decisions from the query result. */
 const extractActiveDecisions = (result: QueryResult): ActiveDecision[] =>
@@ -189,8 +193,10 @@ export const beforeChange = (opts: BeforeChangeOptions): BeforeChangeResult => {
     throw new Error('commitlore_before_change: opts.at is not a valid Date');
   }
 
-  // Derive verification gaps — this determines whether we can trust the context
-  const gaps = deriveVerificationGaps(cwd);
+  // Derive verification gaps — this determines whether we can trust the context.
+  // The source gaps are appended below, in canonical order, from whichever of
+  // the two routes ran.
+  const gaps = historyGap(cwd);
 
   // If history is unavailable entirely, we still report what we can but the
   // caller knows the context is not trustworthy via the gap
@@ -229,7 +235,10 @@ export const beforeChange = (opts: BeforeChangeOptions): BeforeChangeResult => {
       }),
     );
     activeDecisions = extractActiveDecisions(queryResult);
+    gaps.push(...sourceGaps(queryResult.shallow, queryResult.notes));
     if (queryResult.unreadCommits > 0) gaps.push('unread-commits');
+  } else {
+    gaps.push(...sourceGapsFromRepository(cwd));
   }
 
   // Run guard if a proposal was supplied

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -198,6 +198,107 @@ export const hasShallowHistory = (cwd: string): boolean => {
 };
 
 /**
+ * Where an answer was read from — the half of completeness nothing reported.
+ *
+ * Every other availability field describes a *source* or the *scan*: `history`
+ * says whether the object store could be read, `notes` whether the mirror was
+ * fetched, `coverage` and `unreadCommits` whether a budget truncated the walk.
+ * All of them stay healthy while the walk starts from the wrong commit. The
+ * commit source only ever reads `rev-list HEAD` (index-db.ts says so), so an
+ * answer is complete *with respect to a vantage the caller never sees* — and a
+ * checkout behind its own already-fetched upstream returns zero records with
+ * `coverage: "complete"`, byte-identical to a repository where nobody wrote one.
+ * That is the sentence `notes` exists to prevent, arriving by another door.
+ *
+ * `behind` is the whole signal, and the discrimination is the point:
+ *
+ *   at the tip                 behind 0     silent
+ *   behind its upstream        behind n     the dangerous case, and only it
+ *   detached (review worktree) upstream null, ref null -- stated, not warned:
+ *                              that vantage is deliberate, and warning on it
+ *                              would fire on every blind review
+ *   an unmerged local branch   behind 0     silent; HEAD is not missing what
+ *                              its own line never had
+ *
+ * Two cheaper-looking signals were measured and rejected because they fire on
+ * healthy checkouts: `rev-list --branches --remotes --not HEAD` counts 202 on
+ * this repository at the tip of main, and path-scoping it still counts 18 for
+ * README.md. Both are answering "does any unreachable commit exist", which is
+ * yes in every repository that has ever merged a branch.
+ *
+ * Cost, because r-4e29b7 asked for a number and had none: one `rev-parse` and
+ * at most one `rev-list --count`, 18-21 ms together on a 1500-commit repository
+ * with 623 refs, against 436 ms for the `context` call that carries it. Skipped
+ * entirely when there is no upstream to be behind.
+ */
+export interface Vantage {
+  /** The commit walked from. Every record in the answer is reachable from it. */
+  readonly head: string | null;
+  /** The branch HEAD is on, or null when detached. */
+  readonly ref: string | null;
+  /** The tracked upstream, or null when the branch tracks nothing. */
+  readonly upstream: string | null;
+  /**
+   * Commits the upstream has that this vantage cannot reach, and whose records
+   * are therefore absent from the answer. `null` when there is no upstream to
+   * compare against -- unknown, not zero.
+   */
+  readonly behind: number | null;
+}
+
+export const readVantage = (cwd: string): Vantage => {
+  /*
+   * One `rev-parse`, not three. It takes several arguments and prints a line
+   * for each, and every case this has to answer leaves usable output even when
+   * it exits non-zero -- a detached head prints the sha and `HEAD` alongside
+   * `fatal: HEAD does not point to a branch`, and a branch with no upstream
+   * prints the sha and its ref. This runs on the injection path, where the
+   * measured baseline already sits at 74% of that path's test budget under
+   * load, so three spawns for facts one call carries is not a cost worth paying.
+   *
+   * Lines are matched by shape rather than by position, because which of them
+   * are present is exactly what varies between those cases.
+   */
+  const read = execGit(['rev-parse', 'HEAD', '--symbolic-full-name', 'HEAD', '@{upstream}'], {
+    cwd,
+  });
+  const lines = read.stdout.split('\n').map((line) => line.trim()).filter((line) => line !== '');
+
+  const sha = lines.find((line) => isFullObjectId(line)) ?? '';
+  // `refs/heads/x`, never the bare `HEAD` a detached head prints -- reading that
+  // as a branch name is the mistake `symbolic-ref` was here to avoid.
+  const branchRef = lines.find((line) => line.startsWith('refs/heads/'));
+  const branch = branchRef === undefined ? null : branchRef.slice('refs/heads/'.length);
+  const upstreamRef = lines.find((line) => line.startsWith('refs/remotes/'));
+  const upstream =
+    upstreamRef === undefined ? null : upstreamRef.slice('refs/remotes/'.length);
+
+  if (upstream === null) {
+    return { head: sha === '' ? null : sha, ref: branch, upstream: null, behind: null };
+  }
+
+  const counted = execGit(['rev-list', '--count', `HEAD..${upstream}`], { cwd });
+  const parsed = Number.parseInt(counted.stdout.trim(), 10);
+  return {
+    head: sha === '' ? null : sha,
+    ref: branch,
+    upstream,
+    // A git that cannot answer leaves this unknown rather than zero: reporting
+    // 0 here would be this defect rebuilt, an unknown presented as an all-clear.
+    behind: counted.code === 0 && Number.isInteger(parsed) ? parsed : null,
+  };
+};
+
+/** The caveat for a vantage that is behind, in the words a caller can act on. */
+export const vantageCaveat = (vantage: Vantage): string | null =>
+  vantage.behind === null || vantage.behind === 0
+    ? null
+    : `this checkout is ${String(vantage.behind)} commit(s) behind ${vantage.upstream ?? 'its upstream'}, ` +
+      'and records written in them are absent from this answer — an empty result here is not ' +
+      'evidence that nothing was recorded. ' +
+      'fix: git merge --ff-only, or ask again from a checkout that is up to date';
+
+/**
  * Git's `%cI` for a UTC commit, spelled one way (#650).
  *
  * `%cI` is strict ISO 8601, and git changed how it renders a zero offset:

--- a/src/core/notes.ts
+++ b/src/core/notes.ts
@@ -171,9 +171,17 @@ const showNote = (sha: string, opts: NotesOptions): string | null => {
  * (T-204) and the inheritance path (T-302), not here.
  *
  * A note carrying several record blocks (SPEC §2.4, `writeRecordBlocks`)
- * answers here as one flat list — the message's own last paragraph, exactly
- * as `parseCommitMessage` sees it elsewhere. Callers that need every block
- * individually want `readRecordBlocks`.
+ * answers here with **the last block only** — the message's own last paragraph,
+ * exactly as `parseCommitMessage` sees it elsewhere. The earlier blocks are not
+ * folded in; they are dropped. Callers that need every block want
+ * `readRecordBlocks`, which is every caller that reads records rather than one
+ * record.
+ *
+ * The previous sentence here said "one flat list", which reads as all of them
+ * flattened and is how `stale` came to use this function: it reported one
+ * record for a note carrying several, disagreed with the index about the same
+ * repository, and called a `Follows:` dangling when its target sat in an
+ * earlier block of the same note.
  */
 export const readRecord = (sha: string, opts: NotesOptions = {}): Trailer[] => {
   const note = showNote(sha, opts);

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -48,8 +48,11 @@ import {
   execGit,
   hasShallowHistory,
   historyAvailability,
+  readVantage,
   SHALLOW_HISTORY_CAVEAT,
+  vantageCaveat,
   type HistoryAvailability,
+  type Vantage,
 } from './git.js';
 import {
   closeIndex,
@@ -285,6 +288,20 @@ export interface QueryResult {
    * the whole of what a path is subject to.
    */
   unreadCommits: number;
+  /**
+   * Where this answer was read from (#930).
+   *
+   * Every field above describes a *source* or the *scan*, and all of them stay
+   * healthy while the walk starts from the wrong commit: the commit source only
+   * ever reads `rev-list HEAD`. So a checkout behind its own already-fetched
+   * upstream answers with zero records, `coverage: "complete"`, `history:
+   * "ready"` and `notes: "present"` — byte-identical to a repository where
+   * nobody ever wrote one, which is the sentence `notes` exists to prevent.
+   *
+   * `vantage.behind` is the signal; the rest is the vantage stated so a caller
+   * can see what the answer is scoped to rather than infer it.
+   */
+  vantage: Vantage;
   /** Anything the caller should be told about how the answer was produced. */
   diagnostics: string[];
 }
@@ -1039,6 +1056,14 @@ export const runQuery = (opts: QueryOptions = {}): QueryResult => {
       );
     }
 
+    // The same shape as the two above: a typed field for a consumer that
+    // branches, and a diagnostic for one that only reads prose. Both, because
+    // the failure this reports is an *empty* answer, and a caller who has to
+    // know to look at a new field to find that out is the defect rebuilt.
+    const vantage = readVantage(cwd);
+    const behindCaveat = vantageCaveat(vantage);
+    if (behindCaveat !== null) diagnostics.push(behindCaveat);
+
     return {
       records:
         opts.limit === undefined ? records : records.slice(0, Math.max(0, Math.trunc(opts.limit))),
@@ -1054,6 +1079,7 @@ export const runQuery = (opts: QueryOptions = {}): QueryResult => {
       notes,
       unreadCommits: unread,
       coverage: unread > 0 ? 'partial' : 'complete',
+      vantage,
       diagnostics,
     };
   } finally {

--- a/src/core/squash.ts
+++ b/src/core/squash.ts
@@ -57,7 +57,12 @@
 
 import { execGit } from './git.js';
 import { listRecordShas, readRecordBlocks, writeRecordBlocks } from './notes.js';
-import { parseCommitMessage, parseRecordBlocks, serializeTrailers } from './trailers.js';
+import {
+  parseCommitMessage,
+  parseRecordBlocksWithAtom,
+  readTrailersAtom,
+  serializeTrailers,
+} from './trailers.js';
 import {
   BLAST_VALUES,
   CERTAINTY_VALUES,
@@ -68,7 +73,36 @@ import {
 
 export interface SquashOptions {
   cwd?: string;
+  /**
+   * What one invocation has already read, reused across its own ranges.
+   *
+   * `collectRange` is called once per candidate branch by the
+   * `squash-conservation` doctor row, and each call listed the whole notes
+   * mirror again and re-parsed every message the ranges have in common.
+   * Measured on this repository: 70 identical `git notes list` invocations for
+   * one answer, and 114 byte-identical spawns out of 800 for the row.
+   *
+   * The mirror is a property of the repository rather than of the range, and a
+   * sha's message is immutable, so both are read once. The caller owns the
+   * cache and it dies with the invocation, for the same reason the collector's
+   * does: module-level state would outlive a `git replace` or a fetch in a
+   * long-lived server.
+   *
+   * Absent means no reuse, which is right for `squash-preserve`, whose one call
+   * has nothing to share with.
+   */
+  cache?: RangeCache;
 }
+
+/** Per-invocation scratch for `collectRange`. Never share one across calls. */
+export interface RangeCache {
+  /** Record blocks by commit sha, from the message. */
+  readonly messages: Map<string, Trailer[][]>;
+  /** The note-annotated shas, listed once. */
+  mirrored?: ReadonlySet<string>;
+}
+
+export const newRangeCache = (): RangeCache => ({ messages: new Map() });
 
 export interface AttachOptions extends SquashOptions {
   /** Replace an existing note on the target. Without it, one is an error. */
@@ -261,27 +295,44 @@ export const collectRange = (range: string, opts: SquashOptions = {}): Collected
     throw new Error(`expected a range <base>..<head>, got ${JSON.stringify(range)}`);
   }
 
-  const result = execGit(
-    ['log', '--reverse', '-z', `--format=${LOG_FORMAT}`, '--end-of-options', range, '--'],
-    gitOptions(opts),
-  );
+  const selection = ['--reverse', '--end-of-options', range, '--'];
+  const result = execGit(['log', '-z', `--format=${LOG_FORMAT}`, ...selection], gitOptions(opts));
   if (result.code !== 0) {
     throw new Error(`cannot walk range ${JSON.stringify(range)}: ${firstLine(result.stderr)}`);
   }
 
   // One `git notes list` instead of one `git notes show` per commit: most
   // commits carry no note, and the mirror is usually far smaller than the range.
-  const mirrored = new Set(listRecordShas(opts));
+  // With a cache, one for the whole invocation rather than one per range.
+  const mirrored = opts.cache?.mirrored ?? new Set(listRecordShas(opts));
+  if (opts.cache !== undefined) opts.cache.mirrored = mirrored;
+
+  const chunks = result.stdout.split(NUL).filter((chunk) => chunk.length > 0);
+  // The last block of every commit in the range from one more process
+  // (`TRAILERS_ATOM`), so a message pays a process only for the earlier blocks
+  // of SPEC §2.4. Run only when at least two uncached messages would read it:
+  // the doctor row walks one short range per candidate branch, and for a
+  // single message the walk costs exactly the process it saves.
+  const messageCache = opts.cache?.messages;
+  const wouldUseAtom = chunks.filter((chunk) => {
+    const at = chunk.indexOf(UNIT);
+    if (at === -1 || messageCache?.has(chunk.slice(0, at)) === true) return false;
+    return CANDIDATE_LINE_RE.test(chunk.slice(at + 1));
+  }).length;
+  const atoms = wouldUseAtom >= 2 ? readTrailersAtom(selection, gitOptions(opts)) : undefined;
 
   const collected: CollectedRecord[] = [];
-  for (const chunk of result.stdout.split(NUL)) {
-    if (chunk.length === 0) continue;
+  for (const chunk of chunks) {
     const separator = chunk.indexOf(UNIT);
     if (separator === -1) continue;
 
     const sha = chunk.slice(0, separator);
     const message = chunk.slice(separator + 1);
-    const messageBlocks = CANDIDATE_LINE_RE.test(message) ? parseRecordBlocks(message) : [];
+    const cachedBlocks = opts.cache?.messages.get(sha);
+    const messageBlocks =
+      cachedBlocks ??
+      (CANDIDATE_LINE_RE.test(message) ? parseRecordBlocksWithAtom(message, atoms?.get(sha)) : []);
+    if (cachedBlocks === undefined) opts.cache?.messages.set(sha, messageBlocks);
     const noteBlocks = mirrored.has(sha) ? readRecordBlocks(sha, opts) : [];
     const blocks = mergeCommitBlocks(messageBlocks, noteBlocks);
 

--- a/src/core/trailers.ts
+++ b/src/core/trailers.ts
@@ -8,7 +8,7 @@
  * context for agents.
  */
 
-import { execGitOrThrow } from './git.js';
+import { type ExecGitOptions, execGit, execGitOrThrow } from './git.js';
 import { KNOWN_KEYS, type Trailer } from './types.js';
 
 const RECORD_ID_KEY = 'Record-Id';
@@ -24,13 +24,86 @@ const RECORD_ID_KEY = 'Record-Id';
  * protocol's separator is `:` (SPEC §2.2 EBNF), so it is fixed here rather
  * than inherited from whatever repo the CLI happens to run in.
  */
-const PARSE_ARGS = [
-  '-c',
-  'trailer.separators=:',
-  'interpret-trailers',
-  '--parse',
-  '--no-divider',
-];
+export const SEPARATOR_PIN = ['-c', 'trailer.separators=:'];
+
+const PARSE_ARGS = [...SEPARATOR_PIN, 'interpret-trailers', '--parse', '--no-divider'];
+
+/**
+ * The same parser, reached through `git log` instead of one process per
+ * message: `%(trailers)` is `trailer_info_get` over the commit's message with
+ * `no_divider` set, which is what `--parse --no-divider` asks of
+ * `interpret-trailers`. `only` drops non-trailer lines and `unfold` joins
+ * continuations (B4), so a message's own block (B1) comes back byte-equal to
+ * `parseCommitMessage` — `test/trailer-atom.test.ts` holds the two to that over
+ * this repository's whole history and over the hazard cases the equivalence
+ * was doubted on. `core/index-db.ts` has read every record through this atom
+ * since the index existed.
+ *
+ * The separators are bytes a trailer value has no business containing, but git
+ * does not escape, so a value that does contain one would split wrong. That is
+ * why {@link atomIsAmbiguous} exists: a reader consults it first and pays the
+ * process for exactly those messages.
+ */
+export const TRAILERS_ATOM =
+  '%(trailers:only=true,unfold=true,key_value_separator=%x1f,separator=%x1e)';
+
+const ATOM_TRAILER_SEP = '';
+const ATOM_KV_SEP = '';
+
+/** Whether `message` carries a byte the atom uses as a separator, so its atom output cannot be framed. */
+export const atomIsAmbiguous = (message: string): boolean =>
+  message.includes(ATOM_TRAILER_SEP) || message.includes(ATOM_KV_SEP);
+
+/** `Key\x1fvalue\x1eKey\x1fvalue` -> trailers, in message order (B5). Empty field, no trailers. */
+export const parseTrailersAtom = (field: string): Trailer[] => {
+  if (field === '') return [];
+  return field.split(ATOM_TRAILER_SEP).map((entry) => {
+    const separator = entry.indexOf(ATOM_KV_SEP);
+    if (separator === -1) return { key: entry, value: '' };
+    return { key: entry.slice(0, separator), value: entry.slice(separator + 1) };
+  });
+};
+
+/**
+ * The atom for every commit a `git log` walk visits, in one process: sha ->
+ * raw field. `selection` is what follows `log` to choose and order the walk —
+ * the same arguments the caller gave the walk that fetched the messages, so
+ * the two visit the same shas.
+ *
+ * A walk that fails answers an empty map. Every message then goes through the
+ * process, which is the oracle, so a failure here costs the processes it
+ * would have saved and never an answer.
+ */
+export const readTrailersAtom = (
+  selection: readonly string[],
+  opts: ExecGitOptions = {},
+): Map<string, string> => {
+  const result = execGit(
+    [...SEPARATOR_PIN, 'log', '-z', `--format=%H${ATOM_KV_SEP}${TRAILERS_ATOM}`, ...selection],
+    opts,
+  );
+  const atoms = new Map<string, string>();
+  if (result.code !== 0) return atoms;
+  for (const chunk of result.stdout.split('\0')) {
+    // The sha is hex, so the first separator byte ends it; any later one is
+    // the atom's own.
+    const at = chunk.indexOf(ATOM_KV_SEP);
+    if (at === -1) continue;
+    atoms.set(chunk.slice(0, at), chunk.slice(at + 1));
+  }
+  return atoms;
+};
+
+/**
+ * `parseRecordBlocks` with the message's own block taken from the atom when
+ * the caller holds one and the message cannot confuse its framing; otherwise
+ * exactly `parseRecordBlocks(message)`. The one entry point for a reader that
+ * ran {@link readTrailersAtom}, so no reader composes the grammar itself.
+ */
+export const parseRecordBlocksWithAtom = (message: string, atom: string | undefined): Trailer[][] =>
+  atom === undefined || atomIsAmbiguous(message)
+    ? parseRecordBlocks(message)
+    : parseRecordBlocks(message, { last: parseTrailersAtom(atom) });
 
 /** Loose on purpose: see `parseRecordBlocks`. */
 const MENTIONS_RECORD_ID = /record-id/i;
@@ -222,9 +295,19 @@ const asIsolatedBlock = (paragraph: string): Trailer[] =>
  * would stop at the first one and miss everything earlier.
  *
  * Returned in the order the blocks appear in the message.
+ *
+ * `opts.last` is the message's own block when the caller already holds it —
+ * read from {@link TRAILERS_ATOM} in the `git log` that fetched the message,
+ * one process for the walk instead of one per commit. It replaces only where
+ * the last block's bytes come from; which paragraphs are tested, and whether
+ * the result is accepted, is decided here for every caller alike, so a reader
+ * with the atom and a reader without it compose the grammar in one place.
  */
-export const parseRecordBlocks = (message: string): Trailer[][] => {
-  const last = parseCommitMessage(message);
+export const parseRecordBlocks = (
+  message: string,
+  opts: { last?: Trailer[] } = {},
+): Trailer[][] => {
+  const last = opts.last ?? parseCommitMessage(message);
   const paragraphs = splitParagraphs(message);
   const earlier = paragraphs.slice(0, -1);
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -619,7 +619,12 @@ export const createServer = (opts: McpServerOptions = {}): Server => {
         'or notes: "unfetched" means the answer is unknown, not empty. coverage: "partial" means this ' +
         'answer is missing records — the scan stopped at its time budget, so absence of a record is not ' +
         'evidence the record does not exist; run `commitlore init` and ask again before concluding anything ' +
-        'from what is not there.' +
+        'from what is not there. coverage: "complete" is not the converse: it says only that the scan was ' +
+        'not truncated, never that the answer is whole. Read vantage as well — every record here is one ' +
+        'the commit in vantage.head can reach, and vantage.behind > 0 means the checkout is behind its ' +
+        'upstream and records written in those commits are absent, so an empty answer is not evidence ' +
+        'that nothing was recorded. vantage.ref: null is a detached head, usually a review worktree, where ' +
+        'that narrower scope is deliberate — state it rather than treat it as a fault.' +
         '\n\nRecording: when a change carries decision context the diff cannot show — a constraint that shaped ' +
         'it, an alternative tried and dropped and why, a warning for whoever touches it next — record it before ' +
         `committing: ${PREPARE_CAPTURE_TOOL} with this session's transcript, then ${VERIFY_CAPTURE_TOOL}, then ` +

--- a/test/__snapshots__/doctor-snapshot.test.ts.snap
+++ b/test/__snapshots__/doctor-snapshot.test.ts.snap
@@ -54,7 +54,7 @@ ok      unattended capture initiator — unattended capture is off; no host init
 ok      capture policy overlay — no policy file and no .commitlore-policy.local.json — the built-in defaults apply and nothing overrides them
 ok      pending captures — no captures are waiting
 ok      git interpret-trailers — git version <git>
-ok      history depth — full history is available
+ok      history depth — full history is available, and HEAD is on main and tracks nothing
 ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS5 (value search falls back to LIKE)
 skipped squash conservation — no local branch looks like the source of a squash — nothing to check
 ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way"
@@ -87,7 +87,7 @@ ok      unattended capture initiator — unattended capture is off; no host init
 ok      capture policy overlay — no policy file and no .commitlore-policy.local.json — the built-in defaults apply and nothing overrides them
 ok      pending captures — no captures are waiting
 ok      git interpret-trailers — git version <git>
-ok      history depth — full history is available
+ok      history depth — full history is available, and HEAD is on main and tracks nothing
 ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS5 (value search falls back to LIKE)
 skipped squash conservation — no local branch looks like the source of a squash — nothing to check
 ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way"
@@ -116,7 +116,7 @@ ok      unattended capture initiator — unattended capture is off; no host init
 ok      capture policy overlay — no policy file and no .commitlore-policy.local.json — the built-in defaults apply and nothing overrides them
 ok      pending captures — no captures are waiting
 ok      git interpret-trailers — git version <git>
-ok      history depth — full history is available
+ok      history depth — full history is available, and HEAD is on main and tracks nothing
 ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS5 (value search falls back to LIKE)
 skipped squash conservation — no local branch looks like the source of a squash — nothing to check
 ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way",
@@ -141,7 +141,7 @@ ok      unattended capture initiator — unattended capture is off; no host init
 ok      capture policy overlay — no policy file and no .commitlore-policy.local.json — the built-in defaults apply and nothing overrides them
 ok      pending captures — no captures are waiting
 ok      git interpret-trailers — git version <git>
-ok      history depth — full history is available
+ok      history depth — full history is available, and HEAD is on main and tracks nothing
 ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS5 (value search falls back to LIKE)
 skipped squash conservation — no local branch looks like the source of a squash — nothing to check
 ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way",

--- a/test/before-change.test.ts
+++ b/test/before-change.test.ts
@@ -447,3 +447,66 @@ describe('#597 signature-required policy reaches before-change', () => {
     expect(control.active_decisions.some((decision) => decision.trust === 'directive')).toBe(true);
   });
 });
+
+/**
+ * The canonical order of `verification_gaps` is stated in
+ * `core/before-change.ts` and in Amendment 4, and nothing pinned it: reversing
+ * the two source gaps passed the whole file. A documented invariant with no
+ * test is a claim.
+ *
+ * The order matters because the set is closed and ordered by contract, so a
+ * consumer is entitled to compare two responses element-wise rather than as
+ * sets -- which is exactly what the byte-identical assertion above does.
+ */
+describe('verification_gaps: the canonical order is pinned, not just documented', () => {
+  const shallowRepoWithUnfetchedNotes = (): string => {
+    const remote = createTestRepo({ path: join(tmpBase, 'gap-remote'), bare: true });
+    const seed = createTestRepo({ path: join(tmpBase, 'gap-seed') });
+    const git = (cwd: string, ...args: string[]): void => {
+      execFileSync('git', ['-c', 'user.email=t@e.invalid', '-c', 'user.name=T', ...args], { cwd });
+    };
+    writeFileSync(join(seed, 'src.ts'), 'export const a = 1;\n');
+    git(seed, 'add', 'src.ts');
+    git(seed, 'commit', '--quiet', '-m', 'one\n\nLimit: first\nRecord-Id: r-gapone01');
+    writeFileSync(join(seed, 'src.ts'), 'export const a = 2;\n');
+    git(seed, 'add', 'src.ts');
+    git(seed, 'commit', '--quiet', '-m', 'two\n\nLimit: second\nRecord-Id: r-gaptwo01');
+    git(seed, 'push', '--quiet', remote, 'HEAD:refs/heads/main');
+
+    // `file://` on purpose: git ignores --depth for a local-path clone and says
+    // so, which produced a fixture with no `.git/shallow` and a case that pinned
+    // half of what it claimed to. The transport is what makes the clone shallow.
+    // A default clone's refspec does not cover refs/notes, which is what makes
+    // the notes answer `unfetched` rather than `absent` -- both conditions this
+    // case needs, from one fixture.
+    const clone = join(tmpBase, 'gap-clone');
+    execFileSync('git', ['clone', '--quiet', '--depth', '1', `file://${remote}`, clone]);
+    return clone;
+  };
+
+  it('reports shallow-history before notes-unfetched', async () => {
+    const cwd = shallowRepoWithUnfetchedNotes();
+    const result = await beforeChange({ path: 'src.ts', cwd });
+
+    // Both conditions must actually hold, or this case pins nothing.
+    expect(result.verification_gaps).toContain('shallow-history');
+    expect(result.verification_gaps).toContain('notes-unfetched');
+    expect(result.verification_gaps.indexOf('shallow-history')).toBeLessThan(
+      result.verification_gaps.indexOf('notes-unfetched'),
+    );
+  });
+
+  /*
+   * The source gaps are read from the query result on the path where a query
+   * runs, and measured directly on the path where one does not. Two routes to
+   * one answer is two places for it to drift, so the case that has no history
+   * must still report what the other route would.
+   */
+  it('reports the same source gaps when no history is available to query', async () => {
+    const cwd = mkdtempSync(join(tmpBase, 'gap-nohistory-'));
+    const result = await beforeChange({ path: 'src.ts', cwd });
+
+    expect(result.verification_gaps).toContain('history-unavailable');
+    expect(result.verification_gaps[0]).toBe('history-unavailable');
+  });
+});

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1543,6 +1543,179 @@ describe('doctor: squash conservation (bug-issue-60 finding 1)', () => {
     expect(entry?.detail).toContain('reachable from HEAD');
   });
 
+  /**
+   * A file name outside ASCII. Under the default `core.quotePath`, `git diff`
+   * without `-z` prints it C-quoted, and the quoted spelling resolves to
+   * nothing in any tree, so every branch touching such a file landed on
+   * `unknown` — a squash reported as undetermined, and an abandoned branch
+   * told to identify a squash commit that never existed.
+   */
+  it('classifies a squashed branch whose file name is not ASCII', () => {
+    const repo = initRepo('squash-conservation-quoted');
+    git(repo, ['commit', '--quiet', '--allow-empty', '-m', 'seed']);
+    git(repo, ['checkout', '--quiet', '-b', 'feature']);
+    writeFileSync(join(repo, '설계.md'), '# 설계\n');
+    git(repo, ['add', '--', '설계.md']);
+    git(repo, ['commit', '--quiet', '-m', 'add the design note\n\nLimit: capped\nRecord-Id: r-quoted01\n']);
+    git(repo, ['checkout', '--quiet', 'main']);
+    squashWithoutPreserving(repo);
+
+    const entry = runDoctor({ cwd: repo }).checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('warn');
+    expect(entry?.evidence['squashed_count']).toBe('1');
+    expect(entry?.evidence['undetermined_count']).toBe('0');
+  });
+
+  /**
+   * A branch that deleted a file cannot be classified by blob comparison: the
+   * path has no blob on either side. Pinned so a faster comparison cannot
+   * quietly start counting the deletion as a match or as a miss.
+   */
+  it('leaves a branch that deleted a file undetermined', () => {
+    const repo = initRepo('squash-conservation-deletion');
+    writeFileSync(join(repo, 'doomed.ts'), 'export const gone = true;\n');
+    git(repo, ['add', '--', 'doomed.ts']);
+    git(repo, ['commit', '--quiet', '-m', 'seed']);
+    git(repo, ['checkout', '--quiet', '-b', 'feature']);
+    git(repo, ['rm', '--quiet', '--', 'doomed.ts']);
+    writeFileSync(join(repo, 'feature.ts'), 'export const x = 1;\n');
+    git(repo, ['add', '--', 'feature.ts']);
+    git(repo, ['commit', '--quiet', '-m', 'replace the doomed file\n\nLimit: capped\nRecord-Id: r-deletion01\n']);
+    git(repo, ['checkout', '--quiet', 'main']);
+    squashWithoutPreserving(repo);
+
+    const entry = runDoctor({ cwd: repo }).checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('warn');
+    expect(entry?.evidence['undetermined_count']).toBe('1');
+    expect(entry?.evidence['squashed_count']).toBe('0');
+  });
+
+  /**
+   * A rename is listed by its destination alone, the only path whose blob is on
+   * the branch. Abandoned rather than squashed, because a parser that took the
+   * source instead would still land the squashed case on the right answer by
+   * accident — neither tree has the source — and only this one exposes it.
+   */
+  it('classifies an abandoned branch that renamed a file', () => {
+    const repo = initRepo('squash-conservation-renamed');
+    writeFileSync(join(repo, 'before.ts'), 'export const same = 1;\n');
+    git(repo, ['add', '--', 'before.ts']);
+    git(repo, ['commit', '--quiet', '-m', 'seed']);
+    git(repo, ['checkout', '--quiet', '-b', 'renamer']);
+    git(repo, ['mv', '--', 'before.ts', 'after.ts']);
+    git(repo, ['commit', '--quiet', '-m', 'rename it\n\nLimit: capped\nRecord-Id: r-renamed01\n']);
+    git(repo, ['checkout', '--quiet', 'main']);
+
+    const entry = runDoctor({ cwd: repo }).checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('warn');
+    expect(entry?.evidence['unmerged_count']).toBe('1');
+    expect(entry?.evidence['undetermined_count']).toBe('0');
+  });
+
+  /**
+   * A submodule pointer, on an abandoned branch, with HEAD's pointer moved
+   * elsewhere. This is the shape that catches the regression the file ranks
+   * worst, and only this shape catches it.
+   *
+   * The tree diff carries gitlinks as mode 160000 entries, so the bumped
+   * pointer is compared like any other path. Someone later adding
+   * `--ignore-submodules` to that diff, or filtering 160000 out to mirror
+   * `diff.ignoreSubmodules`, makes the entry vanish -- and the loop reads a
+   * missing entry as "the trees agree", returns `present-in-head`, and
+   * prescribes `squash-preserve --target` for work HEAD never took. That is the
+   * manufactured provenance this check's own header calls the failure the tool
+   * exists to prevent.
+   *
+   * Abandoned rather than squashed on purpose: a squashed bump passes under
+   * that regression by accident, because "no entry" happens to be the right
+   * answer there. Only the abandoned one, with HEAD pointing somewhere else,
+   * flips.
+   *
+   * The gitlink is written with `update-index --cacheinfo`, so the target
+   * commit deliberately does not exist in this object store -- no second
+   * repository, no `.gitmodules`, no `protocol.file.allow`. That absence also
+   * keeps live the property that ruled out `cat-file --batch-check` for this
+   * loop: it reports such a gitlink `missing`, where a tree diff compares it.
+   */
+  it('leaves an abandoned branch undetermined when its only change is a submodule pointer', () => {
+    const repo = initRepo('squash-conservation-gitlink');
+    const link = (sha: string): void => {
+      git(repo, ['update-index', '--add', '--cacheinfo', `160000,${sha},sm`]);
+    };
+    writeFileSync(join(repo, 'keep.ts'), 'export const keep = 1;\n');
+    git(repo, ['add', '--', 'keep.ts']);
+    link('1111111111111111111111111111111111111111');
+    git(repo, ['commit', '--quiet', '-m', 'seed with a submodule']);
+
+    git(repo, ['checkout', '--quiet', '-b', 'feature']);
+    link('2222222222222222222222222222222222222222');
+    git(repo, [
+      'commit',
+      '--quiet',
+      '-m',
+      'bump the submodule\n\nLimit: the pointer is the whole change\nRecord-Id: r-gitlink01\n',
+    ]);
+
+    // HEAD moves the same pointer somewhere else: the branch was abandoned, and
+    // its bump is not what HEAD holds.
+    git(repo, ['checkout', '--quiet', 'main']);
+    link('3333333333333333333333333333333333333333');
+    git(repo, ['commit', '--quiet', '-m', 'move the submodule elsewhere']);
+
+    const entry = runDoctor({ cwd: repo }).checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('warn');
+    // Undetermined, not absent: HEAD holds a pointer at `sm` too, just a
+    // different one, so the branch is neither all-matching nor all-missing.
+    expect(entry?.evidence['undetermined_count']).toBe('1');
+    // The one answer that must not appear. `squashed` is what prescribes
+    // `--target`, and it is what a diff blind to gitlinks would produce.
+    expect(entry?.evidence['squashed_count']).toBe('0');
+  });
+
+  /**
+   * HEAD replaced the branch's file with a directory of the same name. The
+   * tree lookup the old loop used resolved `<head>:<path>` to a tree id, which
+   * equals no blob, so the path counted as neither a match nor a miss -- and
+   * `headHasTreeHere` is the one line of the replacement that preserves it.
+   * Nothing else touches that line.
+   */
+  it('counts a path HEAD turned into a directory as neither match nor miss', () => {
+    const repo = initRepo('squash-conservation-file-to-dir');
+    writeFileSync(join(repo, 'thing'), 'a file\n');
+    git(repo, ['add', '--', 'thing']);
+    git(repo, ['commit', '--quiet', '-m', 'seed']);
+
+    git(repo, ['checkout', '--quiet', '-b', 'feature']);
+    writeFileSync(join(repo, 'thing'), 'the branch edits it\n');
+    writeFileSync(join(repo, 'also.ts'), 'export const also = 1;\n');
+    git(repo, ['add', '--', 'thing', 'also.ts']);
+    git(repo, [
+      'commit',
+      '--quiet',
+      '-m',
+      'edit the file\n\nLimit: capped\nRecord-Id: r-filetodir01\n',
+    ]);
+
+    git(repo, ['checkout', '--quiet', 'main']);
+    rmSync(join(repo, 'thing'), { force: true });
+    mkdirSync(join(repo, 'thing'), { recursive: true });
+    writeFileSync(join(repo, 'thing', 'child.txt'), 'now a directory\n');
+    git(repo, ['add', '--all', '--', 'thing']);
+    git(repo, ['commit', '--quiet', '-m', 'replace the file with a directory']);
+
+    const entry = runDoctor({ cwd: repo }).checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('warn');
+    // `also.ts` is missing from HEAD and `thing` counts as neither, so the
+    // branch is neither all-matching nor all-missing.
+    expect(entry?.evidence['undetermined_count']).toBe('1');
+    expect(entry?.evidence['squashed_count']).toBe('0');
+  });
+
   it('discloses the 200-branch limit instead of reporting an unqualified subset', () => {
     const repo = initRepo('squash-conservation-capped');
     preservedSquash(repo, 'r-capped01');

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -748,6 +748,11 @@ describe('commitlore_query', () => {
       'runtime',
       'scanned',
       'unreadCommits',
+      // #930: the vantage the walk started from. It reaches MCP through the same
+      // `contextJson` the CLI serializes, so it is listed for the same reason as
+      // `runtime` — and because an agent deciding whether an empty answer means
+      // "nothing was recorded" is exactly the caller this tool exists for.
+      'vantage',
     ]);
     const [record] = overMcp['records'] as Record<string, unknown>[];
     expect(Object.keys(record ?? {}).sort()).toEqual([

--- a/test/query-vantage.test.ts
+++ b/test/query-vantage.test.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import { runQuery } from '../src/core/query.js';
+import { createTestRepo } from './git-fixtures.js';
 
 const scratch: string[] = [];
 afterAll(() => {
@@ -47,8 +48,12 @@ const cloneWithTwoRecords = (label: string): { work: string; base: string; tip: 
   scratch.push(root);
   const remote = join(root, 'remote.git');
   const work = join(root, 'work');
-  execFileSync('git', ['init', '--quiet', '--bare', remote]);
-  execFileSync('git', ['clone', '--quiet', remote, work]);
+  // `createTestRepo` rather than a raw `git init`/`clone`: it pins
+  // `--initial-branch=main`, and the first version of this fixture inherited the
+  // runner's `init.defaultBranch` instead. Every case passed locally and all
+  // four failed in CI with `fatal: branch 'main' does not exist`.
+  createTestRepo({ path: remote, bare: true });
+  createTestRepo({ path: work, source: remote });
 
   mkdirSync(join(work, 'src'), { recursive: true });
   writeFileSync(join(work, 'src/a.ts'), 'export const v = 1;\n');

--- a/test/query-vantage.test.ts
+++ b/test/query-vantage.test.ts
@@ -1,0 +1,167 @@
+/**
+ * #930: `coverage: "complete"` says the scan was not truncated. It reads as
+ * "this answer is whole", and nothing in the envelope ever described the other
+ * half of completeness -- *where the walk started*.
+ *
+ * The commit source only ever reads `rev-list HEAD` (index-db.ts says so, and
+ * that scoping is deliberate: an unreachable note's `Supersedes:` must not
+ * silence a live record). So an answer is complete with respect to a vantage
+ * the caller never sees. A checkout behind its own already-fetched upstream
+ * returns zero records with `coverage: "complete"`, `history: "ready"` and
+ * `notes: "present"` -- byte-identical to a repository where nobody ever wrote
+ * one, which `core/query.ts` calls the most dangerous sentence this tool can
+ * produce and already built two typed fields to prevent.
+ *
+ * The discrimination is the whole design, so it is what these cases pin. Two
+ * cheaper-looking signals were measured and rejected for firing on healthy
+ * checkouts -- `rev-list --branches --remotes --not HEAD` counts 202 on this
+ * repository at the tip of main -- and a signal that fires everywhere is the
+ * one operators learn to skip.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { runQuery } from '../src/core/query.js';
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const d of scratch) rmSync(d, { recursive: true, force: true });
+});
+
+const git = (cwd: string, ...args: string[]): string =>
+  execFileSync('git', ['-c', 'user.email=t@e.invalid', '-c', 'user.name=T', ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+
+/**
+ * A clone whose `main` tracks `origin/main`, with a record on each of two
+ * commits. The later one is the record a stale vantage cannot reach.
+ */
+const cloneWithTwoRecords = (label: string): { work: string; base: string; tip: string } => {
+  const root = mkdtempSync(join(tmpdir(), `commitlore-930-${label}-`));
+  scratch.push(root);
+  const remote = join(root, 'remote.git');
+  const work = join(root, 'work');
+  execFileSync('git', ['init', '--quiet', '--bare', remote]);
+  execFileSync('git', ['clone', '--quiet', remote, work]);
+
+  mkdirSync(join(work, 'src'), { recursive: true });
+  writeFileSync(join(work, 'src/a.ts'), 'export const v = 1;\n');
+  git(work, 'add', 'src/a.ts');
+  git(work, 'commit', '--quiet', '-m', 'seed\n\nLimit: the seed record\nRecord-Id: r-vseed930');
+  git(work, 'push', '--quiet', 'origin', 'HEAD:refs/heads/main');
+  const base = git(work, 'rev-parse', 'HEAD').trim();
+
+  writeFileSync(join(work, 'src/a.ts'), 'export const v = 2;\n');
+  git(work, 'add', 'src/a.ts');
+  git(work, 'commit', '--quiet', '-m', 'later\n\nLimit: THE LATER RECORD\nRecord-Id: r-vlater930');
+  git(work, 'push', '--quiet', 'origin', 'HEAD:refs/heads/main');
+  const tip = git(work, 'rev-parse', 'HEAD').trim();
+
+  git(work, 'branch', '--quiet', '--set-upstream-to=origin/main', 'main');
+  return { work, base, tip };
+};
+
+const ask = (cwd: string) => runQuery({ cwd, path: 'src/a.ts' });
+
+describe('#930 the answer states the vantage it was read from', () => {
+  it('is silent at the tip: nothing is behind, so nothing is claimed', () => {
+    const { work } = cloneWithTwoRecords('tip');
+
+    const result = ask(work);
+
+    expect(result.records).toHaveLength(2);
+    expect(result.vantage.behind).toBe(0);
+    expect(result.vantage.ref).toBe('main');
+    expect(result.vantage.upstream).toBe('origin/main');
+    // The caveat must not fire here, or it fires on every healthy repository.
+    expect(result.diagnostics.join(' ')).not.toContain('behind');
+  });
+
+  /*
+   * The case the issue was filed for. Every other availability field reads
+   * healthy while a record that exists in this very object store is missing.
+   */
+  it('reports behind when the checkout is behind its own fetched upstream', () => {
+    const { work, base } = cloneWithTwoRecords('behind');
+    git(work, 'reset', '--quiet', '--hard', base);
+
+    const result = ask(work);
+
+    expect(result.records).toHaveLength(1);
+    // The fields that used to be the whole story, all still green.
+    expect(result.coverage).toBe('complete');
+    expect(result.history).toBe('ready');
+    expect(result.unreadCommits).toBe(0);
+    // The one that is not.
+    expect(result.vantage.behind).toBe(1);
+    expect(result.vantage.upstream).toBe('origin/main');
+    expect(result.diagnostics.join(' ')).toContain('behind');
+    // A caller reading only prose must still be told the empty-answer reading
+    // is unsafe, which is why this is a diagnostic and not only a field.
+    expect(result.diagnostics.join(' ')).toContain('not');
+  });
+
+  /*
+   * A review worktree, which `git worktree add <path> <ref>` produces. The
+   * narrower scope is the point of being there, so the vantage is stated and
+   * not complained about -- a warning here would fire on every blind review.
+   */
+  it('states a detached head without warning about it', () => {
+    const { work, base } = cloneWithTwoRecords('detached');
+    git(work, 'checkout', '--quiet', '--detach', base);
+
+    const result = ask(work);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.vantage.ref).toBeNull();
+    expect(result.vantage.head).toBe(base);
+    // No upstream to be behind: unknown, and unknown is not zero.
+    expect(result.vantage.upstream).toBeNull();
+    expect(result.vantage.behind).toBeNull();
+    expect(result.diagnostics.join(' ')).not.toContain('behind');
+  });
+
+  /*
+   * An unmerged local branch holds records HEAD cannot reach, and that is
+   * ordinary. `main` is not missing anything its own line ever had, so the
+   * answer must stay silent -- this is the case that kills a "does any
+   * unreachable commit exist" signal.
+   */
+  it('stays silent when another local branch is ahead but HEAD is current', () => {
+    const { work, base, tip } = cloneWithTwoRecords('branch');
+    git(work, 'reset', '--quiet', '--hard', base);
+    git(work, 'push', '--quiet', '--force', 'origin', 'HEAD:refs/heads/main');
+    git(work, 'fetch', '--quiet', 'origin');
+    git(work, 'branch', '--quiet', '--force', 'feature', tip);
+
+    const result = ask(work);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.vantage.behind).toBe(0);
+    expect(result.diagnostics.join(' ')).not.toContain('behind');
+  });
+
+  it('reports no upstream as unknown rather than as zero', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'commitlore-930-solo-'));
+    scratch.push(dir);
+    execFileSync('git', ['init', '--quiet'], { cwd: dir });
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src/a.ts'), 'export const v = 1;\n');
+    git(dir, 'add', 'src/a.ts');
+    git(dir, 'commit', '--quiet', '-m', 'seed\n\nLimit: alone\nRecord-Id: r-vsolo930');
+
+    const result = ask(dir);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.vantage.upstream).toBeNull();
+    // Zero here would be this defect rebuilt: an unknown presented as all-clear.
+    expect(result.vantage.behind).toBeNull();
+    expect(result.vantage.ref).toBe(git(dir, 'symbolic-ref', '--short', 'HEAD').trim());
+  });
+});

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1716,9 +1716,9 @@ describe('--json', () => {
             ],
             "provenance": null,
             "recordId": "r-st2222",
-            "sha": "<sha-1>",
+            "sha": "<sha-2>",
             "shas": [
-              "<sha-1>",
+              "<sha-2>",
             ],
             "source": "commit",
             "sources": [
@@ -1752,15 +1752,15 @@ describe('--json', () => {
             ],
             "provenance": null,
             "recordId": "r-st1111",
-            "sha": "<sha-2>",
+            "sha": "<sha-3>",
             "shas": [
-              "<sha-2>",
+              "<sha-3>",
             ],
             "source": "commit",
             "sources": [
               "commit",
             ],
-            "supersededBy": "<sha-3>",
+            "supersededBy": "<sha-1>",
             "trailers": [
               {
                 "key": "Limit",
@@ -1780,6 +1780,12 @@ describe('--json', () => {
         },
         "scanned": 2,
         "unreadCommits": 0,
+        "vantage": {
+          "behind": null,
+          "head": "<sha-1>",
+          "ref": "main",
+          "upstream": null,
+        },
       }
     `);
   });
@@ -1810,6 +1816,16 @@ describe('--json', () => {
       // field is a contract change and belongs in the pinned shape.
       runtime: { version: expect.any(String), build_id: expect.any(String) },
       coverage: expect.any(String),
+      // #930: where the answer was read from. `coverage` says the scan was not
+      // truncated and cannot say the walk started somewhere that can reach the
+      // records, so a client deciding what an empty answer means reads this too.
+      // Declared for the same reason `runtime` is: a client reads this schema.
+      vantage: {
+        head: expect.any(String),
+        ref: expect.any(String),
+        upstream: null,
+        behind: null,
+      },
       at: '2026-01-20T00:00:00.000Z',
       paths: [],
       aliases: [],

--- a/test/stale-multiblock.test.ts
+++ b/test/stale-multiblock.test.ts
@@ -25,6 +25,8 @@ import { join } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import { buildReport, collectRecords } from '../src/commands/stale.js';
+import { writeRecordBlocks } from '../src/core/notes.js';
+import type { Trailer } from '../src/core/types.js';
 
 const scratch: string[] = [];
 afterAll(() => {
@@ -115,5 +117,95 @@ describe('#898 the stale scan reads every record block in a message', () => {
 
     expect(report.danglingRefs).toHaveLength(1);
     expect(report.danglingRefs[0]?.value).toBe('r-doesnotexist9');
+  });
+});
+
+/**
+ * The same defect on the notes mirror. `squash-preserve --target` writes one
+ * block per inherited record into a single note (`core/squash.ts`
+ * `writeRecordBlocks`), and the index reads every one of them back through
+ * `parseRecordBlocks` (`core/index-db.ts`). `collectRecords` read the note with
+ * `readRecord`, which is `parseCommitMessage` — git's last paragraph — so every
+ * block above the last was invisible to `stale`, and only to `stale`. In this
+ * repository 7 of 11 notes carry more than one block; one carries 25.
+ */
+describe('the stale scan reads every record block in a note', () => {
+  const trailer = (key: string, value: string): Trailer => ({ key, value });
+  const rootOf = (dir: string): string => git(dir, ['rev-list', '--max-parents=0', 'HEAD']).trim();
+  const idsOf = (records: readonly { trailers: Trailer[] }[]): string[] =>
+    records
+      .map((record) => record.trailers.find((item) => item.key === 'Record-Id')?.value)
+      .filter((id): id is string => id !== undefined)
+      .sort();
+
+  it('collects one notes record per block, not the last block only', () => {
+    const dir = squashedChain();
+    writeRecordBlocks(
+      rootOf(dir),
+      [
+        [trailer('Limit', 'the first inherited decision'), trailer('Record-Id', 'r-noteblock01')],
+        [trailer('Limit', 'the second inherited decision'), trailer('Record-Id', 'r-noteblock02')],
+      ],
+      { cwd: dir },
+    );
+
+    const scan = collectRecords({ cwd: dir, allHistory: true });
+    const notes = scan.records.filter((record) => record.source === 'notes');
+
+    // Reading only the last paragraph finds r-noteblock02 and nothing else.
+    expect(idsOf(notes)).toEqual(['r-noteblock01', 'r-noteblock02']);
+    // A note is not a commit: the count is still the two commits of the chain.
+    expect(scan.commits).toBe(2);
+  });
+
+  it('does not report a Follows: whose target is an earlier block of the same note as dangling', () => {
+    const dir = squashedChain();
+    writeRecordBlocks(
+      rootOf(dir),
+      [
+        [trailer('Limit', 'the first inherited decision'), trailer('Record-Id', 'r-noteblock01')],
+        [
+          trailer('Limit', 'the second inherited decision'),
+          trailer('Record-Id', 'r-noteblock02'),
+          trailer('Follows', 'r-noteblock01'),
+        ],
+      ],
+      { cwd: dir },
+    );
+
+    const report = buildReport(collectRecords({ cwd: dir, allHistory: true }), new Date());
+
+    expect(report.danglingRefs).toEqual([]);
+    // Three ids from the two commits, two from the note.
+    expect(report.totalRecords).toBe(5);
+  });
+
+  it('keeps a note-only block that precedes a block mirroring the commit', () => {
+    const dir = squashedChain();
+    const head = git(dir, ['rev-parse', 'HEAD']).trim();
+    // The last block mirrors the commit's own last block; the block before it
+    // exists only in the mirror. Under the last-paragraph read the mirrored
+    // block was dropped as a mirror and the note-only one was never seen.
+    writeRecordBlocks(
+      head,
+      [
+        [trailer('Limit', 'recorded only in the mirror'), trailer('Record-Id', 'r-noteonly01')],
+        [
+          trailer('Limit', 'the later refinement'),
+          trailer('Record-Id', 'r-later8980001'),
+          trailer('Follows', 'r-earlier89801'),
+          trailer('Blast', 'module'),
+        ],
+      ],
+      { cwd: dir },
+    );
+
+    const notes = collectRecords({ cwd: dir, allHistory: true }).records.filter(
+      (record) => record.source === 'notes',
+    );
+
+    // The mirrored block is one record with its commit (r-refint74) and stays
+    // dropped; the note-only block is a record of its own.
+    expect(idsOf(notes)).toEqual(['r-noteonly01']);
   });
 });

--- a/test/trailer-atom.test.ts
+++ b/test/trailer-atom.test.ts
@@ -1,0 +1,270 @@
+/**
+ * The deciding artifact for reading a message's own trailer block from
+ * `git log --format=%(trailers:...)` instead of one `git interpret-trailers`
+ * process per message.
+ *
+ * SPEC §2.1 B3 and r-5a8c04 give git the last word on what a trailer block is;
+ * nothing here loosens that. The question is narrower: are the two doors into
+ * git's parser the same parser? `core/index-db.ts` has answered yes since the
+ * index existed and reads every record through the atom. This file holds the
+ * answer to evidence on two fronts:
+ *
+ * 1. Hazard cases built in a scratch repository — a `---` divider before and
+ *    after the block, a last paragraph that is prose (B3), folded
+ *    continuations (B4), a value carrying the atom's own separator bytes, an
+ *    empty message, a subject-only message, CRLF, an empty value, and the
+ *    multi-block shape of §2.4.
+ * 2. This repository's whole history, every commit, exactly as
+ *    `test/dogfood.test.ts` walks it. Any disagreement is reported with its
+ *    sha and both outputs.
+ *
+ * The oracle on every case is `parseCommitMessage` — `interpret-trailers
+ * --parse --no-divider` under the pinned separator — never a fixture written
+ * by hand.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  SEPARATOR_PIN,
+  TRAILERS_ATOM,
+  atomIsAmbiguous,
+  parseCommitMessage,
+  parseRecordBlocks,
+  parseRecordBlocksWithAtom,
+  parseTrailersAtom,
+  readTrailersAtom,
+} from '../src/core/trailers.js';
+import type { Trailer } from '../src/core/types.js';
+import { createTestRepo } from './git-fixtures.js';
+
+const REPO_ROOT = new URL('..', import.meta.url).pathname;
+const UNIT = '';
+
+const git = (cwd: string, args: string[]): string =>
+  execFileSync('git', args, { cwd, encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 });
+
+/** sha -> message, and sha -> atom field, over one revision expression. */
+const readBoth = (cwd: string, revision: string): Map<string, { message: string; atom: string }> => {
+  const messages = git(cwd, ['log', '-z', `--format=%H${UNIT}%B`, '--end-of-options', revision]);
+  const atoms = git(cwd, [
+    ...SEPARATOR_PIN,
+    'log',
+    '-z',
+    `--format=%H${UNIT}${TRAILERS_ATOM}`,
+    '--end-of-options',
+    revision,
+  ]);
+  const firstField = (chunk: string): [string, string] => {
+    const at = chunk.indexOf(UNIT);
+    return at === -1 ? [chunk, ''] : [chunk.slice(0, at), chunk.slice(at + 1)];
+  };
+  const byLog = new Map<string, { message: string; atom: string }>();
+  for (const chunk of messages.split('\0')) {
+    if (chunk === '') continue;
+    const [sha, message] = firstField(chunk);
+    byLog.set(sha, { message, atom: '' });
+  }
+  for (const chunk of atoms.split('\0')) {
+    if (chunk === '') continue;
+    const [sha, atom] = firstField(chunk);
+    const entry = byLog.get(sha);
+    if (entry === undefined) throw new Error(`atom walk saw ${sha} and the message walk did not`);
+    entry.atom = atom;
+  }
+  return byLog;
+};
+
+/** What a reader built on the atom answers for the message's own block. */
+const lastBlockViaAtom = (message: string, atom: string): Trailer[] =>
+  atomIsAmbiguous(message) ? parseCommitMessage(message) : parseTrailersAtom(atom);
+
+interface Disagreement {
+  sha: string;
+  message: string;
+  viaProcess: unknown;
+  viaAtom: unknown;
+}
+
+const disagreementsOver = (
+  entries: Map<string, { message: string; atom: string }>,
+): { raw: Disagreement[]; blocks: Disagreement[]; commits: number; ambiguous: number } => {
+  const raw: Disagreement[] = [];
+  const blocks: Disagreement[] = [];
+  let ambiguous = 0;
+  for (const [sha, { message, atom }] of entries) {
+    if (atomIsAmbiguous(message)) ambiguous += 1;
+    const viaProcess = parseCommitMessage(message);
+    const viaAtom = lastBlockViaAtom(message, atom);
+    if (JSON.stringify(viaProcess) !== JSON.stringify(viaAtom)) {
+      raw.push({ sha, message, viaProcess, viaAtom });
+    }
+    // The block grammar only does work beyond the last paragraph when the
+    // message names Record-Id more than once or outside its last paragraph;
+    // everywhere else both readers are the single block just compared.
+    if ((message.match(/record-id/gi) ?? []).length > 1 || !/record-id/i.test(message.split(/\n\n+/).at(-1) ?? '') && /record-id/i.test(message)) {
+      const today = parseRecordBlocks(message);
+      const withAtom = parseRecordBlocks(message, { last: viaAtom });
+      if (JSON.stringify(today) !== JSON.stringify(withAtom)) {
+        blocks.push({ sha, message, viaProcess: today, viaAtom: withAtom });
+      }
+    }
+  }
+  return { raw, blocks, commits: entries.size, ambiguous };
+};
+
+const render = (found: Disagreement[]): string =>
+  found
+    .map(
+      (d) =>
+        `${d.sha}\n  message: ${JSON.stringify(d.message)}\n  process: ${JSON.stringify(d.viaProcess)}\n  atom:    ${JSON.stringify(d.viaAtom)}`,
+    )
+    .join('\n');
+
+// ---------------------------------------------------------------------------
+// 1. Hazard cases
+// ---------------------------------------------------------------------------
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Every message committed byte-for-byte (`--cleanup=verbatim`, stdin), no hook, no signing. */
+const commitVerbatim = (dir: string, message: string): string => {
+  const result = spawnSync(
+    'git',
+    [
+      '-c', 'user.name=CommitLore Test',
+      '-c', 'user.email=test@example.invalid',
+      '-c', 'commit.gpgsign=false',
+      'commit', '--allow-empty', '--allow-empty-message', '--no-verify', '--cleanup=verbatim', '-F', '-',
+    ],
+    { cwd: dir, shell: false, encoding: 'utf8', input: message },
+  );
+  if (result.status !== 0) throw new Error(`git commit failed: ${result.stderr}`);
+  return git(dir, ['rev-parse', 'HEAD']).trim();
+};
+
+/** The cases the equivalence was doubted on. Each is the exact text committed. */
+const HAZARDS: Record<string, string> = {
+  'divider before the block': 'Subject\n\nBody prose.\n---\nnot: after a divider\n\nLimit: after the divider line\nRecord-Id: r-divider0001\n',
+  'divider after the block': 'Subject\n\nLimit: before the divider line\nRecord-Id: r-divider0002\n---\nprose after the divider\n',
+  'last paragraph is prose (B3), earlier block present (2.4)':
+    'Subject\n\nLimit: the early decision\nRecord-Id: r-earlyblock1\n\nRecord-Id: r-notatrailer\nand this sentence continues the paragraph\n',
+  'folded continuation lines (B4)':
+    'Subject\n\nRuled-out: alpha | a reason that\n  continues on a second line\n\tand a tab-indented third\nRecord-Id: r-folded0001\n',
+  'value carrying the atom separator bytes':
+    'Subject\n\nLimit: has  record separator and  field separator inside\nRecord-Id: r-bytes00001\n',
+  'value carrying other control bytes': 'Subject\n\nLimit: has  and  inside\nRecord-Id: r-bytes00002\n',
+  'empty message': '',
+  'subject only': 'Limit: a subject that looks like a trailer\n',
+  'CRLF line endings': 'Subject\r\n\r\nLimit: crlf value\r\nRecord-Id: r-crlf000001\r\n',
+  'empty value': 'Subject\n\nLimit:\nRecord-Id: r-emptyval01\n',
+  'no space after the separator': 'Subject\n\nLimit:tight\nRecord-Id: r-tight00001\n',
+  'space before the separator': 'Subject\n\nLimit : spaced\nRecord-Id: r-spaced0001\n',
+  'trailer-shaped line followed by prose (B3)': 'Subject\n\nLimit: looks like one\nbut this line is prose\n',
+  'body paragraph without identity (B2)': 'Subject\n\nContext: some\nSource: thing\n\nLimit: real\nRecord-Id: r-b2example1\n',
+  'two record blocks (2.4)':
+    'feat: squash\n\nLimit: the earlier decision\nRecord-Id: r-multi000001\n\nLimit: the later refinement\nRecord-Id: r-multi000002\nFollows: r-multi000001\n',
+  'earlier block, unrelated subject between (bug-issue-60)':
+    'Merge\n\nLimit: first\nRecord-Id: r-interleave1\n\nsecond commit subject\n\nLimit: second\nRecord-Id: r-interleave2\n',
+  'unicode value': 'Subject\n\nLimit: 한국어 값 — ünïcode ✓\nRecord-Id: r-unicode001\n',
+  'trailing blank lines': 'Subject\n\nLimit: trailing\nRecord-Id: r-trailing01\n\n\n',
+  'conventional trailers only': 'Subject\n\nCo-authored-by: Someone <s@example.invalid>\nSigned-off-by: Someone <s@example.invalid>\n',
+  'long value': `Subject\n\nLimit: ${'x'.repeat(4000)}\nRecord-Id: r-longvalue1\n`,
+  'colon-space inside the value': 'Subject\n\nLimit: ratio is 3: 1 at peak\nRecord-Id: r-colonspace1\n',
+  'continuation as the first line of the last paragraph': 'Subject\n\n  indented first line\nLimit: x\n',
+  'comment-looking lines kept verbatim': 'Subject\n\n# not a comment after cleanup=verbatim\nLimit: x\nRecord-Id: r-hashline01\n',
+};
+
+describe('the trailers atom answers exactly as interpret-trailers on the hazard cases', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'commitlore-atom-'));
+  scratch.push(dir);
+  createTestRepo({ path: dir });
+  const shaByCase = new Map<string, string>();
+  for (const [name, message] of Object.entries(HAZARDS)) shaByCase.set(name, commitVerbatim(dir, message));
+  const entries = readBoth(dir, 'HEAD');
+
+  it.each([...shaByCase.entries()])('%s', (name, sha) => {
+    const entry = entries.get(sha);
+    expect(entry, `the walk did not return ${name}`).toBeDefined();
+    if (entry === undefined) return;
+    const viaProcess = parseCommitMessage(entry.message);
+    const viaAtom = lastBlockViaAtom(entry.message, entry.atom);
+    expect(viaAtom, `own block — process vs atom for ${JSON.stringify(entry.message)}`).toEqual(viaProcess);
+    expect(parseRecordBlocks(entry.message, { last: viaAtom })).toEqual(parseRecordBlocks(entry.message));
+  });
+
+  it('routes a value carrying the separator bytes to the process, not the atom', () => {
+    const sha = shaByCase.get('value carrying the atom separator bytes') ?? '';
+    const entry = entries.get(sha);
+    expect(entry).toBeDefined();
+    if (entry === undefined) return;
+    expect(atomIsAmbiguous(entry.message)).toBe(true);
+    // The raw atom output really is unframeable here — which is the reason the
+    // guard exists, not a fault in the parser.
+    expect(parseTrailersAtom(entry.atom)).not.toEqual(parseCommitMessage(entry.message));
+  });
+
+  it('readTrailersAtom returns the same field for every commit of the walk', () => {
+    // The production walk, not this file's own: a walk that failed would hand
+    // every reader an empty map and every reader would quietly fall back to
+    // the process, which no other assertion here could tell from success.
+    const viaReader = readTrailersAtom(['--end-of-options', 'HEAD'], { cwd: dir });
+    expect(viaReader.size).toBe(entries.size);
+    for (const [sha, entry] of entries) expect(viaReader.get(sha), sha).toBe(entry.atom);
+  });
+
+  it('parseRecordBlocksWithAtom answers as parseRecordBlocks on every case', () => {
+    for (const [sha, entry] of entries) {
+      expect(parseRecordBlocksWithAtom(entry.message, entry.atom), sha).toEqual(parseRecordBlocks(entry.message));
+    }
+    // And with no atom at all it is parseRecordBlocks, byte for byte.
+    const [first] = entries.values();
+    expect(first && parseRecordBlocksWithAtom(first.message, undefined)).toEqual(first && parseRecordBlocks(first.message));
+  });
+
+  it('reads the divider cases with --no-divider semantics on both doors', () => {
+    const before = entries.get(shaByCase.get('divider before the block') ?? '');
+    const after = entries.get(shaByCase.get('divider after the block') ?? '');
+    expect(before && parseTrailersAtom(before.atom)).toEqual([
+      { key: 'Limit', value: 'after the divider line' },
+      { key: 'Record-Id', value: 'r-divider0001' },
+    ]);
+    expect(after && parseTrailersAtom(after.atom)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. This repository, every commit
+// ---------------------------------------------------------------------------
+
+const isShallow = (): boolean => {
+  try {
+    return git(REPO_ROOT, ['rev-parse', '--is-shallow-repository']).trim() === 'true';
+  } catch {
+    return true;
+  }
+};
+
+describe('the trailers atom answers exactly as interpret-trailers over this repository', () => {
+  it.skipIf(isShallow())('disagrees on no commit reachable from HEAD', () => {
+    const entries = readBoth(REPO_ROOT, 'HEAD');
+    const result = disagreementsOver(entries);
+    expect(result.commits).toBeGreaterThan(0);
+    // A history in which every message carried a separator byte would route
+    // every commit to the process and prove nothing about the atom.
+    expect(result.commits - result.ambiguous, 'commits the atom was consulted for').toBeGreaterThan(0);
+    expect(result.raw, `own block disagreements over ${result.commits} commits:\n${render(result.raw)}`).toEqual([]);
+    expect(result.blocks, `record block disagreements over ${result.commits} commits:\n${render(result.blocks)}`).toEqual([]);
+    // The oracle side is one process per commit — the cost this file exists to
+    // retire — so the walk takes ~20s on a laptop at 1500 commits and sat on
+    // the default limit; a loaded machine took three times that.
+  }, 180_000);
+});


### PR DESCRIPTION
One report and four defects that were silent by construction.

An MCP server answered "no records" from a checkout that had drifted behind its own already-fetched upstream. Chasing why nothing said so found three more places where the tool reported confidently about something it could not see — and one place where it was doing enormous work to find out.

## The reporting defects

**#930 — an answer never said where it was read from.** `coverage: "complete"` means the scan was not truncated. It reads as *this answer is whole*, and every other field in the envelope described a source or the scan too, so all of them stayed healthy while the walk started from the wrong commit. Reproduced: a checkout five commits behind returned zero records with `coverage: "complete"`, `history: "ready"`, `notes: "present"` — byte-identical to the answer from a repository where nobody ever wrote one, with the record one `git merge --ff-only` away. That is the sentence `core/query.ts` already calls the most dangerous this tool can produce; it had built two typed fields to prevent it and this was a third door.

Every answer now carries `vantage`. `behind` is the whole signal, and the discrimination is the design: at the tip it is 0 and silent, behind an upstream it fires, a detached head states its scope without warning (a review worktree is *meant* to be narrow), and an unmerged local branch is silent because HEAD is not missing what its own line never had. Two cheaper-looking signals were measured and thrown away for firing on healthy checkouts — `rev-list --branches --remotes --not HEAD` counts 202 on this repository at the tip of `main`.

**A branch touching a non-ASCII filename was never classified.** `squash-conservation` compared blobs path by path; the paths came from `git diff --name-only`, which C-quotes anything outside ASCII (`"\354\204\244\352\263\204.md"`). No tree resolves that spelling, so the branch returned `unknown` — a squashed branch reported as undetermined, an abandoned one never told there was nothing to preserve. Silent, because `unknown` is the safe verdict and looks like caution. One `git diff-tree -r -z` now answers for every path at once; the `-z` is the fix and the single spawn is the side effect.

**`stale` read only the last block of a note.** Every other reader recovers all of them, so `stale` alone answered differently about the same repository: a two-block note yielded one record, and a `Follows:` whose target sat in an earlier block of the same note was reported dangling. That shape is what `squash-preserve --target` writes, so it was the path a preserved squash's own records travel.

**A documented invariant had no test.** `verification_gaps` is declared a closed, ordered set in two places; reversing the two source gaps passed the entire file.

## The pipeline

`validate --range` collects the whole reachable history once per commit in the range and re-read everything each time. On this project's own CI that is the step named "The CLI validates this repository's own history" — run 34576438460 spent **2833s and 3578s** in it, per matrix leg, on every release.

The walks stay: each one's reachable set *is* the question the reference check asks. What changed is that a message is parsed once, the notes mirror is read once, and the last trailer block comes from git's own trailer atom in the `git log` the walk already runs.

Measured by counting every `git` invocation, which is the only metric that holds here — wall time on this machine moved 3x with load, and the same test varied 11.75s–19.11s across three runs of identical code:

| | before | after |
|---|---|---|
| `validate --range HEAD~20..HEAD` (164 commits) | 147,156+ spawns, stopped at ~42 min | **1,193** |
| `doctor --only squash-conservation` | 924 spawns | **642** (`git notes list` 70 → 1) |
| the blob-comparison loop | 132 path lookups | **0** |

Answers byte-identical throughout.

## Why the parser change is carried by a test, not a benchmark

Replacing `interpret-trailers` with git's trailer atom is a parser swap, so it ships with a differential harness rather than a measurement: every commit in this repository's history plus 23 constructed hazards (`---` dividers on both sides, prose last paragraphs, folded continuations, CRLF, a 4000-character value, unicode, control bytes), both readers compared. **Zero disagreements** — and it found one real failure: a value containing the atom's own separator bytes cannot be framed, so those messages route to the process reader. Both of the harness's own controls fail it, which is what makes it evidence: dropping `unfold=true` and disabling the separator guard each break it.

`r-staleblocks898` rules out "two extraction paths for one message". That record forbids a second *composition* of the §2.4 grammar — and `parseRecordBlocks` remains the only one, now with a seam for where the last block's bytes come from. `index-db.ts` has used this transport since it was written; what it never had was the proof.

## What is not claimed

- The `before` figure for `validate` is an observed lower bound, not a total. The run was stopped because it was saturating the machine the measurement ran on.
- CI wall-time improvement is unverified here and cannot be; the spawn counts are the evidence and the next release is the test.
- Three corrections are recorded in the commits rather than quietly dropped: the blob-comparison loop was 7% of its check's cost, not the 75% first attributed to it; a fix aimed at the injection path was applied to a path injection does not take; and a 22% regression attributed to a new field was noise, on a measurement whose own spread was 63%.

## Verification

Full suite **3,329 passed, 4 skipped, 0 failed**; `tsc --noEmit` exit 0. Every change carries a negative control that was run: reverting it fails the specific case and restoring passes. Poisoning the parse cache fails four existing `validate` cases, so that path is covered rather than passing by absence. Planting the exact regression predicted for the submodule case — `--ignore-submodules` on the tree diff — fails that case and only it.

Closes #930
