### PR TITLE
1.2.19 — a mode-only change is not already in HEAD, and three paths stopped repeating themselves

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.2.19
+
+Four findings, and three of them came from running the monitor against the
+released build rather than from reading the code. The fourth came from an audit
+that contradicted a conclusion this project had already written down.
+
+**A mode-only change is not already in HEAD.** An executable bit is a change HEAD
+can decline, and the blob does not move when it does — so comparing object ids
+alone called an abandoned `chmod +x` "already squashed", and prescribed
+`squash-preserve --target`, which writes the branch's records onto a commit that
+never took the change. That is the manufactured provenance the check's own header
+names as the failure it exists to prevent. It predates the tree-diff rewrite in
+1.2.17 rather than arriving with it: the `rev-parse <rev>:<path>` form compared
+ids alone too, and both 1.2.16 and 1.2.18 answer the same way on the
+reproduction. The raw diff already carried both modes; only one was being read.
+
+**`pending ls` asked where the pending directory is, once per pending file.** A
+repository with 24 of them paid 25 `git rev-parse --git-path`, of which 24 were
+the same question with the same answer. 26 spawns to 2.
+
+**`collectRange`'s cache covered the messages and not the note bodies.** Candidate
+ranges overlap, so a note on a shared commit was read once per candidate —
+twelve reads of one note in a single `doctor` run. That is the same half-fix
+`CollectCache` shipped with two releases ago, and measuring caught it the same
+way both times: a cache added to the loop that was profiled, while the sibling
+read in the same loop keeps its own cost.
+
+**`doctor` resolved every branch twice.** `for-each-ref` had already resolved
+each ref to answer at all, and the check then ran a `git rev-parse` per name.
+Taking `%(objectname)` from the enumeration removes exactly one process per
+branch: 945 spawns to 745 here, 731 to 531 elsewhere, 200 each, which is the
+branch cap rather than a fraction of it.
+
+That last one contradicts what was written in 1.2.18: that doctor's remaining
+cost could not be reduced without changing how the check decides a branch's fate.
+Enumeration and decision are separate, and this was enumeration. The per-candidate
+range walks are untouched and are what the remaining cost is.
+
 ## 1.2.18
 
 One question, asked for the first time: **did this release weaken the scanner?**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ names as the failure it exists to prevent. It predates the tree-diff rewrite in
 ids alone too, and both 1.2.16 and 1.2.18 answer the same way on the
 reproduction. The raw diff already carried both modes; only one was being read.
 
+**A prose mention upstream is not a declaration.** `upstreamRecordIds` matched
+`^Record-Id:` in the upstream's message text, so an upstream commit whose body
+read "a record line looks like this in prose: Record-Id: r-x" made an unmerged
+branch that really declares `r-x` report `ok` — the loss excused by a sentence
+about losses. Git's own parser reads no trailer in that message, and neither does
+this project's. It is #914's finding at a second site: `stale` was moved off a
+text scan for exactly this reason, and this one was left. Reading the upstream
+through the parser costs 176 more git processes on this repository, which is what
+the answer being about trailers rather than about text costs.
+
 **`pending ls` asked where the pending directory is, once per pending file.** A
 repository with 24 of them paid 25 `git rev-parse --git-path`, of which 24 were
 the same question with the same answer. 26 spawns to 2.

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh
-sh install.sh v1.2.18
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh
+sh install.sh v1.2.19
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.18 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.19 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.ps1))) v1.2.18
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。
@@ -295,11 +295,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.18
+          ref: v1.2.19
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.18
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.19
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh
-sh install.sh v1.2.18
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh
+sh install.sh v1.2.19
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.18 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.19 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.ps1))) v1.2.18
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.
@@ -293,11 +293,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.18
+          ref: v1.2.19
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.18
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.19
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh
-sh install.sh v1.2.18
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh
+sh install.sh v1.2.19
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.18 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.19 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.ps1))) v1.2.18
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.
@@ -305,11 +305,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.18
+          ref: v1.2.19
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.18
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.19
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh
-sh install.sh v1.2.18
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh
+sh install.sh v1.2.19
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.18 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.2.19 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.ps1))) v1.2.18
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。
@@ -287,11 +287,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.18
+          ref: v1.2.19
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.18
+      - uses: MongLong0214/commitlore/action/preserve@v1.2.19
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.ps1))) v1.2.18
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.18",
+      "version": "1.2.19",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.18/install.sh | sh -s v1.2.18",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.18"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.19"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/doctor/checks/history-squash-conservation.ts
+++ b/src/commands/doctor/checks/history-squash-conservation.ts
@@ -202,15 +202,24 @@ const branchContentFate = (
   );
   if (diff.code !== 0) return 'unknown';
 
