### PR TITLE
Let a budgeted scan carry on from where it stopped (#951 item 3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.2.19",
+  "version": "1.3.0",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.2.19",
+  "version": "1.3.0",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,67 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.3.0
+
+A scan that ran out of budget stopped, and then never started again. Everything
+below follows from that one thing, and from an external review that reproduced
+four ways the first fix for it would still have lost work.
+
+**A budgeted scan now carries on from where it stopped.** A truncated scan used
+to persist one number — how many commits it had left unread — and a number
+cannot be resumed from. Measured on a 1544-commit repository against an injected
+clock: the first budgeted call read 448 commits, and seven further budgeted
+calls read none. The index stayed 29% built until somebody ran `commitlore
+init`, which is the one command the situation exists to avoid needing. The
+unread work is now recorded as the work itself, in a `scan_pending` table, and a
+later budgeted call drains it. Four calls take that repository to a complete
+index whose rows are identical, one for one, to a single unbudgeted rebuild.
+
+**A slice per call, not the whole budget.** Finishing the index is not what the
+caller asked for; answering is. Spending the rest of the budget on the backlog
+converged in four calls and made every one of them cost three seconds — an edit
+hook that used to return in milliseconds paying full price on every fire. The
+drain takes a quarter of the ceiling, so the backlog still empties and each call
+stays close to what it cost before.
+
+**The unread count added commits to notes.** One `meta.unread_commits` held
+both, so draining either source could report the other complete. They are
+counted separately now, and `doctor` reports each.
+
+**A truncated notes pass claimed the mirror was indexed.** The rebuild stamped
+`notes_ref_sha` whether or not the notes were all read, and `indexNotes` returns
+immediately when that stamp matches — so the notes left over were never read
+again. Eleven of this repository's own notes were being dropped permanently
+while the stamp said otherwise. The stamp is now written only for a pass that
+finished, and outstanding notes carry the mirror they were listed from: draining
+a queue listed from an older mirror can no longer certify a newer one.
+
+**The walk enumerated a name it had already resolved.** `rebuildIndex` read
+`HEAD` with one git process and then walked `HEAD` with another, so a checkout
+landing between them attached the walk — and `last_indexed_sha` — to a history
+it never read. It walks the resolved object now.
+
+**A budgeted incremental had the same defect the scan had.** New commits beyond
+the ceiling were read, discarded, and left out of both the index and the unread
+count: reproduced at 130 new commits against a budget reaching 64, where three
+successive calls made no progress, all 130 were missing, and the index reported
+nothing owed. What the ceiling cuts off now joins the queue.
+
+**A queued entry is retired by identity, not by position.** A drainer selects
+its rows and then reads git holding no transaction, and a rebuild can replace
+the queue inside that window. Deleting on position alone retired whatever had
+moved into that slot — work nobody had done — and the index then called itself
+complete with a record permanently absent.
+
+**`doctor` called an index current that was missing history.** `index-health`
+compared `last_indexed_sha` against HEAD, and a budgeted scan stamps that equal
+the moment it starts, outstanding work or not. It reads what is outstanding now,
+and warns.
+
+**The index schema is v5.** A v4 index left partial by an earlier release has no
+position to carry forward, so it is rebuilt once on first use — which is the
+existing mechanism for exactly this, and costs one rebuild.
+
 ## 1.2.19
 
 Four findings, and three of them came from running the monitor against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ were not written here.
 ## 1.3.0
 
 A scan that ran out of budget stopped, and then never started again. Everything
-below follows from that one thing, and from an external review that reproduced
-four ways the first fix for it would still have lost work.
+below follows from that one thing, and from two rounds of external review that
+reproduced, between them, eight ways the fix for it would still have lost work.
 
 **A budgeted scan now carries on from where it stopped.** A truncated scan used
 to persist one number — how many commits it had left unread — and a number
@@ -55,6 +55,30 @@ its rows and then reads git holding no transaction, and a rebuild can replace
 the queue inside that window. Deleting on position alone retired whatever had
 moved into that slot — work nobody had done — and the index then called itself
 complete with a record permanently absent.
+
+**A note's identity is its commit, and its commit does not change when it
+does.** Retiring queued notes by sha therefore could not tell one version of a
+mirror's work from another: a drainer reading 64 notes from one version while
+another process re-listed the queue against the next retired the new queue's
+entries with the old version's content, leaving 64 old notes, 66 new ones and
+nothing outstanding. The mirror is checked again inside the write, and a queue
+that moved underneath is refused rather than retired.
+
+**A mirror that disappears takes its rows with it.** A truncated notes pass
+leaves both rows and a queue, belonging to one mirror. Dropping only the queue
+left an indexed prefix nothing pointed at, with `notes_ref_sha` and the live ref
+both unset — so `indexNotes` returned at its first line and those notes were
+served for good.
+
+**The one-batch floor is spent once per call, not once per source.** Giving it
+to both readers let a call with an already-spent budget read a full commit batch
+and then a full notes batch, twice what the floor is supposed to cost.
+
+**An unborn HEAD kept what it could no longer reach.** Switching to an orphan
+branch returns from `updateIndex` before either pending path, so the previous
+branch's rows and its whole backlog survived — the orphan served records from a
+history it does not contain, and three calls later still owed 130 commits
+against it. Everything derived is cleared with the history it came from.
 
 **`doctor` called an index current that was missing history.** `index-health`
 compared `last_indexed_sha` against HEAD, and a budgeted scan stamps that equal

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh
-sh install.sh v1.2.19
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh
+sh install.sh v1.3.0
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.2.19 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.3.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。
@@ -295,11 +295,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.19
+          ref: v1.3.0
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.19
+      - uses: MongLong0214/commitlore/action/preserve@v1.3.0
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh
-sh install.sh v1.2.19
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh
+sh install.sh v1.3.0
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.2.19 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.3.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.
@@ -293,11 +293,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.19
+          ref: v1.3.0
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.19
+      - uses: MongLong0214/commitlore/action/preserve@v1.3.0
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh
-sh install.sh v1.2.19
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh
+sh install.sh v1.3.0
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.2.19 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.3.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.
@@ -305,11 +305,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.19
+          ref: v1.3.0
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.19
+      - uses: MongLong0214/commitlore/action/preserve@v1.3.0
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh
-sh install.sh v1.2.19
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh
+sh install.sh v1.3.0
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.2.19 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.3.0 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。
@@ -287,11 +287,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.2.19
+          ref: v1.3.0
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.2.19
+      - uses: MongLong0214/commitlore/action/preserve@v1.3.0
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.ps1))) v1.2.19
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.2.19",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.2.19",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "commitlore",
-  "version": "1.2.19",
+  "version": "1.3.0",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,
   "commitlore": {
-    "indexSchemaVersion": 4
+    "indexSchemaVersion": 5
   },
   "type": "module",
   "files": [

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.2.19",
+  "version": "1.3.0",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.2.19/install.sh | sh -s v1.2.19",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.2.19"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.3.0"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/commands/doctor/checks/index-index-health.ts
+++ b/src/commands/doctor/checks/index-index-health.ts
@@ -40,34 +40,55 @@ export const checkIndex = (ctx: DoctorContext): DoctorCheck => {
     const head = git(['rev-parse', 'HEAD'], gitOptions(opts));
     const behind = head.code === 0 && info.lastIndexedSha !== head.stdout.trim();
     const fts = info.fts ? 'FTS5' : 'no FTS5 (value search falls back to LIKE)';
+    // A budgeted scan stamps `last_indexed_sha = HEAD` whether or not it read
+    // everything, so the HEAD comparison alone says "current" over an index
+    // that is still missing history. Reporting that as `ok` made this check
+    // agree with the one number it read and disagree with what the index holds.
+    const outstanding = info.unread.commits + info.unread.notes;
     const indexEvidence = {
       trailers: String(info.trailers),
       commits: String(info.commits),
       last_indexed_sha: info.lastIndexedSha || 'none',
       head_sha: head.code === 0 ? head.stdout.trim() || 'none' : 'unavailable',
       fts: info.fts ? 'true' : 'false',
+      unread_commits: String(info.unread.commits),
+      unread_notes: String(info.unread.notes),
     };
-    return behind
-      ? check(
-          'index-health', 'index',
-          'index health',
-          'warn',
-          `${info.trailers} trailers over ${info.commits} commits, behind HEAD — ${fts}`,
-          'commitlore index',
-          false,
-          undefined,
-          { evidence: indexEvidence },
-        )
-      : check(
-          'index-health', 'index',
-          'index health',
-          'ok',
-          `${info.trailers} trailers over ${info.commits} commits, current with HEAD — ${fts}`,
-          null,
-          false,
-          undefined,
-          { evidence: indexEvidence },
-        );
+    if (behind) {
+      return check(
+        'index-health', 'index',
+        'index health',
+        'warn',
+        `${info.trailers} trailers over ${info.commits} commits, behind HEAD — ${fts}`,
+        'commitlore index',
+        false,
+        undefined,
+        { evidence: indexEvidence },
+      );
+    }
+    if (outstanding > 0) {
+      return check(
+        'index-health', 'index',
+        'index health',
+        'warn',
+        `${info.trailers} trailers over ${info.commits} commits, current with HEAD but ` +
+          `${outstanding} still unread from a budgeted scan — ${fts}`,
+        'commitlore index',
+        false,
+        undefined,
+        { evidence: indexEvidence },
+      );
+    }
+    return check(
+      'index-health', 'index',
+      'index health',
+      'ok',
+      `${info.trailers} trailers over ${info.commits} commits, current with HEAD — ${fts}`,
+      null,
+      false,
+      undefined,
+      { evidence: indexEvidence },
+    );
   } catch (error) {
     return check(
       'index-health', 'index',

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -1910,12 +1910,19 @@ const drainPending = (
     ...(outer.now === undefined ? {} : { now: outer.now }),
   };
 
+  // The floor is one batch for the whole drain, not one per source. Passing it
+  // to both readers let a call with an already-spent budget read a full commit
+  // batch and then a full notes batch, which is twice the overshoot the floor is
+  // supposed to cost.
+  let floorSpent = false;
+
   const commits = pendingEntries(handle.db, 'commit');
   if (commits.length > 0) {
     const cost: ScanCost = { unreadCommits: 0, unreadNotes: 0 };
     const shas = commits.map((entry) => entry.sha);
     const records = readCommitRecords(handle.cwd, shas, excluded, budget, cost, true);
     const read = shas.length - cost.unreadCommits;
+    floorSpent = read > 0;
     if (read > 0) {
       runInTransaction(handle.db, () => {
         const counts = insertRecords(handle, records, { repeatable: true });
@@ -1948,33 +1955,55 @@ const drainPending = (
   const currentRef = revParseRef(handle.cwd, NOTES_REF);
   if (listedFrom === null || listedFrom !== currentRef) {
     runInTransaction(handle.db, () => {
+      // The rows already written came from the mirror the queue named, so they
+      // go with it. Keeping them and dropping only the queue leaves an
+      // indexed prefix of a mirror nothing points at any more, and nothing
+      // outstanding to correct it: reproduced by deleting the mirror with 64
+      // notes indexed and 66 queued, after which `refSha` and `notes_ref_sha`
+      // are both null, `indexNotes` returns at its first line, and those 64
+      // obsolete notes are served for good.
+      deleteNoteRows(handle);
       writePending(handle.db, 'notes', []);
       writeMeta(handle.db, NOTES_PENDING_REF_META, null);
+      // Left unset rather than stamped: when a mirror still exists `indexNotes`
+      // must re-read it whole, and when it does not, an empty table stamped
+      // null is the true answer.
+      writeMeta(handle.db, 'notes_ref_sha', null);
     });
     return;
   }
 
   const cost: ScanCost = { unreadCommits: 0, unreadNotes: 0 };
   const shas = notes.map((entry) => entry.sha);
-  const records = readNotesFor(handle.cwd, shas, excluded, budget, cost, true);
+  const records = readNotesFor(handle.cwd, shas, excluded, budget, cost, !floorSpent);
   const read = shas.length - cost.unreadNotes;
   if (read === 0) return;
 
-  runInTransaction(handle.db, () => {
+  const applied = runInTransaction(handle.db, () => {
+    // The mirror is checked again here, inside the write, and this is not
+    // belt-and-braces. An annotated commit's sha is the same object whichever
+    // version of its note the mirror holds, so the sha-qualified retirement
+    // cannot tell one from the other: reproduced as a drainer reading 64 notes
+    // from v1 while another process re-listed the queue against v2, then
+    // retiring v2's entries with v1's content and leaving the index holding 64
+    // old notes, 66 new ones, and nothing outstanding.
+    if (readMeta(handle.db, NOTES_PENDING_REF_META) !== listedFrom) return false;
+
     const counts = insertRecords(handle, records, { repeatable: true });
     stats.noteTrailersIndexed += counts.trailers;
     stats.pathsIndexed += counts.paths;
     const done = handle.db.prepare(PENDING_DONE_SQL);
     for (const entry of notes.slice(0, read)) done.run('notes', entry.ord, entry.sha);
     // Stamped with the mirror the queue was listed from, never with whatever the
-    // ref points at now. The two are equal here only because the guard above
+    // ref points at now. The two are equal here only because both guards above
     // already refused the case where they are not.
     if (pendingCount(handle.db, 'notes') === 0) {
       writeMeta(handle.db, 'notes_ref_sha', listedFrom);
       writeMeta(handle.db, NOTES_PENDING_REF_META, null);
     }
+    return true;
   });
-  stats.notesScanned += read;
+  if (applied) stats.notesScanned += read;
 };
 
 /**
@@ -2041,7 +2070,22 @@ export const updateIndex = (
   if (head === null) {
     /* An empty repository is not an error; it is a repository with no records. */
     const stats = emptyStats(handle, started);
-    writeMeta(handle.db, 'last_indexed_sha', null);
+    // Everything derived goes with the history it was derived from. An unborn
+    // HEAD reaches no commit, so every row here describes a history this
+    // repository no longer has -- and the queue describes work against it.
+    // Leaving them made an orphan branch serve the old branch's records and
+    // hold its backlog for ever: reproduced as three calls reading nothing and
+    // retaining all 130 queued commits, because this branch returns before
+    // either pending path is reached.
+    runInTransaction(handle.db, () => {
+      if (handle.fts) handle.db.exec('DELETE FROM trailers_fts');
+      handle.db.exec('DELETE FROM trailers');
+      handle.db.exec('DELETE FROM commit_paths');
+      handle.db.exec('DELETE FROM scan_pending');
+      writeMeta(handle.db, NOTES_PENDING_REF_META, null);
+      writeMeta(handle.db, 'notes_ref_sha', null);
+      writeMeta(handle.db, 'last_indexed_sha', null);
+    });
     stats.noteTrailersIndexed = indexNotes(handle, {}, excluded);
     applyExclusions(stats, excluded);
     stats.elapsedMs = Date.now() - started;

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -152,10 +152,29 @@ export type IndexDatabase = DatabaseSync;
  * in the same batched pass as its trailers. Signature verification is an
  * opt-in grading condition, so serving a v3 row without this fact could
  * incorrectly promote a record after a repository enables that mode.
+ *
+ * v5 adds `scan_pending` and changes what `meta.unread_commits` meant. A v4
+ * index recorded how many commits a truncated scan left but not WHICH, and a
+ * count cannot be resumed from: measured on a 1544-commit repository, the first
+ * budgeted call read 448 commits and seven further budgeted calls read none.
+ * The count also conflated commits with notes, so draining one source could
+ * report the other complete. A v4 index left partial therefore has no position
+ * to carry forward, and the version gate rebuilding it is that restart path.
  */
-export const SCHEMA_VERSION = 4;
+export const SCHEMA_VERSION = 5;
 
 export const NOTES_REF = 'refs/notes/commitlore';
+
+/**
+ * How much of a budgeted call may go into finishing a previous truncated scan.
+ *
+ * A quarter of `CONSUMER_SCAN_BUDGET_MS`, and the fraction is the point: the
+ * caller is a query, not a rebuild, and the backlog is drained opportunistically
+ * out of what the answer did not need. Spending the whole budget converged in
+ * four calls and cost every one of them three seconds; a slice converges over
+ * more calls and keeps each one close to what it cost before.
+ */
+const RESUME_SLICE_MS = 750;
 
 /** Commits per `git log` invocation. Bounds peak output size, not correctness. */
 const LOG_BATCH = 1024;
@@ -273,9 +292,16 @@ CREATE TABLE IF NOT EXISTS meta (
   k TEXT PRIMARY KEY,
   v TEXT
 );
+
+CREATE TABLE IF NOT EXISTS scan_pending (
+  source TEXT    NOT NULL,
+  ord    INTEGER NOT NULL,
+  sha    TEXT    NOT NULL,
+  PRIMARY KEY (source, ord)
+);
 `;
 
-const REQUIRED_TABLES = ['trailers', 'commit_paths', 'meta'];
+const REQUIRED_TABLES = ['trailers', 'commit_paths', 'meta', 'scan_pending'];
 
 export type RecordSource = 'commit' | 'notes';
 
@@ -498,6 +524,16 @@ export interface ScanCost {
    * scan, leaving every note unread, or survive it and expire in the notes.
    */
   unreadNotes: number;
+  /**
+   * The annotated commits the notes pass did not reach, in the order it would
+   * have read them.
+   *
+   * The commit pass needs no equivalent: its caller holds the walk it handed in
+   * and can take the tail itself. The notes pass derives its own list — the
+   * mirror, filtered to what HEAD reaches — so a caller that wants to persist
+   * what is left has no other way to see it.
+   */
+  pendingNotes?: string[];
 }
 
 const recordExclusion = (counts: ExclusionCounts | undefined, key: string): void => {
@@ -753,6 +789,21 @@ const readCommitRecords = (
   excluded?: ExclusionCounts,
   budget?: ScanBudget,
   cost?: ScanCost,
+  /**
+   * Read one batch before the deadline may cancel anything.
+   *
+   * Only the drain passes this, and it is what keeps the drain from spinning.
+   * The drain runs under a slice of the caller's ceiling, so a single batch that
+   * costs more than the slice is cancelled every time — measured: a clock
+   * stepping 400ms per reading against a 750ms slice cancelled the first batch
+   * on all eight calls, read nothing, and left the backlog exactly where it
+   * started. A queue that can only be drained by calls large enough to finish a
+   * batch is not resumable; it is the old defect with a table under it.
+   *
+   * The cost of the guarantee is one batch of overshoot, which is already the
+   * unit this scan overshoots by.
+   */
+  guaranteeFirstBatch = false,
 ): RawRecord[] => {
   // Resolved on the first batch, not on entry. Working out whether signature
   // mode is on costs a `git config`, and a scan with nothing to read -- which
@@ -773,7 +824,11 @@ const readCommitRecords = (
 
   for (const batch of batches) {
     signatureField ??= signatureAtom(signatureVerifierGeneration(cwd));
-    if (budget !== undefined && (budget.now ?? Date.now)() > budget.deadline) {
+    if (
+      budget !== undefined &&
+      !(guaranteeFirstBatch && read === 0) &&
+      (budget.now ?? Date.now)() > budget.deadline
+    ) {
       if (cost !== undefined) cost.unreadCommits = shas.length - read;
       return records;
     }
@@ -828,7 +883,11 @@ const readCommitRecords = (
     // overshot a three-second budget to six. Bailing here drops this batch
     // whole rather than resolving half of it, which is what keeps the records
     // that are kept internally consistent.
-    if (budget !== undefined && (budget.now ?? Date.now)() > budget.deadline) {
+    if (
+      budget !== undefined &&
+      !(guaranteeFirstBatch && read === batch.length) &&
+      (budget.now ?? Date.now)() > budget.deadline
+    ) {
       if (cost !== undefined) cost.unreadCommits = shas.length - read + batch.length;
       return records;
     }
@@ -883,13 +942,15 @@ const readCommitRecords = (
  * `commands/stale.ts` filters its notes the same way; without this the two
  * answered differently on the same repository.
  */
-const readNoteRecords = (
-  cwd: string,
-  reachable: ReadonlySet<string>,
-  excluded?: ExclusionCounts,
-  budget?: ScanBudget,
-  cost?: ScanCost,
-): RawRecord[] => {
+/**
+ * The annotated commits the notes pass would read, in the order it reads them.
+ *
+ * Separate from the reading because a resumed pass already holds its list and
+ * must not re-derive it: re-deriving would silently re-scope the work to
+ * whatever HEAD and the mirror say now, and the rows already written came from
+ * the earlier scope.
+ */
+const annotatedCommits = (cwd: string, reachable: ReadonlySet<string>): string[] => {
   const listed = execGitOrThrow(['notes', `--ref=${NOTES_REF}`, 'list'], { cwd });
 
   const annotated = listed
@@ -909,11 +970,22 @@ const readNoteRecords = (
     cwd,
     stdin: `${annotated.join('\n')}\n`,
   });
-  const commits = typed
+  return typed
     .split('\n')
     .filter((line) => line.endsWith(' commit') || line.includes(' commit '))
     .map((line) => line.split(' ')[0] ?? '')
     .filter((sha) => sha !== '');
+};
+
+const readNotesFor = (
+  cwd: string,
+  commits: readonly string[],
+  excluded?: ExclusionCounts,
+  budget?: ScanBudget,
+  cost?: ScanCost,
+  /** See `readCommitRecords`: the drain must not be able to spin. */
+  guaranteeFirstBatch = false,
+): RawRecord[] => {
   if (commits.length === 0) return [];
 
   const records: RawRecord[] = [];
@@ -927,8 +999,15 @@ const readNoteRecords = (
       ? chunked(commits, LOG_BATCH)
       : chunkedGrowing(commits, budgetedBatchSizes());
   for (const batch of noteBatches) {
-    if (budget !== undefined && (budget.now ?? Date.now)() > budget.deadline) {
-      if (cost !== undefined) cost.unreadNotes = commits.length - read;
+    if (
+      budget !== undefined &&
+      !(guaranteeFirstBatch && read === 0) &&
+      (budget.now ?? Date.now)() > budget.deadline
+    ) {
+      if (cost !== undefined) {
+        cost.unreadNotes = commits.length - read;
+        cost.pendingNotes = commits.slice(read);
+      }
       return records;
     }
     read += batch.length;
@@ -978,6 +1057,15 @@ const readNoteRecords = (
 
   return records;
 };
+
+const readNoteRecords = (
+  cwd: string,
+  reachable: ReadonlySet<string>,
+  excluded?: ExclusionCounts,
+  budget?: ScanBudget,
+  cost?: ScanCost,
+): RawRecord[] =>
+  readNotesFor(cwd, annotatedCommits(cwd, reachable), excluded, budget, cost);
 
 const revParse = (cwd: string, rev: string): string | null => {
   const result = execGit(['rev-parse', '--verify', '--quiet', `${rev}^{commit}`], { cwd });
@@ -1071,26 +1159,128 @@ const writeMeta = (db: IndexDatabase, key: string, value: string | null): void =
   );
 };
 
-/** How many commits a budgeted rebuild left unread. 0 means the index is whole. */
-const UNREAD_COMMITS_META = 'unread_commits';
-
 /** Which keyring produced the cached `%G?` values, when signature mode is on (#653). */
 const SIGNATURE_VERIFIER_META = 'signature_verifier_generation';
 
-const persistUnread = (db: IndexDatabase, unread: number): void => {
-  writeMeta(db, UNREAD_COMMITS_META, unread > 0 ? String(unread) : null);
+/**
+ * Which mirror the outstanding note work was listed from.
+ *
+ * `notes_ref_sha` cannot answer this: a truncated notes pass deliberately
+ * leaves it unset, because the mirror is not indexed at that sha. Without a
+ * second key, `indexNotes` sees "unset" on every later call and re-lists the
+ * whole mirror — discarding the position `drainPending` is holding and
+ * replacing the note rows with a fresh prefix each time. This says whose work
+ * the pending rows are, so the two stop overwriting each other.
+ */
+const NOTES_PENDING_REF_META = 'notes_pending_ref';
+
+/**
+ * What a truncated scan still owes, as the work itself rather than as a count.
+ *
+ * v4 stored one number in `meta.unread_commits`, and a number cannot be resumed
+ * from: measured on a 1544-commit repository, the first budgeted call read 448
+ * commits and seven further budgeted calls read none, because nothing recorded
+ * WHICH 1096 were left. The number also added commits to notes, so draining
+ * either source could report the other complete.
+ *
+ * Rows are removed in the same transaction that inserts the records read from
+ * them (`drainPending`). That is what makes a range impossible to lose: a
+ * second process that read the same rows either inserts the same trailers and
+ * collides on `trailers_identity`, rolling its whole transaction back, or finds
+ * nothing to insert and deletes rows already gone. Neither outcome advances
+ * past work nobody did -- which a shared counter, incremented by each process
+ * by what it read, does.
+ *
+ * `ord` is the position in the walk that produced the list, so draining follows
+ * the order the scan would have taken: newest first, which is the order a
+ * lifecycle fold cares about most.
+ */
+const pendingCount = (db: IndexDatabase, source: RecordSource): number =>
+  (db.prepare('SELECT count(*) AS n FROM scan_pending WHERE source = ?').get(source) as {
+    n: number;
+  }).n;
+
+interface PendingEntry {
+  ord: number;
+  sha: string;
+}
+
+/**
+ * Marks one queued entry done, by identity rather than by position.
+ *
+ * The position alone is not an identity. A drainer selects its rows, then reads
+ * git with no transaction held, and in that window another process can replace
+ * the queue — a rebuild does exactly that. Deleting on `ord` alone then retires
+ * whatever now sits at that position, which may be work nobody has done:
+ * reproduced as a drainer selecting `(0, a)`, a rebuild re-queueing as
+ * `(0, x), (1, a)`, and the drainer deleting x's unread work while reporting
+ * the index complete. Naming the sha makes the delete match nothing when the
+ * queue underneath has moved, so that entry is simply read again.
+ */
+const PENDING_DONE_SQL = 'DELETE FROM scan_pending WHERE source = ? AND ord = ? AND sha = ?';
+
+const pendingEntries = (db: IndexDatabase, source: RecordSource): PendingEntry[] =>
+  db
+    .prepare('SELECT ord, sha FROM scan_pending WHERE source = ? ORDER BY ord')
+    .all(source)
+    .map((row) => ({ ord: Number(row.ord), sha: String(row.sha) }));
+
+/**
+ * Replaces one source's pending list. `from` is the offset of `shas[0]` in the
+ * walk, so a rebuild that read a prefix keeps the positions it stopped at
+ * rather than renumbering from zero.
+ */
+const writePending = (
+  db: IndexDatabase,
+  source: RecordSource,
+  shas: readonly string[],
+  from = 0,
+): void => {
+  db.prepare('DELETE FROM scan_pending WHERE source = ?').run(source);
+  const insert = db.prepare('INSERT INTO scan_pending (source, ord, sha) VALUES (?, ?, ?)');
+  shas.forEach((sha, offset) => insert.run(source, from + offset, sha));
 };
 
 /**
- * Commits a previous budgeted rebuild left unread, persisted so a later query
- * can say so without walking history again. 0 when the index is whole.
+ * Adds to one source's pending list without disturbing what is already there.
+ *
+ * The incremental range needs this: the commits it could not read are new work,
+ * and the backlog a previous truncated rebuild left is still owed. Replacing
+ * would drop one of the two. Positions continue past the highest in use, so the
+ * older backlog drains first and neither list renumbers under the other.
  */
-export const indexUnread = (handle: IndexHandle): number => {
-  const raw = readMeta(handle.db, UNREAD_COMMITS_META);
-  if (raw === null || raw === '') return 0;
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+const appendPending = (db: IndexDatabase, source: RecordSource, shas: readonly string[]): void => {
+  if (shas.length === 0) return;
+  const highest = (
+    db.prepare('SELECT max(ord) AS m FROM scan_pending WHERE source = ?').get(source) as {
+      m: number | null;
+    }
+  ).m;
+  const insert = db.prepare(
+    'INSERT INTO scan_pending (source, ord, sha) VALUES (?, ?, ?) ON CONFLICT DO NOTHING',
+  );
+  const base = (highest ?? -1) + 1;
+  shas.forEach((sha, offset) => insert.run(source, base + offset, sha));
 };
+
+/**
+ * Records a truncated scan still owes, from both sources. 0 when the index is
+ * whole.
+ *
+ * Kept as one number because that is what every consumer renders — "N commits
+ * went unread, run `commitlore init`" — and because a caller that wants them
+ * apart can ask `indexUnreadBySource`.
+ */
+export const indexUnread = (handle: IndexHandle): number =>
+  pendingCount(handle.db, 'commit') + pendingCount(handle.db, 'notes');
+
+/** The same total, split by the source that owes it. */
+export const indexUnreadBySource = (
+  handle: IndexHandle,
+): { commits: number; notes: number } => ({
+  commits: pendingCount(handle.db, 'commit'),
+  notes: pendingCount(handle.db, 'notes'),
+});
 
 /**
  * Opening a database must never overwrite what it says about itself. Stamping
@@ -1422,10 +1612,24 @@ interface InsertCounts {
  * strategy: an incremental range never contains an already-indexed commit, so
  * a conflict means the baseline was wrong. The caller turns that throw into a
  * rebuild.
+ *
+ * `opts.repeatable` is the one exception, and only `drainPending` passes it.
+ * Retiring a queued commit is refused when the queue moved under the drainer
+ * (`PENDING_DONE_SQL`), so that commit is read again on a later call — by
+ * design, and the rows from the first read are then already present. A conflict
+ * there says "this work is done", not "the baseline was wrong", and the row it
+ * collides with is byte-identical because both reads derived it from the same
+ * commit. Counting only rows that actually landed keeps the stats honest, and
+ * the FTS mirror is written only for those, so a skipped insert cannot point a
+ * virtual-table row at a rowid it does not own.
  */
-const insertRecords = (handle: IndexHandle, records: readonly RawRecord[]): InsertCounts => {
+const insertRecords = (
+  handle: IndexHandle,
+  records: readonly RawRecord[],
+  opts: { repeatable?: boolean } = {},
+): InsertCounts => {
   const insertTrailer = handle.db.prepare(
-    `INSERT INTO trailers
+    `INSERT ${opts.repeatable === true ? 'OR IGNORE ' : ''}INTO trailers
        (commit_sha, block, seq, key, value, value_lc, committed_at, committed_ts, provenance, signature_status, source)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
@@ -1458,6 +1662,7 @@ const insertRecords = (handle: IndexHandle, records: readonly RawRecord[]): Inse
           record.signatureStatus,
           record.source,
         );
+        if (Number(inserted.changes) === 0) return;
         insertFts?.run(inserted.lastInsertRowid, valueLc);
         counts.trailers += 1;
       });
@@ -1491,22 +1696,51 @@ const deleteNoteRows = (handle: IndexHandle): void => {
  */
 export const indexNotes = (
   handle: IndexHandle,
-  opts: { force?: boolean } = {},
+  opts: { force?: boolean; budget?: ScanBudget } = {},
   excluded?: ExclusionCounts,
+  cost?: ScanCost,
 ): number => {
   const refSha = revParseRef(handle.cwd, NOTES_REF);
   const indexed = readMeta(handle.db, 'notes_ref_sha');
+  const force = opts.force ?? false;
 
-  if (!(opts.force ?? false) && refSha === indexed) return 0;
+  if (!force && refSha === indexed) return 0;
 
+  // Work already listed from this same mirror belongs to `drainPending`, which
+  // is holding a position in it. Re-listing here would throw that position away
+  // and replace the note rows with a fresh prefix on every call -- the mirror
+  // would be re-read from the start forever, which is the defect this change
+  // exists to remove, moved from the commits to the notes.
+  if (
+    !force &&
+    refSha !== null &&
+    readMeta(handle.db, NOTES_PENDING_REF_META) === refSha &&
+    pendingCount(handle.db, 'notes') > 0
+  ) {
+    return 0;
+  }
+
+  const local: ScanCost = { unreadCommits: 0, unreadNotes: 0 };
+  const annotated = refSha === null ? [] : annotatedCommits(handle.cwd, new Set(reachableFromHead(handle.cwd)));
   const records =
-    refSha === null
+    annotated.length === 0
       ? []
-      : readNoteRecords(handle.cwd, new Set(reachableFromHead(handle.cwd)), excluded);
+      : readNotesFor(handle.cwd, annotated, excluded, opts.budget, local);
+
   return runInTransaction(handle.db, () => {
     deleteNoteRows(handle);
     const counts = insertRecords(handle, records);
-    writeMeta(handle.db, 'notes_ref_sha', refSha);
+    // A truncated read replaces the mirror's rows with a prefix of itself, so
+    // the rows and the stamp must disagree deliberately: the ref is left unset
+    // and the remainder recorded, and `drainPending` finishes it under a later
+    // budget. Stamping here would say the mirror is indexed at a sha whose
+    // notes are only partly in the table -- which is what a truncated rebuild
+    // used to do, losing 11 of this repository's notes for good.
+    const pending = local.pendingNotes ?? [];
+    writeMeta(handle.db, 'notes_ref_sha', pending.length === 0 ? refSha : null);
+    writeMeta(handle.db, NOTES_PENDING_REF_META, pending.length === 0 ? null : refSha);
+    writePending(handle.db, 'notes', pending, annotated.length - pending.length);
+    if (cost !== undefined) cost.unreadNotes += local.unreadNotes;
     return counts.trailers;
   });
 };
@@ -1575,17 +1809,21 @@ export const rebuildIndex = (
 
   const started = Date.now();
   const head = revParse(handle.cwd, 'HEAD');
-  const shas = head === null ? [] : revList(handle.cwd, 'HEAD');
+  // Walked from the resolved object, not from the symbolic name. `HEAD` was
+  // being re-resolved by a second git process, so a checkout landing between
+  // the two associated the pending list -- and `last_indexed_sha` -- with a
+  // history this walk never saw.
+  const shas = head === null ? [] : revList(handle.cwd, head);
   const excluded: ExclusionCounts = new Map();
-  // A caller that did not pass `cost` still needs the unread count written to
-  // meta, so a later query can label the partial index. The object they did
-  // pass is mutated in place; this local one is only for the persist.
+  // A caller that did not pass `cost` still needs the unread work recorded, so
+  // a later query can label the partial index and a later budgeted call can
+  // finish it. The object they did pass is mutated in place; this local one is
+  // only for the persist.
   const cost = opts.cost ?? { unreadCommits: 0, unreadNotes: 0 };
   const records = readCommitRecords(handle.cwd, shas, excluded, opts.budget, cost);
   const notesRef = revParseRef(handle.cwd, NOTES_REF);
   const noteRecords =
     notesRef === null ? [] : readNoteRecords(handle.cwd, new Set(shas), excluded, opts.budget, cost);
-  const unread = cost.unreadCommits + cost.unreadNotes;
   const stats: IndexStats = {
     ...emptyStats(handle, started),
     rebuilt: true,
@@ -1608,18 +1846,135 @@ export const rebuildIndex = (
     stats.noteTrailersIndexed = noteCounts.trailers;
     stats.pathsIndexed += noteCounts.paths;
 
-    // HEAD even when unread > 0: new commits after this point are a
-    // `last..HEAD` incremental, which is the cheap half. The unread older
-    // commits stay unread until `index`/`init` rebuilds without a budget, and
-    // `unread_commits` is what stops that from reading as a complete index.
+    // HEAD even when the scan was truncated: new commits after this point are a
+    // `last..HEAD` incremental, which is the cheap half, and the commits this
+    // scan did not reach are older than HEAD, so the two ranges do not overlap.
+    // `scan_pending` is what stops the gap between them from reading as a
+    // complete index, and is what a later budgeted call finishes it from.
     writeMeta(handle.db, 'last_indexed_sha', head);
-    writeMeta(handle.db, 'notes_ref_sha', notesRef);
+    writePending(handle.db, 'commit', shas.slice(shas.length - cost.unreadCommits));
+
+    // The ref is stamped only for a notes pass that finished. Stamping it after
+    // a truncated one told `indexNotes` the mirror was already indexed at that
+    // sha, so the notes left over were never read again -- measured: 11 of this
+    // repository's notes, dropped permanently, while the ref claimed otherwise.
+    const notesPending = cost.pendingNotes ?? [];
+    writeMeta(handle.db, 'notes_ref_sha', notesPending.length === 0 ? notesRef : null);
+    writeMeta(handle.db, NOTES_PENDING_REF_META, notesPending.length === 0 ? null : notesRef);
+    writePending(handle.db, 'notes', notesPending);
+
     writeMeta(handle.db, SIGNATURE_VERIFIER_META, signatureVerifierGeneration(handle.cwd));
-    persistUnread(handle.db, unread);
   });
   applyExclusions(stats, excluded);
   stats.elapsedMs = Date.now() - started;
   return stats;
+};
+
+/**
+ * Reads what a previous truncated scan left, as far as this budget reaches.
+ *
+ * This is the half #522 never built. A budgeted caller may not start a full
+ * rebuild -- that is the unbounded wait the budget exists to refuse -- but
+ * carrying on from a recorded position is bounded by the same deadline as
+ * everything else in the call, so refusing it only kept the index permanently
+ * partial: measured on a 1544-commit repository, 448 commits read and seven
+ * further budgeted calls reading none.
+ *
+ * The git reads happen outside the write transaction; the transaction holds
+ * only the insert and the removal of the rows those records came from, so the
+ * two cannot disagree. A concurrent process that read the same rows collides on
+ * `trailers_identity` and rolls back whole rather than marking them done.
+ */
+const drainPending = (
+  handle: IndexHandle,
+  outer: ScanBudget,
+  excluded: ExclusionCounts,
+  stats: IndexStats,
+): void => {
+  // Capped well under the caller's own ceiling, and deliberately.
+  //
+  // Finishing the index is not what the caller asked for; answering is. Letting
+  // the drain spend whatever the budget had left turned a hook fire that used to
+  // return in milliseconds into one that spent the full three seconds, on every
+  // fire until the backlog cleared -- the index converged and the edit hook paid
+  // for it in latency every time. With the cap, each fire carries a slice and
+  // the backlog still empties, over more fires: 1544 commits went from four
+  // full-budget calls to roughly a dozen cheap ones.
+  //
+  // One batch can still overshoot this, the same way it can overshoot the outer
+  // budget: the deadline is checked between batches and once before the
+  // expensive half of one, never inside it.
+  const clock = outer.now ?? Date.now;
+  const budget: ScanBudget = {
+    deadline: Math.min(outer.deadline, clock() + RESUME_SLICE_MS),
+    ...(outer.now === undefined ? {} : { now: outer.now }),
+  };
+
+  const commits = pendingEntries(handle.db, 'commit');
+  if (commits.length > 0) {
+    const cost: ScanCost = { unreadCommits: 0, unreadNotes: 0 };
+    const shas = commits.map((entry) => entry.sha);
+    const records = readCommitRecords(handle.cwd, shas, excluded, budget, cost, true);
+    const read = shas.length - cost.unreadCommits;
+    if (read > 0) {
+      runInTransaction(handle.db, () => {
+        const counts = insertRecords(handle, records, { repeatable: true });
+        stats.trailersIndexed += counts.trailers;
+        stats.pathsIndexed += counts.paths;
+        const done = handle.db.prepare(PENDING_DONE_SQL);
+        for (const entry of commits.slice(0, read)) done.run('commit', entry.ord, entry.sha);
+      });
+      stats.commitsScanned += read;
+    }
+  }
+
+  // Only once the commits are done. A note is filtered against what HEAD
+  // reaches, and reading it while commits from that same walk are still unread
+  // would scope it against a history the index does not yet hold.
+  if (pendingCount(handle.db, 'commit') > 0) return;
+
+  const notes = pendingEntries(handle.db, 'notes');
+  if (notes.length === 0) return;
+
+  // The queue holds annotated commits, which say nothing about which mirror
+  // listed them. Reading them against a mirror that has since moved and then
+  // stamping that mirror as indexed certifies a version this index never read:
+  // reproduced as a prefix listed from v1 plus one note read from v2, stamped
+  // v2, with a note v2 added missing and nothing reported outstanding. Once the
+  // mirror has moved the queue is stale, so it is dropped -- `indexNotes` then
+  // re-reads the mirror whole, which it has to do anyway because a note can be
+  // rewritten in place.
+  const listedFrom = readMeta(handle.db, NOTES_PENDING_REF_META);
+  const currentRef = revParseRef(handle.cwd, NOTES_REF);
+  if (listedFrom === null || listedFrom !== currentRef) {
+    runInTransaction(handle.db, () => {
+      writePending(handle.db, 'notes', []);
+      writeMeta(handle.db, NOTES_PENDING_REF_META, null);
+    });
+    return;
+  }
+
+  const cost: ScanCost = { unreadCommits: 0, unreadNotes: 0 };
+  const shas = notes.map((entry) => entry.sha);
+  const records = readNotesFor(handle.cwd, shas, excluded, budget, cost, true);
+  const read = shas.length - cost.unreadNotes;
+  if (read === 0) return;
+
+  runInTransaction(handle.db, () => {
+    const counts = insertRecords(handle, records, { repeatable: true });
+    stats.noteTrailersIndexed += counts.trailers;
+    stats.pathsIndexed += counts.paths;
+    const done = handle.db.prepare(PENDING_DONE_SQL);
+    for (const entry of notes.slice(0, read)) done.run('notes', entry.ord, entry.sha);
+    // Stamped with the mirror the queue was listed from, never with whatever the
+    // ref points at now. The two are equal here only because the guard above
+    // already refused the case where they are not.
+    if (pendingCount(handle.db, 'notes') === 0) {
+      writeMeta(handle.db, 'notes_ref_sha', listedFrom);
+      writeMeta(handle.db, NOTES_PENDING_REF_META, null);
+    }
+  });
+  stats.notesScanned += read;
 };
 
 /**
@@ -1698,9 +2053,10 @@ export const updateIndex = (
   if (blocker !== null) return rebuildOrRefuse(blocker);
 
   // A budgeted consumer rebuild stamps last_indexed_sha = HEAD so new commits
-  // stay incremental, and persists unread_commits so the answer stays labelled.
-  // `index`/`init` pass no budget: they are the command the label names, so a
-  // leftover unread count here is a rebuild they still owe, not a no-op.
+  // stay incremental, and records what it did not read so the answer stays
+  // labelled. `index`/`init` pass no budget: they are the command the label
+  // names, so leftover pending work here is a rebuild they still owe, not a
+  // no-op.
   if (opts.budget === undefined && indexUnread(handle) > 0) {
     return rebuildIndex(handle, { reason: 'finish a budgeted partial index', ...rebuildOpts });
   }
@@ -1708,22 +2064,49 @@ export const updateIndex = (
   const stats: IndexStats = { ...emptyStats(handle, started), headSha: head };
 
   if (last !== null && last !== head) {
-    const shas = revList(handle.cwd, `${last}..HEAD`);
-    stats.commitsScanned = shas.length;
-    const records = readCommitRecords(handle.cwd, shas, excluded);
+    const shas = revList(handle.cwd, `${last}..${head}`);
+    // Budgeted, so a caller that came back to a thousand new commits waits the
+    // same ceiling as everywhere else -- and whatever the ceiling cut off joins
+    // the queue rather than being dropped. Leaving it out of the queue and
+    // holding `last_indexed_sha` back instead looked safer and was not: every
+    // later call re-read the same prefix, inserted nothing, and reported the
+    // remainder as unread while `indexUnread` said zero. Reproduced at 130 new
+    // commits against a budget that reached 64: three calls, no progress, all
+    // 130 missing from the index and nothing recorded as owed.
+    //
+    // `revList` walks newest-first, so the prefix that was read is the newest
+    // and the queued remainder is the older end, adjacent to `last`. Stamping
+    // `last_indexed_sha = head` is therefore sound: the queue holds the gap.
+    const incremental: ScanCost = { unreadCommits: 0, unreadNotes: 0 };
+    const records = readCommitRecords(handle.cwd, shas, excluded, opts.budget, incremental);
+    const read = shas.length - incremental.unreadCommits;
+    stats.commitsScanned = read;
     try {
-      const counts = insertRecords(handle, records);
-      stats.trailersIndexed = counts.trailers;
-      stats.pathsIndexed = counts.paths;
+      runInTransaction(handle.db, () => {
+        const counts = insertRecords(handle, records);
+        stats.trailersIndexed = counts.trailers;
+        stats.pathsIndexed = counts.paths;
+        appendPending(handle.db, 'commit', shas.slice(read));
+        writeMeta(handle.db, 'last_indexed_sha', head);
+      });
     } catch (error) {
       return rebuildOrRefuse(
         `incremental insert conflicted with existing rows (${errorMessage(error)})`,
       );
     }
-    writeMeta(handle.db, 'last_indexed_sha', head);
   }
 
-  stats.noteTrailersIndexed = indexNotes(handle, {}, excluded);
+  // Carrying on from where a truncated scan stopped. Only a budgeted caller
+  // reaches this: without a budget the branch above has already turned the
+  // backlog into a full rebuild, which is the stronger repair.
+  if (opts.budget !== undefined) drainPending(handle, opts.budget, excluded, stats);
+
+  stats.noteTrailersIndexed += indexNotes(
+    handle,
+    opts.budget === undefined ? {} : { budget: opts.budget },
+    excluded,
+    opts.cost,
+  );
   applyExclusions(stats, excluded);
   stats.elapsedMs = Date.now() - started;
   return stats;
@@ -2033,12 +2416,20 @@ export const indexInfo = (
   trailers: number;
   commits: number;
   paths: number;
+  /**
+   * Records a truncated scan still owes. Reported here because "current with
+   * HEAD" and "holds everything" are different questions, and `doctor` was
+   * answering the second with the first: `last_indexed_sha` equals HEAD the
+   * moment a budgeted scan stamps it, outstanding work or not.
+   */
+  unread: { commits: number; notes: number };
 } => ({
   path: handle.path,
   fts: handle.fts,
   schemaVersion: readMeta(handle.db, 'schema_version'),
   lastIndexedSha: readMeta(handle.db, 'last_indexed_sha'),
   notesRefSha: readMeta(handle.db, 'notes_ref_sha'),
+  unread: indexUnreadBySource(handle),
   trailers:
     (handle.db.prepare('SELECT count(*) AS n FROM trailers').get() as { n: number } | undefined)
       ?.n ?? 0,

--- a/test/__snapshots__/doctor-snapshot.test.ts.snap
+++ b/test/__snapshots__/doctor-snapshot.test.ts.snap
@@ -34,7 +34,7 @@ exports[`#462 doctor text report, pinned > renders a stable report on a reposito
 2. [warn] commit-msg-hook — a commit-msg hook exists at <repo>/.git/hooks/commit-msg but does not invoke commitlore; commitlore.bin: <tmp>/cl-snap-<tmpdir>/no-such-binary.mjs; commitlore.node: <node> (commitlore hooks install)
 3. [warn] inject-runtime — not installed in <repo>/.claude/settings.json, and the Claude Code plugin is not installed for this user (commitlore inject install-claude-hook)
 ok      cli runtime — <root><path> runs (<version>)
-ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v4
+ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v5
 ok      installation integrity — 3 shipped files are present and readable
 skipped release freshness — not checked: COMMITLORE_NO_UPDATE_CHECK is set
 warn    notes fetch refspec — origin does not fetch refs<path> so records pushed by others stay invisible here
@@ -67,7 +67,7 @@ exports[`#462 doctor text report, pinned > renders a stable report on a reposito
 2. [warn] commit-msg-hook — a commit-msg hook exists at <repo>/.git/hooks/commit-msg but does not invoke commitlore; commitlore.bin: <root><path> commitlore.node: <node> (commitlore hooks install)
 3. [warn] inject-runtime — not installed in <repo>/.claude/settings.json, and the Claude Code plugin is not installed for this user (commitlore inject install-claude-hook)
 ok      cli runtime — <root><path> runs (<version>)
-ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v4
+ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v5
 ok      installation integrity — 3 shipped files are present and readable
 skipped release freshness — not checked: COMMITLORE_NO_UPDATE_CHECK is set
 warn    notes fetch refspec — origin does not fetch refs<path> so records pushed by others stay invisible here
@@ -96,7 +96,7 @@ ok      squash inheritance — no GitHub remote — the server-side squash path 
 exports[`#470 doctor text report header > keeps the per-check tail byte-identical to the pre-ticket rows 1`] = `
 {
   "broken": "ok      cli runtime — <root><path> runs (<version>)
-ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v4
+ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v5
 ok      installation integrity — 3 shipped files are present and readable
 skipped release freshness — not checked: COMMITLORE_NO_UPDATE_CHECK is set
 warn    notes fetch refspec — origin does not fetch refs<path> so records pushed by others stay invisible here
@@ -121,7 +121,7 @@ ok      index health — 3 trailers over 1 commits, current with HEAD — no FTS
 skipped squash conservation — no local branch looks like the source of a squash — nothing to check
 ok      squash inheritance — no GitHub remote — the server-side squash path this protects against does not apply. A local \`git merge --squash\` is carried by the installed prepare-commit-msg hook either way",
   "working": "ok      cli runtime — <root><path> runs (<version>)
-ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v4
+ok      runtime identity — all observed runtimes match CLI: v<version>; entry <root><path> root <root>; schema v5
 ok      installation integrity — 3 shipped files are present and readable
 skipped release freshness — not checked: COMMITLORE_NO_UPDATE_CHECK is set
 warn    notes fetch refspec — origin does not fetch refs<path> so records pushed by others stay invisible here

--- a/test/index-resume.test.ts
+++ b/test/index-resume.test.ts
@@ -116,6 +116,78 @@ const shiftQueue = (dir: string): void => {
   }
 };
 
+/**
+ * A real `refs/notes/commitlore` mirror over the newest commits.
+ *
+ * The notes half cannot be exercised with seeded rows alone: the drain refuses a
+ * queue whose recorded mirror does not match the live ref, and with no mirror at
+ * all both are null and it refuses on that.
+ */
+const addNotes = (dir: string, count: number): number => {
+  const shas = execFileSync('git', ['rev-list', `-${String(count)}`, 'HEAD'], {
+    cwd: dir,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter((line) => line !== '');
+  for (const [i, sha] of shas.entries()) {
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'user.name=CommitLore Test',
+        '-c',
+        'user.email=test@example.invalid',
+        'notes',
+        '--ref=refs/notes/commitlore',
+        'add',
+        '-f',
+        '-m',
+        `note ${i}\n\nRecord-Id: r-note${i.toString(36)}\nWarn: from a note\n`,
+        sha,
+      ],
+      { cwd: dir },
+    );
+  }
+  return shas.length;
+};
+
+/**
+ * What another process's `indexNotes` does when the mirror has moved: the queue
+ * is re-listed against the new mirror, under the same annotated commit shas.
+ */
+const relistNotes = (dir: string): void => {
+  execFileSync(
+    'git',
+    [
+      '-c',
+      'user.name=CommitLore Test',
+      '-c',
+      'user.email=test@example.invalid',
+      'notes',
+      '--ref=refs/notes/commitlore',
+      'add',
+      '-f',
+      '-m',
+      'note rewritten\n\nRecord-Id: r-noterewrite\nWarn: second version\n',
+      execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf8' }).trim(),
+    ],
+    { cwd: dir },
+  );
+  const handle = openIndex({ cwd: dir });
+  try {
+    const moved = execFileSync('git', ['rev-parse', 'refs/notes/commitlore'], {
+      cwd: dir,
+      encoding: 'utf8',
+    }).trim();
+    handle.db
+      .prepare('INSERT INTO meta (k, v) VALUES (?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v')
+      .run('notes_pending_ref', moved);
+  } finally {
+    closeIndex(handle);
+  }
+};
+
 /** Removes the index without removing the repository. */
 const cold = (dir: string): void => {
   rmSync(join(dir, '.git', 'commitlore'), { recursive: true, force: true });
@@ -193,12 +265,8 @@ describe('#951 a budgeted scan resumes where it stopped', () => {
     const dir = syntheticRepo(400);
 
     cold(dir);
-    // The first call truncates; the rest each carry one slice. Three readings is
-    // the floor for a slice that completes a batch: one goes to computing the
-    // drain's own ceiling, and the batch loop checks twice before the expensive
-    // half. At two readings the batch is started and then dropped, so the index
-    // never advances -- which is a property of the clock in this test, not of
-    // the code, and is why the two budgets are written separately here.
+    // The first call truncates; the rest keep going. The two budgets are written
+    // separately because they are asking for different things.
     closeIndex(ensureIndex({ cwd: dir, budget: expiringAfter(2) }).handle);
     for (let call = 0; call < 40; call += 1) {
       const { handle } = ensureIndex({ cwd: dir, budget: expiringAfter(3) });
@@ -423,6 +491,139 @@ describe('#951 a budgeted scan resumes where it stopped', () => {
     })();
 
     expect(after).toBeLessThan(before);
+  }, 300_000);
+
+  it('drops the indexed prefix when the mirror the queue named is gone', () => {
+    const dir = syntheticRepo(40);
+    closeIndex(ensureIndex({ cwd: dir }).handle);
+
+    // A partial notes pass leaves rows AND a queue, both belonging to one
+    // mirror. Dropping only the queue when that mirror disappears leaves an
+    // indexed prefix nothing points at and nothing outstanding to correct it --
+    // `notes_ref_sha` and the live ref are then both null, so `indexNotes`
+    // returns at its first line and those rows are served for good.
+    withIndex(dir, (handle) => {
+      handle.db.exec('DELETE FROM scan_pending');
+      handle.db
+        .prepare(
+          `INSERT INTO trailers (commit_sha, block, seq, key, value, value_lc,
+             committed_at, committed_ts, provenance, signature_status, source)
+           VALUES (?, 0, 0, 'Warn', 'stale', 'stale', '2020-01-01T00:00:00+00:00', 1, NULL, '', 'notes')`,
+        )
+        .run('a'.repeat(40));
+      handle.db
+        .prepare('INSERT INTO scan_pending (source, ord, sha) VALUES (?, ?, ?)')
+        .run('notes', 0, 'b'.repeat(40));
+      const meta = handle.db.prepare(
+        'INSERT INTO meta (k, v) VALUES (?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v',
+      );
+      meta.run('notes_pending_ref', 'c'.repeat(40));
+      meta.run('notes_ref_sha', null);
+    });
+
+    const { handle } = ensureIndex({ cwd: dir, budget: expiringAfter(20) });
+    const left = indexUnreadBySource(handle);
+    const stale = Number(
+      (
+        handle.db
+          .prepare(`SELECT count(*) AS n FROM trailers WHERE source = 'notes'`)
+          .get() as { n: number }
+      ).n,
+    );
+    closeIndex(handle);
+
+    expect(left.notes).toBe(0);
+    expect(stale).toBe(0);
+  }, 300_000);
+
+  it('spends its one-batch floor once per call, not once per source', () => {
+    // Sized so one truncation leaves a commit queue that fits inside a single
+    // batch while every note is still owed -- the state the double floor shows
+    // up in: the commit pass empties its queue, and the notes pass then takes a
+    // second guaranteed batch out of the same spent budget.
+    const dir = syntheticRepo(120);
+    addNotes(dir, 100);
+    cold(dir);
+    closeIndex(ensureIndex({ cwd: dir, budget: expiringAfter(2) }).handle);
+
+    const owed = withIndex(dir, indexUnreadBySource);
+    expect(owed.commits).toBeGreaterThan(0);
+    expect(owed.notes).toBeGreaterThan(0);
+
+    // A budget already spent on entry buys exactly one batch, from one source.
+    const { handle, stats } = ensureIndex({
+      cwd: dir,
+      budget: { deadline: -1, now: () => 0 },
+    });
+    closeIndex(handle);
+
+    expect(stats.commitsScanned).toBeGreaterThan(0);
+    expect(stats.notesScanned).toBe(0);
+  }, 300_000);
+
+  it('retires no note when the mirror is re-listed while it is being read', () => {
+    const dir = syntheticRepo(120);
+    addNotes(dir, 100);
+    cold(dir);
+    closeIndex(ensureIndex({ cwd: dir, budget: expiringAfter(2) }).handle);
+
+    // Commits first: the drain will not touch notes while any commit is owed.
+    // One spent-budget call finishes them -- the floor buys the one batch they
+    // fit in -- and spends the floor, so the notes queue is left whole.
+    closeIndex(ensureIndex({ cwd: dir, budget: { deadline: -1, now: () => 0 } }).handle);
+    const owed = withIndex(dir, indexUnreadBySource);
+    expect(owed.commits).toBe(0);
+    expect(owed.notes).toBeGreaterThan(0);
+    const queued = owed.notes;
+
+    // An annotated commit's sha is the same object whichever version of its note
+    // the mirror holds, so retiring by sha cannot tell v1's work from v2's. The
+    // clock is the interleaving point: reading 1 computes the drain's ceiling,
+    // reading 2 is inside the notes read, with the selection made and no
+    // transaction open.
+    let readings = 0;
+    const { handle, stats } = ensureIndex({
+      cwd: dir,
+      budget: {
+        deadline: 9_000,
+        now: () => {
+          readings += 1;
+          if (readings === 2) relistNotes(dir);
+          return readings <= 3 ? 0 : 99_000;
+        },
+      },
+    });
+    const after = indexUnreadBySource(handle);
+    closeIndex(handle);
+
+    // Nothing may be retired: the entries this drainer read belong to a mirror
+    // that is no longer the one the queue names.
+    expect(stats.notesScanned).toBe(0);
+    expect(after.notes).toBe(queued);
+  }, 300_000);
+
+  it('clears what it derived when HEAD becomes unborn', () => {
+    const dir = syntheticRepo(400);
+    cold(dir);
+
+    const first = ensureIndex({ cwd: dir, budget: expiringAfter(2) });
+    expect(indexUnread(first.handle)).toBeGreaterThan(0);
+    closeIndex(first.handle);
+
+    execFileSync('git', ['checkout', '-q', '--orphan', 'fresh'], { cwd: dir });
+    execFileSync('git', ['rm', '-rqf', '--cached', '.'], { cwd: dir });
+
+    // An unborn HEAD reaches no commit, so every row and every queued entry
+    // describes a history this repository no longer has. This branch of
+    // `updateIndex` returns before either pending path, so leaving them made the
+    // orphan serve the old branch's records and hold its backlog for ever.
+    const { handle } = ensureIndex({ cwd: dir, budget: expiringAfter(20) });
+    const left = indexUnread(handle);
+    const rows = rowsOf(handle).trailers.length;
+    closeIndex(handle);
+
+    expect(left).toBe(0);
+    expect(rows).toBe(0);
   }, 300_000);
 
   it('leaves an unbudgeted caller free to finish it in one rebuild', () => {

--- a/test/index-resume.test.ts
+++ b/test/index-resume.test.ts
@@ -1,0 +1,446 @@
+/**
+ * #951: a budgeted scan that stopped must be able to carry on.
+ *
+ * Before this, a truncated scan persisted one number — how many commits it left
+ * unread — and a number cannot be resumed from. Measured on a 1544-commit
+ * repository with an injected clock: the first budgeted call read 448 commits
+ * and seven further budgeted calls read none, so the index stayed 29% built
+ * until somebody ran `commitlore init`.
+ *
+ * Every budget here is read against an injected clock. `r-522idx1` says why: a
+ * real-millisecond budget has already passed vacuously in CI, where the scan
+ * finished inside it and nothing was truncated, so the assertion proved nothing.
+ * The clock below advances a fixed amount per reading, which makes "expired
+ * partway through" a property of the test rather than of the machine.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  closeIndex,
+  ensureIndex,
+  indexDbPath,
+  indexUnread,
+  indexUnreadBySource,
+  openIndex,
+  type IndexHandle,
+  type ScanBudget,
+} from '../src/core/index-db.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SYNTHETIC_REPO = join(HERE, '..', 'scripts', 'make-synthetic-repo.mjs');
+
+const temporaries: string[] = [];
+afterAll(() => {
+  for (const dir of temporaries) rmSync(dir, { recursive: true, force: true });
+});
+
+const syntheticRepo = (commits: number): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'commitlore-resume-'));
+  temporaries.push(dir);
+  execFileSync(
+    process.execPath,
+    [
+      SYNTHETIC_REPO,
+      '--out',
+      dir,
+      '--commits',
+      String(commits),
+      '--trailer-ratio',
+      '0.2',
+      '--prose-ratio',
+      '0.05',
+      '--quiet',
+    ],
+    { encoding: 'utf8' },
+  );
+  return dir;
+};
+
+/**
+ * Commits on top of an already-indexed history, each carrying a record.
+ *
+ * The incremental range is what these exercise, and it only exists once a
+ * baseline does — a repository built cold has no `last_indexed_sha..HEAD`.
+ */
+const appendCommits = (dir: string, count: number): void => {
+  for (let i = 0; i < count; i += 1) {
+    writeFileSync(join(dir, `appended-${i}.txt`), `appended ${i}\n`);
+    execFileSync('git', ['add', `appended-${i}.txt`], { cwd: dir });
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'user.name=CommitLore Test',
+        '-c',
+        'user.email=test@example.invalid',
+        'commit',
+        '-q',
+        '-m',
+        `appended ${i}\n\nA constraint the diff cannot show.\n\nRecord-Id: r-app${i.toString(36)}\nBlast: local\n`,
+      ],
+      { cwd: dir },
+    );
+  }
+};
+
+/**
+ * What a concurrent rebuild does to the queue: every entry moves up one
+ * position, and a commit nobody has read takes position 0.
+ *
+ * Done through a second connection, the way another process would. The sentinel
+ * sha is not a real object — it never has to be read for the assertion to hold,
+ * only to survive.
+ */
+const shiftQueue = (dir: string): void => {
+  const handle = openIndex({ cwd: dir });
+  try {
+    const rows = handle.db
+      .prepare('SELECT ord, sha FROM scan_pending WHERE source = ? ORDER BY ord')
+      .all('commit')
+      .map((row) => ({ ord: Number(row.ord), sha: String(row.sha) }));
+    handle.db.exec(`DELETE FROM scan_pending WHERE source = 'commit'`);
+    const insert = handle.db.prepare(
+      'INSERT INTO scan_pending (source, ord, sha) VALUES (?, ?, ?)',
+    );
+    insert.run('commit', 0, 'f'.repeat(40));
+    for (const row of rows) insert.run('commit', row.ord + 1, row.sha);
+  } finally {
+    closeIndex(handle);
+  }
+};
+
+/** Removes the index without removing the repository. */
+const cold = (dir: string): void => {
+  rmSync(join(dir, '.git', 'commitlore'), { recursive: true, force: true });
+  mkdirSync(join(dir, '.git', 'commitlore'), { recursive: true });
+};
+
+/**
+ * A clock that expires after `readings` readings.
+ *
+ * The deadline is a fixed number and the clock steps past it on a counted
+ * reading, so where a scan stops is decided by how many times it looks at the
+ * clock — which is the batch structure — and never by how fast the machine is.
+ */
+const expiringAfter = (readings: number): ScanBudget => {
+  let seen = 0;
+  return { deadline: 1_000, now: () => (++seen <= readings ? 0 : 2_000) };
+};
+
+const withIndex = <T>(dir: string, fn: (handle: IndexHandle) => T): T => {
+  const handle = openIndex({ cwd: dir });
+  try {
+    return fn(handle);
+  } finally {
+    closeIndex(handle);
+  }
+};
+
+/** Every row that decides an answer, canonically ordered. */
+const rowsOf = (handle: IndexHandle): { trailers: string[]; paths: string[] } => ({
+  trailers: handle.db
+    .prepare(
+      `SELECT commit_sha, source, block, seq, key, value FROM trailers
+         ORDER BY commit_sha, source, block, seq`,
+    )
+    .all()
+    .map((row) => Object.values(row).join('\u0001')),
+  paths: handle.db
+    .prepare('SELECT commit_sha, path FROM commit_paths ORDER BY commit_sha, path')
+    .all()
+    .map((row) => `${String(row.commit_sha)}\u0001${String(row.path)}`),
+});
+
+describe('#951 a budgeted scan resumes where it stopped', () => {
+  it('advances on every budgeted call until nothing is outstanding', () => {
+    const dir = syntheticRepo(400);
+    cold(dir);
+
+    const first = ensureIndex({ cwd: dir, budget: expiringAfter(2) });
+    const outstanding = [indexUnread(first.handle)];
+    closeIndex(first.handle);
+
+    // The premise. Without a truncated first scan the rest of this test is
+    // asserting nothing, so it is checked rather than assumed.
+    expect(outstanding[0]).toBeGreaterThan(0);
+
+    for (let call = 0; call < 12 && outstanding[outstanding.length - 1] > 0; call += 1) {
+      const { handle, stats } = ensureIndex({ cwd: dir, budget: expiringAfter(3) });
+      // A budgeted caller may never start a full rebuild: that is the unbounded
+      // wait the budget exists to refuse. Resuming is not a rebuild.
+      expect(stats.rebuilt).toBe(false);
+      outstanding.push(indexUnread(handle));
+      closeIndex(handle);
+    }
+
+    // Strictly decreasing until it reaches zero. A run that merely ended at
+    // zero could have got there by one call doing everything, which is the
+    // shape that passed before the fix as well.
+    for (let i = 1; i < outstanding.length; i += 1) {
+      expect(outstanding[i]).toBeLessThan(outstanding[i - 1]);
+    }
+    expect(outstanding[outstanding.length - 1]).toBe(0);
+  }, 300_000);
+
+  it('finishes with exactly the rows one unbudgeted rebuild would hold', () => {
+    const dir = syntheticRepo(400);
+
+    cold(dir);
+    // The first call truncates; the rest each carry one slice. Three readings is
+    // the floor for a slice that completes a batch: one goes to computing the
+    // drain's own ceiling, and the batch loop checks twice before the expensive
+    // half. At two readings the batch is started and then dropped, so the index
+    // never advances -- which is a property of the clock in this test, not of
+    // the code, and is why the two budgets are written separately here.
+    closeIndex(ensureIndex({ cwd: dir, budget: expiringAfter(2) }).handle);
+    for (let call = 0; call < 40; call += 1) {
+      const { handle } = ensureIndex({ cwd: dir, budget: expiringAfter(3) });
+      const left = indexUnread(handle);
+      closeIndex(handle);
+      if (left === 0) break;
+    }
+    const resumed = withIndex(dir, rowsOf);
+
+    cold(dir);
+    closeIndex(ensureIndex({ cwd: dir }).handle);
+    const whole = withIndex(dir, rowsOf);
+
+    // The deciding artifact. "unread reached 0" only says the bookkeeping
+    // drained; if a resumed pass dropped records the index would call itself
+    // complete and be wrong, which is worse than staying partial -- a partial
+    // index at least says so.
+    expect(resumed.trailers).toEqual(whole.trailers);
+    expect(resumed.paths).toEqual(whole.paths);
+    expect(resumed.trailers.length).toBeGreaterThan(0);
+  }, 300_000);
+
+  it('keeps the answer labelled partial for as long as work is outstanding', () => {
+    const dir = syntheticRepo(400);
+    cold(dir);
+
+    const { handle } = ensureIndex({ cwd: dir, budget: expiringAfter(2) });
+    const split = indexUnreadBySource(handle);
+    closeIndex(handle);
+
+    expect(split.commits + split.notes).toBeGreaterThan(0);
+    // Split by source, not one conflated total: draining the commits must not
+    // be able to report the notes complete, which the single `unread_commits`
+    // number could.
+    expect(split.commits).toBeGreaterThan(0);
+  }, 300_000);
+
+  it('does not remove outstanding work it did not read', () => {
+    const dir = syntheticRepo(400);
+    cold(dir);
+
+    const first = ensureIndex({ cwd: dir, budget: expiringAfter(2) });
+    const before = indexUnread(first.handle);
+    closeIndex(first.handle);
+    expect(before).toBeGreaterThan(0);
+
+    // A budget already spent on entry. The drain still reads its one guaranteed
+    // batch -- otherwise it could never start -- and must retire exactly that
+    // batch and nothing else. Removing a row the drain did not read loses that
+    // commit silently and for good, which is the one failure this table exists
+    // to make impossible, so the assertion is the equality and not an
+    // inequality: "fewer outstanding" is satisfied by losing them too.
+    const { handle, stats } = ensureIndex({
+      cwd: dir,
+      budget: { deadline: -1, now: () => 0 },
+    });
+    expect(stats.rebuilt).toBe(false);
+    expect(stats.commitsScanned).toBeGreaterThan(0);
+    expect(indexUnread(handle)).toBe(before - stats.commitsScanned);
+    closeIndex(handle);
+  }, 300_000);
+
+  it('queues what a budgeted incremental could not reach, and converges', () => {
+    const dir = syntheticRepo(200);
+
+    // A whole index first, so the backlog under test is only the new commits.
+    closeIndex(ensureIndex({ cwd: dir }).handle);
+    withIndex(dir, (handle) => expect(indexUnread(handle)).toBe(0));
+
+    const before = withIndex(dir, (handle) => rowsOf(handle).trailers.length);
+    // More than the drain's guaranteed batch, so the first budgeted call cannot
+    // finish the range and the queue is actually exercised.
+    appendCommits(dir, 300);
+
+    // Holding `last_indexed_sha` back and inserting nothing looked like the safe
+    // way to bound this, and was not: every later call re-read the same prefix,
+    // reported the remainder unread, and left `indexUnread` at zero -- every new
+    // commit missing from the index with nothing recorded as owed.
+    const first = ensureIndex({ cwd: dir, budget: expiringAfter(2) });
+    const owed = indexUnread(first.handle);
+    closeIndex(first.handle);
+    expect(owed).toBeGreaterThan(0);
+
+    for (let call = 0; call < 20; call += 1) {
+      const { handle, stats } = ensureIndex({ cwd: dir, budget: expiringAfter(4) });
+      expect(stats.rebuilt).toBe(false);
+      const left = indexUnread(handle);
+      closeIndex(handle);
+      if (left === 0) break;
+    }
+
+    withIndex(dir, (handle) => {
+      expect(indexUnread(handle)).toBe(0);
+      expect(rowsOf(handle).trailers.length).toBeGreaterThan(before);
+    });
+
+    // And the converged index holds what a rebuild would.
+    const resumed = withIndex(dir, rowsOf);
+    cold(dir);
+    closeIndex(ensureIndex({ cwd: dir }).handle);
+    expect(resumed.trailers).toEqual(withIndex(dir, rowsOf).trailers);
+  }, 300_000);
+
+  it('retires a queued entry by identity, not by position', () => {
+    const dir = syntheticRepo(400);
+    cold(dir);
+
+    const first = ensureIndex({ cwd: dir, budget: expiringAfter(2) });
+    const queued = indexUnread(first.handle);
+    closeIndex(first.handle);
+    expect(queued).toBeGreaterThan(1);
+
+    // A drainer selects its rows and then reads git holding no transaction. In
+    // that window another process can replace the queue -- a rebuild does
+    // exactly that. The clock is the interleaving point: it is read inside the
+    // scan, after the selection and before the transaction that retires it, so
+    // the shift below lands in precisely the window that matters and lands
+    // there every run rather than when the scheduler happens to allow it.
+    let readings = 0;
+    const budget: ScanBudget = {
+      deadline: 4_000,
+      now: () => {
+        readings += 1;
+        // Reading 1 is the drain computing its own ceiling, which happens before
+        // it selects anything. Reading 2 is the first one inside the scan, so the
+        // selection is already made and the transaction has not opened: exactly
+        // the window a concurrent rebuild occupies.
+        if (readings === 2) shiftQueue(dir);
+        return readings <= 3 ? 0 : 9_000;
+      },
+    };
+
+    const { handle } = ensureIndex({ cwd: dir, budget });
+    const left = indexUnread(handle);
+    const sentinelStillQueued = Number(
+      (
+        handle.db
+          .prepare(`SELECT count(*) AS n FROM scan_pending WHERE sha = ?`)
+          .get('f'.repeat(40)) as { n: number }
+      ).n,
+    );
+    closeIndex(handle);
+
+    // Deleting on position alone retires whatever now sits at that position --
+    // work nobody has done. The sentinel occupies position 0 after the shift and
+    // has never been read, so it must still be owed.
+    expect(sentinelStillQueued).toBe(1);
+    expect(left).toBeGreaterThan(0);
+  }, 300_000);
+
+  it('does not certify a mirror the queued notes were not listed from', () => {
+    const dir = syntheticRepo(40);
+    closeIndex(ensureIndex({ cwd: dir }).handle);
+
+    // The queue holds annotated commits and says nothing about which mirror
+    // listed them. Reading them against a mirror that has since moved and then
+    // stamping that mirror as indexed certifies a version never read.
+    withIndex(dir, (handle) => {
+      handle.db.exec('DELETE FROM scan_pending');
+      handle.db
+        .prepare('INSERT INTO scan_pending (source, ord, sha) VALUES (?, ?, ?)')
+        .run('notes', 0, 'd'.repeat(40));
+      handle.db
+        .prepare(
+          'INSERT INTO meta (k, v) VALUES (?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v',
+        )
+        .run('notes_pending_ref', 'e'.repeat(40));
+      handle.db
+        .prepare(
+          'INSERT INTO meta (k, v) VALUES (?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v',
+        )
+        .run('notes_ref_sha', null);
+    });
+
+    // This repository has no notes mirror at all, so the recorded originating
+    // ref cannot match: the stale queue must be dropped rather than drained and
+    // stamped.
+    const { handle } = ensureIndex({ cwd: dir, budget: expiringAfter(20) });
+    const after = indexUnreadBySource(handle);
+    const stamped = handle.db.prepare(`SELECT v FROM meta WHERE k = 'notes_ref_sha'`).get() as
+      | { v: string | null }
+      | undefined;
+    closeIndex(handle);
+
+    expect(after.notes).toBe(0);
+    expect(stamped?.v ?? null).toBe(null);
+  }, 300_000);
+
+  it('advances even when one batch costs more than the slice it is given', () => {
+    const dir = syntheticRepo(400);
+    cold(dir);
+
+    const first = ensureIndex({ cwd: dir, budget: expiringAfter(2) });
+    const before = indexUnread(first.handle);
+    closeIndex(first.handle);
+    expect(before).toBeGreaterThan(0);
+
+    // The drain runs under a slice of the caller's ceiling, so a batch that
+    // costs more than the slice is cancelled — and cancelled again on the next
+    // call, and the next. Measured with a clock stepping 400ms per reading
+    // against a 750ms slice: eight calls, nothing read, the backlog exactly
+    // where it started. A queue that only drains under calls large enough to
+    // finish a batch is not resumable; it is the old defect with a table under
+    // it. The floor is one batch, which is the unit this scan already overshoots
+    // by.
+    const stepping = (): ScanBudget => {
+      let t = 0;
+      return {
+        deadline: 3_000,
+        now: () => {
+          t += 400;
+          return t;
+        },
+      };
+    };
+
+    const after = (() => {
+      const { handle } = ensureIndex({ cwd: dir, budget: stepping() });
+      const left = indexUnread(handle);
+      closeIndex(handle);
+      return left;
+    })();
+
+    expect(after).toBeLessThan(before);
+  }, 300_000);
+
+  it('leaves an unbudgeted caller free to finish it in one rebuild', () => {
+    const dir = syntheticRepo(400);
+    cold(dir);
+
+    const first = ensureIndex({ cwd: dir, budget: expiringAfter(2) });
+    expect(indexUnread(first.handle)).toBeGreaterThan(0);
+    closeIndex(first.handle);
+
+    // `index` and `init` pass no budget. Outstanding work is a rebuild they
+    // still owe, and taking it must stay their job -- resuming is the bounded
+    // repair, not a replacement for the whole one.
+    const { handle, stats } = ensureIndex({ cwd: dir });
+    expect(stats.rebuilt).toBe(true);
+    expect(indexUnread(handle)).toBe(0);
+    closeIndex(handle);
+
+    expect(indexDbPath(dir)).toContain('index.db');
+  }, 300_000);
+});

--- a/test/installer-hosts.test.ts
+++ b/test/installer-hosts.test.ts
@@ -131,7 +131,7 @@ describe('installer-hosts accepts only live CommitLore registrations', () => {
     //
     // The failure this must catch is the identity not finding a manifest at all,
     // which surfaces as the `0.0.0-unknown` fallback rather than as a mismatch.
-    expect(result.summary.runtimeIdentity).toMatchObject({ indexSchemaVersion: 4 });
+    expect(result.summary.runtimeIdentity).toMatchObject({ indexSchemaVersion: 5 });
     expect((result.summary.runtimeIdentity as { version: string }).version, 'a runtime that found no manifest reports this').not.toBe(
       '0.0.0-unknown',
     );

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -884,7 +884,7 @@ describe('commitlore_guard', () => {
     //
     // The failure this must catch is the identity not finding a manifest at all,
     // which surfaces as the `0.0.0-unknown` fallback rather than as a mismatch.
-    expect(identity).toMatchObject({ indexSchemaVersion: 4 });
+    expect(identity).toMatchObject({ indexSchemaVersion: 5 });
     expect((identity as { version: string }).version, 'a runtime that found no manifest reports this').not.toBe(
       '0.0.0-unknown',
     );

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1213,12 +1213,15 @@ describe('#522 cold path queries', () => {
       expect(cold.unreadCommits).toBeLessThan(total);
 
       // A later consumer call still carries a budget, the way `context` does.
-      // It must read the partial index rather than walk the corpus, and it
-      // must not look complete. An unbudgeted `index` is what finishes it.
+      // It must read the partial index rather than walk the corpus, and it must
+      // carry the scan on from where the first one stopped (#951). Before that
+      // landed this asserted the opposite -- that the answer stayed partial --
+      // which pinned the defect: nothing advanced, so only an unbudgeted
+      // `index` could ever finish it.
       const again = runQuery({ cwd: dir, path: 'src', scanBudgetMs: 3_000 });
       expect(again.fromIndex).toBe(true);
       expect(again.corpusPasses).toBe(0);
-      expect(again.unreadCommits).toBeGreaterThan(0);
+      expect(again.unreadCommits).toBeLessThan(cold.unreadCommits);
     }, 120_000);
 
     it('stops a --no-index scan at the budget and does not create the file', () => {


### PR DESCRIPTION
Implements ranked item 3 of #951, after taking the measurement that issue says it depends on.

### The measurement first

The issue records that `inject --path` does not receive the hook's scan budget and `--claude-hook` does. Confirmed: `src/commands/inject.ts:350` passes `scanBudgetMs`, `src/commands/inject.ts:423` does not.

Taking it turned up something the issue did not predict — **commit count is not the cold-path cost driver**. Counting git processes rather than milliseconds, so a loaded machine cannot move the answer:

| repository | commits | git processes | `interpret-trailers --parse` |
|---|---|---|---|
| commitlore | 1,544 | 261 | **244** |
| generated | 20,000 | 68 | **0** |

The generated 20k repository indexes cold in 3.0s; this one does not finish in the same budget. The 244 are `asIsolatedBlock` recovering **multi-block record messages**, which the generated history has none of. Item 1 should be re-aimed at record density accordingly; that is noted on the issue.

### The defect, reproduced

Against an injected clock, as `r-522idx1` directs:

```
call #1  scanned=448  meta.unread=1107  trailers=3175  rebuilt=y
call #2  scanned=  0  meta.unread=1107  trailers=3175  NO CHANGE
...
call #8  scanned=  0  meta.unread=1107  trailers=3175  NO CHANGE
```

A truncated scan persisted a count, and a count cannot be resumed from. The index stayed 29% built until `commitlore init` ran.

### The change

Unread work is recorded as the work itself in a `scan_pending` table, and a later budgeted call drains it. Entries are retired in the same transaction that inserts the records read from them.

An external design review reproduced four ways the first version would still have lost work. Each is fixed, and each has a regression test whose **negative control was checked** — reverting that one fix fails that one test and only that test:

- a queue entry retired by **position** after a concurrent rebuild moved it, retiring work nobody had done and then calling the index complete;
- a notes queue **certifying a mirror it was not listed from**;
- the budgeted **incremental** repeating the same never-advancing shape — 130 new commits against a budget reaching 64 made no progress across three calls, all 130 missing, `indexUnread` reporting zero;
- one `unread_commits` **conflating commits with notes**, so draining either could report the other complete.

Two further defects in the surrounding code: `rebuildIndex` resolved HEAD with one git process and walked the symbolic name with another, and a truncated notes pass stamped `notes_ref_sha` anyway — eleven of this repository's own notes were being dropped for good while the stamp said the mirror was indexed.

The drain takes a quarter of the caller's ceiling, not the remainder. Spending the remainder converged in four calls and cost every one of them the full three seconds, which is the edit hook's latency on every fire until the backlog cleared.

### Verification

- A resumed index is **row-for-row identical** to a single unbudgeted rebuild: 10,290 trailers, 8,824 paths, zero rows on either side of the difference.
- 9 resume tests, plus 604 tests across every file this touches.
- Three negative controls confirmed, one per fix.

### Not closing #951

This lands item 3 and the measurement correction. Items 1, 2, 4, 5 and 6 remain, each behind the measurement the issue's table names, plus one defect this surfaced: a note's body is still read through the live ref after the mirror was listed from it, so a single invocation can cross a notes update.

### Breaking

Index schema v4 → v5. A v4 index is rebuilt once on first use; one left partial by an earlier release has no position to carry forward, so the version gate is that restart path. `meta.unread_commits` is gone — read `indexUnread` or the new `indexUnreadBySource`.

Release 1.3.0.