### PR TITLE
Stop re-deriving the block the walk already read (#951 item 1, first half)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "commitlore",
   "displayName": "CommitLore",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Recorded decisions from git history, delivered to the agent before it edits. Constraints, alternatives already ruled out, and warnings left by whoever was here last.",
   "author": {
     "name": "MongLong0214",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Decision memory from Git history, with verified capture for coding sessions.",
   "author": {
     "name": "MongLong0214",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Release notes for 1.0.0, 1.0.1 and 1.0.2 are on the
 [GitHub releases page](https://github.com/MongLong0214/commitlore/releases); they
 were not written here.
 
+## 1.3.1
+
+The index paid a process to work out something it had already been told.
+
+**The recovery pass re-derived the block the walk had handed it.**
+`readCommitRecords` reads `TRAILERS_ATOM` in the same `git log` that fetches
+each commit, so a message's own trailer block arrives with it. The pass that
+recovers *earlier* blocks (SPEC §2.4) then called the grammar with no block in
+hand, and the grammar spawned `git interpret-trailers --parse` to work out the
+one already in hand. `stale` and `squash-preserve` were both moved onto
+`parseRecordBlocksWithAtom` for exactly this reason; the index was left behind.
+
+A cold rebuild of this repository went from **261 git processes to 172**, of
+which `interpret-trailers` went from 244 to 155 — and the index it produces is
+identical, row for row, on both trailers and paths. Nothing about which
+paragraphs are tested changed: the atom decides only where the last block's
+bytes come from, and the process still answers whenever the message's framing
+makes the atom ambiguous.
+
+This is the first half of #951's ranked item 1, and it is the half that needed
+no new measurement. The measurement the issue asked for said the rest: commit
+count is not the cold-path driver — 20,000 generated commits index cold in three
+seconds while 1,544 real ones do not, because the generated history carries no
+multi-block messages. What is left is the 155, which are one process per
+candidate paragraph, of which 88 of 114 on this history are paragraphs that
+could never have become a block.
+
 ## 1.3.0
 
 A scan that ran out of budget stopped, and then never started again. Everything

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 ```
 
 <details>
 <summary>先にインストーラーを読みたいですか？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh
-sh install.sh v1.3.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh
+sh install.sh v1.3.1
 
 # あるいはスクリプトを使わずに。スクリプトが作るチェックアウトは自分でも作れます。
-git clone --depth 1 --branch v1.3.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.3.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore はその判断をコードのそばに残します。
 macOS と Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.ps1))) v1.3.1
 ```
 
 Node.js 22.23.2+ と Git が必要です。スクリプトは何かを書き込む前に両方を確認します。
@@ -295,11 +295,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.3.0
+          ref: v1.3.1
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.3.0
+      - uses: MongLong0214/commitlore/action/preserve@v1.3.1
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 ```
 
 <details>
 <summary>먼저 설치기를 읽어 보고 싶나요?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh
-sh install.sh v1.3.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh
+sh install.sh v1.3.1
 
 # 또는 스크립트를 건너뜁니다. 스크립트가 만드는 체크아웃은 직접 만들 수 있습니다.
-git clone --depth 1 --branch v1.3.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.3.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -107,13 +107,13 @@ CommitLore는 그 판단을 코드 곁에 보관합니다.
 macOS와 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.ps1))) v1.3.1
 ```
 
 Node.js 22.23.2+와 Git이 필요합니다. 스크립트는 무엇이든 쓰기 전에 둘을 확인합니다.
@@ -293,11 +293,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.3.0
+          ref: v1.3.1
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.3.0
+      - uses: MongLong0214/commitlore/action/preserve@v1.3.1
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 ```
 
 <details>
 <summary>Prefer to read the installer first?</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh
-sh install.sh v1.3.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh
+sh install.sh v1.3.1
 
 # Or skip the script: the checkout it makes is one you can make yourself.
-git clone --depth 1 --branch v1.3.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.3.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -109,13 +109,13 @@ preserve, not for narrating every change.
 macOS and Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 ```
 
 Windows:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.ps1))) v1.3.1
 ```
 
 Requires Node.js 22.23.2+ and Git. The script checks both before it writes anything.
@@ -305,11 +305,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.3.0
+          ref: v1.3.1
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.3.0
+      - uses: MongLong0214/commitlore/action/preserve@v1.3.1
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,18 +47,18 @@
 </p>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 ```
 
 <details>
 <summary>想先阅读安装器吗？</summary>
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh
-sh install.sh v1.3.0
+curl -fsSLO https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh
+sh install.sh v1.3.1
 
 # 或者跳过脚本：它创建的检出，你自己也能创建。
-git clone --depth 1 --branch v1.3.0 https://github.com/MongLong0214/commitlore
+git clone --depth 1 --branch v1.3.1 https://github.com/MongLong0214/commitlore
 node commitlore/dist/commitlore.mjs --version
 ```
 
@@ -105,13 +105,13 @@ CommitLore 把那份判断留在代码旁边。
 macOS 和 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 ```
 
 Windows：
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.ps1))) v1.3.1
 ```
 
 需要 Node.js 22.23.2+ 和 Git。脚本会在写入任何内容前检查两者。
@@ -287,11 +287,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: MongLong0214/commitlore
-          ref: v1.3.0
+          ref: v1.3.1
           path: .commitlore-cli
           persist-credentials: false
 
-      - uses: MongLong0214/commitlore/action/preserve@v1.3.0
+      - uses: MongLong0214/commitlore/action/preserve@v1.3.1
         with:
           cli-path: .commitlore-cli/dist/cli.js
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,8 @@
 <#
     Installs commitlore from source on Windows, for any agent that is not Claude Code.
 
-      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1 | iex
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.ps1))) v1.3.0
+      irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.ps1 | iex
+      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.ps1))) v1.3.1
 
     Claude Code users do not need this script. The repository is itself a plugin
     marketplace (ADR-0011), so two /plugin commands register the MCP server, the

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Installs commitlore from source, for any agent that is not Claude Code.
 #
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh
-#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1
 #
 # **Claude Code users do not need this script.** The repository is itself a
 # plugin marketplace (ADR-0011), so two `/plugin` commands register the MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commitlore",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commitlore",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commitlore",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Git-native, lifecycle-aware decision memory for coding agents",
   "license": "MIT",
   "private": true,

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/MongLong0214/commitlore#readme",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "registryFit": "Distribution is a tagged git checkout plus a Claude Code plugin marketplace (ADR-0011 registry-free git distribution, ADR-0026 no compiled executables and no uploaded release asset), so no official package type applies and this record relies on websiteUrl plus publisher metadata.",
@@ -18,8 +18,8 @@
           "/plugin marketplace add MongLong0214/commitlore",
           "/plugin install commitlore@commitlore"
         ],
-        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.0/install.sh | sh -s v1.3.0",
-        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.3.0"
+        "installer": "curl -fsSL https://raw.githubusercontent.com/MongLong0214/commitlore/v1.3.1/install.sh | sh -s v1.3.1",
+        "release": "https://github.com/MongLong0214/commitlore/releases/tag/v1.3.1"
       },
       "runtime": {
         "transport": "stdio",

--- a/src/core/index-db.ts
+++ b/src/core/index-db.ts
@@ -57,7 +57,7 @@ import { dirname, resolve } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 
 import { canonicalCommittedAt, execGit, execGitOrThrow, historyAvailability } from './git.js';
-import { parseRecordBlocks } from './trailers.js';
+import { parseRecordBlocks, parseRecordBlocksWithAtom } from './trailers.js';
 import { signatureVerifierGeneration } from './trusted-authors.js';
 import {
   canonicalConventionalTrailerKey,
@@ -421,6 +421,16 @@ interface RawRecord {
   source: RecordSource;
   trailers: Trailer[];
   paths: string[];
+  /**
+   * The raw `TRAILERS_ATOM` field this record's own block came from, when the
+   * pass that produced it read one.
+   *
+   * Carried so `explodeRecordBlocks` can hand it to
+   * `parseRecordBlocksWithAtom` instead of paying a `git interpret-trailers`
+   * process to re-derive the block the walk already returned. Not stored: the
+   * rows come from `trailers`, and this only decides how they were obtained.
+   */
+  atom?: string;
 }
 
 const errorMessage = (error: unknown): string =>
@@ -731,7 +741,15 @@ const explodeRecordBlocks = (
     // did.
     if (atomPassHasEverything(message)) return [record];
 
-    const blocks = parseRecordBlocks(message);
+    // The walk already read this commit's own block as an atom, so re-deriving
+    // it here cost one `git interpret-trailers` process per message that
+    // reached this pass -- 94 of them on this repository's history, for an
+    // answer already in hand. `stale` and `squash-preserve` were moved onto
+    // `parseRecordBlocksWithAtom` for exactly this reason and the index was
+    // left; it decides nothing about which paragraphs are tested, only where
+    // the last block's bytes come from, and it falls back to the process
+    // whenever the atom cannot frame the message (`atomIsAmbiguous`).
+    const blocks = parseRecordBlocksWithAtom(message, record.atom);
     if (blocks.length <= 1) return [record];
 
     const earlierBlocks = blocks
@@ -869,6 +887,7 @@ const readCommitRecords = (
         source: 'commit',
         trailers: stripConventional(rawTrailers, excluded),
         paths: [],
+        atom: trailerField ?? '',
       });
     }
 

--- a/test/index-atom-reuse.test.ts
+++ b/test/index-atom-reuse.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #951 item 1: the index paid a process to re-derive a block it already held.
+ *
+ * `readCommitRecords` reads `TRAILERS_ATOM` in the same `git log` that fetches
+ * the commit, so the message's own trailer block arrives with the walk. The
+ * recovery pass then called `parseRecordBlocks(message)` with no `last`, which
+ * spawns `git interpret-trailers --parse` to work out the block that was
+ * already in hand — 94 processes on this repository's history, and 244 of the
+ * 261 git processes a cold rebuild spent were `interpret-trailers`.
+ *
+ * `stale` and `squash-preserve` were moved onto `parseRecordBlocksWithAtom`
+ * for this reason and the index was left behind.
+ *
+ * The fixtures below are shaped so the saving is the whole of the count. A
+ * message reaches the recovery pass when `record-id` appears more than once,
+ * and pays one process per earlier paragraph that mentions it. Put both
+ * mentions in the message's own trailer block and no earlier paragraph is a
+ * candidate: every process the pass spends is then the re-derivation, so the
+ * expected count is zero rather than "fewer than before".
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI = join(HERE, '..', 'dist', 'commitlore.mjs');
+
+const temporaries: string[] = [];
+afterAll(() => {
+  for (const dir of temporaries) rmSync(dir, { recursive: true, force: true });
+});
+
+const scratch = (label: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), `commitlore-atom-${label}-`));
+  temporaries.push(dir);
+  return dir;
+};
+
+const GIT_IDENTITY = [
+  '-c',
+  'user.name=CommitLore Test',
+  '-c',
+  'user.email=test@example.invalid',
+  '-c',
+  'commit.gpgsign=false',
+];
+
+/**
+ * A git that logs its own argv before running.
+ *
+ * The same shape `test/update-apply.test.ts` uses: the log arrives through the
+ * environment rather than living beside the shim, so a run cannot read another
+ * run's calls.
+ */
+const CALL_LOG_VAR = 'COMMITLORE_TEST_CALL_LOG';
+
+const gitShim = (): string => {
+  const dir = scratch('bin');
+  const realGit = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+  writeFileSync(
+    join(dir, 'git'),
+    `#!/bin/sh\necho "git $*" >> "\${${CALL_LOG_VAR}:-/dev/null}"\nexec ${realGit} "$@"\n`,
+  );
+  execFileSync('chmod', ['+x', join(dir, 'git')]);
+  return dir;
+};
+
+/**
+ * `count` commits whose own trailer block mentions `record-id` twice and whose
+ * body mentions it not at all.
+ *
+ * The second mention is a `Warn:` value, which is a real record line rather
+ * than a contrivance: a warning about records is the ordinary way a message
+ * says the word twice.
+ */
+const repoWithSelfMentioningRecords = (count: number): string => {
+  const dir = scratch('repo');
+  execFileSync('git', ['init', '-q', '--initial-branch=main'], { cwd: dir });
+  for (let i = 0; i < count; i += 1) {
+    writeFileSync(join(dir, `file-${String(i)}.txt`), `revision ${String(i)}\n`);
+    execFileSync('git', ['add', '-A'], { cwd: dir });
+    execFileSync(
+      'git',
+      [
+        ...GIT_IDENTITY,
+        'commit',
+        '-q',
+        '--no-verify',
+        '-m',
+        `change ${String(i)}\n\n` +
+          'A constraint the diff cannot show, written without the word in it.\n\n' +
+          `Record-Id: r-atom${i.toString(36)}\n` +
+          'Warn: whoever edits this next should check the record-id on the parent\n' +
+          'Blast: local\n',
+      ],
+      { cwd: dir },
+    );
+  }
+  return dir;
+};
+
+interface RebuildResult {
+  parses: number;
+  totalGit: number;
+  trailers: number;
+}
+
+const rebuild = (repo: string): RebuildResult => {
+  const bin = gitShim();
+  const log = join(scratch('log'), 'calls.txt');
+  writeFileSync(log, '');
+  const result = spawnSync(process.execPath, [CLI, 'index', '--rebuild', '--json'], {
+    cwd: repo,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env['PATH'] ?? ''}`,
+      [CALL_LOG_VAR]: log,
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(`index --rebuild failed (${String(result.status)}): ${result.stderr}`);
+  }
+  const calls = readFileSync(log, 'utf8').split('\n').filter((line) => line !== '');
+  const parsed = JSON.parse(result.stdout) as { trailersIndexed?: number };
+  return {
+    parses: calls.filter((line) => line.includes('interpret-trailers')).length,
+    totalGit: calls.length,
+    trailers: parsed.trailersIndexed ?? 0,
+  };
+};
+
+describe('#951 the index reuses the block the walk already read', () => {
+  it('spends no interpret-trailers process on a message with no earlier candidate', () => {
+    const commits = 24;
+    const outcome = rebuild(repoWithSelfMentioningRecords(commits));
+
+    // The premise: these commits really were indexed. Without it a rebuild that
+    // read nothing would also spend no processes, and pass.
+    expect(outcome.trailers).toBe(commits * 3);
+    expect(outcome.totalGit).toBeGreaterThan(0);
+
+    // Every message here reaches the recovery pass and offers it no candidate
+    // paragraph, so the only process the pass could spend is the one that
+    // re-derives the block the atom already carried.
+    expect(outcome.parses).toBe(0);
+  }, 300_000);
+});


### PR DESCRIPTION
`readCommitRecords` asks for `TRAILERS_ATOM` in the same `git log` that fetches each commit, so a message's own trailer block arrives with the message. The pass that recovers earlier blocks (SPEC §2.4) then called the grammar with nothing in hand, and the grammar spawned `git interpret-trailers --parse` to work out the block already sitting in the record it was handed.

`stale` and `squash-preserve` were both moved onto `parseRecordBlocksWithAtom` for this reason. The index was the one reader still composing the grammar without its atom — and the one that runs on the cold path.

### Measured

Counting processes rather than milliseconds, because a loaded machine cannot move a count:

| | git processes | `interpret-trailers` | trailer rows | path rows |
|---|---|---|---|---|
| before | 261 | 244 | 10,290 | 8,824 |
| after | **172** | **155** | 10,290 | 8,824 |

Rows compared per row, both directions, on `trailers` and on `commit_paths`: **nothing on either side of the difference**.

### Why this is half of item 1

The issue's item 1 asked for "validation CPU and allocation profiles with commit count and record count varied independently". That measurement is taken and it reframes the item:

| repository | commits | git processes | `interpret-trailers` |
|---|---|---|---|
| commitlore | 1,544 | 261 | 244 |
| generated | 20,000 | 68 | **0** |

20,000 generated commits index cold in 3.0s; 1,544 real ones do not finish in the same budget. **Commit count is not the driver** — the generated history carries no multi-block messages, so it never reaches this pass at all.

The remaining 155 are one process per candidate paragraph, and **88 of this history's 114 candidates are paragraphs that could never have become a block**. That is the other half, and it needs a design rather than a one-line change: a tighter prefilter is not sound while `trailer.<token>.key` can alias the key git emits, and batching the parses needs a sentinel because git emits nothing between files in one invocation. Both are recorded as `Ruled-out:` on the commit with their reasons.

### Verification

- Rows identical over this repository's full history, compared per row.
- 844 tests across index, query, stale, squash, parse, dogfood, guard, hooks, validate and the version surface.
- The new test is discriminating rather than directional: its fixtures offer the recovery pass no candidate paragraph, so the expected count is **0**, and the negative control reads **24** — exactly one per message.

Release 1.3.1: no behaviour change, so a patch.