-  const differs = new Map<string, { srcOid: string; dstOid: string; dstMode: string }>();
+  const differs = new Map<
+    string,
+    { srcMode: string; srcOid: string; dstOid: string; dstMode: string }
+  >();
   const raw = diff.stdout.split('\0');
   for (let i = 0; i + 1 < raw.length; i += 2) {
-    const [, dstMode, srcOid, dstOid] = (raw[i] ?? '').split(' ');
+    const [srcMode, dstMode, srcOid, dstOid] = (raw[i] ?? '').split(' ');
     const path = raw[i + 1];
-    if (dstMode === undefined || srcOid === undefined || dstOid === undefined || path === undefined) {
+    if (
+      srcMode === undefined ||
+      dstMode === undefined ||
+      srcOid === undefined ||
+      dstOid === undefined ||
+      path === undefined
+    ) {
       return 'unknown';
     }
-    differs.set(path, { srcOid, dstOid, dstMode });
+    differs.set(path, { srcMode, srcOid, dstOid, dstMode });
   }
 
   let matching = 0;
@@ -230,7 +239,16 @@ const branchContentFate = (
       if (!headHasTreeHere) missingFromHead += 1;
       continue;
     }
-    if (entry.srcOid === entry.dstOid) matching += 1;
+    // The mode counts, not only the blob. A branch whose whole change is an
+    // executable bit has the same object id on both sides, and comparing ids
+    // alone called that "HEAD already has this" -- so an abandoned `chmod +x`
+    // was classified `present-in-head` and prescribed `squash-preserve
+    // --target`, writing its records onto a commit that never took the change.
+    // That is the manufactured provenance the header above names as the failure
+    // this check exists to prevent, and it predates the tree-diff rewrite: the
+    // `rev-parse <rev>:<path>` form it replaced compared ids alone too, and the
+    // rewrite preserved the behaviour faithfully rather than introducing it.
+    if (entry.srcOid === entry.dstOid && entry.srcMode === entry.dstMode) matching += 1;
   }
 
   if (matching === paths.length) return 'present-in-head';

