### PR TITLE
canonical-merge: an informational lookup stopped ending the job

### DIFF
--- a/.github/workflows/canonical-merge.yml
+++ b/.github/workflows/canonical-merge.yml
@@ -323,7 +323,21 @@ jobs:
             exit 1
           fi
 
-          pusher="$(gh api "repos/${GITHUB_REPOSITORY}/commits/$expected" --jq '.committer.login // "unknown"')"
+          # The ref above is already visible while this commit endpoint can still
+          # 404 -- a read-after-write race, seen on run 34659967269 when the
+          # branch had just been deleted and re-pushed. This value is only
+          # echoed, and it already has an "unknown" fallback for a commit with
+          # no linked account, so a lookup that cannot answer must not end the
+          # job: `set -e` made an informational read load-bearing on failure.
+          pusher=unknown
+          for attempt in 1 2 3 4 5; do
+            if answer="$(gh api "repos/${GITHUB_REPOSITORY}/commits/$expected" --jq '.committer.login // "unknown"' 2>/dev/null)"; then
+              pusher="$answer"
+              break
+            fi
+            echo "--- commit $expected not readable yet (attempt $attempt); waiting"
+            sleep 3
+          done
           echo "--- pushed $branch at $expected; committer on the server: $pusher"
 
           existing="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // ""')"


### PR DESCRIPTION
Split out of #940, which canonical-merge correctly refused: it builds the canonical branch, so a pull request that rewrites the builder cannot be validated by the builder it rewrites. The refusal is the guard working.

**What happened.** `canonical-merge` pushed `canonical/pr-936`, confirmed the ref on the server, then asked the commits endpoint who committed it and got 404 — a read-after-write race, seconds after the same branch had been deleted and re-pushed. The job ended there having done all its work: the branch was correct and carried the workflow's own rebuild, and the pull request it exists to open had to be opened by hand.

**Why it was fatal.** The lookup feeds one `echo` and already falls back to `"unknown"` for a commit with no linked account. `set -euo pipefail` is what turned a read that cannot answer into a failed run — a value made load-bearing by the shell rather than by anyone's intent.

**The fix.** A bounded retry for the useful case, a fallback for the rest. Five attempts over about fifteen seconds, then `unknown` and continue.

**Untouched:** the ref comparison above it, which compares the pushed sha against what landed. That one must stay fatal — it is the guard against another writer landing between the push and the pull request, which is a different fact about a different thing.

This touches no source and needs no canonical rebuild, which is why it lands on its own.