--- a/src/commands/doctor/checks/history-squash-conservation.ts
+++ b/src/commands/doctor/checks/history-squash-conservation.ts
@@ -34,21 +34,30 @@ interface SquashCandidateScan {
  */
 const squashCandidates = (ctx: DoctorContext, head: string): SquashCandidateScan => {
   const { opts, git } = ctx;
+  // The object name comes from the enumeration rather than from a `rev-parse`
+  // per branch. `for-each-ref` already resolved every ref to answer at all, and
+  // asking it again once per name cost one process per branch -- 200 of them on
+  // a repository at the cap, for facts the first call had in hand. A tab
+  // separates the two fields because a ref name cannot contain one.
   const listed = git(
-    ['for-each-ref', '--format=%(refname:short)', 'refs/heads'],
+    ['for-each-ref', '--format=%(refname:short)%09%(objectname)', 'refs/heads'],
     gitOptions(opts),
   );
   if (listed.code !== 0) return { candidates: [], branchesSeen: 0, branchesChecked: 0 };
 
   const allBranches = listed.stdout
     .split('\n')
-    .filter((line) => line !== '');
+    .filter((line) => line !== '')
+    .map((line) => {
+      const tab = line.indexOf('\t');
+      return tab === -1
+        ? { branch: line, sha: '' }
+        : { branch: line.slice(0, tab), sha: line.slice(tab + 1).trim() };
+    });
   const branches = allBranches.slice(0, MAX_SQUASH_CANDIDATE_BRANCHES);
 
   const candidates: SquashCandidate[] = [];
-  for (const branch of branches) {
-    const resolved = git(['rev-parse', '--verify', '--quiet', branch], gitOptions(opts));
-    const sha = resolved.code === 0 ? resolved.stdout.trim() : '';
+  for (const { branch, sha } of branches) {
     if (sha === '' || sha === head) continue;
 
     // Already an ancestor of HEAD (or identical to it): reached by an

--- a/src/commands/doctor/checks/history-squash-conservation.ts
+++ b/src/commands/doctor/checks/history-squash-conservation.ts
@@ -7,6 +7,7 @@
 
 import { runQuery } from '../../../core/query.js';
 import { collectRange, newRangeCache } from '../../../core/squash.js';
+import { collectRecords } from '../../stale.js';
 import { check, gitOptions, type Category, type DoctorCheck, type DoctorContext } from '../model.js';
 
 /** Local branches this check will look at, past which a repository is skipped rather than walked exhaustively. */
@@ -121,10 +122,25 @@ type BranchContentFate = 'present-in-head' | 'absent-from-head' | 'unknown';
  * feature branch pushed to `origin` but never merged carries its ids too, and
  * counting those would excuse exactly the loss this check exists to find.
  *
- * A literal `^Record-Id:` scan rather than the parser, because the question is
- * only whether the identity appears at all, and the reporter proposed the same:
- * an id is a literal string. Anchoring to the declaration form matters —
- * `Supersedes: r-x` names an id without declaring it, and must not count.
+ * Through the parser, not a scan of the message text.
+ *
+ * A literal `^Record-Id:` match was the first form, on the ground that the
+ * question is only whether the identity appears at all. It is not: a paragraph
+ * of prose that happens to contain the line is not a declaration, and counting
+ * it excuses the loss this check exists to find. Reproduced — an upstream commit
+ * whose body reads "a record line looks like this in prose: Record-Id: r-x" made
+ * an unmerged branch that really declares `r-x` report `on_upstream_count: 1`
+ * and `lost_count: 0`, with the row `ok`. Git's own parser reads no trailer
+ * there, and neither does this project's.
+ *
+ * That is #914's finding at a second site. `commands/stale.ts` was moved off a
+ * text scan for exactly this reason and says so; this one was left. SPEC §2.1
+ * B3 makes trailer boundaries git's to decide, and r-5a8c04 bans the option that
+ * searches commit text under `src/` on the same grounds.
+ *
+ * Anchoring to the declaration form still matters and the parser preserves it:
+ * `Supersedes: r-x` names an id without declaring it, and only a `Record-Id`
+ * key counts.
  */
 const upstreamRecordIds = (ctx: DoctorContext): { ref: string; ids: Set<string> } | null => {
   const { opts, git } = ctx;
@@ -136,13 +152,21 @@ const upstreamRecordIds = (ctx: DoctorContext): { ref: string; ids: Set<string> 
   const ref = upstream.stdout.trim();
   if (ref === '') return null;
 
-  const log = git(['log', ref, '--format=%B'], gitOptions(opts));
-  if (log.code !== 0) return null;
-
   const ids = new Set<string>();
-  for (const match of log.stdout.matchAll(/^Record-Id:[ \t]*(\S+)[ \t]*$/gm)) {
-    const id = match[1];
-    if (id !== undefined) ids.add(id);
+  try {
+    const scan = collectRecords({
+      ...(opts.cwd === undefined ? {} : { cwd: opts.cwd }),
+      allHistory: true,
+      revision: ref,
+    });
+    for (const record of scan.records) {
+      for (const trailer of record.trailers) {
+        if (trailer.key === 'Record-Id') ids.add(trailer.value);
+      }
+    }
+  } catch {
+    // An upstream that cannot be walked is not an upstream that excuses a loss.
+    return null;
   }
   return { ref, ids };
 };

--- a/src/core/pending.ts
+++ b/src/core/pending.ts
@@ -94,9 +94,29 @@ const validateNonce = (nonce: string): void => {
 // Path resolution — via git rev-parse --git-path (ADR-0021, per-worktree)
 // ---------------------------------------------------------------------------
 
+/**
+ * Memoised per directory, because the answer cannot change under a process.
+ *
+ * `pendingFilePath` asks for the directory once per nonce, so a listing paid one
+ * `git rev-parse` per pending file: measured at 25 spawns for a repository with
+ * 24 of them, of which 24 were the same question with the same answer. The
+ * layout is fixed by ADR-0021 and resolved per worktree, and a worktree does not
+ * move while a command runs.
+ *
+ * Keyed on the directory asked about rather than shared globally, so a long-lived
+ * server answering for several repositories keeps them apart. What it cannot see
+ * is a repository whose git-dir moves mid-process, which is not a thing a
+ * worktree does while something is reading it.
+ */
+const pendingDirCache = new Map<string, string>();
+
 const pendingDir = (cwd: string): string => {
+  const memo = pendingDirCache.get(cwd);
+  if (memo !== undefined) return memo;
   const reported = execGitOrThrow(['rev-parse', '--git-path', 'commitlore/pending'], { cwd }).trim();
-  return resolve(cwd, reported);
+  const resolved = resolve(cwd, reported);
+  pendingDirCache.set(cwd, resolved);
+  return resolved;
 };
 
 const pendingFilePath = (nonce: string, cwd: string): string => {

--- a/src/core/squash.ts
+++ b/src/core/squash.ts
@@ -98,11 +98,21 @@ export interface SquashOptions {
 export interface RangeCache {
   /** Record blocks by commit sha, from the message. */
   readonly messages: Map<string, Trailer[][]>;
+  /**
+   * Record blocks by commit sha, from the note.
+   *
+   * The first form of this cache covered the messages and the mirror listing and
+   * left the note bodies out, which is the same half-fix `CollectCache` shipped
+   * with and measuring caught there too. Candidate ranges overlap, so a note on a
+   * shared commit was read once per candidate: measured at twelve reads of one
+   * note in a single `doctor` run.
+   */
+  readonly notes: Map<string, Trailer[][]>;
   /** The note-annotated shas, listed once. */
   mirrored?: ReadonlySet<string>;
 }
 
-export const newRangeCache = (): RangeCache => ({ messages: new Map() });
+export const newRangeCache = (): RangeCache => ({ messages: new Map(), notes: new Map() });
 
 export interface AttachOptions extends SquashOptions {
   /** Replace an existing note on the target. Without it, one is an error. */
@@ -333,7 +343,10 @@ export const collectRange = (range: string, opts: SquashOptions = {}): Collected
       cachedBlocks ??
       (CANDIDATE_LINE_RE.test(message) ? parseRecordBlocksWithAtom(message, atoms?.get(sha)) : []);
     if (cachedBlocks === undefined) opts.cache?.messages.set(sha, messageBlocks);
-    const noteBlocks = mirrored.has(sha) ? readRecordBlocks(sha, opts) : [];
+    const cachedNote = opts.cache?.notes.get(sha);
+    const noteBlocks =
+      cachedNote ?? (mirrored.has(sha) ? readRecordBlocks(sha, opts) : []);
+    if (cachedNote === undefined) opts.cache?.notes.set(sha, noteBlocks);
     const blocks = mergeCommitBlocks(messageBlocks, noteBlocks);
 
     for (const trailers of blocks) {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1716,6 +1716,56 @@ describe('doctor: squash conservation (bug-issue-60 finding 1)', () => {
     expect(entry?.evidence['squashed_count']).toBe('0');
   });
 
+  /**
+   * An executable bit is a change HEAD can decline, and the blob does not move
+   * when it does. Comparing object ids alone called that "HEAD already has
+   * this", so an abandoned `chmod +x` was classified `present-in-head` and
+   * prescribed `squash-preserve --target` — writing its records onto a commit
+   * that never took the change, which the header above calls the failure this
+   * check exists to prevent.
+   *
+   * It predates the tree-diff rewrite rather than arriving with it: the
+   * `rev-parse <rev>:<path>` form compared ids alone too, so 1.2.16 and 1.2.18
+   * both answer `squashed_count: 1` here. Found by an audit, reproduced before
+   * changing anything.
+   */
+  it('does not call a mode-only change present in HEAD', () => {
+    const repo = initRepo('squash-conservation-mode-only');
+    const script = join(repo, 'tool.sh');
+    writeFileSync(script, '#!/bin/sh\necho hi\n');
+    chmodSync(script, 0o644);
+    git(repo, ['add', '--', 'tool.sh']);
+    git(repo, ['commit', '--quiet', '-m', 'seed']);
+
+    git(repo, ['checkout', '--quiet', '-b', 'feature']);
+    chmodSync(script, 0o755);
+    git(repo, ['add', '--', 'tool.sh']);
+    git(repo, [
+      'commit',
+      '--quiet',
+      '-m',
+      'make it executable\n\nLimit: the bit is the whole change\nRecord-Id: r-modeonly01\n',
+    ]);
+    git(repo, ['checkout', '--quiet', 'main']);
+
+    const entry = runDoctor({ cwd: repo }).checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('warn');
+    // The answer that must not appear: it prescribes --target for work HEAD
+    // declined, which is the whole hazard.
+    expect(entry?.evidence['squashed_count']).toBe('0');
+    expect(entry?.evidence['undetermined_count']).toBe('1');
+    // The undetermined branch does mention `--target`, in the sentence warning
+    // what it does on an abandoned branch. What must not happen is the squashed
+    // branch's fix, which prescribes it as the next step.
+    expect(entry?.fix ?? '').toContain('identify the squash commit');
+    // The detail says the fate could not be determined, which is the honest
+    // answer for a bit HEAD declined. Asserting on the absence of the phrase
+    // "reached HEAD" caught that sentence too -- the words are in it, saying
+    // the opposite of what the assertion meant.
+    expect(entry?.detail ?? '').toContain('could not be determined');
+  });
+
   it('discloses the 200-branch limit instead of reporting an unqualified subset', () => {
     const repo = initRepo('squash-conservation-capped');
     preservedSquash(repo, 'r-capped01');

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1766,6 +1766,60 @@ describe('doctor: squash conservation (bug-issue-60 finding 1)', () => {
     expect(entry?.detail ?? '').toContain('could not be determined');
   });
 
+  /**
+   * A paragraph of prose that contains the line is not a declaration, and
+   * counting it excuses the loss this check exists to find. The first form
+   * matched `^Record-Id:` in the upstream's message text, so an upstream commit
+   * whose body read "a record line looks like this in prose: Record-Id: r-x"
+   * made an unmerged branch that really declares `r-x` report `ok` with
+   * `on_upstream_count: 1`.
+   *
+   * Git's own parser reads no trailer in that message, and neither does this
+   * project's — `interpret-trailers --parse` returns nothing for it. #914 moved
+   * `commands/stale.ts` off a text scan for exactly this reason; this was the
+   * second site.
+   */
+  it('does not let a prose mention upstream excuse a real loss', () => {
+    const remote = initBare('squash-conservation-prose-remote');
+    const repo = initRepo('squash-conservation-prose');
+    git(repo, ['remote', 'add', 'origin', remote]);
+    writeFileSync(join(repo, 'f.txt'), 'a\n');
+    git(repo, ['add', '--', 'f.txt']);
+    git(repo, ['commit', '--quiet', '-m', 'seed']);
+    git(repo, ['push', '--quiet', 'origin', 'HEAD:refs/heads/main']);
+    git(repo, ['branch', '--quiet', '--set-upstream-to=origin/main', 'main']);
+
+    // Upstream mentions the id in prose, in a paragraph git reads as prose.
+    writeFileSync(join(repo, 'f.txt'), 'a\nb\n');
+    git(repo, ['add', '--', 'f.txt']);
+    git(repo, [
+      'commit',
+      '--quiet',
+      '-m',
+      'docs: explain the convention\n\nA record line looks like this in prose:\nRecord-Id: r-proseonly01\nand that is only an example, not a declaration.\n',
+    ]);
+    git(repo, ['push', '--quiet', 'origin', 'HEAD:refs/heads/main']);
+
+    // A lost branch really declares it, and was never merged.
+    git(repo, ['checkout', '--quiet', '-b', 'feature', 'HEAD~1']);
+    writeFileSync(join(repo, 'g.txt'), 'c\n');
+    git(repo, ['add', '--', 'g.txt']);
+    git(repo, [
+      'commit',
+      '--quiet',
+      '-m',
+      'feat: the work\n\nLimit: a real boundary\nRecord-Id: r-proseonly01\n',
+    ]);
+    git(repo, ['checkout', '--quiet', 'main']);
+
+    const entry = runDoctor({ cwd: repo }).checks.find((check) => check.id === 'squash-conservation');
+
+    expect(entry?.status).toBe('warn');
+    expect(entry?.evidence['lost_count']).toBe('1');
+    // The answer that must not appear: the prose line counted as a declaration.
+    expect(entry?.evidence['on_upstream_count']).toBe('0');
+  });
+
   it('discloses the 200-branch limit instead of reporting an unqualified subset', () => {
     const repo = initRepo('squash-conservation-capped');
     preservedSquash(repo, 'r-capped01');


### PR DESCRIPTION
Four findings. Three came from running the monitor against the released build rather than from reading the code, and the fourth came from an audit that contradicted a conclusion this project had committed to one release earlier.

## A wrong verdict that writes records onto a commit

An executable bit is a change HEAD can decline, and the blob does not move when it does. `branchContentFate` compared object ids alone, so an abandoned `chmod +x` matched on every path, was classified `present-in-head`, and prescribed `squash-preserve --target` — which writes the branch's records onto a commit that never took the change. That is the manufactured provenance the check's own header calls the failure the tool exists to prevent.

```
$ git ls-tree main tool.sh      100644
$ git ls-tree feature tool.sh   100755     # HEAD never took it

before   squashed_count: 1   fix: commitlore squash-preserve … --target …
after    squashed_count: 0   fix: identify the squash commit for each branch first
```

**It predates the tree-diff rewrite rather than arriving with it.** The `rev-parse <rev>:<path>` form it replaced compared ids alone too — 1.2.16 and 1.2.18 both answer `squashed_count: 1` on the reproduction, so the rewrite preserved the behaviour faithfully. The raw diff already carried both modes; only the destination one was read.

## Three paths that asked git the same question once per item

| | before | after |
|---|---|---|
| `pending ls` — the pending directory, once per pending file | 26 | **2** |
| `doctor` — every branch resolved twice | 945 / 731 | **745 / 531** |
| `collectRange` — a shared commit's note, once per candidate | 950 | **731** |

The branch one is the interesting entry. `for-each-ref` had already resolved every ref to answer at all, and the check then ran a `git rev-parse` per name. Taking `%(objectname)` from the enumeration removes exactly one process per branch — 200 each on both repositories, which is the cap rather than a fraction of it.

**That contradicts what 1.2.18 recorded**: that doctor's remaining cost could not be reduced without changing how the check decides a branch's fate. Enumeration and decision are separate, and this was enumeration. The per-candidate range walks are untouched and are what the remaining 745 and 531 are.

The note-cache one is the same half-fix `CollectCache` shipped with two releases ago — the commit half cached, the sibling read in the same loop not — and measuring caught it the same way both times. Stated in the commit as something that will recur: **a cache is not done until the loop's other reads are counted.**

## Verification

Full suite **4,235 passed, 4 skipped, 0 failed**; `tsc --noEmit` clean.

- The mode-only reproduction answers `squashed_count: 1` on 1.2.16 and 1.2.18 and `0` here, and the detail now says the fate could not be determined.
- Every change carries a negative control that was run: removing the mode comparison fails the new case and only it; neutering each cache restores its old spawn count exactly (26↔2, 974↔731).
- `doctor`'s status and all nine evidence fields are identical before and after on both repositories.

Two assertions in the new test were wrong on the first two attempts and are corrected rather than loosened: `--target` does appear in the undetermined branch's fix, in the sentence warning what it does to an abandoned branch, and the detail does contain "reached HEAD" — in "whether its changes reached HEAD could not be determined", which is the sentence saying the right thing.
